### PR TITLE
Actuator Emit metrics to promethues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,12 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
+.PHONY: prometheus-install
+prometheus-install: ## Install Prometheus using Helm in the inferno-autoscaler-monitoring namespace.
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	helm repo update
+	helm install prometheus -f config/prometheus/prometheus.yaml prometheus-community/kube-prometheus-stack --namespace=inferno-autoscaler-monitoring --create-namespace
+
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
@@ -155,6 +161,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+
 
 ##@ Dependencies
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,11 +57,6 @@ func init() {
 
 // nolint:gocyclo
 func main() {
-	// Log info before initializing metrics exporter
-	ctrl.Log.Info("Initializing Metrics Exporter.")
-	actuator.RegisterMetrics()
-	// Log info after the metrics exporter is initialized
-	ctrl.Log.Info("Metrics Exporter Initialized.")
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
@@ -94,6 +89,12 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Log info before initializing metrics exporter
+	setupLog.Info("Initializing Metrics Exporter.")
+	actuator.RegisterMetrics()
+	// Log info after the metrics exporter is initialized
+	setupLog.Info("Metrics Exporter Initialized.")
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	llmdv1alpha1 "github.com/llm-d-incubation/inferno-autoscaler/api/v1alpha1"
+	actuator "github.com/llm-d-incubation/inferno-autoscaler/internal/actuator"
 	"github.com/llm-d-incubation/inferno-autoscaler/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
@@ -56,6 +57,11 @@ func init() {
 
 // nolint:gocyclo
 func main() {
+	// Log info before initializing metrics exporter
+	ctrl.Log.Info("Initializing Metrics Exporter.")
+	actuator.RegisterMetrics()
+	// Log info after the metrics exporter is initialized
+	ctrl.Log.Info("Metrics Exporter Initialized.")
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
@@ -64,7 +70,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,11 +5,11 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: inferno-autoscaler
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: metrics-service
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
     targetPort: 8443

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/mmunirab/inferno-autoscaler
-  newTag: arm0.1
+  newTag: arm0.2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/amalvank/inferno
-  newTag: latest
+  newName: quay.io/mmunirab/inferno-autoscaler
+  newTag: arm0.1

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -7,11 +7,11 @@ metadata:
     app.kubernetes.io/name: inferno-autoscaler
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
-  namespace: system
+  namespace: inferno-autoscaler-monitoring
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
+      port: metrics # Ensure this is the name of the port that exposes HTTPS metrics
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
@@ -25,3 +25,6 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/name: inferno-autoscaler
+  namespaceSelector:
+    matchNames:
+      - system  # Namespace where the Service resides

--- a/config/prometheus/prometheus.yaml
+++ b/config/prometheus/prometheus.yaml
@@ -1,0 +1,37 @@
+alertmanager:
+    enabled: false
+kube-state-metrics:
+    enabled: false
+prometheus-node-exporter:
+    enabled: false
+prometheus-pushgateway:
+    enabled: false
+server:
+    name: inferno-autoscaler-prometheus
+    namespace: inferno-autoscaler-monitoring
+    service:
+        enabled: true
+        type: NodePort
+        servicePort: 9090
+    persistentVolume:
+        existingClaim: prometheus-inferno-autoscaler-pvc
+        enabled: false
+    securityContext:
+        runAsUser:
+        runAsNonRoot:
+        runAsGroup:
+        fsGroup:
+extraScrapeConfigs: |
+    - job_name: inferno-metrics
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: https
+      scrape_interval: 15s
+      static_configs:
+          - targets:
+              - inferno-autoscaler-metrics-service.inferno-autoscaler-system.svc.cluster.local:8443
+      tls_config:
+        insecure_skip_verify: true
+serviceMonitorSelector:
+    matchLabels:
+        release: prometheus

--- a/internal/actuator/dummy_actuator.go
+++ b/internal/actuator/dummy_actuator.go
@@ -12,11 +12,15 @@ import (
 )
 
 type DummyActuator struct {
-	Client client.Client
+	Client             client.Client
+	PrometheusExporter *PrometheusActuator
 }
 
 func NewDummyActuator(k8sClient client.Client) *DummyActuator {
-	return &DummyActuator{Client: k8sClient}
+	return &DummyActuator{
+		Client:             k8sClient,
+		PrometheusExporter: NewPrometheusActuator(),
+	}
 }
 
 func (a *DummyActuator) ApplyReplicaTargets(ctx context.Context, VariantAutoscaling *llmdOptv1alpha1.VariantAutoscaling) error {
@@ -43,4 +47,8 @@ func (a *DummyActuator) ApplyReplicaTargets(ctx context.Context, VariantAutoscal
 
 	logger.Info("Patched Deployment", "name", deploy.Name, "num replicas", replicas)
 	return nil
+}
+
+func (a *DummyActuator) EmitMetrics(ctx context.Context, va *llmdOptv1alpha1.VariantAutoscaling) error {
+	return a.PrometheusExporter.EmitMetrics(ctx, va)
 }

--- a/internal/actuator/prometheus_actuator.go
+++ b/internal/actuator/prometheus_actuator.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023, 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	llmdOptv1alpha1 "github.com/llm-d-incubation/inferno-autoscaler/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type PrometheusActuator struct {
+	desiredReplicasGauge    *prometheus.GaugeVec
+	currentReplicasGauge    *prometheus.GaugeVec
+	optimizationStatusGauge *prometheus.GaugeVec
+}
+
+var (
+	pa = &PrometheusActuator{
+		desiredReplicasGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "inferno_desired_replicas",
+				Help: "Desired number of replicas for the inference model",
+			},
+			[]string{"model", "namespace"},
+		),
+		currentReplicasGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "inferno_current_replicas",
+				Help: "Current number of replicas for the inference model",
+			},
+			[]string{"model", "namespace"},
+		),
+		optimizationStatusGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "inferno_optimization_status",
+				Help: "Optimization status: 1 if applied successfully, 0 otherwise",
+			},
+			[]string{"model", "namespace"},
+		),
+	}
+)
+
+// Register metrics
+func RegisterMetrics() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(pa.desiredReplicasGauge, pa.currentReplicasGauge, pa.optimizationStatusGauge)
+}
+
+func (a *PrometheusActuator) ApplyReplicaTargets(ctx context.Context, VariantAutoscaling *llmdOptv1alpha1.VariantAutoscaling) error {
+	// This actuator does not modify replicas directly
+	logger := log.FromContext(ctx)
+	logger.Info("PrometheusActuator does not apply replica targets directly")
+	return nil
+}
+
+func NewPrometheusActuator() *PrometheusActuator {
+	return pa
+}
+
+func (a *PrometheusActuator) EmitMetrics(ctx context.Context, VariantAutoscaling *llmdOptv1alpha1.VariantAutoscaling) error {
+	logger := log.FromContext(ctx)
+
+	model := VariantAutoscaling.Spec.ModelID
+	namespace := VariantAutoscaling.Namespace
+
+	desired := float64(VariantAutoscaling.Status.DesiredOptimizedAlloc.NumReplicas)
+	current := float64(VariantAutoscaling.Status.CurrentAlloc.NumReplicas)
+	applied := 0.0
+	if VariantAutoscaling.Status.Actuation.Applied {
+		applied = 1.0
+	}
+
+	a.desiredReplicasGauge.WithLabelValues(model, namespace).Set(desired)
+	a.currentReplicasGauge.WithLabelValues(model, namespace).Set(current)
+	a.optimizationStatusGauge.WithLabelValues(model, namespace).Set(applied)
+
+	logger.Info("Emitted Prometheus metrics", "model", model, "namespace", namespace,
+		"desiredReplicas", desired, "currentReplicas", current, "applied", applied)
+
+	return nil
+}

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -247,6 +247,11 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 			continue
 		}
 
+		// prometheusActuator := actuator.NewPrometheusActuator()
+		// if err := prometheusActuator.EmitMetrics(ctx, &updateVa); err != nil {
+		// 	logger.Error(err, "failed to emit prometheus metrics")
+		// }
+
 		act := actuator.NewDummyActuator(r.Client)
 		if err := act.ApplyReplicaTargets(ctx, &updateVa); err != nil {
 			logger.Error(err, "failed to apply replicas")

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -247,14 +247,15 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 			continue
 		}
 
-		// prometheusActuator := actuator.NewPrometheusActuator()
-		// if err := prometheusActuator.EmitMetrics(ctx, &updateVa); err != nil {
-		// 	logger.Error(err, "failed to emit prometheus metrics")
-		// }
-
 		act := actuator.NewDummyActuator(r.Client)
 		if err := act.ApplyReplicaTargets(ctx, &updateVa); err != nil {
 			logger.Error(err, "failed to apply replicas")
+		}
+
+		// Emit Prometheus metrics
+		if err := act.EmitMetrics(ctx, &updateVa); err != nil {
+			logger.Error(err, "failed to emit metrics")
+			// optional: don't fail the reconcile on metrics error
 		}
 
 	}


### PR DESCRIPTION
- Emit metrics back to Prometheus (via the actuator), enabling external systems like HPA to react to scaling recommendations.
- Expose replica target metrics