### PR TITLE
Align vllme metrics with vllm for autoscaler compatibility

### DIFF
--- a/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
@@ -2,15 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vllme-deployment
-  # labels:
-  #   inferno.server.managed: "true"
-  #   inferno.server.name: vllm-001
-  #   inferno.server.model: llama_13b
-  #   inferno.server.class: Premium
-  #   inferno.server.allocation.accelerator: MI250
-  #   inferno.server.allocation.maxbatchsize: "8"
-  #   inferno.server.load.rpm: "30.2"
-  #   inferno.server.load.numtokens: "1560"
 spec:
   replicas: 1
   selector:
@@ -23,21 +14,33 @@ spec:
     spec:
       containers:
       - name: vllme
-        image: quay.io/infernoautoscaler/vllme:slim-1.0
+        image: quay.io/infernoautoscaler/vllme:slim-1.0 # TODO: change the image
         imagePullPolicy: Always
-        env:
-          - name: DECODE_TIME
-            value: "20"
-          - name: PREFILL_TIME
-            value: "20"
-          - name: AVG_TOKENS
-            value: "128"
-          - name: TOKENS_DISTRIBUTION
-            value: "deterministic"
-          - name: MAX_BATCH_SIZE
-            value: "8"
-          - name: KVC_PER_TOKEN
-            value: "2"
+        env: 
+        - name: MODEL_NAME
+          value: "default" 
+        - name: DECODE_TIME
+          value: "20"        # In milliseconds, e.g., 50ms per token decode
+        - name: PREFILL_TIME
+          value: "20"       # In milliseconds, e.g., 100ms for prefill
+        - name: MODEL_SIZE
+          value: "25000"     # In MB, e.g., 25GB model size
+        - name: KVC_PER_TOKEN
+          value: "2"       # In MB, e.g., 100MB per token for KV cache
+        - name: MAX_SEQ_LEN
+          value: "2048"      # Max sequence length
+        - name: MEM_SIZE
+          value: "80000"     # Total device memory in MB, e.g., 80GB
+        - name: AVG_TOKENS
+          value: "128"       # Average generated tokens
+        - name: TOKENS_DISTRIBUTION
+          value: "deterministic"   # "uniform", "normal", "deterministic"
+        - name: MAX_BATCH_SIZE
+          value: "8"         # Max concurrent requests in a batch 
+        - name: REALTIME
+          value: "True"      # Boolean: "True" or "False"
+        - name: MUTE_PRINT
+          value: "False"     # Boolean: "True" or "False"
         ports:
         - containerPort: 80
         resources:

--- a/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllme
-        image: quay.io/infernoautoscaler/vllme:slim-1.0 # TODO: change the image
+        image: quay.io/infernoautoscaler/vllme:0.2.0
         imagePullPolicy: Always
         env: 
         - name: MODEL_NAME

--- a/hack/vllme/vllm_emulator/loadgen.py
+++ b/hack/vllme/vllm_emulator/loadgen.py
@@ -1,0 +1,95 @@
+import time
+import random
+import threading
+from openai import OpenAI
+
+# Configuration parameters
+API_KEY = "fake-api-key"
+MODEL = "gpt-1337-turbo-pro-max"
+RATE = 60  # default rate (requests per minute)
+MEAN_INTERVAL = 60 / RATE  # mean inter-arrival time in seconds
+CONTENT_LENGTH = 150  # default content length
+
+# Predefined URL options
+URL_OPTIONS = {
+    1: "http://localhost:30000/v1",
+    2: "http://localhost:30010/v1",
+    3: "http://localhost:8000/v1"
+}
+
+# Function to simulate a single client sending a request
+def send_request():
+    client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
+    content = "x" * CONTENT_LENGTH
+
+    try:
+        chat_completion = client.chat.completions.create(
+            messages=[
+                {"role": "user", "content": content}
+            ],
+            model=MODEL,
+        )
+        # Uncomment below to print API response (can be noisy)
+        # print(chat_completion.choices[0].message.content)
+    except Exception as e:
+        print(f"Request failed: {e}")
+
+# Function to simulate Poisson process and generate requests
+def poisson_request_generator():
+    client_threads = []
+    request_count = 0
+    start_time = time.time()
+
+    try:
+        while True:
+            inter_arrival_time = random.expovariate(1 / MEAN_INTERVAL)
+            time.sleep(inter_arrival_time)
+            
+            thread = threading.Thread(target=send_request)
+            thread.start()
+            client_threads.append(thread)
+
+            request_count += 1
+
+            if time.time() - start_time >= 60:
+                print(f"Total requests sent in the last minute: {request_count}")
+                request_count = 0
+                start_time = time.time()
+
+            client_threads = [t for t in client_threads if t.is_alive()]
+    except KeyboardInterrupt:
+        print("\nLoad generator stopped by user.")
+
+
+def main():
+    global BASE_URL, MODEL, RATE, MEAN_INTERVAL, CONTENT_LENGTH
+
+    print("Select the server base URL:")
+    for option, url in URL_OPTIONS.items():
+        print(f"{option}: {url}")
+
+    while True:
+        try:
+            choice = int(input("Enter the option number (1/2): ").strip())
+            if choice in URL_OPTIONS:
+                BASE_URL = URL_OPTIONS[choice]
+                break
+            else:
+                print("Invalid option. Please choose 1 or 2.")
+        except ValueError:
+            print("Invalid input. Please enter a valid number (1 or 2).")
+
+    MODEL = input("Enter the model name (e.g., gpt-1337-turbo-pro-max): ").strip()
+    RATE = int(input("Enter the rate (requests per minute): ").strip())
+    MEAN_INTERVAL = 60 / RATE
+    CONTENT_LENGTH = int(input("Enter the content length (e.g., 100-200): ").strip())
+
+    print("Starting load generator...")
+    print(f"Server Address: {BASE_URL}")
+    print(f"Request Rate = {RATE}")
+    print(f"Model: {MODEL}")
+    print(f"Content Length: {CONTENT_LENGTH}")
+    poisson_request_generator()
+
+if __name__ == "__main__":
+    main()

--- a/hack/vllme/vllm_emulator/metrics.py
+++ b/hack/vllme/vllm_emulator/metrics.py
@@ -18,40 +18,53 @@ class Metrics:
             documentation="GPU KV-cache usage. 1 means 100 percent usage.",
             labelnames=labelnames)
         
-        # request rate (req per min) for a server (deployment)
-        # avg num of tokens per request (input + output)
-    
-        """
-        Counter for request rate
-        A counter is a cumulative metric that represents a single monotonically increasing counter 
-        whose value can only increase or be reset to zero on restart. 
-        For example, you can use a counter to represent the number of requests served, tasks completed, or errors.
-        """
-        self.counter_requests_total = prometheus_client.Counter(
-            name="vllm:requests_count", # prometheus adds a _total suffix at the end
-            documentation="Total number of requests received.",
-            labelnames=labelnames)
-
-        """
-        Counter for total number of tokens generated (input + output)
-        """
-        self.counter_tokens_total = prometheus_client.Counter(
-            name="vllm:tokens_count", # prometheus adds a _total suffix at the end
-            documentation="Total number of tokens generated.",
-            labelnames=labelnames)
-        
         request_latency_buckets = [
             0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
             40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 7680.0
         ]
 
         """
+        Counter for request arrivals
+        """
+        self.counter_request_arrival_total = prometheus_client.Counter(
+            name="vllm:request_arrival", # prometheus adds a _total suffix at the end
+            documentation="Total number of requests received (arrivals).",
+            labelnames=labelnames)
+        
+        """
+        Counter for request successes (departures)
+        """
+        self.counter_request_success_total = prometheus_client.Counter(
+            name="vllm:request_success",
+            documentation="Total number of requests successfully completed (departures).",
+            labelnames=labelnames)
+        
+        """
+        Counter for total number of tokens generated (input + output)
+        """
+        self.counter_tokens_total = prometheus_client.Counter(
+            name="vllm:tokens", # prometheus adds a _total suffix at the end
+            documentation="Total number of tokens generated.",
+            labelnames=labelnames)
+        
+        """
+        Histogram for Inter-Token Latency (ITL)
+        """
+        self.histogram_time_per_output_token = prometheus_client.Histogram(
+            name="vllm:time_per_output_token_seconds",
+            documentation="Histogram of inter-token latency in seconds.",
+            labelnames=labelnames,
+            buckets=[
+                0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,
+                1.0, 2.5
+        ])
+        
+        """
         Histogram for time spent in waiting
         """
         self.histogram_queue_time_request = prometheus_client.Histogram(
-        name="vllm:request_queue_time_seconds",
-        documentation="Histogram of time spent in WAITING phase for request.",
-        labelnames=labelnames,
-        # buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60) # customize if needed
-        buckets=request_latency_buckets
-        )  
+            name="vllm:request_queue_time_seconds",
+            documentation="Histogram of time spent in WAITING phase for request.",
+            labelnames=labelnames,
+            # buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60) # customize if needed
+            buckets=request_latency_buckets)  

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -82,7 +82,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 	// Setup Prometheus client
 	// TODO: agree on using standard vllm metrics
 	// Query 1: Arrival rate (requests per minute)
-	arrivalQuery := fmt.Sprintf(`sum(rate(vllm:requests_count_total{model_name="%s",namespace="%s"}[1m])) * 60`, modelName, deployNamespace)
+	arrivalQuery := fmt.Sprintf(`sum(rate(vllm:request_success_total{model_name="%s",namespace="%s"}[1m])) * 60`, modelName, deployNamespace)
 	arrivalVal := 0.0
 	if val, warn, err := promAPI.Query(ctx, arrivalQuery, time.Now()); err == nil && val.Type() == model.ValVector {
 		vec := val.(model.Vector)
@@ -99,7 +99,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 
 	// Query 2: Average token length
 	// TODO: split composite query to individual queries
-	tokenQuery := fmt.Sprintf(`delta(vllm:tokens_count_total{model_name="%s",namespace="%s"}[1m])/delta(vllm:requests_count_total{model_name="%s",namespace="%s"}[1m])`,
+	tokenQuery := fmt.Sprintf(`delta(vllm:tokens_total{model_name="%s",namespace="%s"}[1m])/delta(vllm:request_success_total{model_name="%s",namespace="%s"}[1m])`,
 		modelName, deployNamespace, modelName, deployNamespace)
 	avgLen := 0.0
 	if val, _, err := promAPI.Query(ctx, tokenQuery, time.Now()); err == nil && val.Type() == model.ValVector {


### PR DESCRIPTION
This PR addresses [Issue #23](https://github.com/llm-d-incubation/inferno-autoscaler/issues/23)

Summary of changes:
- Renamed `tokens_count_total` metric in vllme to `tokens_total` to match real vllm
- Added `vllm:request_success_total` metric to capture the number of requests successfully completed (departures).
- Added loadgen.py for light weight load generation
- Updated deployment YAML showing vllme config parameters set as env fields.
- Modified `collector.go` that works with both vllme and vllm.

NOTE: A new vllme image needs to be created and pushed to `quay.io/infernoautoscaler` for testing. 