### PR TITLE
Scale down variant to one replica when no traffic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 godebug default=go1.23
 
 require (
-	github.com/llm-inferno/optimizer-light v0.2.0
+	github.com/llm-inferno/optimizer-light v0.2.1-0.20250728202009-225d8f3a1988
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	k8s.io/apimachinery v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/llm-inferno/optimizer-light v0.2.0 h1:aZwmadEuNW6+4fLMJHqGTY4A6wSTGNpwKZAOhU7wEVk=
 github.com/llm-inferno/optimizer-light v0.2.0/go.mod h1:1B2hIejjUpETBg4SGzr33sORHCB9FCPKwOlmXN2OJyQ=
+github.com/llm-inferno/optimizer-light v0.2.1-0.20250728202009-225d8f3a1988 h1:0VHqUYlIgld5p8VG9q2pkxXHhS//YyfkgSd6V+PdlTU=
+github.com/llm-inferno/optimizer-light v0.2.1-0.20250728202009-225d8f3a1988/go.mod h1:1B2hIejjUpETBg4SGzr33sORHCB9FCPKwOlmXN2OJyQ=
 github.com/llm-inferno/queue-analysis v0.1.0 h1:1GfOZ82MVYTHVqf3szru87JWP6g6q22eaZ5lRok0JJU=
 github.com/llm-inferno/queue-analysis v0.1.0/go.mod h1:v/9Ae2WaDwn86zJDMCQxBADtT4nxmkyuwOzmkSypzfg=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -178,11 +178,12 @@ func AddServerInfoToSystemData(
 
 	// all server data
 	serverSpec := &infernoConfig.ServerSpec{
-		Name:         FullName(va.Name, va.Namespace),
-		Class:        className,
-		Model:        va.Spec.ModelID,
-		CurrentAlloc: *AllocationData,
-		DesiredAlloc: infernoConfig.AllocationData{},
+		Name:           FullName(va.Name, va.Namespace),
+		Class:          className,
+		Model:          va.Spec.ModelID,
+		MinNumReplicas: 1,
+		CurrentAlloc:   *AllocationData,
+		DesiredAlloc:   infernoConfig.AllocationData{},
 	}
 	sd.Spec.Servers.Spec = append(sd.Spec.Servers.Spec, *serverSpec)
 	return nil


### PR DESCRIPTION
Traffic was increased to 60 requests/min, then stopped.
The number of replicas went from 1 to 3, then 4 during the ramping up of load. Then, dropped to 1 after the traffic stopped.

```
{"level":"info","ts":1753737228.249484,"caller":"controller/variantautoscaling_controller.go:108","msg":"current inventory in the clustercapacitymap[a100-cluster-control-plane:map[NVIDIA-A100-PCIE-80GB:{8 81920}] a100-cluster-worker:map[AMD-MI300X-192G:{8 196608}] a100-cluster-worker2:map[Intel-Gaudi-2-96GB:{8 98304}]]"}
{"level":"info","ts":1753737228.2497,"caller":"controller/variantautoscaling_controller.go:131","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753737228.3657222,"caller":"controller/variantautoscaling_controller.go:212","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default false 1 {A100 1 256 40 0 4010.43 {147.98 118 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 8} {Intel-Gaudi-2-96GB 8} {NVIDIA-A100-PCIE-80GB 8}]}}}"}
{"level":"info","ts":1753737228.3657758,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=147.98; tk=118; sol=3, alloc={acc=G2; num=3; maxBatch=4; cost=69, val=39.9, servTime=18.043447, waitTime=121.47412, rho=0.8254339}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=Intel-Gaudi-2-96GB, count=3, limit=8, cost=69 \ntotalCost=69 \n"}
{"level":"info","ts":1753737228.373942,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas3"}




{"level":"info","ts":1753737277.75362,"caller":"controller/variantautoscaling_controller.go:108","msg":"current inventory in the clustercapacitymap[a100-cluster-control-plane:map[NVIDIA-A100-PCIE-80GB:{8 81920}] a100-cluster-worker:map[AMD-MI300X-192G:{8 196608}] a100-cluster-worker2:map[Intel-Gaudi-2-96GB:{8 98304}]]"}
{"level":"info","ts":1753737277.7537448,"caller":"controller/variantautoscaling_controller.go:131","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753737277.764456,"caller":"controller/variantautoscaling_controller.go:212","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default false 1 {A100 3 256 120 0 6654.77 {213.33 118 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 8} {Intel-Gaudi-2-96GB 8} {NVIDIA-A100-PCIE-80GB 8}]}}}"}
{"level":"info","ts":1753737277.764498,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=213.33; tk=118; sol=3, alloc={acc=G2; num=4; maxBatch=4; cost=92, val=-6.7999997, servTime=18.082441, waitTime=163.55469, rho=0.8500142}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=Intel-Gaudi-2-96GB, count=4, limit=8, cost=92 \ntotalCost=92 \n"}
{"level":"info","ts":1753737277.769375,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas4"}




{"level":"info","ts":1753737337.753506,"caller":"controller/variantautoscaling_controller.go:108","msg":"current inventory in the clustercapacitymap[a100-cluster-control-plane:map[NVIDIA-A100-PCIE-80GB:{8 81920}] a100-cluster-worker:map[AMD-MI300X-192G:{8 196608}] a100-cluster-worker2:map[Intel-Gaudi-2-96GB:{8 98304}]]"}
{"level":"info","ts":1753737337.753953,"caller":"controller/variantautoscaling_controller.go:131","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753737337.7640908,"caller":"controller/variantautoscaling_controller.go:212","msg":"inferno data systemData &{{{[{MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:default Premium default false 1 {A100 4 256 160 0 14988.84 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 8} {NVIDIA-A100-PCIE-80GB 8} {AMD-MI300X-192G 8}]}}}"}
{"level":"info","ts":1753737337.764234,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=3, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-120, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=8, cost=40 \ntotalCost=40 \n"}
{"level":"info","ts":1753737337.775289,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
```
