### PR TITLE
add retries

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -84,8 +84,6 @@ const (
 )
 
 func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
-	// TODO: decide on whether to keep accelerator properties (device name, cost) in same configMap, provided by administrator
 	acceleratorCm, err := r.readAcceleratorConfig(ctx, "accelerator-unit-costs", "default")
 	if err != nil {
 		logger.Log.Error(err, "unable to read accelerator configmap, skipping optimiziing")
@@ -105,12 +103,22 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Filter out resources with DeletionTimestamp set
+	activeVAs := make([]llmdVariantAutoscalingV1alpha1.VariantAutoscaling, 0, len(variantAutoscalingList.Items))
+	for _, va := range variantAutoscalingList.Items {
+		if va.DeletionTimestamp.IsZero() {
+			activeVAs = append(activeVAs, va)
+		} else {
+			logger.Log.Info("Skipping deleted VariantAutoscaling", "name", va.Name)
+		}
+	}
+
 	newInventory, err := collector.CollectInventoryK8S(ctx, r.Client)
 
-	if err == nil {
-		logger.Log.Info("current inventory in the cluster", "capacity", newInventory)
-	} else {
+	if err != nil {
 		logger.Log.Error(err, "failed to get cluster inventory")
+		//node listing failed, rely on reconciler to requeue and retry.
+		return ctrl.Result{}, err
 	}
 
 	systemData := utils.CreateSystemData(acceleratorCm, serviceClassCm, newInventory)
@@ -119,8 +127,9 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	var allAnalyzerResponses = make(map[string]*interfaces.ModelAnalyzeResponse)
 	var vaMap = make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling)
 
-	for _, va := range variantAutoscalingList.Items {
+	for _, va := range activeVAs {
 		modelName := va.Labels["inference.optimization/modelName"]
+		//TODO this should be part of the webhook to validate VAs
 		if modelName == "" {
 			logger.Log.Info("variantAutoscaling missing modelName label, skipping optimization", "name", va.Name)
 			return ctrl.Result{}, err
@@ -152,15 +161,33 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		//TODO: remove calling duplicate deployment calls
 		// Check if Deployment exists for this variantAutoscaling
 		var deploy appsv1.Deployment
-		err = r.Get(ctx, types.NamespacedName{
-			Name:      va.Name,
-			Namespace: va.Namespace,
-		}, &deploy)
+		backoff := wait.Backoff{
+			Duration: 100 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   0.1,
+			Steps:    5,
+		}
+		err = wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+			err := r.Get(ctx, types.NamespacedName{
+				Name:      va.Name,
+				Namespace: va.Namespace,
+			}, &deploy)
+			if err == nil {
+				return true, nil
+			}
+			if apierrors.IsNotFound(err) {
+				// No need to retry if not found
+				return false, err
+			}
+			// Retry on other errors
+			logger.Log.Error(err, "transient error getting Deployment, retrying", "variantAutoscaling", va.Name)
+			return false, nil
+		})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			logger.Log.Error(err, "failed to get Deployment", "variantAutoscaling", va.Name)
+			logger.Log.Error(err, "failed to get Deployment after retries", "variantAutoscaling", va.Name)
 			return ctrl.Result{}, err
 		}
 


### PR DESCRIPTION
Add retry logic in the reconciler loop.

```
-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"info","ts":1753807693.0393708,"caller":"controller/variantautoscaling_controller.go:143","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753807693.0488646,"caller":"controller/variantautoscaling_controller.go:242","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default false 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4} {NVIDIA-A100-PCIE-80GB 4}]}}}"}
{"level":"info","ts":1753807693.0490127,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=3, alloc={acc=G2; num=1; maxBatch=4; cost=23, val=-10.7, servTime=17.49, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=Intel-Gaudi-2-96GB, count=1, limit=4, cost=23 \ntotalCost=23 \n"}
{"level":"info","ts":1753807693.0603435,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
```