### PR TITLE
enable HA in controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/name: inferno-autoscaler
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:
@@ -61,7 +61,7 @@ spec:
       - command:
         - /manager
         args:
-          - --leader-elect
+          - --leader-elect=true
           - --health-probe-bind-address=:8081
         image: controller:latest
         env:


### PR DESCRIPTION
controller logs:

```
abhishekmalvankar@abhisheks-mbp inferno-autoscaler % kubectl apply -f /Users/abhishekmalvankar/inferno_exp/0714/fork-inferno/inferno-autoscaler/hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
variantautoscaling.llmd.ai/vllme-deployment created
abhishekmalvankar@abhisheks-mbp inferno-autoscaler % kubectl get deployments
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
vllme-deployment   1/1     1            1           147m
abhishekmalvankar@abhisheks-mbp inferno-autoscaler % kubectl logs inferno-autoscaler-controller-manager-794c69dcd-v4lrx  -n inferno-autoscaler-system
{"level":"info","ts":1753816161.4803965,"caller":"controller/variantautoscaling_controller.go:321","msg":"Prometheus client initialized"}
2025-07-29T19:09:21Z    INFO    setup   starting manager
2025-07-29T19:09:21Z    INFO    controller-runtime.metrics      Starting metrics server
2025-07-29T19:09:21Z    INFO    setup   disabling http/2
2025-07-29T19:09:21Z    INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
I0729 19:09:21.509294       1 leaderelection.go:257] attempting to acquire leader lease inferno-autoscaler-system/72dd1cf1.llm-d.ai...
I0729 19:09:21.517549       1 leaderelection.go:271] successfully acquired lease inferno-autoscaler-system/72dd1cf1.llm-d.ai
2025-07-29T19:09:21Z    DEBUG   events  inferno-autoscaler-controller-manager-794c69dcd-v4lrx_c2f6435b-a67b-4d7b-9777-f198fd8ba4fc became leader     {"type": "Normal", "object": {"kind":"Lease","namespace":"inferno-autoscaler-system","name":"72dd1cf1.llm-d.ai","uid":"3336d121-4de4-4900-8f4e-12b5a6d897b9","apiVersion":"coordination.k8s.io/v1","resourceVersion":"10153"}, "reason": "LeaderElection"}
2025-07-29T19:09:21Z    INFO    Starting EventSource    {"controller": "variantAutoscaling", "controllerGroup": "llmd.ai", "controllerKind": "VariantAutoscaling", "source": "kind source: *v1.Node"}
{"level":"info","ts":1753816161.5185544,"caller":"controller/variantautoscaling_controller.go:332","msg":"Elected as leader, starting optimization loop"}
2025-07-29T19:09:21Z    INFO    Starting EventSource    {"controller": "variantAutoscaling", "controllerGroup": "llmd.ai", "controllerKind": "VariantAutoscaling", "source": "kind source: *v1alpha1.VariantAutoscaling"}
{"level":"info","ts":1753816161.6525197,"caller":"controller/variantautoscaling_controller.go:442","msg":"Started periodic optimization tickerinterval1m"}
2025-07-29T19:09:21Z    INFO    Starting Controller     {"controller": "variantAutoscaling", "controllerGroup": "llmd.ai", "controllerKind": "VariantAutoscaling"}
2025-07-29T19:09:21Z    INFO    Starting workers        {"controller": "variantAutoscaling", "controllerGroup": "llmd.ai", "controllerKind": "VariantAutoscaling", "worker count": 1}
2025-07-29T19:09:21Z    INFO    controller-runtime.metrics      Serving metrics server  {"bindAddress": ":8443", "secure": true}
{"level":"debug","ts":1753816221.6534624,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"debug","ts":1753816221.6537702,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"debug","ts":1753816221.6537764,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"info","ts":1753816221.654244,"caller":"controller/variantautoscaling_controller.go:231","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"error","ts":1753816221.6543481,"caller":"controller/variantautoscaling_controller.go:237","msg":"no feasible solution foundunable to perform model optimization, skipping this variantAutoscaling loop","stacktrace":"github.com/llm-d-incubation/inferno-autoscaler/internal/controller.(*VariantAutoscalingReconciler).Reconcile\n\t/workspace/internal/controller/variantautoscaling_controller.go:237\ngithub.com/llm-d-incubation/inferno-autoscaler/internal/controller.(*VariantAutoscalingReconciler).watchAndRunLoop.func1\n\t/workspace/internal/controller/variantautoscaling_controller.go:429"}
{"level":"debug","ts":1753816228.1778548,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"debug","ts":1753816228.177912,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"debug","ts":1753816228.1779184,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"info","ts":1753816228.1781096,"caller":"controller/variantautoscaling_controller.go:142","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753816228.2960596,"caller":"controller/variantautoscaling_controller.go:231","msg":"inferno data systemData &{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default true 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"info","ts":1753816228.2962277,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"info","ts":1753816228.3094153,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
abhishekmalvankar@abhisheks-mbp inferno-autoscaler % kubectl get pods -n inferno-autoscaler-system
NAME                                                    READY   STATUS    RESTARTS   AGE
inferno-autoscaler-controller-manager-794c69dcd-g4l6k   1/1     Running   0          99s
inferno-autoscaler-controller-manager-794c69dcd-v4lrx   1/1     Running   0          99s
abhishekmalvankar@abhisheks-mbp inferno-autoscaler % kubectl logs inferno-autoscaler-controller-manager-794c69dcd-g4l6k   -n inferno-autoscaler-system
{"level":"info","ts":1753816161.4791143,"caller":"controller/variantautoscaling_controller.go:321","msg":"Prometheus client initialized"}
2025-07-29T19:09:21Z    INFO    setup   starting manager
2025-07-29T19:09:21Z    INFO    controller-runtime.metrics      Starting metrics server
2025-07-29T19:09:21Z    INFO    setup   disabling http/2
2025-07-29T19:09:21Z    INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
I0729 19:09:21.480085       1 leaderelection.go:257] attempting to acquire leader lease inferno-autoscaler-system/72dd1cf1.llm-d.ai...
2025-07-29T19:09:21Z    INFO    controller-runtime.metrics      Serving metrics server  {"bindAddress": ":8443", "secure": true}
```