### PR TITLE
update reconciler to smaller, composable helper functions and reduce inline logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -88,17 +87,10 @@ func main() {
 
 	flag.Parse()
 
-	encoderCfg := zap.NewProductionEncoderConfig()
-	encoderCfg.TimeKey = "ts"
-	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
-	level := logger.GetZapLevelFromEnv()
-	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(encoderCfg),
-		zapcore.AddSync(os.Stdout),
-		level,
-	)
-
-	setupLog = zap.New(core)
+	setupLog, err := logger.NewLogger()
+	if err != nil {
+		panic("unable to initialize logger: " + err.Error())
+	}
 	defer setupLog.Sync()
 
 	ctrllog.SetLogger(ctrlzap.New(ctrlzap.UseDevMode(false), ctrlzap.WriteTo(os.Stdout)))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	flag.Parse()
 
-	setupLog, err := logger.NewLogger()
+	setupLog, err := logger.InitLogger()
 	if err != nil {
 		panic("unable to initialize logger: " + err.Error())
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -37,3 +37,19 @@ func GetZapLevelFromEnv() zapcore.Level {
 		return zapcore.InfoLevel // fallback
 	}
 }
+
+func NewLogger() (*zap.Logger, error) {
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.TimeKey = "ts"
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	level := GetZapLevelFromEnv()
+
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.AddSync(os.Stdout),
+		level,
+	)
+
+	return zap.New(core), nil
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -11,19 +11,7 @@ import (
 var Log *zap.SugaredLogger
 
 func init() {
-
-	levelStr := strings.ToLower(os.Getenv("LOG_LEVEL")) // "debug", "info", etc.
-	var level zapcore.Level
-	switch levelStr {
-	case "debug":
-		level = zapcore.DebugLevel
-	case "warn":
-		level = zapcore.WarnLevel
-	case "error":
-		level = zapcore.ErrorLevel
-	default:
-		level = zapcore.InfoLevel // default
-	}
+	level := GetZapLevelFromEnv() // Use the function from utils
 	config := zap.NewProductionConfig()
 	config.Level = zap.NewAtomicLevelAt(level)
 
@@ -32,4 +20,20 @@ func init() {
 		panic("failed to build zap logger: " + err.Error())
 	}
 	Log = raw.Sugar()
+}
+
+func GetZapLevelFromEnv() zapcore.Level {
+	levelStr := strings.ToLower(os.Getenv("LOG_LEVEL"))
+	switch levelStr {
+	case "debug":
+		return zapcore.DebugLevel
+	case "info":
+		return zapcore.InfoLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel // fallback
+	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,7 +3,9 @@ package utils
 import (
 	"fmt"
 	"math"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d-incubation/inferno-autoscaler/api/v1alpha1"
@@ -11,6 +13,7 @@ import (
 	interfaces "github.com/llm-d-incubation/inferno-autoscaler/internal/interfaces"
 	"github.com/llm-d-incubation/inferno-autoscaler/internal/logger"
 	infernoConfig "github.com/llm-inferno/optimizer-light/pkg/config"
+	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -217,4 +220,20 @@ func FullName(name string, namespace string) string {
 // Helper to check if a value is valid (not NaN or infinite)
 func CheckValue(x float64) bool {
 	return !(math.IsNaN(x) || math.IsInf(x, 0))
+}
+
+func GetZapLevelFromEnv() zapcore.Level {
+	levelStr := strings.ToLower(os.Getenv("LOG_LEVEL"))
+	switch levelStr {
+	case "debug":
+		return zapcore.DebugLevel
+	case "info":
+		return zapcore.InfoLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel // fallback
+	}
 }


### PR DESCRIPTION
controller logs:

```
{"level":"debug","ts":1753821511.7286205,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"debug","ts":1753821511.728626,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"info","ts":1753821511.729006,"caller":"controller/variantautoscaling_controller.go:196","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753821511.7376022,"caller":"controller/variantautoscaling_controller.go:136","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default true 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 4} {NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4}]}}}"}
{"level":"info","ts":1753821511.7377691,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"info","ts":1753821511.7448106,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
{"level":"debug","ts":1753821571.7278035,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"debug","ts":1753821571.727931,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"debug","ts":1753821571.7279496,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"info","ts":1753821571.72834,"caller":"controller/variantautoscaling_controller.go:196","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753821571.7383797,"caller":"controller/variantautoscaling_controller.go:136","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default true 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4} {NVIDIA-A100-PCIE-80GB 4}]}}}"}
{"level":"info","ts":1753821571.7384927,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"info","ts":1753821571.7436945,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
{"level":"debug","ts":1753821631.7282667,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"debug","ts":1753821631.7286322,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"debug","ts":1753821631.728652,"caller":"collector/collector.go:60","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"info","ts":1753821631.7291615,"caller":"controller/variantautoscaling_controller.go:196","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"info","ts":1753821631.739341,"caller":"controller/variantautoscaling_controller.go:136","msg":"inferno data systemData &{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:default Premium default true 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"info","ts":1753821631.7394855,"caller":"optimizer/optimizer.go:43","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"info","ts":1753821631.746934,"caller":"actuator/dummy_actuator.go:44","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
```