### PR TITLE
rem modelservice requeue for reconcile

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -126,10 +126,10 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	modelAnalyzer := analyzer.NewModelAnalyzer(system)
 	for _, s := range system.Servers() {
-		modelAnalyzeResponse, err := modelAnalyzer.AnalyzeModel(ctx, *vaMap[s.Name()])
-		if err != nil {
-			logger.Log.Error("model analyzer error", "failed to analyze", err)
-			return ctrl.Result{}, err
+		modelAnalyzeResponse := modelAnalyzer.AnalyzeModel(ctx, *vaMap[s.Name()])
+		if len(modelAnalyzeResponse.Allocations) == 0 {
+			logger.Log.Info("No allocations found for server", "serverName", s.Name())
+			continue
 		}
 		allAnalyzerResponses[s.Name()] = modelAnalyzeResponse
 	}

--- a/internal/modelanalyzer/analyzer.go
+++ b/internal/modelanalyzer/analyzer.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	llmdOptv1alpha1 "github.com/llm-d-incubation/inferno-autoscaler/api/v1alpha1"
 	interfaces "github.com/llm-d-incubation/inferno-autoscaler/internal/interfaces"
@@ -24,12 +23,12 @@ func NewModelAnalyzer(system *inferno.System) *ModelAnalyzer {
 
 // Analyze a particular variant and generate corresponding allocations that achieve SLOs for all accelerators, used by the optimizer
 func (ma *ModelAnalyzer) AnalyzeModel(ctx context.Context,
-	va llmdOptv1alpha1.VariantAutoscaling) (*interfaces.ModelAnalyzeResponse, error) {
+	va llmdOptv1alpha1.VariantAutoscaling) *interfaces.ModelAnalyzeResponse {
 
 	serverName := utils.FullName(va.Name, va.Namespace)
 	if server, exists := ma.system.Servers()[serverName]; exists {
 		server.Calculate(ma.system.Accelerators())
-		return CreateModelAnalyzeResponseFromAllocations(server.AllAllocations()), nil
+		return CreateModelAnalyzeResponseFromAllocations(server.AllAllocations())
 	}
-	return nil, fmt.Errorf("server %s not found", serverName)
+	return &interfaces.ModelAnalyzeResponse{}
 }


### PR DESCRIPTION
controller logs:

```
{"level":"info","ts":"2025-07-30T15:40:08Z","msg":"Starting workers","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","worker count":1}
{"level":"info","ts":"2025-07-30T15:40:08Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8443","secure":true}
{"level":"DEBUG","ts":"2025-07-30T15:40:36.663Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"DEBUG","ts":"2025-07-30T15:40:36.663Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"DEBUG","ts":"2025-07-30T15:40:36.663Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"INFO","ts":"2025-07-30T15:40:36.664Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"INFO","ts":"2025-07-30T15:40:36.788Z","msg":"inferno data systemData &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:default Premium default true 1 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4} {NVIDIA-A100-PCIE-80GB 4}]}}}"}
{"level":"INFO","ts":"2025-07-30T15:40:36.788Z","msg":"optimization solution system Solution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"INFO","ts":"2025-07-30T15:40:36.802Z","msg":"Patched Deploymentnamevllme-deploymentnum replicas1"}
```