### PR TITLE
Remove hard-coded accelerator name

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -202,7 +202,8 @@ func (r *VariantAutoscalingReconciler) prepareVariantAutoscalings(
 			}
 		}
 
-		acceleratorCostVal, ok := acceleratorCm["A100"]["cost"]
+		accName := va.Labels["inference.optimization/acceleratorName"]
+		acceleratorCostVal, ok := acceleratorCm[accName]["cost"]
 		if !ok {
 			logger.Log.Error("variantAutoscaling missing accelerator cost in configmap, skipping optimization", "variantAutoscaling-name", va.Name)
 			continue


### PR DESCRIPTION
Cost in current allocation is based on a hard-coded accelerator name `A100`.  Should be taken from the VariantAutoscaling label.