### PR TITLE
Obtain modelname from spec

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: variantautoscaling-config
+  name: inferno-autoscaler-variantautoscaling-config
   namespace: inferno-autoscaler-system
   labels:
     app.kubernetes.io/name: inferno-autoscaler

--- a/deploy/configmap-serviceclass.yaml
+++ b/deploy/configmap-serviceclass.yaml
@@ -8,9 +8,9 @@ data:
     name: Premium
     priority: 1
     data:
-      - model: default
-        slo-itl: 24
-        slo-ttw: 500
+      - model: default/default
+        slo-itl: 12
+        slo-ttw: 20
       - model: llama0-70b
         slo-itl: 80
         slo-ttw: 500

--- a/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
@@ -23,7 +23,7 @@ spec:
         imagePullPolicy: Always
         env: 
         - name: MODEL_NAME
-          value: "default" 
+          value: "default/default" 
         - name: DECODE_TIME
           value: "20"        # In milliseconds, e.g., 50ms per token decode
         - name: PREFILL_TIME

--- a/hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
@@ -5,7 +5,7 @@ kind: VariantAutoscaling
 metadata:
   # Unique name of the variant
   name: vllme-deployment 
-  namespace: default
+  namespace: llm-d-sim
   labels:
     inference.optimization/acceleratorName: A100
 # This is essentially static input to the optimizer

--- a/hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
@@ -5,20 +5,19 @@ kind: VariantAutoscaling
 metadata:
   # Unique name of the variant
   name: vllme-deployment 
-  namespace: llm-d-sim
+  namespace: default
   labels:
-    inference.optimization/modelName: default
     inference.optimization/acceleratorName: A100
 # This is essentially static input to the optimizer
 spec:
   # OpenAI API compatible name of the model
-  modelID: default
+  modelID: default/default
   # Add SLOs in configmap, add reference to this per model data
   # to avoid duplication and Move to ISOs when available
   sloClassRef:
     # Configmap name to load in the same namespace as optimizer object
     # we start with static (non-changing) ConfigMaps (for ease of implementation only)
-    name: premium-slo
+    name: premium
     # Key (modelID) present inside configmap
     key: opt-125m
   # Static profiled benchmarked data for a variant running on different accelerators

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -201,7 +201,7 @@ func (r *VariantAutoscalingReconciler) prepareVariantAutoscalings(
 	}
 
 	for _, va := range activeVAs {
-		modelName := va.Labels["inference.optimization/modelName"]
+		modelName := va.Spec.ModelID
 		if modelName == "" {
 			logger.Log.Info("variantAutoscaling missing modelName label, skipping optimization", "name", va.Name)
 			continue


### PR DESCRIPTION
ModelID is obtained from spec to support `\` in modelname format.