### PR TITLE
Remove requeue when optimization fails

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -151,8 +151,8 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	optimizedAllocation, err := engine.Optimize(ctx, *updateList, allAnalyzerResponses)
 	if err != nil {
-		logger.Log.Error(err, "unable to perform model optimization")
-		return ctrl.Result{}, err
+		logger.Log.Error(err, "unable to perform model optimization, skipping this iteration")
+		return ctrl.Result{}, nil
 	}
 
 	logger.Log.Debug("Optimization completed successfully, emitting optimization metrics")

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -151,7 +151,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	optimizedAllocation, err := engine.Optimize(ctx, *updateList, allAnalyzerResponses)
 	if err != nil {
-		logger.Log.Error(err, "unable to perform model optimization, retrying")
+		logger.Log.Error(err, "unable to perform model optimization")
 		return ctrl.Result{}, err
 	}
 
@@ -162,8 +162,9 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	if err := r.applyOptimizedAllocations(ctx, updateList, optimizedAllocation); err != nil {
+		// If we fail to apply optimized allocations, we log the error but do not return it.
+		// In next tick, the controller will retry.
 		logger.Log.Error(err, "failed to apply optimized allocations")
-		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -176,7 +177,7 @@ func filterActiveVariantAutoscalings(items []llmdVariantAutoscalingV1alpha1.Vari
 		if va.DeletionTimestamp.IsZero() {
 			active = append(active, va)
 		} else {
-			logger.Log.Info("Skipping deleted VariantAutoscaling", "name", va.Name)
+			logger.Log.Info("skipping deleted VariantAutoscaling", "name", va.Name)
 		}
 	}
 	return active
@@ -505,7 +506,7 @@ func (r *VariantAutoscalingReconciler) watchAndRunLoop(ctx context.Context) {
 
 	for {
 		cm := &corev1.ConfigMap{}
-		err := r.Get(context.Background(), types.NamespacedName{
+		err := r.Get(ctx, types.NamespacedName{
 			Name:      configMapName,
 			Namespace: configMapNamespace,
 		}, cm)


### PR DESCRIPTION
solves #47 

controller scale up and scale down logs:
 
 ```
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=37.45; tk=328; sol=1, alloc={acc=A100; num=4; maxBatch=4; cost=160, val=120, servTime=21.427635, waitTime=74.58447, rho=0.6631317}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=4, limit=4, cost=160 \ntotalCost=160 \n"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 16:21:34.408822808 +0000 UTC m=+180.220128128 A100 4}"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.408Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T16:21:34.418Z","msg":"Patched Deploymentname: vllme-deployment num-replicas: 4"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.433Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T16:21:34.433Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.433Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T16:21:34.433Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T16:21:34.433Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-04T16:22:34.401Z","msg":"Reconcile function calledrequest_namerequest_namespace"}
{"level":"DEBUG","ts":"2025-08-04T16:22:34.402Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"DEBUG","ts":"2025-08-04T16:22:34.402Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"DEBUG","ts":"2025-08-04T16:22:34.402Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"INFO","ts":"2025-08-04T16:22:34.402Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T16:22:34.411Z","msg":"System data prepared for optimizationsystemData&{{{[{MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 4 256 160 20 0 {62.67 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 4} {Intel-Gaudi-2-96GB 4} {NVIDIA-A100-PCIE-80GB 4}]}}}"}
{"level":"ERROR","ts":"2025-08-04T16:22:34.411Z","msg":"no feasible solution foundunable to perform model optimization"}
{"level":"ERROR","ts":"2025-08-04T16:22:34.411Z","msg":"no feasible solution foundManual reconcile failed"}
{"level":"DEBUG","ts":"2025-08-04T16:23:34.399Z","msg":"Reconcile function calledrequest_namerequest_namespace"}
{"level":"DEBUG","ts":"2025-08-04T16:23:34.400Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"DEBUG","ts":"2025-08-04T16:23:34.400Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"DEBUG","ts":"2025-08-04T16:23:34.400Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"INFO","ts":"2025-08-04T16:23:34.400Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T16:23:34.407Z","msg":"System data prepared for optimizationsystemData&{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 4 256 160 20 0 {52 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 4} {NVIDIA-A100-PCIE-80GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"ERROR","ts":"2025-08-04T16:23:34.407Z","msg":"no feasible solution foundunable to perform model optimization"}
{"level":"ERROR","ts":"2025-08-04T16:23:34.407Z","msg":"no feasible solution foundManual reconcile failed"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.399Z","msg":"Reconcile function calledrequest_namerequest_namespace"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.399Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.399Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.399Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"INFO","ts":"2025-08-04T16:24:34.400Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"System data prepared for optimizationsystemData&{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 4 256 160 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{Intel-Gaudi-2-96GB 4} {NVIDIA-A100-PCIE-80GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-120, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 16:24:34.407828769 +0000 UTC m=+360.219134131 A100 1}"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.407Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T16:24:34.416Z","msg":"Patched Deploymentname: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.423Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T16:24:34.423Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.423Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T16:24:34.423Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T16:24:34.423Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}

```
