### PR TITLE
simplify watchandrun loop

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,10 +62,6 @@ import (
 type VariantAutoscalingReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
-
-	mu         sync.Mutex
-	ticker     *time.Ticker
-	stopTicker chan struct{}
 
 	PromAPI promv1.API
 }
@@ -113,6 +108,11 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	activeVAs := filterActiveVariantAutoscalings(variantAutoscalingList.Items)
+
+	if len(activeVAs) == 0 {
+		logger.Log.Info("No active VariantAutoscalings found, skipping optimization")
+		return ctrl.Result{}, nil
+	}
 
 	newInventory, err := collector.CollectInventoryK8S(ctx, r.Client)
 	if err != nil {
@@ -501,8 +501,18 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 
 func (r *VariantAutoscalingReconciler) watchAndRunLoop(ctx context.Context) error {
 	var lastInterval string
+	var lastTick time.Time
+	var intervalDuration time.Duration
 
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Log.Info("Context cancelled, stopping watch loop")
+			return nil
+		default:
+			// Continue
+		}
+
 		cm := &corev1.ConfigMap{}
 		err := r.Get(ctx, types.NamespacedName{
 			Name:      configMapName,
@@ -510,7 +520,7 @@ func (r *VariantAutoscalingReconciler) watchAndRunLoop(ctx context.Context) erro
 		}, cm)
 		if err != nil {
 			logger.Log.Error(err, "Unable to read optimization config")
-			time.Sleep(30 * time.Second)
+			time.Sleep(10 * time.Second)
 			return err
 		}
 
@@ -520,62 +530,46 @@ func (r *VariantAutoscalingReconciler) watchAndRunLoop(ctx context.Context) erro
 		// Handle manual trigger
 		if trigger == "true" {
 			logger.Log.Info("Manual optimization trigger received")
-			_, err := r.Reconcile(context.Background(), ctrl.Request{})
+			_, err := r.Reconcile(ctx, ctrl.Request{})
 			if err != nil {
 				logger.Log.Error(err, "Manual reconcile failed")
 			}
 
-			// Reset trigger in ConfigMap
+			// Reset the trigger
 			cm.Data["GLOBAL_OPT_TRIGGER"] = "false"
-			if err := r.Update(context.Background(), cm); err != nil {
+			if err := r.Update(ctx, cm); err != nil {
 				logger.Log.Error(err, "Failed to reset GLOBAL_OPT_TRIGGER")
 			}
 		}
 
-		r.mu.Lock()
+		// Handle interval change
 		if interval != lastInterval {
-			// Stop previous ticker if any
-			if r.stopTicker != nil {
-				close(r.stopTicker)
-			}
-
 			if interval != "" {
-				d, err := time.ParseDuration(interval)
+				dur, err := time.ParseDuration(interval)
 				if err != nil {
 					logger.Log.Error(err, "Invalid GLOBAL_OPT_INTERVAL")
-					r.mu.Unlock()
+					time.Sleep(10 * time.Second)
 					return err
 				}
-
-				r.stopTicker = make(chan struct{})
-				ticker := time.NewTicker(d)
-				r.ticker = ticker
-
-				go func(stopCh <-chan struct{}, tick <-chan time.Time) {
-					for {
-						select {
-						case <-tick:
-							_, err := r.Reconcile(ctx, ctrl.Request{})
-							if err != nil {
-								logger.Log.Error(err, "Manual reconcile failed")
-							}
-						case <-stopCh:
-							return
-						case <-ctx.Done():
-							logger.Log.Info("Context cancelled, stopping ticker loop")
-							return
-						}
-					}
-				}(r.stopTicker, ticker.C)
-
-				logger.Log.Info("Started periodic optimization ticker", "interval", interval)
+				intervalDuration = dur
+				logger.Log.Info("Updated periodic optimization interval", "interval", interval)
 			} else {
-				r.ticker = nil
+				intervalDuration = 0
 				logger.Log.Info("GLOBAL_OPT_INTERVAL unset, disabling periodic optimization")
 			}
 			lastInterval = interval
+			lastTick = time.Time{} // Reset ticker
 		}
-		r.mu.Unlock()
+
+		// Run periodic reconcile
+		if intervalDuration > 0 && time.Since(lastTick) >= intervalDuration {
+			_, err := r.Reconcile(ctx, ctrl.Request{})
+			if err != nil {
+				logger.Log.Error(err, "Periodic reconcile failed")
+			} else {
+				lastTick = time.Now()
+			}
+		}
 
 		time.Sleep(10 * time.Second)
 	}


### PR DESCRIPTION
Watchandrunloop used mutexes and a go thread to trigger periodic reconciliation; this loop has now been simplified.

controller logs:

```
{"level":"DEBUG","ts":"2025-08-04T18:56:05.504Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=34.67; tk=328; sol=1, alloc={acc=A100; num=3; maxBatch=4; cost=120, val=80, servTime=21.523851, waitTime=162.03223, rho=0.7407185}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=3, limit=4, cost=120 \ntotalCost=120 \n"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.504Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.505Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.505Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 18:56:05.50498037 +0000 UTC m=+120.243703683 A100 3}"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.505Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.505Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T18:56:05.517Z","msg":"Patched Deploymentname: vllme-deployment num-replicas: 3"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.530Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T18:56:05.530Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.530Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T18:56:05.530Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T18:56:05.530Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.539Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.539Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.539Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"INFO","ts":"2025-08-04T18:57:05.540Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"System data prepared for optimizationsystemData&{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 3 256 120 20 0 {33.33 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {AMD-MI300X-192G 4} {Intel-Gaudi-2-96GB 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=33.33; tk=328; sol=1, alloc={acc=A100; num=3; maxBatch=4; cost=120, val=0, servTime=21.5046, waitTime=140.10889, rho=0.7264265}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=3, limit=4, cost=120 \ntotalCost=120 \n"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 18:57:05.550150648 +0000 UTC m=+180.288873920 A100 3}"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.550Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T18:57:05.556Z","msg":"Patched Deploymentname: vllme-deployment num-replicas: 3"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.564Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T18:57:05.564Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.564Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T18:57:05.564Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T18:57:05.564Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.568Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-workermodelAMD-MI300X-192Gcount4mem196608"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.569Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-worker2modelIntel-Gaudi-2-96GBcount4mem98304"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.569Z","msg":"found inventorynodeNamekind-inferno-gpu-cluster-control-planemodelNVIDIA-A100-PCIE-80GBcount4mem81920"}
{"level":"INFO","ts":"2025-08-04T18:58:05.569Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.575Z","msg":"System data prepared for optimizationsystemData&{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 3 256 120 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 4} {Intel-Gaudi-2-96GB 4} {NVIDIA-A100-PCIE-80GB 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-80, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 18:58:05.576029844 +0000 UTC m=+240.314753157 A100 1}"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.576Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T18:58:05.586Z","msg":"Patched Deploymentname: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-04T18:58:05.595Z","msg":"EmitReplicaMetrics completed"}
```