### PR TITLE
Modified vllme load generator

### DIFF
--- a/hack/vllme/vllm_emulator/loadgen.py
+++ b/hack/vllme/vllm_emulator/loadgen.py
@@ -1,95 +1,222 @@
+import json
 import time
 import random
 import threading
+import argparse
+from typing import Union, Tuple, List
 from openai import OpenAI
 
-# Configuration parameters
-API_KEY = "fake-api-key"
-MODEL = "gpt-1337-turbo-pro-max"
-RATE = 60  # default rate (requests per minute)
-MEAN_INTERVAL = 60 / RATE  # mean inter-arrival time in seconds
-CONTENT_LENGTH = 150  # default content length
 
-# Predefined URL options
-URL_OPTIONS = {
-    1: "http://localhost:30000/v1",
-    2: "http://localhost:30010/v1",
-    3: "http://localhost:8000/v1"
-}
+def get_current_rate(elapsed: float, rate_spec: Union[float, list[Tuple[float, float]]]) -> float:
+    if isinstance(rate_spec, float):
+        return rate_spec
+    time_marker = 0
+    for duration, rpm in rate_spec:
+        if elapsed <= time_marker + duration:
+            return rpm
+        time_marker += duration
+    return 0.0  # After all scheduled periods
+
 
 # Function to simulate a single client sending a request
-def send_request():
-    client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
-    content = "x" * CONTENT_LENGTH
+def send_request(client, model, content_length):
+    content = "x" * content_length
 
     try:
         chat_completion = client.chat.completions.create(
             messages=[
                 {"role": "user", "content": content}
             ],
-            model=MODEL,
+            model=model,
         )
-        # Uncomment below to print API response (can be noisy)
+        # Uncomment below to print API response
         # print(chat_completion.choices[0].message.content)
     except Exception as e:
         print(f"Request failed: {e}")
 
 # Function to simulate Poisson process and generate requests
-def poisson_request_generator():
+def poisson_request_generator(client, model, rate, content_length):
     client_threads = []
     request_count = 0
     start_time = time.time()
+    last_report_time = start_time
+    total_duration = 0
+
+    if isinstance(rate, list):
+        for duration, _ in rate:
+            total_duration += duration
+    else:
+        total_duration = float("inf")
 
     try:
-        while True:
-            inter_arrival_time = random.expovariate(1 / MEAN_INTERVAL)
+        while time.time() - start_time <= total_duration:
+            elapsed = time.time() - start_time
+            current_rpm = get_current_rate(elapsed, rate)
+            if current_rpm <= 0:
+                break # stop sending requests
+
+            mean_interval = 60.0 / current_rpm
+            inter_arrival_time = random.expovariate(1 / mean_interval)
             time.sleep(inter_arrival_time)
-            
-            thread = threading.Thread(target=send_request)
+
+            thread = threading.Thread(target=send_request, args=(client, model, content_length))
             thread.start()
             client_threads.append(thread)
 
             request_count += 1
 
-            if time.time() - start_time >= 60:
+            if time.time() - last_report_time >= 60:
                 print(f"Total requests sent in the last minute: {request_count}")
                 request_count = 0
-                start_time = time.time()
+                last_report_time = time.time()
 
-            client_threads = [t for t in client_threads if t.is_alive()]
+        if request_count > 0:
+             print(f"Total requests sent in the last minute: {request_count}")
+
+        print("Load generation finished. Waiting for all threads to complete...")
+
+        for thread in client_threads:
+            thread.join()
+
+    except KeyboardInterrupt:
+        print("\nLoad generator stopped by user.")
+
+def deterministic_request_generator(client, model, rate, content_length):
+    client_threads = []
+    request_count = 0
+    start_time = time.time()
+    last_report_time = start_time
+    total_duration = 0
+
+    if isinstance(rate, list):
+        for duration, _ in rate:
+            total_duration += duration
+    else:
+        # For a constant rate, you might need a different way to stop,
+        # perhaps an explicit --duration argument. For now, let's assume
+        # the user will stop it with Ctrl-C.
+        total_duration = float('inf')
+    
+    try:
+        while time.time() - start_time <= total_duration:
+            elapsed = time.time() - start_time
+            current_rpm = get_current_rate(elapsed, rate)
+            if current_rpm <= 0:
+                break # stop sending requests
+
+            sleep_interval = 60.0 / current_rpm
+            time.sleep(sleep_interval)
+
+            thread = threading.Thread(target=send_request, args=(client, model, content_length))
+            thread.start()
+            client_threads.append(thread)
+
+            request_count += 1
+
+            if time.time() - last_report_time >= 60:
+                print(f"Total requests sent in the last minute: {request_count}")
+                request_count = 0
+                last_report_time = time.time()
+        
+        if request_count > 0:
+             print(f"Total requests sent in the last minute: {request_count}")
+
+        print("Load generation finished. Waiting for all threads to complete...")
+
+        for thread in client_threads:
+            thread.join()
+
     except KeyboardInterrupt:
         print("\nLoad generator stopped by user.")
 
 
+def parse_request_rate(arg: str) -> Union[float, list[tuple[float, float]]]:
+    """Parses the request rate argument from CLI. Supports float or JSON list."""
+    try:
+        return float(arg)  # If a single float is passed, return it as a constant rate
+    except ValueError:
+        return json.loads(arg)  # If a JSON string is passed, parse it as a list
+
+
 def main():
-    global BASE_URL, MODEL, RATE, MEAN_INTERVAL, CONTENT_LENGTH
+    parser = argparse.ArgumentParser(description="OpenAI-compatible load generator")
+    parser.add_argument(
+        "--api-key", 
+        default="fake-api-key", 
+        help="OpenAI API key (default: fake-api-key)"
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:30000/v1",
+        help="Base URL for the OpenAI-compatible server (default: http://localhost:30000/v1)"
+    )
+    parser.add_argument(
+        "--model", 
+        default="gpt-1337-turbo-pro-max", 
+        help="Model name"
+    )
+    parser.add_argument(
+        "--content-length", 
+        type=int,
+        default=150, 
+        help="Length of prompt content"
+    )
+    parser.add_argument(
+        "--seed", 
+        type=int, 
+        default=None, 
+        help="Seed for random number generator"
+    )
+    parser.add_argument(
+        "--mode", 
+        choices=["poisson", "deterministic"], 
+        default="deterministic", 
+        help="Distribution of request arrivals"
+    )
+    parser.add_argument(
+        "--rate",
+        type=parse_request_rate,
+        default=float("inf"),
+        help=(
+            "Number of requests per second. Can be either:\n"
+            "  - A single float (e.g., '4.0') for a constant rate.\n"
+            "  - A JSON string list (e.g., '[[60, 4], [60, 6], [60, 8]]') "
+            "for a dynamically changing rate."
+        ),
+    )
 
-    print("Select the server base URL:")
-    for option, url in URL_OPTIONS.items():
-        print(f"{option}: {url}")
+    args = parser.parse_args()
 
-    while True:
-        try:
-            choice = int(input("Enter the option number (1/2): ").strip())
-            if choice in URL_OPTIONS:
-                BASE_URL = URL_OPTIONS[choice]
-                break
-            else:
-                print("Invalid option. Please choose 1 or 2.")
-        except ValueError:
-            print("Invalid input. Please enter a valid number (1 or 2).")
+    # Set seed for reproducibility
+    if args.seed is not None:
+        random.seed(args.seed)
+        print(f"Random seed set to: {args.seed}")
 
-    MODEL = input("Enter the model name (e.g., gpt-1337-turbo-pro-max): ").strip()
-    RATE = int(input("Enter the rate (requests per minute): ").strip())
-    MEAN_INTERVAL = 60 / RATE
-    CONTENT_LENGTH = int(input("Enter the content length (e.g., 100-200): ").strip())
+    print(f"Starting load generator with {args.mode} mode")
+    print(f"Server Address: {args.url}")
+    print(f"Request Rate = {args.rate}")
+    print(f"Model: {args.model}")
+    print(f"Content Length: {args.content_length}")
+    print(f"API Key: {args.api_key}")
 
-    print("Starting load generator...")
-    print(f"Server Address: {BASE_URL}")
-    print(f"Request Rate = {RATE}")
-    print(f"Model: {MODEL}")
-    print(f"Content Length: {CONTENT_LENGTH}")
-    poisson_request_generator()
+    client = OpenAI(api_key=args.api_key, base_url=args.url)
+
+    if args.mode == "poisson":
+        poisson_request_generator(
+            client=client,
+            model=args.model,
+            rate=args.rate,
+            content_length=args.content_length,
+        )
+    else:
+        deterministic_request_generator(
+            client=client,
+            model=args.model,
+            rate=args.rate,
+            content_length=args.content_length,
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The vllme load generator supports
1. deterministic (fixed-interval) arrivals
2. dynamic rates
3. setting a seed for the pseudo random number generator

On the client side, run the load generator as
```sh
python loadgen.py --model default  --rate '[[120, 60], [120, 80]]' --url http://localhost:30000/v1
```
For every such run, you should observe:
```sh
Starting load generator with deterministic mode
Server Address: http://localhost:30000/v1
Request Rate = [[120, 60], [120, 80]]
Model: default
Content Length: 150
API Key: fake-api-key
Total requests sent in the last minute: 60
Total requests sent in the last minute: 60
Total requests sent in the last minute: 80
Total requests sent in the last minute: 78
Load generation finished. Waiting for all threads to complete...
```


For Poisson arrivals, 
```sh
python loadgen.py --model default --seed 42 --rate '[[120, 60], [120, 80], [120, 40]]' --mode poisson --url http://localhost:30000/v1
```
Output on the client side:
```sh
Random seed set to: 42
Starting load generator with poisson mode
Server Address: http://localhost:30000/v1
Request Rate = [[120, 60], [120, 80], [120, 40]]
Model: default
Content Length: 150
API Key: fake-api-key
Total requests sent in the last minute: 66
Total requests sent in the last minute: 55
Total requests sent in the last minute: 79
Total requests sent in the last minute: 62
Total requests sent in the last minute: 42
Total requests sent in the last minute: 29
Load generation finished. Waiting for all threads to complete...
```