### PR TITLE
Update readme and install cm in inferno ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,6 @@ NAME               MODEL     ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
 vllme-deployment   default   A100          1                 1           16m
 ```
 
-**Note**:
-- With the default installation, the Inferno-autoscaler will not scale up to more than 2 replicas due to the default number of GPUs created into the cluster.
-- To change this behaviour, add more GPUs to the cluster when launching the Make target. Here is an example that creates 3 nodes, 4 GPUs per node, from mixed vendors:
-
-```sh
-make deploy-llm-d-inferno-emulated-on-kind -n 3 -g 4
-```
-
 ### Uninstalling llm-d and Inferno-autoscaler 
 Use this target to undeploy the integrated test environment and related resources:
 
@@ -221,10 +213,12 @@ Use this target to undeploy the integrated test environment and related resource
 make undeploy-llm-d-inferno-emulated-on-kind
 ```
 
-## Quickstart: Standalone Inferno-autoscaler emulated deployment on Kind
+## Details on emulated mode deployment on Kind
+
 - Emulated deployment, creates fake gpu resources on the node and deploys inferno on the cluster where inferno consumes fake gpu resources. As well as the emulated vllm server (vllme).
 
-### To Deploy on the cluster
+### Deploy on the cluster
+
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -248,17 +242,6 @@ make deploy-inferno-emulated-on-kind IMG=<some-registry>/inferno-controller:tag 
 # make deploy-inferno-emulated-on-kind 
 ```
 
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
-
-The default set up:
-- Deploys a Kind cluster with 3 nodes, 2 GPUs per node, mixed vendors with fake GPU resources
-- Preloaded Inferno image
-- CRDs and controller deployment
-- Apply configuration data
-- Install Prometheus via Helm
-- vLLM emulator and load generator (OpenAI-based)
-
 ```console
 Summary: GPU resource capacities and allocatables for cluster 'kind-inferno-gpu-cluster':
 -------------------------------------------------------------------------------------------------------------------------------
@@ -276,11 +259,6 @@ kind-inferno-gpu-cluster-worker2         intel.com/gpu        2          2      
 kubectl get pods -n inferno-autoscaler-system
 ```
 
-```sh
-NAME                                                     READY   STATUS    RESTARTS   AGE
-inferno-autoscaler-controller-manager-78677ddc5b-cgtd8   1/1     Running   0          55s
-inferno-autoscaler-controller-manager-78677ddc5b-vg9pg   1/1     Running   0          55s
-```
 
 **Check the configmap is installed:**
 
@@ -288,23 +266,13 @@ inferno-autoscaler-controller-manager-78677ddc5b-vg9pg   1/1     Running   0    
 kubectl get cm -n inferno-autoscaler-system
 ```
 
-```sh
-NAME                                           DATA   AGE
-inferno-autoscaler-variantautoscaling-config   3      92s
-```
 
-### To Uninstall
+### Uninstall
 
 **Delete the APIs(CRDs) from the cluster:**
 
 ```sh
-make undeploy-inferno-on-kind
-```
-
-**Delete the APIs(CRDs) from the cluster:**
-
-```sh
-make uninstall
+make undeploy
 ```
 
 **Delete cluster**
@@ -313,7 +281,7 @@ make uninstall
 make destroy-kind-cluster
 ```
 
-## Local development vllme setup
+### Prometheus vllme setup
 
 Local development will need emulated vllm server, prometheus installed in KinD cluster. 
 
@@ -341,7 +309,7 @@ kubectl port-forward svc/prometheus-operated 9090:9090 -n inferno-autoscaler-mon
 # server can be accessed at location: http://localhost:9090
 ```
 
-**Important**: Always ensure pods are ready before attempting port forwarding to avoid connection errors.
+**Note**: Always ensure pods are ready before attempting port forwarding to avoid connection errors.
 
 **Check vllm emulated deployment**
 
@@ -357,47 +325,9 @@ vllme-deployment   1/1     1            1           35s
 kubectl port-forward svc/vllme-service 8000:80 -n llm-d-sim
 ```
 
-**Sanity checks**
+**Sanity check**
 
 Go to http://localhost:8000/metrics and check if you see metrics starting with vllm:. Refresh to see the values changing with the load generator on.
-
-**Create variant autoscaling object for controller**
-```sh
-kubectl apply -f hack/vllme/deploy/vllme-setup/vllme-variantautoscaling.yaml
-
-# view status of the variant autoscaling object to get status of optimization
-kubectl get variantautoscaling vllme-deployment -n llm-d-sim -o yaml
-```
-
-**Load generation**
-
-- Generates synthetic load
-- Takes server url, model name, requests-per-minute (RPM) and content length as input
-- Default = 60 RPM
-- Can be overridden by running:
-
-```sh
-#run script
-cd ./hack/vllme/vllm_emulator
-pip install -r requirements.txt # if the requirements are not installed on your machine
-python3 loadgen.py # to run the load gen script  
-
-# rpm - request per minute (default = 60)
-
-# Select the server base URL:
-# 1: http://localhost:30000/v1
-# 2: http://localhost:30010/v1
-# 3: http://localhost:8000/v1
-# Enter the option number (1/2): 3
-# Enter the model name (e.g., gpt-1337-turbo-pro-max): gpt-1337-turbo-pro-max
-# Enter the rate (requests per minute): 60
-# Enter the content length (e.g., 100-200): 150
-# Starting load generator...
-# Server Address: http://localhost:8000/v1
-# Request Rate = 60
-# Model: gpt-1337-turbo-pro-max
-# Content Length: 150
-```
 
 **Run sample query**
 
@@ -426,150 +356,14 @@ kubectl get servicemonitor inferno-autoscaler -n inferno-autoscaler-monitoring -
 # Note: ServiceMonitor discovery takes 1-2 minutes to complete
 ```
 
-**Note**: The vllme ServiceMonitor is automatically created in the correct namespace (`inferno-autoscaler-monitoring`) with the proper labels for Prometheus discovery.
-
-**Important**: The inferno-autoscaler ServiceMonitor must be deployed in the `inferno-autoscaler-monitoring` namespace (not `inferno-autoscaler-system`) for Prometheus to discover it. The ServiceMonitor includes a `namespaceSelector` to target services in the `inferno-autoscaler-system` namespace.
-
-**Common Issue**: If the inferno-autoscaler target doesn't appear in Prometheus, check that the ServiceMonitor includes the `namespaceSelector` configuration. Without it, Prometheus won't discover services across different namespaces.
-
-**Timing Note**: ServiceMonitor discovery can take 1-2 minutes after applying. Don't worry if targets don't appear immediately - this is normal behavior.
-
-**Custom Metrics Verification**
-
-To verify the custom metrics are working:
-
-1. **Check Prometheus targets**: Ensure both targets are active
-   ```sh
-   # Check inferno-autoscaler target
-   curl -s "http://localhost:9090/api/v1/targets" | jq '.data.activeTargets[] | select(.labels.job | contains("inferno"))'
-   
-   # Check vllme target
-   curl -s "http://localhost:9090/api/v1/targets" | jq '.data.activeTargets[] | select(.labels.job | contains("vllme"))'
-   ```
-   
-   **Note**: If targets don't appear immediately, wait 1-2 minutes for ServiceMonitor discovery to complete.
-
-     **If targets still don't appear after waiting:**
-     ```sh
-     # Check Prometheus operator logs for discovery events
-     kubectl logs -n inferno-autoscaler-monitoring deployment/kube-prometheus-stack-operator --tail=10
-
-     # Check Prometheus pod logs for configuration reloads
-     kubectl logs -n inferno-autoscaler-monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus --tail=10
-     ```
-
-2. **Query custom metrics**: Check if inferno metrics are being scraped
-   ```sh
-   # Core inferno metrics
-   curl -s "http://localhost:9090/api/v1/query?query=inferno_replica_scaling_total"
-   curl -s "http://localhost:9090/api/v1/query?query=inferno_current_replicas"
-   curl -s "http://localhost:9090/api/v1/query?query=inferno_desired_replicas"
-   
-   # vLLM metrics
-   curl -s "http://localhost:9090/api/v1/query?query=vllm:gpu_cache_usage_perc"
-   ```
-
-3. **Direct metrics endpoint access**: Verify metrics are exposed
-   ```sh
-   # Note: Ensure pods are ready before port forwarding
-   # Inferno controller metrics
-   kubectl port-forward svc/inferno-autoscaler-controller-manager-metrics-service 8080:8080 -n inferno-autoscaler-system &
-   curl -s "http://localhost:8080/metrics" | grep -E "(inferno_|# HELP inferno)"
-   
-   # vLLM emulator metrics
-   kubectl port-forward svc/vllme-service 8000:80 &
-   curl -s "http://localhost:8000/metrics" | grep -E "(vllm|# HELP vllm)"
-   ```
-
 For detailed information about the custom metrics, see [Custom Metrics Documentation](docs/custom-metrics.md).
 
 **Accessing the Grafana**
-
 
 ```sh
 # username:admin
 # password: prom-operator
 kubectl port-forward svc/kube-prometheus-stack-grafana 3000:80 -n inferno-autoscaler-monitoring
-```
-
-**Running the controller locally for dev**
-
-If running the controller locally using `make run`, make sure to install [prerequisites](https://github.com/llm-inferno/optimizer?tab=readme-ov-file#prerequisites) first.
-
-Once you've forwarded prometheus to localhost:9090, the command to run:
-
-```shell
-make run PROMETHEUS_BASE_URL=http://localhost:9090
-```
-
-**Prometheus Configuration**
-
-The controller supports flexible Prometheus configuration through multiple methods (in order of precedence):
-
-1. **Environment Variable** (highest priority):
-   ```shell
-   PROMETHEUS_BASE_URL=http://localhost:9090
-   ```
-
-2. **ConfigMap Configuration**:
-   The `inferno-autoscaler-variantautoscaling-config` ConfigMap in the `inferno-autoscaler-system` namespace contains:
-   ```yaml
-   data:
-     PROMETHEUS_BASE_URL: "http://prometheus-operated.inferno-autoscaler-monitoring.svc.cluster.local:9090"
-     GLOBAL_OPT_INTERVAL: "60s"
-     GLOBAL_OPT_TRIGGER: "false"
-   ```
-
-3. **Default In-Cluster Address** (fallback):
-   ```shell
-   http://prometheus-operated.inferno-autoscaler-monitoring.svc.cluster.local:9090
-   ```
-
-**Customizing Prometheus URL for Different Environments:**
-
-**Local Development:**
-```shell
-# When running locally with port-forwarded Prometheus
-PROMETHEUS_BASE_URL=http://localhost:9090
-```
-
-**Different Cluster Namespace:**
-```shell
-# If Prometheus is in a different namespace
-PROMETHEUS_BASE_URL=http://prometheus-operated.monitoring.svc.cluster.local:9090
-```
-
-**External Prometheus:**
-```shell
-# For external Prometheus instances
-PROMETHEUS_BASE_URL=https://prometheus.example.com:9090
-```
-
-**Custom Prometheus Installation:**
-```shell
-# For custom Prometheus deployments
-PROMETHEUS_BASE_URL=http://my-prometheus.my-namespace.svc.cluster.local:9090
-```
-
-**Note**: The `PROMETHEUS_BASE_URL` is now automatically set in the deployment configuration for in-cluster deployments. The controller includes retry logic to handle Prometheus startup delays and will wait up to 5 minutes for Prometheus to become available.
-
-## Security Considerations
-
-### Metrics Endpoint Security
-The controller's metrics endpoint is currently configured for HTTP access on port 8080 without TLS encryption. This configuration is suitable for development and testing environments but should be secured for production deployments.
-
-**For Production Deployments:**
-1. Enable secure metrics by setting `--metrics-secure=true`
-2. Configure TLS certificates for the metrics endpoint
-3. Use network policies to restrict access to the metrics port
-4. Consider using a reverse proxy with TLS termination
-
-**Example Production Configuration:**
-```yaml
-# In config/default/manager_metrics_patch.yaml
-- op: replace
-  path: /spec/template/spec/containers/0/args/1
-  value: --metrics-secure=true
 ```
 
 ## Contributing
@@ -579,20 +373,4 @@ Please join llmd autoscaling community meetings and feel free to submit github i
 **NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
-
-## License
-
-Copyright 2025.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 

--- a/deploy/configmap-accelerator-unitcost.yaml
+++ b/deploy/configmap-accelerator-unitcost.yaml
@@ -10,7 +10,7 @@ kind: ConfigMap
 #
 metadata:
   name: accelerator-unit-costs
-  namespace: default
+  namespace: inferno-autoscaler-system
 data:
   A100: |
     {

--- a/deploy/configmap-serviceclass.yaml
+++ b/deploy/configmap-serviceclass.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: service-classes-config
-  namespace: default
+  namespace: inferno-autoscaler-system
 data:
   premium.yaml: |
     name: Premium

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -133,13 +133,13 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// TODO: decide on whether to keep accelerator properties (device name, cost) in same configMap, provided by administrator
-	acceleratorCm, err := r.readAcceleratorConfig(ctx, "accelerator-unit-costs", "default")
+	acceleratorCm, err := r.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
 	if err != nil {
 		logger.Log.Error(err, "unable to read accelerator configmap, skipping optimizing")
 		return ctrl.Result{}, err
 	}
 
-	serviceClassCm, err := r.readServiceClassConfig(ctx, "service-classes-config", "default")
+	serviceClassCm, err := r.readServiceClassConfig(ctx, "service-classes-config", configMapNamespace)
 	if err != nil {
 		logger.Log.Error(err, "unable to read serviceclass configmap, skipping optimizing")
 		return ctrl.Result{}, err


### PR DESCRIPTION
Controller logs:

```
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting workers","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","worker count":1}
{"level":"INFO","ts":"2025-08-05T15:06:36.161Z","msg":"No active VariantAutoscalings found, skipping optimization"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.355Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 4 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.356Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 4 , mem - 98304"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.356Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 4 , mem - 196608"}
{"level":"INFO","ts":"2025-08-05T15:09:44.356Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 1 256 40 20 0 {38.67 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=38.67; tk=328; sol=1, alloc={acc=A100; num=4; maxBatch=4; cost=160, val=120, servTime=21.441248, waitTime=83.93652, rho=0.675089}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=4, limit=4, cost=160 \ntotalCost=160 \n"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-05 15:09:44.466699276 +0000 UTC m=+188.589714466 A100 4}"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-05T15:09:44.484Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 4"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-05T15:09:44.490Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-05T15:09:44.490Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 4 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 4 , mem - 98304"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 4 , mem - 196608"}
{"level":"INFO","ts":"2025-08-05T15:10:44.492Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.497Z","msg":"System data prepared for optimization: systemData - &{{{[{MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 4 256 160 20 0 {10.67 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=10.67; tk=328; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-120, servTime=21.485462, waitTime=120.72412, rho=0.71163464}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-05 15:10:44.498044513 +0000 UTC m=+248.621059703 A100 1}"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-05T15:10:44.508Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-05T15:10:44.517Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-05T15:10:44.517Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
abhishekmalvankar@Abhisheks-MBP inferno-autoscaler % kubectl logs inferno-autoscaler-controller-manager-765987986d-gcvxl -n inferno-autoscaler-system 
{"level":"INFO","ts":"2025-08-05T15:06:35.972Z","msg":"Zap logger initialized"}
{"level":"INFO","ts":"2025-08-05T15:06:35.974Z","msg":"Creating metrics emitter instance"}
{"level":"INFO","ts":"2025-08-05T15:06:35.975Z","msg":"Metrics emitter created successfully"}
{"level":"INFO","ts":"2025-08-05T15:06:35.975Z","msg":"Using Prometheus address from environment variable -> address: http://kube-prometheus-stack-prometheus.inferno-autoscaler-monitoring.svc.cluster.local:9090"}
{"level":"INFO","ts":"2025-08-05T15:06:35.975Z","msg":"Initializing Prometheus client -> addresshttp://kube-prometheus-stack-prometheus.inferno-autoscaler-monitoring.svc.cluster.local:9090"}
{"level":"INFO","ts":"2025-08-05T15:06:36.033Z","msg":"Prometheus client and API wrapper initialized and validated successfully"}
{"level":"INFO","ts":"2025-08-05T15:06:36.033Z","msg":"Starting manager"}
{"level":"INFO","ts":"2025-08-05T15:06:36.033Z","msg":"Registering custom metrics with Prometheus registry"}
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"starting server","name":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2025-08-05T15:06:36Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2025-08-05T15:06:36Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
I0805 15:06:36.039884       1 leaderelection.go:257] attempting to acquire leader lease inferno-autoscaler-system/72dd1cf1.llm-d.ai...
I0805 15:06:36.053213       1 leaderelection.go:271] successfully acquired lease inferno-autoscaler-system/72dd1cf1.llm-d.ai
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting EventSource","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","source":"kind source: *v1.ConfigMap"}
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting EventSource","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","source":"kind source: *v1alpha1.VariantAutoscaling"}
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting EventSource","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","source":"kind source: *v1.Node"}
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting Controller","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling"}
{"level":"info","ts":"2025-08-05T15:06:36Z","msg":"Starting workers","controller":"variantAutoscaling","controllerGroup":"llmd.ai","controllerKind":"VariantAutoscaling","worker count":1}
{"level":"INFO","ts":"2025-08-05T15:06:36.161Z","msg":"No active VariantAutoscalings found, skipping optimization"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.355Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 4 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.356Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 4 , mem - 98304"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.356Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 4 , mem - 196608"}
{"level":"INFO","ts":"2025-08-05T15:09:44.356Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 1 256 40 20 0 {38.67 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=38.67; tk=328; sol=1, alloc={acc=A100; num=4; maxBatch=4; cost=160, val=120, servTime=21.441248, waitTime=83.93652, rho=0.675089}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=4, limit=4, cost=160 \ntotalCost=160 \n"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-05 15:09:44.466699276 +0000 UTC m=+188.589714466 A100 4}"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.466Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-05T15:09:44.484Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 4"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-05T15:09:44.490Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-05T15:09:44.490Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-05T15:09:44.490Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 4 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 4 , mem - 98304"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.491Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 4 , mem - 196608"}
{"level":"INFO","ts":"2025-08-05T15:10:44.492Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.497Z","msg":"System data prepared for optimization: systemData - &{{{[{MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 4 256 160 20 0 {10.67 328 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 4} {Intel-Gaudi-2-96GB 4} {AMD-MI300X-192G 4}]}}}"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=10.67; tk=328; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-120, servTime=21.485462, waitTime=120.72412, rho=0.71163464}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=4, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-05 15:10:44.498044513 +0000 UTC m=+248.621059703 A100 1}"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.498Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-05T15:10:44.508Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-05T15:10:44.517Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-05T15:10:44.517Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-05T15:10:44.517Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
```



