### PR TITLE
Report allocatable resources

### DIFF
--- a/hack/create-kind-gpu-cluster.sh
+++ b/hack/create-kind-gpu-cluster.sh
@@ -102,6 +102,10 @@ while [[ $(kubectl get nodes "${control_plane_node}" --no-headers 2>/dev/null | 
     sleep 1
 done
 
+echo "[2.1/6] Removing control-plane node taint to allow scheduling..."
+
+kubectl taint nodes "${control_plane_node}" node-role.kubernetes.io/control-plane- || true
+
 # --------------------------------------------------------------------
 # Patch Node Labels
 # --------------------------------------------------------------------

--- a/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
@@ -52,9 +52,11 @@ spec:
           limits:
             cpu: 500m
             memory: 1Gi
+            nvidia.com/gpu: "1"  # Limit to 1 GPU
           requests:
             cpu: 100m
             memory: 500Mi
+            nvidia.com/gpu: "1"  # Request 1 GPU
 ---
 apiVersion: v1
 kind: Service

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -47,7 +47,7 @@ func CollectInventoryK8S(ctx context.Context, r client.Client) (map[string]map[s
 				// found a GPU of this vendor
 				mem := node.Labels[memKey]
 				count := 0
-				if cap, ok := node.Status.Capacity[corev1.ResourceName(vendor+"/gpu")]; ok {
+				if cap, ok := node.Status.Allocatable[corev1.ResourceName(vendor+"/gpu")]; ok {
 					count = int(cap.Value())
 				}
 				if inv[nodeName] == nil {


### PR DESCRIPTION
Reporting capacity needs resource filtering because we cannot utilize resources owned by deployments that VA does not support. This PR reports `Allocatable` field shows total available capacity minus reserved system resources, not real-time usage.