### PR TITLE
enabling installation for amd64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Image URL to use all building/pushing image targets
 IMAGE_TAG_BASE ?= quay.io/infernoautoscaler
-IMG_TAG ?= latest
+IMG_TAG ?= 0.0.1-multi-arch
 IMG ?= $(IMAGE_TAG_BASE)/inferno-controller:$(IMG_TAG)
 KIND_ARGS ?= -t mix -n 3 -g 2   # Default: 3 nodes, 2 GPUs per node, mixed vendors
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ The inferno-autoscaler assigns GPU types to inference model servers and decides 
 
 - [Description](#description)
 - [Getting Started](#getting-started)
-  - [Building & deploying inferno with llmd infrastructure](#quickstart-guide-installation-of-inferno-autoscaler-along-with-llm-d-infrastructure-emulated-deployment-on-a-kind-cluster)
-  - [Building & deploying inferno in emulated mode](#details-on-emulated-mode-deployment-on-kind)
+  - [Prerequisites](#prerequisites)
+- [Quickstart Guide: Installation of Inferno-autoscaler along with llm-d infrastructure emulated deployment on a Kind cluster](#quickstart-guide-installation-of-inferno-autoscaler-along-with-llm-d-infrastructure-emulated-deployment-on-a-kind-cluster)
+  - [Showing Inferno-autoscaler scaling replicas up and down](#showing-inferno-autoscaler-scaling-replicas-up-and-down)
+  - [Uninstalling llm-d and Inferno-autoscaler](#uninstalling-llm-d-and-inferno-autoscaler)
+- [Details on emulated mode deployment on Kind](#details-on-emulated-mode-deployment-on-kind)
+  - [Deployment](#deployment)
+  - [Uninstall](#uninstall)
+  - [Prometheus vllme setup](#prometheus-vllme-setup)
+    - [Note: The above script already deploys emulated vllm server:](#note-the-above-script-already-deploys-emulated-vllm-server)
+  - [Inferno custom metrics](#inferno-custom-metrics)
 - [Contributing](#contributing)
 
 
@@ -133,17 +141,17 @@ python loadgen.py
 # Content Length: 150
 
 # for deterministic dynamically changing rate
-python loadgen.py --model default  --rate '[[120, 60], [120, 80]]' --url http://localhost:8000/v1
+python loadgen.py --model vllm  --rate '[[120, 60], [120, 80]]' --url http://localhost:8000/v1
 
 # First 120 seconds (2 minutes): Send 60 requests per minute
 # Next 120 seconds (2 minutes): Send 80 requests per minute
 # Can use any combination of rates such as [[120, 60], [120, 80], [120, 40]]
 ```
 
-- To request the port-forwarded gateway, as '*server base URL*' use **http://localhost:8000/v1** [**option 3**]
-- As '*model name*', insert: "**vllm**"
+- To request the port-forwarded gateway, use **--url http://localhost:8000/v1**
+- To request the vLLM emulator servers, insert: "**--model vllm**"
 
-4. **Scaling up**: after launching the load generator script `loadgen.py` with related RPM and context length (such as **RPM=40** and **context length** equal to **50**), we can see the logs from the Inferno-autoscaler controller effectively computing the optimal resource allocation and scaling up the deployments:
+1. **Scaling up**: after launching the load generator script `loadgen.py` with related RPM and context length (such as **RPM=40** and **context length** equal to **50**), we can see the logs from the Inferno-autoscaler controller effectively computing the optimal resource allocation and scaling up the deployments:
 
 ```sh
 kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-controller-manager

--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ infra-sim-inference-gateway   1/1     1            1           5m7s
 vllme-deployment              1/1     1            1           5m58s
 
 kubectl get variantautoscalings.llmd.ai -n llm-d-sim 
-NAME               MODEL     ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
-vllme-deployment   default   A100          1                 1           4m31s
+NAME               MODEL             ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
+vllme-deployment   default/default   A100          1                 1           4m31s
 ```
 
 3. Launch the `loadgen.py` load generator to send requests to the `v1/chat/completions` endpoint:
 ```sh
 cd hack/vllme/vllm_emulator
 pip install -r requirements.txt # if not already installed
-python loadgen.py
+python loadgen.py --model vllm  --rate '[[1200, 40]]' --url http://localhost:8000/v1 --content 50
 
 # Default parameters
 # Starting load generator with deterministic mode
@@ -151,7 +151,7 @@ python loadgen.py --model vllm  --rate '[[120, 60], [120, 80]]' --url http://loc
 - To request the port-forwarded gateway, use **--url http://localhost:8000/v1**
 - To request the vLLM emulator servers, insert: "**--model vllm**"
 
-1. **Scaling up**: after launching the load generator script `loadgen.py` with related RPM and context length (such as **RPM=40** and **context length** equal to **50**), we can see the logs from the Inferno-autoscaler controller effectively computing the optimal resource allocation and scaling up the deployments:
+1. **Scaling up**: after launching the load generator script `loadgen.py` with related RPM and content length (such as **RPM=40** and **content length** equal to **50**), we can see the logs from the Inferno-autoscaler controller effectively computing the optimal resource allocation and scaling up the deployments:
 
 ```sh
 kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-controller-manager
@@ -161,7 +161,7 @@ kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-control
 {"level":"DEBUG","ts":"2025-08-04T19:18:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
 {"level":"INFO","ts":"2025-08-04T19:18:16.481Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
 {"level":"DEBUG","ts":"2025-08-04T19:18:16.483Z","msg":"System data prepared for optimization: systemData - &{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 1 256 40 20 0 {22.67 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
-{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=22.67; tk=178; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=21.555601, waitTime=110.798096, rho=0.7630596}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
+{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=22.67; tk=178; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=21.555601, waitTime=110.798096, rho=0.7630596}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
 {"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization completed successfully, emitting optimization metrics"}
 {"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimized allocation mapkeys1updateList_count1"}
 {"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:18:16.484006425 +0000 UTC m=+1380.284253535 A100 1}"}
@@ -179,7 +179,7 @@ kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-control
 {"level":"DEBUG","ts":"2025-08-04T19:19:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
 {"level":"INFO","ts":"2025-08-04T19:19:16.481Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
 {"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 1 256 40 20 0 {44 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2} {NVIDIA-A100-PCIE-80GB 2}]}}}"}
-{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=44; tk=178; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=40, servTime=21.540192, waitTime=99.1626, rho=0.7524011}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
+{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=44; tk=178; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=40, servTime=21.540192, waitTime=99.1626, rho=0.7524011}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
 {"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization completed successfully, emitting optimization metrics"}
 {"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimized allocation mapkeys1updateList_count1"}
 {"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:19:16.48370162 +0000 UTC m=+1440.283948730 A100 2}"}
@@ -203,8 +203,8 @@ infra-sim-inference-gateway   1/1     1            1           7m3s
 vllme-deployment              2/2     2            2           7m58s
 
 kubectl get variantautoscalings.llmd.ai -n llm-d-sim 
-NAME               MODEL     ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
-vllme-deployment   default   A100          2                 2           6m31s
+NAME               MODEL             ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
+vllme-deployment   default/default   A100          2                 2           6m31s
 ```
 
 5. **Scaling down**: by stopping the load generator script with a keyboard interrupt, we can see that the Inferno-autoscaler effectively scales down the replicas:
@@ -216,7 +216,7 @@ kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-control
 {"level":"DEBUG","ts":"2025-08-04T19:20:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
 {"level":"INFO","ts":"2025-08-04T19:20:16.481Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
 {"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 2 256 80 20 0 {37.76 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
-{"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=37.76; tk=178; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=0, servTime=21.466858, waitTime=56.422607, rho=0.6966711}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
+{"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=37.76; tk=178; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=0, servTime=21.466858, waitTime=56.422607, rho=0.6966711}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
 {"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"Optimization completed successfully, emitting optimization metrics"}
 {"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"Optimized allocation mapkeys1updateList_count1"}
 {"level":"DEBUG","ts":"2025-08-04T19:20:16.484Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:20:16.484244316 +0000 UTC m=+1500.284491425 A100 2}"}
@@ -234,7 +234,7 @@ kubectl logs -n inferno-autoscaler-system deployments/inferno-autoscaler-control
 {"level":"DEBUG","ts":"2025-08-04T19:21:16.482Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
 {"level":"INFO","ts":"2025-08-04T19:21:16.482Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
 {"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0} {Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 2 256 80 20 0 {2.67 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2} {NVIDIA-A100-PCIE-80GB 2}]}}}"}
-{"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default; rate=2.67; tk=178; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-40, servTime=21.058374, waitTime=0.032958984, rho=0.15340477}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
+{"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=2.67; tk=178; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=-40, servTime=21.058374, waitTime=0.032958984, rho=0.15340477}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
 {"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"Optimization completed successfully, emitting optimization metrics"}
 {"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"Optimized allocation mapkeys1updateList_count1"}
 {"level":"DEBUG","ts":"2025-08-04T19:21:16.484Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:21:16.484650177 +0000 UTC m=+1560.284897245 A100 1}"}
@@ -257,8 +257,8 @@ infra-sim-inference-gateway   1/1     1            1           17m
 vllme-deployment              1/1     1            1           18m
 
 kubectl get variantautoscalings.llmd.ai -n llm-d-sim
-NAME               MODEL     ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
-vllme-deployment   default   A100          1                 1           16m
+NAME               MODEL             ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
+vllme-deployment   default/default   A100          1                 1           16m
 ```
 
 ### Uninstalling llm-d and Inferno-autoscaler 

--- a/hack/create-kind-gpu-cluster.sh
+++ b/hack/create-kind-gpu-cluster.sh
@@ -94,7 +94,7 @@ for ((i=1; i<nodes; i++)); do
     echo "- role: worker" >> kind-config.yaml
 done
 
-kind create cluster --name "${cluster_name}" --config kind-config.yaml
+kind create cluster --name "${cluster_name}" --config kind-config.yaml --image kindest/node:v1.30.0
 
 control_plane_node="${cluster_name}-control-plane"
 echo "[2/6] Waiting for node ${control_plane_node} to be ready..."

--- a/hack/deploy-emulated-vllme-server.sh
+++ b/hack/deploy-emulated-vllme-server.sh
@@ -8,7 +8,7 @@ KIND_NAME=${KIND_NAME:-"kind-inferno-gpu-cluster"}
 KIND_CONTEXT=kind-${KIND_NAME}
 MONITORING_NAMESPACE=${MONITORING_NAMESPACE:-"inferno-autoscaler-monitoring"}
 KIND_NODE_NAME=${KIND_NODE_NAME:-"kind-inferno-gpu-cluster-control-plane"}
-WEBHOOK_TIMEOUT=${WEBHOOK_TIMEOUT:-2m}
+WEBHOOK_TIMEOUT=${WEBHOOK_TIMEOUT:-3m}
 LLMD_NAMESPACE=${LLMD_NAMESPACE:-"llm-d-sim"}
 
 _kubectl() {
@@ -30,6 +30,7 @@ helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack -n
 
 # Wait for prometheus installation to complete
 _kubectl apply -f hack/vllme/deploy/prometheus-operator/prometheus-deploy-all-in-one.yaml
+_kubectl wait --for=create pods --all -n ${MONITORING_NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}
 _kubectl wait --for=condition=ready pods --all -n ${MONITORING_NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}
 
 # Create vllm emulated deployment

--- a/hack/deploy-inferno-emulated-on-kind.sh
+++ b/hack/deploy-inferno-emulated-on-kind.sh
@@ -49,8 +49,10 @@ hack/deploy-emulated-vllme-server.sh
 
 # Wait for Prometheus to be ready before deploying controller
 echo "Waiting for Prometheus to be ready..."
+_kubectl wait --for=create pod -l app.kubernetes.io/name=prometheus -n ${MONITORING_NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}
 _kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n ${MONITORING_NAMESPACE} --timeout=5m
 
 echo "Deploying Inferno controller-manager"
 make deploy-emulated
+_kubectl wait --for=create pod -l control-plane=controller-manager -n ${NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}
 _kubectl wait --for=condition=ready pod -l control-plane=controller-manager -n ${NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}

--- a/hack/deploy-llm-d-inferno-emulated-on-kind.sh
+++ b/hack/deploy-llm-d-inferno-emulated-on-kind.sh
@@ -101,6 +101,4 @@ echo "kubectl port-forward -n $LLMD_NAMESPACE svc/$INFRA_RELEASE_NAME-inference-
 echo ">>> Then launch the load generator:"
 echo "cd $PROJ_ROOT_DIR/hack/vllme/vllm_emulator"
 echo "pip install -r requirements.txt"
-echo "python loadgen.py"
-echo ">>> As 'server base URL', use: http://localhost:8000/v1 [option 3]"
-echo ">>> As 'model name', insert: vllm"
+echo "python loadgen.py --model vllm  --rate '[[120, 40], [120, 50]]' --url http://localhost:8000/v1"

--- a/hack/deploy-llm-d-inferno-emulated-on-kind.sh
+++ b/hack/deploy-llm-d-inferno-emulated-on-kind.sh
@@ -101,4 +101,4 @@ echo "kubectl port-forward -n $LLMD_NAMESPACE svc/$INFRA_RELEASE_NAME-inference-
 echo ">>> Then launch the load generator:"
 echo "cd $PROJ_ROOT_DIR/hack/vllme/vllm_emulator"
 echo "pip install -r requirements.txt"
-echo "python loadgen.py --model vllm  --rate '[[120, 40], [120, 50]]' --url http://localhost:8000/v1"
+echo "python loadgen.py --model vllm  --rate '[[1200, 40]]' --url http://localhost:8000/v1 --content 50"

--- a/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
+++ b/hack/vllme/deploy/vllme-setup/vllme-deployment-with-service-and-servicemon.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: vllme
-        image: quay.io/infernoautoscaler/vllme:0.2.1
+        image: quay.io/infernoautoscaler/vllme:0.2.1-multi-arch
         imagePullPolicy: Always
         env: 
         - name: MODEL_NAME


### PR DESCRIPTION
This PR aims to enable the existing llm-d and Inferno-autoscaler installation process with amd64 architectures. It includes:

- A vllme multi-arch image is used by vllme Deployments
- Inferno-autoscaler is deployed using the v0.0.1 multi-arch image
- Other fixes to enable the full correct installation 

Logs from an arm64 arch:
```sh
2025-08-06T13:56:13.107338728Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.106Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
2025-08-06T13:56:13.107376978Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.106Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
2025-08-06T13:56:13.107440853Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.106Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
2025-08-06T13:56:13.107593853Z {"level":"INFO","ts":"2025-08-06T13:56:13.107Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
2025-08-06T13:56:13.210316478Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 1 256 40 20 0 {19.17 278 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
2025-08-06T13:56:13.210334519Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=19.17; tk=278; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=40, servTime=21.371653, waitTime=37.434082, rho=0.61013544}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
2025-08-06T13:56:13.210336936Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Optimization completed successfully, emitting optimization metrics"}
2025-08-06T13:56:13.210338603Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Optimized allocation mapkeys1updateList_count1"}
2025-08-06T13:56:13.210340228Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-06 13:56:13.210211894 +0000 UTC m=+162.340428245 A100 2}"}
2025-08-06T13:56:13.210341644Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
2025-08-06T13:56:13.210342478Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.210Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
2025-08-06T13:56:13.220994228Z {"level":"INFO","ts":"2025-08-06T13:56:13.220Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 2"}
2025-08-06T13:56:13.228085394Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.227Z","msg":"EmitReplicaMetrics completed"}
2025-08-06T13:56:13.228096478Z {"level":"INFO","ts":"2025-08-06T13:56:13.228Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
2025-08-06T13:56:13.228097603Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.228Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
2025-08-06T13:56:13.228098478Z {"level":"DEBUG","ts":"2025-08-06T13:56:13.228Z","msg":"Completed variant processing loop"}
2025-08-06T13:56:13.228099269Z {"level":"INFO","ts":"2025-08-06T13:56:13.228Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}

kubectl get deployments.apps -n llm-d-sim 
NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
gaie-sim-epp                  1/1     1            1           2m59s
infra-sim-inference-gateway   1/1     1            1           2m59s
vllme-deployment              2/2     2            2           3m34s

kubectl get va -n llm-d-sim 
NAME               MODEL             ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
vllme-deployment   default/default   A100          1                 2           62s
```

Logs from an amd64 arch:
```sh
{"level":"DEBUG","ts":"2025-08-06T03:07:37.685Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.685Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.685Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
{"level":"INFO","ts":"2025-08-06T03:07:37.689Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.808Z","msg":"System data prepared for optimization: systemData - &{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 1 256 40 0 0 {0 0 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.808Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=0; tk=0; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=20.99, waitTime=0, rho=0}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.808Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.808Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.808Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-06 03:07:37.808741169 +0000 UTC m=+458.167946502 A100 1}"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.809Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.809Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-06T03:07:37.847Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.906Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-06T03:07:37.906Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.906Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-06T03:07:37.906Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-06T03:07:37.906Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.908Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.908Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.908Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
{"level":"INFO","ts":"2025-08-06T03:08:37.908Z","msg":"Found SLOmodeldefault/defaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default/default A100 1 20.58 0.41 4 128} {default/default MI300X 1 7.77 0.15 4 128} {default/default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default/default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default/default true 1 4 {A100 1 256 40 20 0 {28.61 278 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=28.61; tk=278; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=40, servTime=21.548061, waitTime=163.94727, rho=0.7578878}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Optimized allocation entry key: vllme-deploymentvalue: {2025-08-06 03:08:37.916917307 +0000 UTC m=+518.276122660 A100 2}"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-06T03:08:37.916Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-06T03:08:37.964Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 2"}
{"level":"DEBUG","ts":"2025-08-06T03:08:38.007Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-06T03:08:38.007Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-06T03:08:38.007Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-06T03:08:38.007Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-06T03:08:38.007Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}

kubectl get deployments.apps -n llm-d-sim
NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
gaie-sim-epp                  1/1     1            1           8m14s
infra-sim-inference-gateway   1/1     1            1           8m18s
vllme-deployment              2/2     2            2           9m21s
                                                                         
kubectl get va -n llm-d-sim
NAME               MODEL             ACCELERATOR   CURRENTREPLICAS   OPTIMIZED   AGE
vllme-deployment   default/default   A100          1                 2           90s
```