### PR TITLE
improve logging readability

### DIFF
--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -51,12 +51,12 @@ func (a *Actuator) ApplyReplicaTargets(ctx context.Context, VariantAutoscaling *
 	// Emit metrics for replica scaling
 	if replicas > *original.Spec.Replicas {
 		if err := a.MetricsEmitter.EmitReplicaScalingMetrics(ctx, VariantAutoscaling, "scale_up", "load_increase"); err != nil {
-			logger.Log.Error(err, "Failed to emit scale-up metrics", "name", VariantAutoscaling.Name)
+			logger.Log.Error(err, "Failed to emit scale-up metrics for variantAutoscaling - ", "variantAutoscaling-name: ", VariantAutoscaling.Name)
 			// Don't fail the deployment patch for metric emission errors
 		}
 	} else if replicas < *original.Spec.Replicas {
 		if err := a.MetricsEmitter.EmitReplicaScalingMetrics(ctx, VariantAutoscaling, "scale_down", "load_decrease"); err != nil {
-			logger.Log.Error(err, "Failed to emit scale-down metrics", "name", VariantAutoscaling.Name)
+			logger.Log.Error(err, "Failed to emit scale-down metrics for variantAutoscaling - ", "variantAutoscaling-name: ", VariantAutoscaling.Name)
 			// Don't fail the deployment patch for metric emission errors
 		}
 	}
@@ -74,7 +74,7 @@ func (a *Actuator) EmitMetrics(ctx context.Context, VariantAutoscaling *llmdOptv
 			int32(VariantAutoscaling.Status.DesiredOptimizedAlloc.NumReplicas),
 			VariantAutoscaling.Status.DesiredOptimizedAlloc.Accelerator,
 		); err != nil {
-			logger.Log.Error(err, "Failed to emit replica metrics", "name", VariantAutoscaling.Name)
+			logger.Log.Error(err, "Failed to emit replica metrics for variantAutoscaling - ", "variantAutoscaling-name: ", VariantAutoscaling.Name)
 			// Don't fail the reconciliation for metric emission errors
 			// Metrics are critical for HPA, but emission failures shouldn't break core functionality
 		} else {
@@ -84,6 +84,6 @@ func (a *Actuator) EmitMetrics(ctx context.Context, VariantAutoscaling *llmdOptv
 		logger.Log.Debug("Skipping EmitReplicaMetrics - NumReplicas is 0")
 	}
 
-	logger.Log.Info("Emitted metrics for variant", "name", VariantAutoscaling.Name, "namespace", VariantAutoscaling.Namespace)
+	logger.Log.Info("Emitted metrics for variantAutoscaling - ", "variantAutoscaling-name: ", VariantAutoscaling.Name, ", namespace: ", VariantAutoscaling.Namespace)
 	return nil
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -90,7 +90,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 			arrivalVal = float64(vec[0].Value)
 		}
 		if warn != nil {
-			logger.Log.Warn("Prometheus warnings", "warnings", warn)
+			logger.Log.Warn("Prometheus warnings - ", "warnings: ", warn)
 		}
 	} else {
 		return llmdVariantAutoscalingV1alpha1.Allocation{}, err
@@ -122,7 +122,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 			waitAverageTime = float64(vec[0].Value) * 1000 //msec
 		}
 	} else {
-		logger.Log.Warn("failed to get avg wait time, using 0", "model", modelName)
+		logger.Log.Warn("failed to get avg wait time, using 0: ", "model: ", modelName)
 	}
 	FixValue(&waitAverageTime)
 
@@ -136,7 +136,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 			itlAverage = float64(vec[0].Value) * 1000 //msec
 		}
 	} else {
-		logger.Log.Warn("failed to get avg itl time, using 0", "model", modelName)
+		logger.Log.Warn("failed to get avg itl time, using 0: ", "model: ", modelName)
 	}
 	FixValue(&itlAverage)
 
@@ -147,7 +147,7 @@ func AddMetricsToOptStatus(ctx context.Context,
 	acc := ""
 	var ok bool
 	if acc, ok = opt.Labels["inference.optimization/acceleratorName"]; !ok {
-		logger.Log.Warn("acceleratorName label not found on deployment", "deployment", deployment.Name)
+		logger.Log.Warn("acceleratorName label not found on deployment - ", "deployment-name: ", deployment.Name)
 	}
 
 	// cost

--- a/internal/optimizer/optimizer.go
+++ b/internal/optimizer/optimizer.go
@@ -40,7 +40,7 @@ func (engine *VariantAutoscalingsEngine) Optimize(ctx context.Context,
 		return nil, fmt.Errorf("No feasible solution found: ")
 	}
 
-	logger.Log.Debug("Optimization solution", "system", engine.system)
+	logger.Log.Debug("Optimization solution - ", "system: ", engine.system)
 
 	optimizedAllocMap := make(map[string]llmdOptv1alpha1.OptimizedAlloc)
 	for _, va := range vaList.Items {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -250,4 +252,13 @@ func GetZapLevelFromEnv() zapcore.Level {
 	default:
 		return zapcore.InfoLevel // fallback
 	}
+}
+
+func MarshalStructToJsonString(t any) string {
+	jsonBytes, err := json.MarshalIndent(t, "", " ")
+	if err != nil {
+		return fmt.Sprintf("error marshalling: %v", err)
+	}
+	re := regexp.MustCompile("\"|\n")
+	return re.ReplaceAllString(string(jsonBytes), "")
 }


### PR DESCRIPTION
Logs before these changes: 
```sh
{"level":"DEBUG","ts":"2025-08-04T19:18:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
{"level":"INFO","ts":"2025-08-04T19:18:16.481Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.483Z","msg":"System data prepared for optimization: systemData - &{{{[{G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65} {A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 1 256 40 20 0 {22.67 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{NVIDIA-A100-PCIE-80GB 2} {AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2}]}}}"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=22.67; tk=178; sol=1, alloc={acc=A100; num=1; maxBatch=4; cost=40, val=0, servTime=21.555601, waitTime=110.798096, rho=0.7630596}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=1, limit=2, cost=40 \ntotalCost=40 \n"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:18:16.484006425 +0000 UTC m=+1380.284253535 A100 1}"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.484Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T19:18:16.487Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 1"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.493Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T19:18:16.493Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.493Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T19:18:16.493Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T19:18:16.493Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
# New round:
{"level":"DEBUG","ts":"2025-08-04T19:19:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.481Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
{"level":"INFO","ts":"2025-08-04T19:19:16.481Z","msg":"Found SLOmodeldefaultclassPremiumslo-itl24slo-ttw500"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"System data prepared for optimization: systemData - &{{{[{A100 NVIDIA-A100-PCIE-80GB 1 0 0 {0 0 0 0} 40} {G2 Intel-Gaudi-2-96GB 1 0 0 {0 0 0 0} 23} {MI300X AMD-MI300X-192GB 1 0 0 {0 0 0 0} 65}]} {[{default A100 1 20.58 0.41 4 128} {default MI300X 1 7.77 0.15 4 128} {default G2 1 17.15 0.34 4 128}]} {[{Freemium granite-13b 10 200 2000 0} {Freemium llama0-7b 10 150 1500 0} {Premium default 1 24 500 0} {Premium llama0-70b 1 80 500 0}]} {[{vllme-deployment:llm-d-sim Premium default true 1 4 {A100 1 256 40 20 0 {44 178 0 0}} { 0 0 0 0 0 {0 0 0 0}}}]} {{false false}} {[{AMD-MI300X-192G 2} {Intel-Gaudi-2-96GB 2} {NVIDIA-A100-PCIE-80GB 2}]}}}"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization solutionsystemSolution: \nc=Premium; m=default/default; rate=44; tk=178; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=40, servTime=21.540192, waitTime=99.1626, rho=0.7524011}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization completed successfully, emitting optimization metrics"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimized allocation mapkeys1updateList_count1"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimized allocation entrykeyvllme-deploymentvalue{2025-08-04 19:19:16.48370162 +0000 UTC m=+1440.283948730 A100 2}"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Optimization metrics emitted, starting to process variantsvariant_count1"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.483Z","msg":"Processing variantindex0namevllme-deploymentnamespacellm-d-simhas_optimized_alloctrue"}
{"level":"INFO","ts":"2025-08-04T19:19:16.488Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 2"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.494Z","msg":"EmitReplicaMetrics completed"}
{"level":"INFO","ts":"2025-08-04T19:19:16.494Z","msg":"Emitted metrics for variantnamevllme-deploymentnamespacellm-d-sim"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.494Z","msg":"EmitMetrics call completed successfullynamevllme-deployment"}
{"level":"DEBUG","ts":"2025-08-04T19:19:16.494Z","msg":"Completed variant processing loop"}
{"level":"INFO","ts":"2025-08-04T19:19:16.494Z","msg":"Reconciliation completedvariants_processed1optimization_successfultrue"}
```
Logs after this PR:
```sh
2025-08-06T22:59:15.387132291Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.386Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-control-plane , model - NVIDIA-A100-PCIE-80GB , count - 2 , mem - 81920"}
2025-08-06T22:59:15.387154916Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.387Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker , model - AMD-MI300X-192G , count - 2 , mem - 196608"}
2025-08-06T22:59:15.387156416Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.387Z","msg":"Found inventory: nodeName - kind-inferno-gpu-cluster-worker2 , model - Intel-Gaudi-2-96GB , count - 2 , mem - 98304"}
2025-08-06T22:59:15.387161208Z {"level":"INFO","ts":"2025-08-06T22:59:15.387Z","msg":"Found SLO for model - model: default/default, class: Premium, slo-itl: 24, slo-ttw: 500"}
2025-08-06T22:59:15.389531208Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: capacity - { count: [  {   type: NVIDIA-A100-PCIE-80GB,   count: 2  },  {   type: AMD-MI300X-192G,   count: 2  },  {   type: Intel-Gaudi-2-96GB,   count: 2  } ]}"}
2025-08-06T22:59:15.389538875Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: accelerators - { accelerators: [  {   name: A100,   type: NVIDIA-A100-PCIE-80GB,   multiplicity: 1,   memSize: 0,   memBW: 0,   power: {    idle: 0,    full: 0,    midPower: 0,    midUtil: 0   },   cost: 40  },  {   name: G2,   type: Intel-Gaudi-2-96GB,   multiplicity: 1,   memSize: 0,   memBW: 0,   power: {    idle: 0,    full: 0,    midPower: 0,    midUtil: 0   },   cost: 23  },  {   name: MI300X,   type: AMD-MI300X-192GB,   multiplicity: 1,   memSize: 0,   memBW: 0,   power: {    idle: 0,    full: 0,    midPower: 0,    midUtil: 0   },   cost: 65  } ]}"}
2025-08-06T22:59:15.389540916Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: serviceClasses - { serviceClasses: [  {   name: Freemium,   model: granite-13b,   priority: 10,   slo-itl: 200,   slo-ttw: 2000,   slo-tps: 0  },  {   name: Freemium,   model: llama0-7b,   priority: 10,   slo-itl: 150,   slo-ttw: 1500,   slo-tps: 0  },  {   name: Premium,   model: default/default,   priority: 1,   slo-itl: 24,   slo-ttw: 500,   slo-tps: 0  },  {   name: Premium,   model: llama0-70b,   priority: 1,   slo-itl: 80,   slo-ttw: 500,   slo-tps: 0  } ]}"}
2025-08-06T22:59:15.389542375Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: models - { models: [  {   name: default/default,   acc: A100,   accCount: 1,   alpha: 20.58,   beta: 0.41,   maxBatchSize: 4,   atTokens: 128  },  {   name: default/default,   acc: MI300X,   accCount: 1,   alpha: 7.77,   beta: 0.15,   maxBatchSize: 4,   atTokens: 128  },  {   name: default/default,   acc: G2,   accCount: 1,   alpha: 17.15,   beta: 0.34,   maxBatchSize: 4,   atTokens: 128  } ]}"}
2025-08-06T22:59:15.389544166Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: optimizer - { optimizer: {  unlimited: false,  heterogeneous: false }}"}
2025-08-06T22:59:15.389556750Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"System data prepared for optimization: servers - { servers: [  {   name: vllme-deployment:llm-d-sim,   class: Premium,   model: default/default,   keepAccelerator: true,   minNumReplicas: 1,   maxBatchSize: 4,   currentAlloc: {    accelerator: A100,    numReplicas: 2,    maxBatch: 256,    cost: 80,    itlAverage: 20,    waitAverage: 0,    load: {     arrivalRate: 35.68,     avgLength: 228,     arrivalCOV: 0,     serviceCOV: 0    }   },   desiredAlloc: {    accelerator: ,    numReplicas: 0,    maxBatch: 0,    cost: 0,    itlAverage: 0,    waitAverage: 0,    load: {     arrivalRate: 0,     avgLength: 0,     arrivalCOV: 0,     serviceCOV: 0    }   }  } ]}"}
2025-08-06T22:59:15.389559291Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Optimization solution - system: Solution: \nc=Premium; m=default/default; rate=35.68; tk=228; sol=1, alloc={acc=A100; num=2; maxBatch=4; cost=80, val=0, servTime=21.559748, waitTime=146.16699, rho=0.7658696}; slo-itl=24, slo-ttw=500, slo-tps=0 \nAllocationByType: \nname=NVIDIA-A100-PCIE-80GB, count=2, limit=2, cost=80 \ntotalCost=80 \n"}
2025-08-06T22:59:15.389560625Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Optimization completed successfully, emitting optimization metrics"}
2025-08-06T22:59:15.389561416Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Optimized allocation map - numKeys: 1, updateList_count: 1"}
2025-08-06T22:59:15.389563875Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Optimized allocation entry - key: vllme-deployment, value: {2025-08-06 22:59:15.389496 +0000 UTC m=+309.618050190 A100 2}"}
2025-08-06T22:59:15.389565250Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Optimization metrics emitted, starting to process variants - variant_count: 1"}
2025-08-06T22:59:15.389566125Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.389Z","msg":"Processing variant - index: 0, variantAutoscaling-name: vllme-deployment, namespace: llm-d-sim, has_optimized_alloc: true"}
2025-08-06T22:59:15.393142291Z {"level":"INFO","ts":"2025-08-06T22:59:15.393Z","msg":"Patched Deployment: name: vllme-deployment num-replicas: 2"}
2025-08-06T22:59:15.398083458Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.397Z","msg":"EmitReplicaMetrics completed"}
2025-08-06T22:59:15.398176041Z {"level":"INFO","ts":"2025-08-06T22:59:15.397Z","msg":"Emitted metrics for variantAutoscaling - variantAutoscaling-name: vllme-deployment, namespace: llm-d-sim"}
2025-08-06T22:59:15.398182125Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.397Z","msg":"EmitMetrics call completed successfully for variantAutoscaling - variantAutoscaling-name: vllme-deployment"}
2025-08-06T22:59:15.398183541Z {"level":"DEBUG","ts":"2025-08-06T22:59:15.397Z","msg":"Completed variant processing loop"}
2025-08-06T22:59:15.398184625Z {"level":"INFO","ts":"2025-08-06T22:59:15.397Z","msg":"Reconciliation completed - variants_processed: 1, optimization_successful: true"}
```