### PR TITLE
E2E scaling tests

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/llm-d-incubation/inferno-autoscaler/test/utils"
 )
@@ -44,9 +43,6 @@ var (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "quay.io/infernoautoscaler/inferno-controller:0.0.1-test"
-
-	// k8s client
-	suiteK8sClient *kubernetes.Clientset
 )
 
 // createServiceClassConfigMap creates the serviceclass ConfigMap
@@ -154,6 +150,10 @@ var _ = BeforeSuite(func() {
 	acceleratorConfigMap := createAcceleratorUnitCostConfigMap()
 	_, err = k8sClient.CoreV1().ConfigMaps(controllerNamespace).Create(context.Background(), acceleratorConfigMap, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to create accelerator unitcost ConfigMap")
+
+	cmd = exec.Command("kubectl", "apply", "-f", "hack/vllme/deploy/prometheus-operator/prometheus-deploy-all-in-one.yaml")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy Prometheus resources")
 
 	By("deploying the controller-manager")
 	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -215,7 +215,7 @@ func CheckIfClusterExistsOrCreate() (string, error) {
 	// Create the kind cluster if it doesn't exist
 	expectedVersion := os.Getenv("K8S_EXPECTED_VERSION")
 	if !clusterExists {
-		scriptCmd := exec.Command("bash", "hack/create-kind-gpu-cluster.sh", "K8S_VERSION="+expectedVersion)
+		scriptCmd := exec.Command("bash", "hack/create-kind-gpu-cluster.sh", "-g", "4", "K8S_VERSION="+expectedVersion)
 		if _, err := Run(scriptCmd); err != nil {
 			return "", fmt.Errorf("failed to create kind cluster: %v", err)
 		}


### PR DESCRIPTION
This PR adds E2E tests to verify scaling up for a vLLM-emulator deployment under generated load, and subsequent scale down once the load generation is stopped.

Focusing on the added tests:
```sh
------------------------------
Test vllme deployment with VariantAutoscaling should scale up optimized replicas when load increases
/Users/tom/Desktop/llm-d-communitydev/inferno-autoscaler_tom/test/e2e/e2e_test.go:513
  STEP: verifying initial state of VariantAutoscaling @ 08/11/25 10:56:28.415
  STEP: getting the service endpoint for load generation @ 08/11/25 10:56:28.418
  STEP: setting up port-forward to the vllme service @ 08/11/25 10:56:28.42
  STEP: waiting for port-forward to be ready @ 08/11/25 10:56:28.422
  STEP: starting load generation to create traffic @ 08/11/25 10:56:29.442
  STEP: waiting for load to be processed and scaling decision to be made @ 08/11/25 10:56:29.446
  STEP: verifying that the controller has updated the status @ 08/11/25 10:58:29.464
Load Profile - Arrival Rate: 50.67, Avg Length: 228.00
Current Allocation - Replicas: 2, Accelerator: A100, 
Desired Optimized Allocation - Replicas: 2, Accelerator: A100
Current replicas for Deployment - vllme-deployment: 2
• [121.056 seconds]
------------------------------
Test vllme deployment with VariantAutoscaling should scale down as load stops
/Users/tom/Desktop/llm-d-communitydev/inferno-autoscaler_tom/test/e2e/e2e_test.go:607
  STEP: stopping the load generation script @ 08/11/25 10:58:29.47
  STEP: waiting for scaling down decision to be made @ 08/11/25 10:58:29.47
  STEP: verifying that the controller has updated the status @ 08/11/25 10:59:29.481
Load Profile - Arrival Rate: 2.67, Avg Length: 228.00
Current Allocation - Replicas: 1, Accelerator: A100, 
Desired Optimized Allocation - Replicas: 1, Accelerator: A100
Current replicas for Deployment - vllme-deployment: 1
• [60.016 seconds]
```

Results:
```sh
------------------------------

Ran 12 of 12 Specs in 327.831 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (327.83s)
PASS
ok      github.com/llm-d-incubation/inferno-autoscaler/test/e2e 328.691s
```