### PR TITLE
Remove manual trigger logic

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -27,5 +27,4 @@ data:
   # PROMETHEUS_TOKEN_PATH: "/path/to/token/file"        # Path to bearer token file (production with mounted secrets)
   
   # Optimization configuration
-  GLOBAL_OPT_INTERVAL: "60s"
-  GLOBAL_OPT_TRIGGER: "false" 
+  GLOBAL_OPT_INTERVAL: "60s" 


### PR DESCRIPTION
When integrated with the HPA, the manual trigger could cause weird edge cases with loss of optimization cycle information. Manual triggering was borrowed from legacy inferno design of experimentation and should not be used in production-like deployments.