### PR TITLE
Fix E2E test execution on CI

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           - --leader-elect=true
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: LOG_LEVEL
             value: "debug"  # or "info", "warn", "error"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -114,11 +114,11 @@ var _ = BeforeSuite(func() {
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 
-	By("waiting for the controller-manager to be ready")
+	By("waiting for the controller-manager pods to be ready")
 	Eventually(func(g Gomega) {
-		podList, err := k8sClient.CoreV1().Pods(controllerNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=controller-manager"})
+		podList, err := k8sClient.CoreV1().Pods(controllerNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=inferno-autoscaler"})
 		if err != nil {
-			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to list Pod labelled: %s", "app=controller-manager"))
+			g.Expect(err).NotTo(HaveOccurred(), "Should be able to list manager pods labelled")
 		}
 		g.Expect(podList.Items).NotTo(BeEmpty(), "Pod list should not be empty")
 		for _, pod := range podList.Items {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -120,6 +120,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to list Pod labelled: %s", "app=controller-manager"))
 		}
+		g.Expect(podList.Items).NotTo(BeEmpty(), "Pod list should not be empty")
 		for _, pod := range podList.Items {
 			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), fmt.Sprintf("Pod %s is not running", pod.Name))
 		}
@@ -133,7 +134,8 @@ var _ = BeforeSuite(func() {
 		}
 		g.Expect(leaseList.Items).NotTo(BeEmpty(), "Lease list should not be empty")
 		for _, lease := range leaseList.Items {
-			g.Expect(*lease.Spec.HolderIdentity).To(ContainSubstring("controller-manager"), "Lease holder identity is not correct")
+			g.Expect(lease.Spec.HolderIdentity).NotTo(BeNil(), "Lease holderIdentity should not be nil")
+			g.Expect(*lease.Spec.HolderIdentity).To(ContainSubstring("controller-manager"), "Lease holderIdentity is not correct")
 		}
 	}, 2*time.Minute, 1*time.Second).Should(Succeed())
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 		for _, pod := range podList.Items {
 			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), fmt.Sprintf("Pod %s is not running", pod.Name))
 		}
-	}, 1*time.Minute, 1*time.Second).Should(Succeed())
+	}, 2*time.Minute, 1*time.Second).Should(Succeed())
 
 	By("waiting for the controller-manager to acquire lease")
 	Eventually(func(g Gomega) {
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 		for _, lease := range leaseList.Items {
 			g.Expect(*lease.Spec.HolderIdentity).To(ContainSubstring("controller-manager"), "Lease holder identity is not correct")
 		}
-	}, 1*time.Minute, 1*time.Second).Should(Succeed())
+	}, 2*time.Minute, 1*time.Second).Should(Succeed())
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1340,7 +1340,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 			g.Expect(deployment2.Status.Replicas).To(BeNumerically(">", 1), fmt.Sprintf("Deployment %s should have scaled up - actual replicas: %d", deployment2.Name, deployment2.Status.Replicas))
 			g.Expect(strconv.ParseFloat(va2.Status.CurrentAlloc.Load.ArrivalRate, 64)).To(BeNumerically("~", loadRate, loadThresholdDiff), fmt.Sprintf("Detected load rate %s should be approximately the actual load rate %d for %s", va2.Status.CurrentAlloc.Load.ArrivalRate, loadRate, deployment2.Name))
 
-		}, 4*time.Minute, 10*time.Second).Should(Succeed())
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 		By("verifying that the controller has updated the status")
 		finalVA1 := &v1alpha1.VariantAutoscaling{}


### PR DESCRIPTION
This PR aims to fix the test errors when `make test-e2e` is ran by GHA.
It adds checks to pod readiness and lease acquisition before starting the suite and changes the `imagePullPolicy` for the manager to use the local test image.