### PR TITLE
Add unit tests to Inferno-autoscaler components

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -21,9 +21,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -113,4 +116,102 @@ func getFirstFoundEnvTestBinaryDir() string {
 		}
 	}
 	return ""
+}
+
+// mockPromAPI is a mock implementation of promv1.API for testing
+type mockPromAPI struct{}
+
+func (m *mockPromAPI) Query(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+	// Return mock data that mimics typical Prometheus responses
+	vector := model.Vector{
+		&model.Sample{
+			Metric: model.Metric{},
+			Value:  model.SampleValue(10.0), // Mock arrival rate
+		},
+	}
+	return vector, nil, nil
+}
+
+func (m *mockPromAPI) QueryRange(ctx context.Context, query string, r promv1.Range, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPromAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]promv1.ExemplarQueryResult, error) {
+	return nil, nil
+}
+
+func (m *mockPromAPI) Buildinfo(ctx context.Context) (promv1.BuildinfoResult, error) {
+	return promv1.BuildinfoResult{}, nil
+}
+
+func (m *mockPromAPI) Config(ctx context.Context) (promv1.ConfigResult, error) {
+	return promv1.ConfigResult{}, nil
+}
+
+func (m *mockPromAPI) Flags(ctx context.Context) (promv1.FlagsResult, error) {
+	return promv1.FlagsResult{}, nil
+}
+
+func (m *mockPromAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...promv1.Option) ([]string, promv1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPromAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...promv1.Option) (model.LabelValues, promv1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPromAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...promv1.Option) ([]model.LabelSet, promv1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPromAPI) GetValue(ctx context.Context, timestamp time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m *mockPromAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]promv1.Metadata, error) {
+	return nil, nil
+}
+
+func (m *mockPromAPI) TSDB(ctx context.Context, opts ...promv1.Option) (promv1.TSDBResult, error) {
+	return promv1.TSDBResult{}, nil
+}
+
+func (m *mockPromAPI) WalReplay(ctx context.Context) (promv1.WalReplayStatus, error) {
+	return promv1.WalReplayStatus{}, nil
+}
+
+func (m *mockPromAPI) Targets(ctx context.Context) (promv1.TargetsResult, error) {
+	return promv1.TargetsResult{}, nil
+}
+
+func (m *mockPromAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]promv1.MetricMetadata, error) {
+	return nil, nil
+}
+
+func (m *mockPromAPI) AlertManagers(ctx context.Context) (promv1.AlertManagersResult, error) {
+	return promv1.AlertManagersResult{}, nil
+}
+
+func (m *mockPromAPI) CleanTombstones(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockPromAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	return nil
+}
+
+func (m *mockPromAPI) Snapshot(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error) {
+	return promv1.SnapshotResult{}, nil
+}
+
+func (m *mockPromAPI) Rules(ctx context.Context) (promv1.RulesResult, error) {
+	return promv1.RulesResult{}, nil
+}
+
+func (m *mockPromAPI) Alerts(ctx context.Context) (promv1.AlertsResult, error) {
+	return promv1.AlertsResult{}, nil
+}
+
+func (m *mockPromAPI) Runtimeinfo(ctx context.Context) (promv1.RuntimeinfoResult, error) {
+	return promv1.RuntimeinfoResult{}, nil
 }

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -58,7 +58,8 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					Name: "inferno-autoscaler-system",
 				},
 			}
-			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).NotTo(HaveOccurred())
+
 			By("creating the required configmap for optimization")
 			configMap := ctrlutils.CreateServiceClassConfigMap(ns.Name)
 			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
@@ -119,8 +120,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -129,8 +129,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -139,8 +138,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -206,17 +204,17 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					Name: "inferno-autoscaler-system",
 				},
 			}
-			k8sClient.Create(ctx, ns) // May already exist
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).NotTo(HaveOccurred())
 
 			By("creating the required configmaps")
 			configMap := ctrlutils.CreateServiceClassConfigMap(ns.Name)
-			k8sClient.Create(ctx, configMap)
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
 
 			configMap = ctrlutils.CreateAcceleratorUnitCostConfigMap(ns.Name)
-			k8sClient.Create(ctx, configMap)
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
 
 			configMap = ctrlutils.CreateVariantAutoscalingConfigMap(ns.Name)
-			k8sClient.Create(ctx, configMap)
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -228,8 +226,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err := k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -238,8 +235,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -248,8 +244,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 		})
 
 		It("should return empty on variant autoscaling optimization ConfigMap with missing interval value", func() {
@@ -570,7 +565,7 @@ data:
 					Name: "inferno-autoscaler-system",
 				},
 			}
-			k8sClient.Create(ctx, ns) // May already exist
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).NotTo(HaveOccurred())
 
 			By("creating the required configmaps")
 			// Use custom configmap creation function
@@ -686,8 +681,7 @@ data:
 				},
 			}
 			err := k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -696,8 +690,7 @@ data:
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -706,8 +699,7 @@ data:
 				},
 			}
 			err = k8sClient.Delete(ctx, configMap)
-			client.IgnoreNotFound(err)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
 			err = k8sClient.List(ctx, &variantAutoscalingList)
@@ -722,16 +714,14 @@ data:
 				deployment := &deploymentList.Items[i]
 				if strings.HasPrefix(deployment.Spec.Template.ObjectMeta.Labels["app"], "multi-test-resource") {
 					err = k8sClient.Delete(ctx, deployment)
-					client.IgnoreNotFound(err)
-					Expect(err).NotTo(HaveOccurred(), "Failed to delete deployment")
+					Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred(), "Failed to delete deployment")
 				}
 			}
 
 			// Clean up all VariantAutoscaling resources
 			for i := range variantAutoscalingList.Items {
 				err = k8sClient.Delete(ctx, &variantAutoscalingList.Items[i])
-				client.IgnoreNotFound(err)
-				Expect(err).NotTo(HaveOccurred(), "Failed to delete VariantAutoscaling resource")
+				Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred(), "Failed to delete VariantAutoscaling resource")
 			}
 		})
 

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -18,18 +18,23 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d-incubation/inferno-autoscaler/api/v1alpha1"
+	collector "github.com/llm-d-incubation/inferno-autoscaler/internal/collector"
 	logger "github.com/llm-d-incubation/inferno-autoscaler/internal/logger"
 	ctrlutils "github.com/llm-d-incubation/inferno-autoscaler/internal/utils"
 )
@@ -105,7 +110,39 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 
 			By("Cleanup the specific resource instance VariantAutoscalings")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Deleting the configmap resources")
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-classes-config",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "accelerator-unit-costs",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &VariantAutoscalingReconciler{
@@ -117,6 +154,651 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When handling error conditions on missing config maps", func() {
+		BeforeEach(func() {
+			logger.Log = zap.NewNop().Sugar()
+		})
+
+		It("should fail on missing serviceClass ConfigMap", func() {
+			By("Creating VariantAutoscaling without required ConfigMaps")
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.readServiceClassConfig(ctx, "service-classes-config", configMapNamespace)
+			Expect(err).To(HaveOccurred(), "Expected error when reading missing serviceClass ConfigMap")
+		})
+
+		It("should fail on missing accelerator ConfigMap", func() {
+			By("Creating VariantAutoscaling without required ConfigMaps")
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
+			Expect(err).To(HaveOccurred(), "Expected error when reading missing accelerator ConfigMap")
+		})
+
+		It("should fail on missing variant autoscaling optimization ConfigMap", func() {
+			By("Creating VariantAutoscaling without required ConfigMaps")
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.readOptimizationConfig(ctx)
+			Expect(err).To(HaveOccurred(), "Expected error when reading missing variant autoscaling optimization ConfigMap")
+		})
+	})
+
+	Context("When validating configurations", func() {
+		const configResourceName = "config-test-resource"
+
+		BeforeEach(func() {
+			logger.Log = zap.NewNop().Sugar()
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inferno-autoscaler-system",
+				},
+			}
+			k8sClient.Create(ctx, ns) // May already exist
+
+			By("creating the required configmaps")
+			configMap := ctrlutils.CreateServiceClassConfigMap(ns.Name)
+			k8sClient.Create(ctx, configMap)
+
+			configMap = ctrlutils.CreateAcceleratorUnitCostConfigMap(ns.Name)
+			k8sClient.Create(ctx, configMap)
+
+			configMap = ctrlutils.CreateVariantAutoscalingConfigMap(ns.Name)
+			k8sClient.Create(ctx, configMap)
+		})
+
+		AfterEach(func() {
+			By("Deleting the configmap resources")
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-classes-config",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "accelerator-unit-costs",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return empty on variant autoscaling optimization ConfigMap with missing interval value", func() {
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// delete correct configMap
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "inferno-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"PROMETHEUS_BASE_URL": "https://kube-prometheus-stack-prometheus.inferno-autoscaler-monitoring.svc.cluster.local:9090",
+					"GLOBAL_OPT_INTERVAL": "",
+					"GLOBAL_OPT_TRIGGER":  "false",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			interval, err := controllerReconciler.readOptimizationConfig(ctx)
+			Expect(err).NotTo(HaveOccurred(), "Unexpected error when reading variant autoscaling optimization ConfigMap with missing interval")
+			Expect(interval).To(Equal(""), "Expected empty interval value")
+		})
+
+		It("should return empty on variant autoscaling optimization ConfigMap with missing prometheus base URL", func() {
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// delete correct configMap
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "inferno-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"PROMETHEUS_BASE_URL": "",
+					"GLOBAL_OPT_INTERVAL": "60s",
+					"GLOBAL_OPT_TRIGGER":  "false",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			prometheusURL, err := controllerReconciler.getPrometheusConfigFromConfigMap(ctx)
+			Expect(err).NotTo(HaveOccurred(), "Unexpected error when reading variant autoscaling optimization ConfigMap with missing Prometheus URL")
+			Expect(prometheusURL).To(BeNil(), "Expected empty Prometheus URL")
+		})
+
+		It("should return error on VA optimization ConfigMap with missing prometheus base URL and no env variable", func() {
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// delete correct configMap
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "inferno-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"PROMETHEUS_BASE_URL": "",
+					"GLOBAL_OPT_INTERVAL": "60s",
+					"GLOBAL_OPT_TRIGGER":  "false",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			_, err = controllerReconciler.getPrometheusConfig(ctx)
+			Expect(err).To(HaveOccurred(), "It should fail when neither env variable nor Prometheus URL are found")
+		})
+
+		It("should return default values on variant autoscaling optimization ConfigMap with missing TLS values", func() {
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// delete correct configMap
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "inferno-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"PROMETHEUS_BASE_URL":                 "https://kube-prometheus-stack-prometheus.inferno-autoscaler-monitoring.svc.cluster.local:9090",
+					"GLOBAL_OPT_INTERVAL":                 "60s",
+					"GLOBAL_OPT_TRIGGER":                  "false",
+					"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY": "true",
+					// no values set for TLS config - dev env
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			prometheusConfig, err := controllerReconciler.getPrometheusConfigFromConfigMap(ctx)
+			Expect(err).NotTo(HaveOccurred(), "It should not fail when neither env variable nor Prometheus URL are found")
+
+			Expect(prometheusConfig.BaseURL).To(Equal("https://kube-prometheus-stack-prometheus.inferno-autoscaler-monitoring.svc.cluster.local:9090"), "Expected Base URL to be set")
+			Expect(prometheusConfig.InsecureSkipVerify).To(BeTrue(), "Expected Insecure Skip Verify to be true")
+
+			Expect(prometheusConfig.CACertPath).To(Equal(""), "Expected CA Cert Path to be empty")
+			Expect(prometheusConfig.ClientCertPath).To(Equal(""), "Expected Client Cert path to be empty")
+			Expect(prometheusConfig.ClientKeyPath).To(Equal(""), "Expected Client Key path to be empty")
+			Expect(prometheusConfig.BearerToken).To(Equal(""), "Expected Bearer Token to be empty")
+			Expect(prometheusConfig.TokenPath).To(Equal(""), "Expected Token Path to be empty")
+			Expect(prometheusConfig.ServerName).To(Equal(""), "Expected Server Name to be empty")
+		})
+
+		It("should validate accelerator profiles", func() {
+			By("Creating VariantAutoscaling with invalid accelerator profile")
+			resource := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configResourceName,
+					Namespace: "default",
+				},
+				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+					ModelID: "default/default",
+					ModelProfile: llmdVariantAutoscalingV1alpha1.ModelProfile{
+						Accelerators: []llmdVariantAutoscalingV1alpha1.AcceleratorProfile{
+							{
+								Acc:          "INVALID_GPU",
+								AccCount:     -1,        // Invalid count
+								Alpha:        "invalid", // Invalid format
+								Beta:         "invalid",
+								MaxBatchSize: -1, // Invalid batch size
+							},
+						},
+					},
+					SLOClassRef: llmdVariantAutoscalingV1alpha1.ConfigMapKeyRef{
+						Name: "premium",
+						Key:  "default/default",
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred()) // Expect validation error at API level
+			Expect(err.Error()).To(ContainSubstring("Invalid value"))
+		})
+
+		It("should handle empty ModelID value", func() {
+			By("Creating VariantAutoscaling with empty ModelID")
+			resource := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-model-id",
+					Namespace: "default",
+				},
+				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+					ModelID: "", // Empty ModelID
+					ModelProfile: llmdVariantAutoscalingV1alpha1.ModelProfile{
+						Accelerators: []llmdVariantAutoscalingV1alpha1.AcceleratorProfile{
+							{
+								Acc:          "A100",
+								AccCount:     1,
+								Alpha:        "0.28",
+								Beta:         "0.72",
+								MaxBatchSize: 4,
+							},
+						},
+					},
+					SLOClassRef: llmdVariantAutoscalingV1alpha1.ConfigMapKeyRef{
+						Name: "premium",
+						Key:  "default/default",
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred()) // Expect validation error at API level
+			Expect(err.Error()).To(ContainSubstring("spec.modelID"))
+		})
+
+		It("should handle empty accelerator list", func() {
+			By("Creating VariantAutoscaling with no accelerators")
+			resource := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-accelerators",
+					Namespace: "default",
+				},
+				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+					ModelID: "default/default",
+					ModelProfile: llmdVariantAutoscalingV1alpha1.ModelProfile{
+						Accelerators: []llmdVariantAutoscalingV1alpha1.AcceleratorProfile{
+							// no configuration for accelerators
+						},
+					},
+					SLOClassRef: llmdVariantAutoscalingV1alpha1.ConfigMapKeyRef{
+						Name: "premium",
+						Key:  "default/default",
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.modelProfile.accelerators"))
+		})
+
+		It("should handle empty SLOClassRef", func() {
+			By("Creating VariantAutoscaling with no SLOClassRef")
+			resource := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-slo-class-ref",
+					Namespace: "default",
+				},
+				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+					ModelID: "default/default",
+					ModelProfile: llmdVariantAutoscalingV1alpha1.ModelProfile{
+						Accelerators: []llmdVariantAutoscalingV1alpha1.AcceleratorProfile{
+							{
+								Acc:          "A100",
+								AccCount:     1,
+								Alpha:        "0.28",
+								Beta:         "0.72",
+								MaxBatchSize: 4,
+							},
+						},
+					},
+					SLOClassRef: llmdVariantAutoscalingV1alpha1.ConfigMapKeyRef{
+						// no configuration for SLOClassRef
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.sloClassRef"))
+		})
+	})
+
+	Context("When handling multiple VariantAutoscalings", func() {
+		const totalVAs = 3
+		var dummyInventory map[string]map[string]collector.AcceleratorModelInfo
+
+		var CreateServiceClassConfigMap = func(controllerNamespace string, models ...string) *v1.ConfigMap {
+			data := map[string]string{}
+
+			// Build premium.yaml with all models
+			premiumModels := ""
+			freemiumModels := ""
+
+			for _, model := range models {
+				premiumModels += fmt.Sprintf("  - model: %s\n    slo-tpot: 24\n    slo-ttft: 500\n", model)
+				freemiumModels += fmt.Sprintf("  - model: %s\n    slo-tpot: 200\n    slo-ttft: 2000\n", model)
+			}
+
+			data["premium.yaml"] = fmt.Sprintf(`name: Premium
+priority: 1
+data:
+%s`, premiumModels)
+
+			data["freemium.yaml"] = fmt.Sprintf(`name: Freemium
+priority: 10
+data:
+%s`, freemiumModels)
+
+			return &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-classes-config",
+					Namespace: controllerNamespace,
+				},
+				Data: data,
+			}
+		}
+
+		BeforeEach(func() {
+			logger.Log = zap.NewNop().Sugar()
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inferno-autoscaler-system",
+				},
+			}
+			k8sClient.Create(ctx, ns) // May already exist
+
+			By("creating the required configmaps")
+			// Use custom configmap creation function
+			var modelNames []string
+			for i := range totalVAs {
+				modelNames = append(modelNames, fmt.Sprintf("model-%d/model-%d", i, i))
+			}
+			configMap := CreateServiceClassConfigMap(ns.Name, modelNames...)
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			configMap = ctrlutils.CreateAcceleratorUnitCostConfigMap(ns.Name)
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			configMap = ctrlutils.CreateVariantAutoscalingConfigMap(ns.Name)
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			By("Creating dummy inventory")
+			dummyInventory = map[string]map[string]collector.AcceleratorModelInfo{
+				"gpu-node-1": {
+					"A100": collector.AcceleratorModelInfo{
+						Count:  4,
+						Memory: "40Gi",
+					},
+					"H100": collector.AcceleratorModelInfo{
+						Count:  2,
+						Memory: "80Gi",
+					},
+				},
+				"gpu-node-2": {
+					"A100": collector.AcceleratorModelInfo{
+						Count:  8,
+						Memory: "40Gi",
+					},
+				},
+				"gpu-node-3": {
+					"V100": collector.AcceleratorModelInfo{
+						Count:  4,
+						Memory: "32Gi",
+					},
+				},
+			}
+
+			By("Creating VariantAutoscaling resources and Deployments")
+			for i := range totalVAs {
+				modelID := fmt.Sprintf("model-%d/model-%d", i, i)
+				name := fmt.Sprintf("multi-test-resource-%d", i)
+
+				d := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: "default",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ctrlutils.Ptr(int32(1)),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": name},
+						},
+						Template: v1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"app": name},
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "test-container",
+										Image: "quay.io/infernoautoscaler/vllme:0.2.1-multi-arch",
+										Ports: []v1.ContainerPort{{ContainerPort: 80}},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, d)).To(Succeed())
+
+				r := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: "default",
+						Labels: map[string]string{
+							"inference.optimization/acceleratorName": "A100",
+						},
+					},
+					Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+						ModelID: modelID,
+						ModelProfile: llmdVariantAutoscalingV1alpha1.ModelProfile{
+							Accelerators: []llmdVariantAutoscalingV1alpha1.AcceleratorProfile{
+								{
+									Acc:          "A100",
+									AccCount:     1,
+									Alpha:        "0.28",
+									Beta:         "0.72",
+									MaxBatchSize: 4,
+								},
+							},
+						},
+						SLOClassRef: llmdVariantAutoscalingV1alpha1.ConfigMapKeyRef{
+							Name: "premium",
+							Key:  modelID,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, r)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			By("Deleting the configmap resources")
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-classes-config",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err := k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "accelerator-unit-costs",
+					Namespace: "inferno-autoscaler-system",
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			}
+			err = k8sClient.Delete(ctx, configMap)
+			client.IgnoreNotFound(err)
+			Expect(err).NotTo(HaveOccurred())
+
+			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
+			err = k8sClient.List(ctx, &variantAutoscalingList)
+			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
+
+			var deploymentList appsv1.DeploymentList
+			err = k8sClient.List(ctx, &deploymentList, client.InNamespace("default"))
+			Expect(err).NotTo(HaveOccurred(), "Failed to list deployments")
+
+			// Clean up all deployments
+			for i := range deploymentList.Items {
+				deployment := &deploymentList.Items[i]
+				if strings.HasPrefix(deployment.Spec.Template.ObjectMeta.Labels["app"], "multi-test-resource") {
+					err = k8sClient.Delete(ctx, deployment)
+					client.IgnoreNotFound(err)
+					Expect(err).NotTo(HaveOccurred(), "Failed to delete deployment")
+				}
+			}
+
+			// Clean up all VariantAutoscaling resources
+			for i := range variantAutoscalingList.Items {
+				err = k8sClient.Delete(ctx, &variantAutoscalingList.Items[i])
+				client.IgnoreNotFound(err)
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete VariantAutoscaling resource")
+			}
+		})
+
+		It("should filter out VAs marked for deletion", func() {
+			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
+			err := k8sClient.List(ctx, &variantAutoscalingList)
+			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
+			filterActiveVariantAutoscalings(variantAutoscalingList.Items)
+			Expect(len(variantAutoscalingList.Items)).To(Equal(3), "All VariantAutoscaling resources should be active before deletion")
+
+			// Delete the VAs (this sets DeletionTimestamp)
+			for i := range totalVAs {
+				Expect(k8sClient.Delete(ctx, &variantAutoscalingList.Items[i])).To(Succeed())
+			}
+
+			err = k8sClient.List(ctx, &variantAutoscalingList)
+			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
+			filterActiveVariantAutoscalings(variantAutoscalingList.Items)
+			Expect(len(variantAutoscalingList.Items)).To(Equal(0), "No active VariantAutoscaling resources should be found")
+		})
+
+		It("should prepare active VAs for optimization", func() {
+			controllerReconciler := &VariantAutoscalingReconciler{
+				Client:  k8sClient,
+				Scheme:  k8sClient.Scheme(),
+				PromAPI: &mockPromAPI{}, // Add mock PromAPI
+			}
+
+			By("Reading the required configmaps")
+			accMap, err := controllerReconciler.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Failed to read accelerator config")
+			Expect(accMap).NotTo(BeNil(), "Accelerator config map should not be nil")
+
+			serviceClassMap, err := controllerReconciler.readServiceClassConfig(ctx, "service-classes-config", configMapNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Failed to read service class config")
+			Expect(serviceClassMap).NotTo(BeNil(), "Service class config map should not be nil")
+
+			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
+			err = k8sClient.List(ctx, &variantAutoscalingList)
+			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
+			activeVAs := filterActiveVariantAutoscalings(variantAutoscalingList.Items)
+			Expect(len(activeVAs)).To(Equal(totalVAs), "All VariantAutoscaling resources should be active")
+
+			// Prepare system data for VAs
+			By("Preparing the system data for optimization")
+			systemData := ctrlutils.CreateSystemData(accMap, serviceClassMap, dummyInventory)
+			Expect(systemData).NotTo(BeNil(), "System data should not be nil")
+
+			updateList, vaMap, allAnalyzerResponses, err := controllerReconciler.prepareVariantAutoscalings(ctx, activeVAs, accMap, serviceClassMap, systemData)
+
+			Expect(err).NotTo(HaveOccurred(), "prepareVariantAutoscalings should not return an error")
+			Expect(vaMap).NotTo(BeNil(), "VA map should not be nil")
+			Expect(allAnalyzerResponses).NotTo(BeNil(), "Analyzer responses should not be nil")
+			Expect(len(updateList.Items)).To(Equal(totalVAs), "UpdatedList should be the same number of all active VariantAutoscalings")
+
+			var vaNames []string
+			for _, va := range activeVAs {
+				vaNames = append(vaNames, va.Name)
+			}
+
+			for _, updatedVa := range updateList.Items {
+				Expect(vaNames).To(ContainElement(updatedVa.Name), fmt.Sprintf("Active VariantAutoscaling list should contain %s", updatedVa.Name))
+				Expect(updatedVa.Status.CurrentAlloc.Accelerator).To(Equal("A100"), fmt.Sprintf("Current Accelerator for %s should be \"A100\" after preparation", updatedVa.Name))
+				Expect(updatedVa.Status.CurrentAlloc.NumReplicas).To(Equal(1), fmt.Sprintf("Current NumReplicas for %s should be 1 after preparation", updatedVa.Name))
+				Expect(updatedVa.Status.DesiredOptimizedAlloc.Accelerator).To(BeEmpty(), fmt.Sprintf("Desired Accelerator for %s should be empty value after preparation", updatedVa.Name))
+				Expect(updatedVa.Status.DesiredOptimizedAlloc.NumReplicas).To(BeZero(), fmt.Sprintf("Desired NumReplicas for %s should be zero after preparation", updatedVa.Name))
+			}
 		})
 	})
 })


### PR DESCRIPTION
This PR aims to increase the test coverage for the Inferno-autoscaler components.
Tests can be run using the `make test` target.