### PR TITLE
consolidate yaml samples in markdown file

### DIFF
--- a/hack/samples/guidellm-sample.md
+++ b/hack/samples/guidellm-sample.md
@@ -1,0 +1,73 @@
+## Setting up GuideLLM load generator
+
+We use `guidellm` as the load generator and we run our load generator from a different pod within the same OpenShift cluster. 
+
+### Step 1 : Create an image
+First create a `Dockerfile`
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["tail", "-f", "/dev/null"]
+```
+
+Then create a `requirements.txt` with the following contents in the same directory as your `Dockerfile`
+```Plaintext
+guidellm
+```
+
+Build the image for the correct target CPU architecture. 
+You can get the architecture of the OpenShift node by `oc get nodes -o custom-columns=NAME:.metadata.name,ARCH:.status.nodeInfo.architecture`.
+In our case, it was `linux/amd64`
+```sh
+docker build --platform linux/amd64 -t <image-repo>:<tag> .
+```
+
+Push the image
+```sh
+docker push <image-repo>:<tag>
+```
+
+Make the image **public**.
+
+
+### Create Job
+Create a  load generator job (`oc apply -f guidellm-job.yaml`) based on the following template using the image created in step 1.
+```yaml
+# guidellm-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: guidellm-job
+  namespace: vllm-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: guidellm-benchmark-container
+        image: <image-repo>:<tag>
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: HF_HOME
+          value: "/tmp"
+        command: ["/usr/local/bin/guidellm"]
+        args:
+        - "benchmark"
+        - "--target"
+        - "http://vllm:8000"
+        - "--rate-type"
+        - "constant"
+        - "--rate"
+        - "<rate>"
+        - "--max-seconds"
+        - "<max-seconds>"
+        - "--model"
+        - "unsloth/Meta-Llama-3.1-8B"
+        - "--data"
+        - "prompt_tokens=128,output_tokens=512"
+        - "--output-path"
+        - "/tmp/benchmarks.json" 
+      restartPolicy: Never
+  backoffLimit: 4
+```

--- a/hack/samples/vllm-samples.md
+++ b/hack/samples/vllm-samples.md
@@ -1,0 +1,228 @@
+# vllm with wva autoscaler
+
+
+Notes: 
+1. The following describes setting up vllm deployment and a guidellm job on OpenShift cluster.
+2. We use  `vllm-test` namespace for vllm deployment components and the load generator jobs. If the namespace doesn't already exists, create one by running `oc create ns vllm-test`.
+
+## Setting up a vllm deployment and service
+The following is largely based on existing reference material with a few tweaks. 
+Refs:
+1. https://docs.vllm.ai/en/v0.9.2/deployment/k8s.html#deployment-with-gpus
+2. https://github.com/rh-aiservices-bu/llm-on-openshift/tree/main/llm-servers/vllm/gpu
+
+### Step 1: Create a PVC
+Create PVC (`oc apply -f vllm-deploy/pvc.yaml`) named `vllm-models-cache` with enough space to hold all the models you want to try.
+```yaml
+# pvc.ymal
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-models-cache
+  namespace: vllm-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi
+```
+Note: 
+A storage class field is not explicitly set in the provided yaml, and therefore the created pvc will be bound to the default storage class. To use another storage class, run  `oc get storageclass` to get the available options.
+Before proceeding to next steps, make sure that the `STATUS` of pvc is `BOUND`.
+
+### Step 2: Create a secret
+Secret is optional and only required for accessing gated models, you can skip this step if you are not using gated models.
+
+Run `oc apply -f vllm-deploy/secret.yaml`
+```yaml
+# secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token-secret
+  namespace: vllm-test
+type: Opaque
+stringData:
+  token: "<your-hf-token>"
+```
+
+### Step 3: Create deployment
+The following example deploys the `unsloth/Meta-Llama-3.1-8B` model with 1 replica. We use H100 GPUs for our deployments.
+
+Run `oc apply -f vllm-deploy/deployment.yaml`.
+```yaml
+# deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vllm
+  namespace: vllm-test
+  labels:
+    app: vllm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      affinity: {}
+      terminationGracePeriodSeconds: 120
+      securityContext: {}
+      containers:
+        - resources:
+            limits:
+              cpu: '8'
+              memory: 24Gi
+              nvidia.com/gpu: '1'
+            requests:
+              cpu: '6'
+              memory: 6Gi
+              nvidia.com/gpu: '1'
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 5
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: server
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 8
+            periodSeconds: 100
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: token
+            - name: HOME
+              value: /models-cache
+            - name: VLLM_PORT
+              value: "8000"
+          args: [
+            "vllm serve unsloth/Meta-Llama-3.1-8B --trust-remote-code --download-dir /models-cache --dtype float16"
+            ]
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 1
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 24
+          volumeMounts:
+            - name: models-cache
+              mountPath: /models-cache
+            - name: shm
+              mountPath: /dev/shm
+          terminationMessagePolicy: File
+          image: 'vllm/vllm-openai:latest'
+          command: ["/bin/sh","-c"]
+      volumes:
+        - name: models-cache
+          persistentVolumeClaim:
+            claimName: vllm-models-cache
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+      dnsPolicy: ClusterFirst
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+```
+
+Wait until the pod is in the `READY` state before proceeding to next steps.
+
+### Create a service
+Create a service to expose the vllm deployment: `oc apply -f vllm-deploy/service.yaml`
+```yaml
+# service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: vllm
+  namespace: vllm-test
+  labels:
+    app: vllm
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: http
+  selector:
+    app: vllm
+  type: ClusterIP   # default, enables load-balancing
+```
+
+Run `oc get service` to make sure that the service indeed has `CLUSTER-IP` set.
+
+### Create a ServiceMonitor
+We need service monitor to let Prometheus scrape vllm metrics: `oc apply -f vllm-deploy/service-monitor.yaml `
+```yaml
+# service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm-monitor
+  namespace: vllm-test
+  labels:
+    app: vllm
+    release: kube-prometheus-stack   
+spec:
+  selector:
+    matchLabels:
+      app: vllm
+  endpoints:
+  - port: http
+    interval: 15s
+    path: /metrics
+  namespaceSelector:
+    any: true
+```
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR addresses the review feedback on [PR #129](https://github.com/llm-d-incubation/inferno-autoscaler/pull/129) by splitting the samples from the collector changes. This PR focuses solely on the samples-related changes as requested.

All vllm sample YAML files, have been merged into a single, comprehensive markdown file `vllm-samples.md`.
This PR also adds a second markdown file `guidellm-sample.md` which describes creating a guidellm image and subsequently, provides yaml snippets to create a guidellm job. 
