### PR TITLE
Computing scaling decision based on ratio metric for HPA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ undeploy-inferno-on-kind:
 .PHONY: deploy-llm-d-inferno-emulated-on-kind
 deploy-llm-d-inferno-emulated-on-kind:
 	@echo ">>> Deploying integrated llm-d and Inferno-autoscaler (cluster args: $(KIND_ARGS), image: $(IMG))"
-	export KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) && \
-		hack/deploy-llm-d-inferno-emulated-on-kind.sh $(KIND_ARGS)
+	export KIND=$(KIND) KUBECTL=$(KUBECTL) && \
+		hack/deploy-llm-d-inferno-emulated-on-kind.sh $(KIND_ARGS) -i $(IMG)
 
 ## Deploy Inferno Autoscaler to OpenShift cluster with specified image.
 .PHONY: deploy-inferno-on-openshift

--- a/config/samples/hpa-integration.yaml
+++ b/config/samples/hpa-integration.yaml
@@ -12,13 +12,13 @@ spec:
   maxReplicas: 10
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 0
+      stabilizationWindowSeconds: 45
       policies:
       - type: Pods
         value: 10
         periodSeconds: 15
     scaleDown:
-      stabilizationWindowSeconds: 0
+      stabilizationWindowSeconds: 45
       policies:
       - type: Pods
         value: 10
@@ -27,10 +27,10 @@ spec:
   - type: External
     external:
       metric:
-        name: inferno_desired_replicas
+        name: inferno_desired_ratio
         selector:
           matchLabels:
             variant_name: vllme-deployment
       target:
-        type: AverageValue
-        averageValue: "1"
+        type: Value
+        value: "1"

--- a/config/samples/prometheus-adapter-values.yaml
+++ b/config/samples/prometheus-adapter-values.yaml
@@ -4,15 +4,15 @@ prometheus:
 
 rules:
   external:
-  - seriesQuery: 'inferno_desired_replicas{variant_name!="",exported_namespace!=""}'
+  - seriesQuery: 'inferno_desired_ratio{variant_name!="",exported_namespace!=""}'
     resources:
       overrides:
         exported_namespace: {resource: "namespace"}
         variant_name: {resource: "deployment"}  
     name:
-      matches: "^inferno_desired_replicas"
-      as: "inferno_desired_replicas"
-    metricsQuery: 'inferno_desired_replicas{<<.LabelMatchers>>}'
+      matches: "^inferno_desired_ratio"
+      as: "inferno_desired_ratio"
+    metricsQuery: 'inferno_desired_ratio{<<.LabelMatchers>>}'
 
 replicas: 2
 logLevel: 4

--- a/docs/custom-metrics.md
+++ b/docs/custom-metrics.md
@@ -19,7 +19,7 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
   - `accelerator_type`: Type of accelerator being used
-- **Use Case**: Monitor current scaling state
+- **Use Case**: Monitor current number of replicas per variant
 
 ### `inferno_desired_replicas`
 - **Type**: Gauge
@@ -28,7 +28,16 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
   - `variant_name`: Name of the variant
   - `namespace`: Kubernetes namespace
   - `accelerator_type`: Type of accelerator being used
-- **Use Case**: Compare desired vs current replicas to detect scaling issues
+- **Use Case**: Expose the desired optimized number of replicas per variant
+
+### `inferno_desired_ratio`
+- **Type**: Gauge
+- **Description**: Ratio of the desired number of replicas and the current number of replicas for each variant
+- **Labels**:
+  - `variant_name`: Name of the variant
+  - `namespace`: Kubernetes namespace
+  - `accelerator_type`: Type of accelerator being used
+- **Use Case**: Compare the desired and current number of replicas per variant, for scaling purposes
 
 ### `inferno_replica_scaling_total`
 - **Type**: Counter

--- a/hack/deploy-llm-d-inferno-emulated-on-kind.sh
+++ b/hack/deploy-llm-d-inferno-emulated-on-kind.sh
@@ -23,7 +23,7 @@ print_help() {
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-  -i, --inferno-image IMAGE   Container image to use for the Inferno-autoscaler (default: quay.io/infernoautoscaler/inferno-controller:0.0.1-multi-arch)
+  -i, --inferno-image IMAGE    Container image to use for the Inferno-autoscaler (default: quay.io/infernoautoscaler/inferno-controller:0.0.1-multi-arch)
   -n, --nodes NUM              Number of nodes for KIND cluster (default: 4)
   -g, --gpus NUM               Number of GPUs per node (default: 5)  
   -t, --type TYPE              GPU type: nvidia, amd, intel, or mix (default: nvidia)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,6 +12,7 @@ var (
 	replicaScalingTotal *prometheus.CounterVec
 	desiredReplicas     *prometheus.GaugeVec
 	currentReplicas     *prometheus.GaugeVec
+	desiredRatio        *prometheus.GaugeVec
 )
 
 // InitMetrics registers all custom metrics with the provided registry
@@ -37,6 +38,13 @@ func InitMetrics(registry prometheus.Registerer) error {
 		},
 		[]string{"variant_name", "namespace", "accelerator_type"},
 	)
+	desiredRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "inferno_desired_ratio",
+			Help: "Ratio of the desired number of replicas and the current number of replicas for each variant",
+		},
+		[]string{"variant_name", "namespace", "accelerator_type"},
+	)
 
 	// Register metrics with the registry
 	if err := registry.Register(replicaScalingTotal); err != nil {
@@ -47,6 +55,9 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(currentReplicas); err != nil {
 		return fmt.Errorf("failed to register currentReplicas metric: %w", err)
+	}
+	if err := registry.Register(desiredRatio); err != nil {
+		return fmt.Errorf("failed to register desiredRatio metric: %w", err)
 	}
 
 	return nil
@@ -96,11 +107,12 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 	}
 
 	// These operations are local and should never fail, but we handle errors for debugging
-	if currentReplicas == nil || desiredReplicas == nil {
+	if currentReplicas == nil || desiredReplicas == nil || desiredRatio == nil {
 		return fmt.Errorf("replica metrics not initialized")
 	}
 
 	currentReplicas.With(baseLabels).Set(float64(current))
 	desiredReplicas.With(baseLabels).Set(float64(desired))
+	desiredRatio.With(baseLabels).Set(float64(desired) / float64(current))
 	return nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 
 	// Deploy llm-d and Inferno-autoscaler on the Kind cluster
 	By("deploying llm-d and Inferno-autoscaler on Kind")
-	launchCmd := exec.Command("make", "deploy-llm-d-inferno-emulated-on-kind", fmt.Sprintf("KIND_ARGS=-n %d -g %d -t %s -i %s", numNodes, maximumAvailableGPUs, gpuTypes, projectImage))
+	launchCmd := exec.Command("make", "deploy-llm-d-inferno-emulated-on-kind", fmt.Sprintf("KIND_ARGS=-n %d -g %d -t %s", numNodes, maximumAvailableGPUs, gpuTypes), fmt.Sprintf("IMG=%s", projectImage))
 	_, err = utils.Run(launchCmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install llm-d and Inferno-autoscaler")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -445,7 +445,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", va.Name, va.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			currentReplicasProm, desiredReplicasProm, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
+			currentReplicasProm, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			g.Expect(desiredReplicasProm).To(BeNumerically(">", 1),
@@ -574,7 +574,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 				fmt.Sprintf("DesiredOptimizedAlloc for VA %s should stay at %d replicas with constant load equal to %s", deployName, initialDesiredReplicas, va.Status.CurrentAlloc.Load.ArrivalRate))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicasProm, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -653,7 +653,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 				fmt.Sprintf("No load should trigger scale-down recommendation for: %s", va.Name))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicasProm, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1046,7 +1046,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s", va1.Name))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1065,7 +1065,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s", va2.Name))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas2, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1225,7 +1225,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", firstDeployName, va1.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1244,7 +1244,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", secondDeployName, va2.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas2, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1345,7 +1345,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("No load should trigger scale-down recommendation for VA: %s - actual replicas: %d", firstDeployName, va1.Status.CurrentAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1364,7 +1364,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", secondDeployName, va2.Status.CurrentAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas2, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
+			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.CurrentAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result


### PR DESCRIPTION
This PR aims to add the new `inferno_desired_ratio` metric, that the Inferno-autoscaler will emit for each variant, computed as  the optimized desired number of replicas for the same VA divided by the current number of replicas for the VA:

`inferno_desired_ratio` = $\frac{desiredReplicas}{currentReplicas}$ 

This is needed to work with HPA on a `per variant` logic, rather than a `per pod` logic, aiming to possibly target other `scale` resources in the future (e.g. `LeaderWorkerSets`).
It also includes changes to the HPA documentation and samples.

Minor fixes to the `deploy-llm-d-inferno-emulate-on-kind` target were done to be coherent with the other Make targets.