### PR TITLE
Add option to scale number of replicas to zero

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -27,4 +27,7 @@ data:
   # PROMETHEUS_TOKEN_PATH: "/path/to/token/file"        # Path to bearer token file (production with mounted secrets)
   
   # Optimization configuration
-  GLOBAL_OPT_INTERVAL: "60s" 
+  GLOBAL_OPT_INTERVAL: "60s"
+
+  # Option to scale variants to zero replicas (default: true)
+  SCALE_TO_ZERO: "true"

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -30,4 +30,4 @@ data:
   GLOBAL_OPT_INTERVAL: "60s"
 
   # Option to scale variants to zero replicas (default: true)
-  SCALE_TO_ZERO: "true"
+  WVA_SCALE_TO_ZERO: "true"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,11 +80,11 @@ spec:
                 key: PROMETHEUS_TLS_INSECURE_SKIP_VERIFY
           - name: PROMETHEUS_TOKEN_PATH
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-          - name: SCALE_TO_ZERO
+          - name: WVA_SCALE_TO_ZERO
             valueFrom:
               configMapKeyRef:
                 name: variantautoscaling-config
-                key: SCALE_TO_ZERO
+                key: WVA_SCALE_TO_ZERO
         name: manager
         ports: []
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,6 +80,11 @@ spec:
                 key: PROMETHEUS_TLS_INSECURE_SKIP_VERIFY
           - name: PROMETHEUS_TOKEN_PATH
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          - name: SCALE_TO_ZERO
+            valueFrom:
+              configMapKeyRef:
+                name: variantautoscaling-config
+                key: SCALE_TO_ZERO
         name: manager
         ports: []
         securityContext:

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -34,7 +34,7 @@ func (a *Actuator) getCurrentDeploymentReplicas(ctx context.Context, va *llmdOpt
 	}
 
 	// Prefer status replicas (actual current state)
-	if deploy.Status.Replicas > 0 {
+	if deploy.Status.Replicas >= 0 {
 		return deploy.Status.Replicas, nil
 	}
 

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -49,7 +49,7 @@ func (a *Actuator) getCurrentDeploymentReplicas(ctx context.Context, va *llmdOpt
 
 func (a *Actuator) EmitMetrics(ctx context.Context, VariantAutoscaling *llmdOptv1alpha1.VariantAutoscaling) error {
 	// Emit replica metrics with real-time data for external autoscalers
-	if VariantAutoscaling.Status.DesiredOptimizedAlloc.NumReplicas > 0 {
+	if VariantAutoscaling.Status.DesiredOptimizedAlloc.NumReplicas >= 0 {
 
 		// Get real current replicas from Deployment (not stale VariantAutoscaling status)
 		currentReplicas, err := a.getCurrentDeploymentReplicas(ctx, VariantAutoscaling)

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -99,6 +99,10 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
+	if os.Getenv("SCALE_TO_ZERO") != "false" {
+		logger.Log.Info("Scaling to zero is enabled!")
+	}
+
 	// TODO: decide on whether to keep accelerator properties (device name, cost) in same configMap, provided by administrator
 	acceleratorCm, err := r.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
 	if err != nil {

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -99,7 +99,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	if os.Getenv("SCALE_TO_ZERO") != "false" {
+	if os.Getenv("WVA_SCALE_TO_ZERO") != "false" {
 		logger.Log.Info("Scaling to zero is enabled!")
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -268,7 +268,7 @@ func AddServerInfoToSystemData(
 
 	// all server data
 	minNumReplicas := 0 // default is to scale to zero
-	if os.Getenv("SCALE_TO_ZERO") == "false" {
+	if os.Getenv("WVA_SCALE_TO_ZERO") == "false" {
 		minNumReplicas = 1
 	}
 	serverSpec := &infernoConfig.ServerSpec{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -267,12 +267,16 @@ func AddServerInfoToSystemData(
 	}
 
 	// all server data
+	minNumReplicas := 0 // default is to scale to zero
+	if os.Getenv("SCALE_TO_ZERO") == "false" {
+		minNumReplicas = 1
+	}
 	serverSpec := &infernoConfig.ServerSpec{
 		Name:            FullName(va.Name, va.Namespace),
 		Class:           className,
 		Model:           va.Spec.ModelID,
 		KeepAccelerator: true,
-		MinNumReplicas:  1,
+		MinNumReplicas:  minNumReplicas,
 		CurrentAlloc:    *AllocationData,
 		DesiredAlloc:    infernoConfig.AllocationData{},
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -640,12 +640,6 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 
 		var desiredReplicasProm float64
 		By("waiting for scaling down decision to be made")
-		// Check if SCALE TO ZERO is configured
-		minNumReplicas := 0
-		configMap, _ := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, "inferno-autoscaler-variantautoscaling-config", metav1.GetOptions{})
-		if configMap.Data["SCALE_TO_ZERO"] == "false" {
-			minNumReplicas = 1
-		}
 		Eventually(func(g Gomega) {
 			va := &v1alpha1.VariantAutoscaling{}
 			err := crClient.Get(ctx, client.ObjectKey{
@@ -654,8 +648,8 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 			}, va)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to fetch VariantAutoscaling for: %s", deployName))
 
-			// Verify that the number of replicas has scaled down to minimum number of replicas
-			g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(Equal(minNumReplicas),
+			// Verify that the number of replicas has scaled down to 0
+			g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", 0),
 				fmt.Sprintf("No load should trigger scale-down recommendation for: %s", va.Name))
 
 			// Verify Prometheus replica metrics
@@ -1346,8 +1340,8 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 			}, va1)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to fetch VariantAutoscaling for: %s", firstDeployName))
 
-			// Verify that the number of replicas has scaled down to 1
-			g.Expect(va1.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", 1),
+			// Verify that the number of replicas has scaled down to 0
+			g.Expect(va1.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", 0),
 				fmt.Sprintf("No load should trigger scale-down recommendation for VA: %s - actual replicas: %d", firstDeployName, va1.Status.CurrentAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
@@ -1365,8 +1359,8 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - multiple VAs -
 			}, va2)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to fetch VariantAutoscaling for: %s", secondDeployName))
 
-			// Verify that the number of replicas has scaled down to 1
-			g.Expect(va2.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", 1),
+			// Verify that the number of replicas has scaled down to 0
+			g.Expect(va2.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", 0),
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", secondDeployName, va2.Status.CurrentAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -640,7 +640,7 @@ var _ = Describe("Test Inferno-autoscaler with vllme deployment - single VA - cr
 
 		var desiredReplicasProm float64
 		// Check if SCALE TO ZERO is configured
-		var minNumReplicas int = 0
+		minNumReplicas := 0
 		configMap, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, "inferno-autoscaler-variantautoscaling-config", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "ConfigMap should exist")
 		if configMap.Data["SCALE_TO_ZERO"] == "false" {


### PR DESCRIPTION
- This PR is about adding support to the WVA to scale down the number of replicas of a variant to zero, as opposed to the current minimum of one.
- Scaling to zero occurs when there is no request traffic to a variant.
- A configuration boolean environment variable `WVA_SCALE_TO_ZERO` is added to the `variantautoscaling-config` map, with a default value `true`.
- **The default behavior is scale to zero enabled**. If not desired, `WVA_SCALE_TO_ZERO` has to be set to `false`.
- Scaling up from zero is not addressed by this PR.