### PR TITLE
Directly referencing the internal optimizer code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ godebug default=go1.23
 toolchain go1.23.10
 
 require (
-	github.com/llm-d-incubation/inferno-autoscaler/hack/inferno v0.0.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/stretchr/testify v1.10.0
@@ -104,5 +103,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/llm-d-incubation/inferno-autoscaler/hack/inferno => ./hack/inferno

--- a/hack/inferno/go.mod
+++ b/hack/inferno/go.mod
@@ -1,3 +1,0 @@
-module github.com/llm-d-incubation/inferno-autoscaler/hack/inferno
-
-go 1.23.0

--- a/hack/inferno/go.sum
+++ b/hack/inferno/go.sum
@@ -1,2 +1,0 @@
-github.com/llm-d-incubation/inferno-autoscaler v0.0.0-20250917181728-5f34f062693c h1:R2CauUyFv0gKts4N/fCSdmQUjO75/ZgxeDh45Ckk7Gs=
-github.com/llm-d-incubation/inferno-autoscaler v0.0.0-20250917181728-5f34f062693c/go.mod h1:EEoq3mvH2Ce71kmPK5NMmgD9XRZkXLkxDpQ0AfzvCqE=


### PR DESCRIPTION
This PR changes the main `go.mod` to directly reference the internal optimizer code, rather than creating a new module for it.