### PR TITLE
Removing unsupported architectures from image multi-arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-# Supported platforms: linux/amd64, linux/arm64
 PLATFORMS ?= linux/arm64,linux/amd64 
 BUILDER_NAME ?= workload-variant-autoscaler-builder
 


### PR DESCRIPTION
This PR removes architectures `linux/s390x, linux/ppc64le` from the multi-architecture image build from the `make docker-buildx` target.