### PR TITLE
add cafile trust stanza

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-servicemonitor.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-servicemonitor.yaml
@@ -18,6 +18,9 @@ spec:
         key: token
       tlsConfig:
         insecureSkipVerify: {{ if and .Values.wva.prometheus.tls (hasKey .Values.wva.prometheus.tls "insecureSkipVerify") }}{{ .Values.wva.prometheus.tls.insecureSkipVerify }}{{ else }}true{{ end }}
+        {{- if and .Values.wva.prometheus.caCert (or (not .Values.wva.prometheus.tls) (not (hasKey .Values.wva.prometheus.tls "insecureSkipVerify")) (not .Values.wva.prometheus.tls.insecureSkipVerify)) }}
+        caFile: /etc/ssl/certs/prometheus-ca.crt
+        {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
- When **wva.prometheus.caCert** is set on openshift and TLS verification is enabled, Prometheus relies on that caFile to trust WVA’s certificate. Without it the scrape fails, leading to missing metrics. This stanza keeps dev/test behavior unchanged (because the block is gated behind the existing condition) while ensuring production clusters keep working