### PR TITLE
Changes to crd to support saturation based scaling

### DIFF
--- a/api/v1alpha1/variantautoscaling_types.go
+++ b/api/v1alpha1/variantautoscaling_types.go
@@ -12,13 +12,11 @@ type VariantAutoscalingSpec struct {
 	ModelID string `json:"modelID"`
 	//TODO: remove this
 	// SLOClassRef references the ConfigMap key containing Service Level Objective (SLO) configuration.
-	// +optional
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	SLOClassRef ConfigMapKeyRef `json:"sloClassRef"`
 
 	// ModelProfile provides resource and performance characteristics for the model variant.
-	// +optional
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	ModelProfile ModelProfile `json:"modelProfile"`
 }
 
@@ -43,12 +41,10 @@ type ModelProfile struct {
 type PerfParms struct {
 	// DecodeParms contains parameters for the decode phase (ITL calculation)
 	// Expected keys: "alpha", "beta" for equation: itl = alpha + beta * maxBatchSize
-	// +optional
 	// +kubebuilder:validation:MinProperties=1
 	DecodeParms map[string]string `json:"decodeParms"`
 	// PrefillParms contains parameters for the prefill phase (TTFT calculation)
 	// Expected keys: "gamma", "delta" for equation: ttft = gamma + delta * tokens * maxBatchSize
-	// +optional
 	// +kubebuilder:validation:MinProperties=1
 	PrefillParms map[string]string `json:"prefillParms"`
 }
@@ -65,6 +61,7 @@ type AcceleratorProfile struct {
 	AccCount int `json:"accCount"`
 
 	// PerParms specifies the prefill and decode parameters for ttft and itl models
+	// +kubebuilder:validation:Optional
 	PerfParms PerfParms `json:"perfParms,omitempty"`
 
 	// MaxBatchSize is the maximum batch size supported by the accelerator.
@@ -76,6 +73,7 @@ type AcceleratorProfile struct {
 // including the current allocation, desired optimized allocation, and actuation status.
 type VariantAutoscalingStatus struct {
 	// CurrentAlloc specifies the current resource allocation for the variant.
+	// +kubebuilder:validation:Optional
 	CurrentAlloc Allocation `json:"currentAlloc,omitempty"`
 
 	// DesiredOptimizedAlloc indicates the target optimized allocation based on autoscaling logic.
@@ -85,7 +83,7 @@ type VariantAutoscalingStatus struct {
 	Actuation ActuationStatus `json:"actuation,omitempty"`
 
 	// Conditions represent the latest available observations of the VariantAutoscaling's state
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/config/crd/bases/llmd.ai_variantautoscalings.yaml
+++ b/config/crd/bases/llmd.ai_variantautoscalings.yaml
@@ -115,6 +115,9 @@ spec:
                                 Expected keys: "gamma", "delta" for equation: ttft = gamma + delta * tokens * maxBatchSize
                               minProperties: 1
                               type: object
+                          required:
+                          - decodeParms
+                          - prefillParms
                           type: object
                       required:
                       - acc
@@ -144,8 +147,6 @@ spec:
                 type: object
             required:
             - modelID
-            - modelProfile
-            - sloClassRef
             type: object
           status:
             description: Status represents the current status of autoscaling for the

--- a/docs/user-guide/crd-reference.md
+++ b/docs/user-guide/crd-reference.md
@@ -30,7 +30,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `acc` _string_ | Acc specifies the type or name of the accelerator (e.g., GPU type). |  | MinLength: 1 <br /> |
 | `accCount` _integer_ | AccCount specifies the number of accelerator units to be used. |  | Minimum: 1 <br /> |
-| `perfParms` _[PerfParms](#perfparms)_ | PerParms specifies the prefill and decode parameters for ttft and itl models |  |  |
+| `perfParms` _[PerfParms](#perfparms)_ | PerParms specifies the prefill and decode parameters for ttft and itl models |  | Optional: \{\} <br /> |
 | `maxBatchSize` _integer_ | MaxBatchSize is the maximum batch size supported by the accelerator. |  | Minimum: 1 <br /> |
 
 
@@ -218,8 +218,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `modelID` _string_ | ModelID specifies the unique identifier of the model to be autoscaled. |  | MinLength: 1 <br />Required: \{\} <br /> |
-| `sloClassRef` _[ConfigMapKeyRef](#configmapkeyref)_ | SLOClassRef references the ConfigMap key containing Service Level Objective (SLO) configuration. |  | Required: \{\} <br /> |
-| `modelProfile` _[ModelProfile](#modelprofile)_ | ModelProfile provides resource and performance characteristics for the model variant. |  | Required: \{\} <br /> |
+| `sloClassRef` _[ConfigMapKeyRef](#configmapkeyref)_ | SLOClassRef references the ConfigMap key containing Service Level Objective (SLO) configuration. |  | Optional: \{\} <br /> |
+| `modelProfile` _[ModelProfile](#modelprofile)_ | ModelProfile provides resource and performance characteristics for the model variant. |  | Optional: \{\} <br /> |
 
 
 #### VariantAutoscalingStatus
@@ -236,9 +236,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `currentAlloc` _[Allocation](#allocation)_ | CurrentAlloc specifies the current resource allocation for the variant. |  |  |
+| `currentAlloc` _[Allocation](#allocation)_ | CurrentAlloc specifies the current resource allocation for the variant. |  | Optional: \{\} <br /> |
 | `desiredOptimizedAlloc` _[OptimizedAlloc](#optimizedalloc)_ | DesiredOptimizedAlloc indicates the target optimized allocation based on autoscaling logic. |  |  |
 | `actuation` _[ActuationStatus](#actuationstatus)_ | Actuation provides details about the actuation process and its current status. |  |  |
-| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | Conditions represent the latest available observations of the VariantAutoscaling's state |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | Conditions represent the latest available observations of the VariantAutoscaling's state |  | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
Make perf params options and add TODO to remove CRD section. At this point, the changes are minimal to minimize churn.