### PR TITLE
turn ci e2e off

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -37,6 +37,8 @@ jobs:
       # - name: Run precommit checks
       #   run: make precommit
       
+      # TODO: Re-enable e2e tests once they are updated and stable
+      # E2E tests are temporarily disabled. Uncomment the following to re-enable:
       # - name: Run make test-e2e
       #   shell: bash
       #   run: |


### PR DESCRIPTION
Turning the e2es off in CI temporarily, until the e2es are updated with new capacity work. 