### PR TITLE
Capacity documentation update

### DIFF
--- a/docs/capacity-scaling-config.md
+++ b/docs/capacity-scaling-config.md
@@ -136,11 +136,8 @@ saturationDetector:
   ...
   queueDepthThreshold: 5          # Default: 5 - Backend waiting queue size threshold
   kvCacheUtilThreshold: 0.8       # Default: 0.8 - KV cache utilization threshold (0.0-1.0)
-  metricsStalenessThreshold: 200ms # Default: 200ms - Maximum age for pod metrics
   ...
 ```
-
-**Purpose**: Monitors three metrics from inference servers (backend queue size, KV cache utilization, metrics staleness) to determine saturation status. When saturation is detected, sheddable requests are dropped.
 
 **Configuration Notes**:
 - All parameters are optional; omitting them applies the documented defaults
@@ -154,7 +151,6 @@ saturationDetector:
 |---------|-----------|-----------|-----------------|-------------|
 | **KV Cache Saturation** | `kvCacheThreshold` | `kvCacheUtilThreshold` | **0.80** (80%) | Replica is saturated when KV cache ≥ threshold |
 | **Queue Saturation** | `queueLengthThreshold` | `queueDepthThreshold` | **5** | Replica is saturated when queue length ≥ threshold |
-| **Metrics Freshness** | *(not configurable)* | `metricsStalenessThreshold` | **200ms** | EPP-only: Maximum metric age before considering stale |
 | **Scale-Up Trigger (KV)** | `kvSpareTrigger` | *(not applicable)* | **0.10** (10%) | WVA-only: Trigger scale-up when spare KV < threshold |
 | **Scale-Up Trigger (Queue)** | `queueSpareTrigger` | *(not applicable)* | **3** | WVA-only: Trigger scale-up when spare queue < threshold |
 


### PR DESCRIPTION
WHAT:
- Simplified capacity-scaling-config.md to focus on EPP saturationDetector configuration, aligned with gateway-api-inference-extension reference

WHY:
- Provide clear guidance on coordinating WVA and EPP threshold configuration
- Focus on the three key saturation detector thresholds that matter for capacity-based scaling

HOW:
- Removed verbose EPP plugin and profile configuration sections
- Added concise EPP Configuration Overview with three main sections:
  1. Saturation Detector - Monitors cluster overload (relevant for WVA alignment)
  2. Scheduling Plugins - Request routing logic
  3. Scheduling Profiles - Weighted combinations of scoring plugins
- Focused saturationDetector section on three key thresholds:
  * queueDepthThreshold (5) - Backend waiting queue size threshold
  * kvCacheUtilThreshold (0.8) - KV cache utilization threshold
  * metricsStalenessThreshold (200ms) - Maximum age for pod metrics
- Added configuration notes:
  * All parameters are optional with documented defaults
  * EPP configuration is read only on startup (requires pod restart)
  * Unlike WVA, EPP does not currently support live ConfigMap updates

VERIFICATION:
- Documentation now accurately reflects upstream EPP saturation detector configuration from gateway-api-inference-extension project

Refs: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/epp-configuration/config-text.md