### PR TITLE
Enabling status updates for model-only optimization

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -245,6 +245,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		var finalDecisions []interfaces.VariantDecision
 
 		modelBasedTargets := make(map[string]int)
+		var updateList *llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
 		if enableModelOptimizer {
 			// Read configs needed for model-based optimizer
 			acceleratorCm, err := r.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
@@ -281,7 +282,9 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 			// Create system data and run optimizer
 			systemData := utils.CreateSystemData(acceleratorCm, serviceClassCm)
-			updateList, prepareVaMap, allAnalyzerResponses, err := r.prepareVariantAutoscalings(ctx, modelVAs, acceleratorCm, serviceClassCm, systemData)
+			var prepareVaMap map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling
+			var allAnalyzerResponses map[string]*interfaces.ModelAnalyzeResponse
+			updateList, prepareVaMap, allAnalyzerResponses, err = r.prepareVariantAutoscalings(ctx, modelVAs, acceleratorCm, serviceClassCm, systemData)
 			if err != nil {
 				logger.Log.Errorf("Failed to prepare variant autoscalings: %v", err)
 				errorCount++
@@ -374,10 +377,28 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		} else if enableModelOptimizer {
 			// MODEL-ONLY MODE: Capacity-based failed but model-based succeeded, or capacity analysis unavailable - use model-based only
+			// If prepareVariantAutoscalings failed for all VariantAutoscalings, updateList.Items will be empty
+			if updateList == nil || len(updateList.Items) == 0 {
+				logger.Log.Warnf("Model-only optimization: no VAs prepared, activating safety net: modelID=%s", modelID)
+				r.emitSafetyNetMetrics(ctx, modelVAs)
+				continue
+			}
+
 			logger.Log.Warnf("Capacity analysis unavailable, using model-based targets only: modelID=%s", modelID)
-			for _, va := range modelVAs {
+			for i := range updateList.Items {
+				va := &updateList.Items[i]
 				if targetReplicas, ok := modelBasedTargets[va.Name]; ok {
 					currentReplicas := va.Status.CurrentAlloc.NumReplicas
+
+					// Get accelerator name from current allocation
+					acceleratorName := va.Status.CurrentAlloc.Accelerator
+					if acceleratorName == "" {
+						// Fallback to label if not found
+						logger.Log.Debugf("Accelerator not found in CurrentAlloc, using label: va=%s", va.Name)
+						if acceleratorName = va.Labels["inference.optimization/acceleratorName"]; acceleratorName == "" {
+							logger.Log.Warnf("Accelerator label not found, empty acceleratorName: va=%s", va.Name)
+						}
+					}
 
 					var action interfaces.CapacityAction
 					switch {
@@ -393,13 +414,17 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 						VariantName:        va.Name,
 						Namespace:          va.Namespace,
 						ModelID:            modelID,
+						AcceleratorName:    acceleratorName,
 						CurrentReplicas:    currentReplicas,
 						TargetReplicas:     targetReplicas,
 						Action:             action,
 						ModelBasedDecision: true,
 						CapacityBased:      false,
+						CapacityOnly:       false,
 						Reason:             "model-based only (capacity unavailable)",
 					})
+
+					vaMap[va.Name] = va
 				}
 			}
 		}


### PR DESCRIPTION
This PR aims at provide a fix for the status update failures when `model-only` optimization is enabled.
The issue is detailed at #324.

## Testing

Scale down:
```
{"level":"INFO","ts":"2025-11-26T16:18:49.630Z","msg":"Operating in MODEL-ONLY mode: model-based optimization only"}
{"level":"INFO","ts":"2025-11-26T16:18:49.630Z","msg":"Grouped VAs by model: modelCount=1, totalVAs=1"}
{"level":"INFO","ts":"2025-11-26T16:18:49.630Z","msg":"Processing model: modelID=unsloth/Meta-Llama-3.1-8B, variantCount=1"}
{"level":"INFO","ts":"2025-11-26T16:18:49.630Z","msg":"Found SLO for model: model=unsloth/Meta-Llama-3.1-8B, class=Premium, slo-tpot=10, slo-ttft=1000"}
{"level":"DEBUG","ts":"2025-11-26T16:18:49.639Z","msg":"Optimization solution - system: Solution: \ns=ms-inference-scheduling-llm-d-modelservice-decode:llm-d-inference-scheduler; c=Premium; m=unsloth/Meta-Llama-3.1-8B; rate=0; inTk=0; outTk=0; sol=1, sat=false, alloc={acc=H100; numRep=1; maxBatch=512; cost=100, val=-100, itl=7.514, ttft=15.415337, rho=0, maxRPM=676453.25}; slo-itl=10, slo-ttft=1000, slo-tps=0 \nAllocationByType: \nname=NVIDIA-H100-80GB-HBM3, count=1, limit=0, cost=100 \ntotalCost=100 \n"}
{"level":"DEBUG","ts":"2025-11-26T16:18:49.639Z","msg":"Setting accelerator name Name H100allocationData {H100 1 512 100 7.514 15.415337 {0 0 0}}"}
{"level":"INFO","ts":"2025-11-26T16:18:49.639Z","msg":"Model-based optimization completed for model: unsloth/Meta-Llama-3.1-8B - model-based targets: map[ms-inference-scheduling-llm-d-modelservice-decode:1]"}
{"level":"WARN","ts":"2025-11-26T16:18:49.639Z","msg":"Capacity analysis unavailable, using model-based targets only: modelID=unsloth/Meta-Llama-3.1-8B"}
{"level":"INFO","ts":"2025-11-26T16:18:49.639Z","msg":"Applying scaling decisions: totalDecisions=1"}
{"level":"INFO","ts":"2025-11-26T16:18:49.639Z","msg":"Processing decision: variant=ms-inference-scheduling-llm-d-modelservice-decode, action=scale-down, current=2→target=1"}
{"level":"DEBUG","ts":"2025-11-26T16:18:49.639Z","msg":"Found VA in map: variant=ms-inference-scheduling-llm-d-modelservice-decode, hasCurrentAlloc=true, accelerator=H100"}
{"level":"INFO","ts":"2025-11-26T16:18:49.639Z","msg":"EmitReplicaMetrics completed - variant: ms-inference-scheduling-llm-d-modelservice-decode, current-replicas: 2, desired-replicas: 1, accelerator: H100"}
{"level":"INFO","ts":"2025-11-26T16:18:49.639Z","msg":"Successfully emitted metrics for external autoscalers: variant=ms-inference-scheduling-llm-d-modelservice-decode, targetReplicas=1, accelerator=H100, capacityOnly=false"}
{"level":"INFO","ts":"2025-11-26T16:18:49.644Z","msg":"Applied capacity decision: variant=ms-inference-scheduling-llm-d-modelservice-decode, action=scale-down, current=2, target=1, reason=model-based only (capacity unavailable)"}
{"level":"INFO","ts":"2025-11-26T16:18:49.644Z","msg":"Reconciliation completed successfully: mode=model-only, modelsProcessed=1, decisionsApplied=1"}
```

And scale-up:
```
{"level":"INFO","ts":"2025-11-26T16:24:49.811Z","msg":"Operating in MODEL-ONLY mode: model-based optimization only"}
{"level":"INFO","ts":"2025-11-26T16:24:49.811Z","msg":"Grouped VAs by model: modelCount=1, totalVAs=1"}
{"level":"INFO","ts":"2025-11-26T16:24:49.811Z","msg":"Processing model: modelID=unsloth/Meta-Llama-3.1-8B, variantCount=1"}
{"level":"INFO","ts":"2025-11-26T16:24:49.811Z","msg":"Found SLO for model: model=unsloth/Meta-Llama-3.1-8B, class=Premium, slo-tpot=10, slo-ttft=1000"}
{"level":"DEBUG","ts":"2025-11-26T16:24:49.834Z","msg":"Optimization solution - system: Solution: \ns=ms-inference-scheduling-llm-d-modelservice-decode:llm-d-inference-scheduler; c=Premium; m=unsloth/Meta-Llama-3.1-8B; rate=1572.55; inTk=244; outTk=434; sol=1, sat=false, alloc={acc=H100; numRep=3; maxBatch=512; cost=300, val=200, itl=9.022856, ttft=18.317007, rho=0.06697694, maxRPM=779.28613}; slo-itl=10, slo-ttft=1000, slo-tps=0 \nAllocationByType: \nname=NVIDIA-H100-80GB-HBM3, count=3, limit=0, cost=300 \ntotalCost=300 \n"}
{"level":"DEBUG","ts":"2025-11-26T16:24:49.835Z","msg":"Setting accelerator name Name H100allocationData {H100 3 512 300 9.022856 18.317007 {1572.55 244 434}}"}
{"level":"INFO","ts":"2025-11-26T16:24:49.835Z","msg":"Model-based optimization completed for model: unsloth/Meta-Llama-3.1-8B - model-based targets: map[ms-inference-scheduling-llm-d-modelservice-decode:3]"}
{"level":"WARN","ts":"2025-11-26T16:24:49.835Z","msg":"Capacity analysis unavailable, using model-based targets only: modelID=unsloth/Meta-Llama-3.1-8B"}
{"level":"INFO","ts":"2025-11-26T16:24:49.835Z","msg":"Applying scaling decisions: totalDecisions=1"}
{"level":"INFO","ts":"2025-11-26T16:24:49.835Z","msg":"Processing decision: variant=ms-inference-scheduling-llm-d-modelservice-decode, action=scale-up, current=1→target=3"}
{"level":"DEBUG","ts":"2025-11-26T16:24:49.835Z","msg":"Found VA in map: variant=ms-inference-scheduling-llm-d-modelservice-decode, hasCurrentAlloc=true, accelerator=H100"}
{"level":"INFO","ts":"2025-11-26T16:24:49.835Z","msg":"EmitReplicaMetrics completed - variant: ms-inference-scheduling-llm-d-modelservice-decode, current-replicas: 1, desired-replicas: 3, accelerator: H100"}
{"level":"INFO","ts":"2025-11-26T16:24:49.835Z","msg":"Successfully emitted metrics for external autoscalers: variant=ms-inference-scheduling-llm-d-modelservice-decode, targetReplicas=3, accelerator=H100, capacityOnly=false"}
{"level":"INFO","ts":"2025-11-26T16:24:49.840Z","msg":"Applied capacity decision: variant=ms-inference-scheduling-llm-d-modelservice-decode, action=scale-up, current=1, target=3, reason=model-based only (capacity unavailable)"}
{"level":"INFO","ts":"2025-11-26T16:24:49.840Z","msg":"Reconciliation completed successfully: mode=model-only, modelsProcessed=1, decisionsApplied=1"}
```

HPA reports scale-up too:
```
kubectl get hpa -n llm-d-inference-scheduler -w                               
NAME                  REFERENCE                                                      TARGETS     MINPODS   MAXPODS   REPLICAS   AGE
vllm-deployment-hpa   Deployment/ms-inference-scheduling-llm-d-modelservice-decode   1/1 (avg)   1         10        3          10m
```

Closes #324. 
