### PR TITLE
fix: emit metrics for ActionNoChange decisions in capacity-only mode

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -544,7 +544,6 @@ func convertCapacityTargetsToDecisions(
 			action = interfaces.ActionScaleDown
 		} else {
 			action = interfaces.ActionNoChange
-			continue
 		}
 
 		decision := interfaces.VariantDecision{


### PR DESCRIPTION
This PR resolve issue https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/322

Previously, when all variants were at their optimal replica count (no scaling needed), metrics were not emitted because ActionNoChange decisions were skipped in convertCapacityTargetsToDecisions().

This caused gaps in metric continuity that could affect external autoscalers (e.g., HPA) that rely on continuous metric emission.

Changes:
- Remove 'continue' statement that skipped ActionNoChange decisions
- Add unit tests for convertCapacityTargetsToDecisions function

Now metrics (inferno_desired_replicas, inferno_current_replicas, inferno_desired_ratio) are emitted on every reconciliation cycle, even when no scaling action is needed.