### PR TITLE
add prow github action

### DIFF
--- a/.github/workflows/prow-github.yaml
+++ b/.github/workflows/prow-github.yaml
@@ -1,0 +1,37 @@
+# Run specified actions or jobs for issue and PR comments
+
+name: "Prow github actions"
+on:
+  issue_comment:
+    types: [created]
+
+# Grant additional permissions to the GITHUB_TOKEN
+permissions:
+  # Allow labeling issues
+  issues: write
+  # Allow adding a review to a pull request
+  pull-requests: write
+
+jobs:
+  prow-execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          prow-commands: "/assign
+            /unassign
+            /approve
+            /retitle
+            /area
+            /kind
+            /priority
+            /remove
+            /lgtm
+            /close
+            /reopen
+            /lock
+            /milestone
+            /hold
+            /cc
+            /uncc"

--- a/.github/workflows/prow-pr-automerge.yaml
+++ b/.github/workflows/prow-pr-automerge.yaml
@@ -1,0 +1,17 @@
+# This Github workflow will check every 5 minutes for PRs with the lgtm label and will attempt to automatically merge them.
+# If the hold label is present, it will block automatic merging.
+
+name: "Prow merge on lgtm label"
+on:
+  schedule:
+  - cron: "*/5 * * * *" # every 5 minutes
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: 'lgtm'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          merge-method: 'squash'

--- a/.github/workflows/prow-pr-remove-lgtm.yaml
+++ b/.github/workflows/prow-pr-remove-lgtm.yaml
@@ -1,0 +1,11 @@
+name: Run Jobs on PR
+on: pull_request
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/re-run-action.yaml
+++ b/.github/workflows/re-run-action.yaml
@@ -1,0 +1,16 @@
+name: Re-Run PR tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,0 +1,11 @@
+# Labels for labeling issues and pull requests using GitHub prow action.
+kind:
+  - 'bug'
+  - 'security'
+  - 'feature'
+  - 'docs'
+
+priority:
+  - 'p0'
+  - 'p1'
+  - 'p2'

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,23 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+# List of usernames who may use /lgtm
+reviewers:
+  - WheelyMcBones
+  - atantawi
+  - mamy-CS
+  - asm582
+  - clubanderson
+  - vishakha-ramani
+  - ev-shindin
+  - lionelvillard
+
+# List of usernames who may use /approve
+approvers:
+  - WheelyMcBones
+  - atantawi
+  - mamy-CS
+  - asm582
+  - clubanderson
+  - vishakha-ramani
+  - ev-shindin
+  - lionelvillard


### PR DESCRIPTION
This PR adds Prow GitHub Actions workflows to brings its chat-ops functionality and project management.

- Prow GitHub workflow
- PR auto-merge workflow
- PR LGTM removal workflow
- Re-run action workflow
- Prow labels configuration
- OWNERS file

Documentation: https://github.com/jpmcb/prow-github-actions

This PR is the same as the one created in llm-d-inference-scheduler: https://github.com/llm-d/llm-d-inference-scheduler/pull/290
