### PR TITLE
Fix GITHUB_TOKEN authentication in Helm release workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -91,8 +91,10 @@ jobs:
       # 8. Login to GHCR for chart publishing
       # -----------------------------------------
       - name: Login to GHCR (Helm)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          echo "${{ github.token }}" | \
             helm registry login ghcr.io \
               --username ${{ github.actor }} \
               --password-stdin
@@ -119,6 +121,8 @@ jobs:
       # 11. Commit updated chart files
       # -----------------------------------------
       - name: Commit updated Helm chart files
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
@@ -127,4 +131,5 @@ jobs:
           git add charts/workload-variant-autoscaler/values.yaml
 
           git commit -m "Release ${{ steps.version.outputs.tag }}: update Chart.yaml and values.yaml" || echo "No changes to commit"
+          git remote set-url origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git
           git push


### PR DESCRIPTION
## Summary
Adding a fix for CI failure in `helm-release.yaml` workflow by replacing `secrets.GITHUB_TOKEN` with `github.token` and setting `GITHUB_TOKEN` as an environment variable for tools that require it. Also fixes git push authentication by updating the remote URL to include the token.

Resolves error: "[@octokit/auth-action] `GITHUB_TOKEN` variable is not set"