### PR TITLE
add workflow dispatch ci and fix helm changes

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -3,10 +3,20 @@ name: Release – Docker Image & Publish Helm Chart to GHCR
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.4.1) - for testing without creating a release'
+        required: false
+        type: string
+  push:
+    tags:
+      - 'v*-test'  # Allow test tags like v0.4.1-test
 
 permissions:
   contents: write
   packages: write
+  id-token: write  # Required for Gitsign OIDC authentication
 
 jobs:
   release:
@@ -18,6 +28,11 @@ jobs:
       # -----------------------------------------
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # For workflow_dispatch with tag, checkout the tag; otherwise use default ref
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+          token: ${{ github.token }}
+          persist-credentials: true
 
       # -----------------------------------------
       # 2. Determine version from tag (v0.0.4 → 0.0.4)
@@ -25,7 +40,20 @@ jobs:
       - name: Determine version from tag
         id: version
         run: |
-          RAW_TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual trigger - use input tag or default
+            RAW_TAG="${{ github.event.inputs.tag }}"
+            if [[ -z "$RAW_TAG" ]]; then
+              echo "Error: tag input required for workflow_dispatch" >&2
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # Push event - get tag from ref
+            RAW_TAG="${GITHUB_REF#refs/tags/}"
+          else
+            # Release event - get tag from ref
+            RAW_TAG="${GITHUB_REF#refs/tags/}"
+          fi
           VERSION="${RAW_TAG#v}"
           echo "tag=$RAW_TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -122,23 +150,65 @@ jobs:
             oci://ghcr.io/llm-d-incubation/workload-variant-autoscaler
 
       # -----------------------------------------
-      # 11. Commit updated chart files
+      # 11. Install Gitsign for commit signing
+      # -----------------------------------------
+      - name: Install Gitsign
+        run: |
+          curl -Lo gitsign https://github.com/sigstore/gitsign/releases/latest/download/gitsign-linux-amd64
+          chmod +x gitsign
+          sudo mv gitsign /usr/local/bin/
+
+      # -----------------------------------------
+      # 12. Commit updated chart files
       # -----------------------------------------
       - name: Commit updated Helm chart files
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Configure Git to use Gitsign for verified commits
+          git config --global gpg.format ssh
+          git config --global gpg.ssh.program /usr/local/bin/gitsign
+          git config --global commit.gpgSign true
 
           # Checkout the default branch (we're in detached HEAD from tag checkout)
           git fetch origin
           DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch" | cut -d' ' -f5 || echo "main")
           git checkout $DEFAULT_BRANCH
           
+          # Create a branch for the release update (required due to branch protection)
+          RELEASE_BRANCH="release/update-chart-${{ steps.version.outputs.tag }}"
+          git checkout -b $RELEASE_BRANCH
+          
           git add charts/workload-variant-autoscaler/Chart.yaml
           git add charts/workload-variant-autoscaler/values.yaml
 
           git commit -m "Release ${{ steps.version.outputs.tag }}: update Chart.yaml and values.yaml" || echo "No changes to commit"
-          git remote set-url origin https://${{ github.actor }}:$GITHUB_TOKEN@github.com/${{ github.repository }}.git
-          git push origin $DEFAULT_BRANCH
+          git push origin $RELEASE_BRANCH || echo "Push failed - branch protection may require manual PR creation"
+
+      # -----------------------------------------
+      # 13. Create Pull Request
+      # -----------------------------------------
+      - name: Create Pull Request
+        if: success() || failure()  # Run even if previous step had issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_BRANCH="release/update-chart-${{ steps.version.outputs.tag }}"
+          DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch" | cut -d' ' -f5 || echo "main")
+          
+          # Check if PR already exists
+          PR_EXISTS=$(gh pr list --head $RELEASE_BRANCH --base $DEFAULT_BRANCH --json number --jq 'length' || echo "0")
+          
+          if [ "$PR_EXISTS" = "0" ]; then
+            gh pr create \
+              --title "Release ${{ steps.version.outputs.tag }}: update Chart.yaml and values.yaml" \
+              --body "Automated update from release workflow for version ${{ steps.version.outputs.tag }}. This PR updates the Helm chart files after publishing the release." \
+              --base $DEFAULT_BRANCH \
+              --head $RELEASE_BRANCH \
+              || echo "Failed to create PR - may need manual creation"
+          else
+            echo "PR already exists for this release"
+          fi


### PR DESCRIPTION
Adds workflow_dispatch and push tag triggers to enable testing the Helm release workflow without creating actual GitHub releases and fix helm updates during release by creating pr for changes and properly signing them. 