### PR TITLE
Reconciler refactoring part 1: target resolution condition and engine placeholders

### DIFF
--- a/api/v1alpha1/variantautoscaling_types.go
+++ b/api/v1alpha1/variantautoscaling_types.go
@@ -186,6 +186,8 @@ func init() {
 
 // Condition Types for VariantAutoscaling
 const (
+	// TypeTargetResolved indicates whether the target model variant has been resolved successfully
+	TypeTargetResolved = "TargetResolved"
 	// TypeMetricsAvailable indicates whether vLLM metrics are available from Prometheus
 	TypeMetricsAvailable = "MetricsAvailable"
 	// TypeOptimizationReady indicates whether the optimization engine can run successfully

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -154,7 +154,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// TODO: replace by proper lookup mechanism using spec.scaleTargetRef in future
 	scaleTargetName := va.Name
 
-	// TODO: generalize to other scale target kinds in future
+	// TODO: generalize to other scale target kind in future
 	var deploy appsv1.Deployment
 	if err := utils.GetDeploymentWithBackoff(ctx, r.Client, scaleTargetName, va.Namespace, &deploy); err != nil {
 		logger.Log.Errorf("Failed to get scale target Deployment: name=%s, namespace=%s, error=%v", scaleTargetName, va.Namespace, err)
@@ -164,9 +164,20 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 			"ScaleTargetNotFound",
 			fmt.Sprintf("Scale target Deployment not found: name=%s, namespace=%s", scaleTargetName, va.Namespace),
 		)
+
+		// Update VA status
+		// TODO: refactor to use retry utility function.
+		// UpdateStatusWithBackoff does not work as it goes not refresh the object before update
+		// UpdateStatusWithOptimisticLocking is too complex and not suitable for this case
+		if err := r.Status().Update(ctx, &va); err != nil {
+			logger.Log.Errorf("Failed to update VariantAutoscaling status: name=%s, namespace=%s, error=%v", va.Name, va.Namespace, err)
+			return ctrl.Result{}, err
+		}
+
 		return ctrl.Result{}, err
 	}
 
+	// TODO: Refactor to record mutation and apply as one update operation.
 	llmdVariantAutoscalingV1alpha1.SetCondition(&va,
 		llmdVariantAutoscalingV1alpha1.TypeTargetResolved,
 		metav1.ConditionTrue,
@@ -223,14 +234,11 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		enableSaturationAnalyzer = true
 	}
 
-	// Get list of all VAs
-	var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
-	if err := r.List(ctx, &variantAutoscalingList); err != nil {
-		logger.Log.Errorf("unable to list variantAutoscaling resources: %v", err)
+	activeVAs, err := utils.ActiveVariantAutoscaling(ctx, r.Client)
+	if err != nil {
+		logger.Log.Errorf("unable to get active variant autoscalings: %v", err)
 		return ctrl.Result{}, err
 	}
-
-	activeVAs := filterActiveVariantAutoscalings(variantAutoscalingList.Items)
 
 	if len(activeVAs) == 0 {
 		logger.Log.Infof("No active VariantAutoscalings found, skipping optimization")
@@ -244,8 +252,8 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.Log.Warnf("Saturation scaling config not loaded yet, using defaults")
 	}
 
-	// Group VAs by model for per-model saturation analysis
-	modelGroups := r.groupVAsByModel(activeVAs)
+	// Group VAs by model for per-model capacity analysis
+	modelGroups := utils.GroupVariantAutoscalingByModel(activeVAs)
 	logger.Log.Infof("Grouped VAs by model: modelCount=%d, totalVAs=%d", len(modelGroups), len(activeVAs))
 
 	// Process each model independently
@@ -532,33 +540,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{RequeueAfter: requeueDuration}, nil
 }
 
-// filterActiveVariantAutoscalings returns only those VAs not marked for deletion.
-func filterActiveVariantAutoscalings(items []llmdVariantAutoscalingV1alpha1.VariantAutoscaling) []llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
-	active := make([]llmdVariantAutoscalingV1alpha1.VariantAutoscaling, 0, len(items))
-	for _, va := range items {
-		if va.DeletionTimestamp.IsZero() {
-			active = append(active, va)
-		} else {
-			logger.Log.Infof("skipping deleted variantAutoscaling - variantAutoscaling-name: %s", va.Name)
-		}
-	}
-	return active
-}
-
-// groupVAsByModel groups VariantAutoscalings by ModelID for per-model saturation analysis.
-// CRD validation ensures ModelID is not empty and all required fields are valid.
-func (r *VariantAutoscalingReconciler) groupVAsByModel(
-	vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-) map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
-	groups := make(map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling)
-	for _, va := range vas {
-		modelID := va.Spec.ModelID
-		groups[modelID] = append(groups[modelID], va)
-	}
-	return groups
-}
-
-// buildVariantStates extracts current and desired replica counts from VAs for saturation analysis.
+// buildVariantStates extracts current and desired replica counts from VAs for capacity analysis.
 func (r *VariantAutoscalingReconciler) buildVariantStates(
 	ctx context.Context,
 	vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -533,6 +533,7 @@ data:
 
 		BeforeEach(func() {
 			logger.Log = zap.NewNop().Sugar()
+
 			ns := &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "workload-variant-autoscaler-system",
@@ -670,81 +671,6 @@ data:
 			}
 		})
 
-		It("should filter out VAs marked for deletion", func() {
-			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
-			err := k8sClient.List(ctx, &variantAutoscalingList)
-			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
-			filterActiveVariantAutoscalings(variantAutoscalingList.Items)
-			Expect(len(variantAutoscalingList.Items)).To(Equal(3), "All VariantAutoscaling resources should be active before deletion")
-
-			// Delete the VAs (this sets DeletionTimestamp)
-			for i := range totalVAs {
-				Expect(k8sClient.Delete(ctx, &variantAutoscalingList.Items[i])).To(Succeed())
-			}
-
-			err = k8sClient.List(ctx, &variantAutoscalingList)
-			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
-			filterActiveVariantAutoscalings(variantAutoscalingList.Items)
-			Expect(len(variantAutoscalingList.Items)).To(Equal(0), "No active VariantAutoscaling resources should be found")
-		})
-
-		It("should prepare active VAs for optimization", func() {
-			// Create a mock Prometheus API with valid metric data that passes validation
-			mockPromAPI := &testutils.MockPromAPI{
-				QueryResults: map[string]model.Value{
-					// Default: return a vector with one sample to pass validation
-				},
-				QueryErrors: map[string]error{},
-			}
-
-			controllerReconciler := &VariantAutoscalingReconciler{
-				Client:  k8sClient,
-				Scheme:  k8sClient.Scheme(),
-				PromAPI: mockPromAPI,
-			}
-
-			By("Reading the required configmaps")
-			accMap, err := controllerReconciler.readAcceleratorConfig(ctx, "accelerator-unit-costs", configMapNamespace)
-			Expect(err).NotTo(HaveOccurred(), "Failed to read accelerator config")
-			Expect(accMap).NotTo(BeNil(), "Accelerator config map should not be nil")
-
-			serviceClassMap, err := controllerReconciler.readServiceClassConfig(ctx, "service-classes-config", configMapNamespace)
-			Expect(err).NotTo(HaveOccurred(), "Failed to read service class config")
-			Expect(serviceClassMap).NotTo(BeNil(), "Service class config map should not be nil")
-
-			var variantAutoscalingList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
-			err = k8sClient.List(ctx, &variantAutoscalingList)
-			Expect(err).NotTo(HaveOccurred(), "Failed to list VariantAutoscaling resources")
-			activeVAs := filterActiveVariantAutoscalings(variantAutoscalingList.Items)
-			Expect(len(activeVAs)).To(Equal(totalVAs), "All VariantAutoscaling resources should be active")
-
-			// Prepare system data for VAs
-			By("Preparing the system data for optimization")
-			// WVA operates in unlimited mode - no inventory data needed
-			systemData := utils.CreateSystemData(accMap, serviceClassMap)
-			Expect(systemData).NotTo(BeNil(), "System data should not be nil")
-
-			updateList, vaMap, allAnalyzerResponses, err := controllerReconciler.prepareVariantAutoscalings(ctx, activeVAs, accMap, serviceClassMap, systemData)
-
-			Expect(err).NotTo(HaveOccurred(), "prepareVariantAutoscalings should not return an error")
-			Expect(vaMap).NotTo(BeNil(), "VA map should not be nil")
-			Expect(allAnalyzerResponses).NotTo(BeNil(), "Analyzer responses should not be nil")
-			Expect(len(updateList.Items)).To(Equal(totalVAs), "UpdatedList should be the same number of all active VariantAutoscalings")
-
-			var vaNames []string
-			for _, va := range activeVAs {
-				vaNames = append(vaNames, va.Name)
-			}
-
-			for _, updatedVa := range updateList.Items {
-				Expect(vaNames).To(ContainElement(updatedVa.Name), fmt.Sprintf("Active VariantAutoscaling list should contain %s", updatedVa.Name))
-				Expect(updatedVa.Status.CurrentAlloc.Accelerator).To(Equal("A100"), fmt.Sprintf("Current Accelerator for %s should be \"A100\" after preparation", updatedVa.Name))
-				Expect(updatedVa.Status.CurrentAlloc.NumReplicas).To(Equal(1), fmt.Sprintf("Current NumReplicas for %s should be 1 after preparation", updatedVa.Name))
-				Expect(updatedVa.Status.DesiredOptimizedAlloc.Accelerator).To(BeEmpty(), fmt.Sprintf("Desired Accelerator for %s should be empty value after preparation", updatedVa.Name))
-				Expect(updatedVa.Status.DesiredOptimizedAlloc.NumReplicas).To(BeZero(), fmt.Sprintf("Desired NumReplicas for %s should be zero after preparation", updatedVa.Name))
-			}
-		})
-
 		It("should set MetricsAvailable condition when metrics validation fails", func() {
 			By("Creating a mock Prometheus API that returns no metrics")
 			mockPromAPI := &testutils.MockPromAPI{
@@ -769,7 +695,7 @@ data:
 			err = k8sClient.List(ctx, &variantAutoscalingList)
 			Expect(err).NotTo(HaveOccurred())
 
-			activeVAs := filterActiveVariantAutoscalings(variantAutoscalingList.Items)
+			activeVAs := variantAutoscalingList.Items // All created VAs are active
 			Expect(len(activeVAs)).To(BeNumerically(">", 0))
 
 			By("Preparing system data and calling prepareVariantAutoscalings")

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -65,6 +65,10 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 			}
 			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, ns))).NotTo(HaveOccurred())
 
+			By("creating the required scale target ref deployment")
+			deployment := testutils.CreateLlmdSimDeployment("default", resourceName, "default-default", "default", "8000", 0, 0, 1)
+			Expect(k8sClient.Create(ctx, deployment)).To(Succeed())
+
 			By("creating the required configmap for optimization")
 			configMap := testutils.CreateServiceClassConfigMap(ns.Name)
 			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
@@ -808,7 +812,12 @@ data:
 			}
 
 			By("Performing a full reconciliation")
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "multi-test-resource-0",
+					Namespace: "default",
+				},
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking that conditions are set correctly")

--- a/internal/engines/executor/doc.go
+++ b/internal/engines/executor/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package executor provides task execution strategies.
+
+# Overview
+
+The executor package provides three execution strategies for running
+optimization tasks:
+
+  - [PollingExecutor]: Fixed-interval execution
+  - [ReactiveExecutor]: Event-driven execution (TODO)
+  - [HybridExecutor]: Combined approach (TODO)
+
+# Thread Safety
+
+All executor types are safe for concurrent use from multiple goroutines.
+*/
+package executor

--- a/internal/engines/executor/executor.go
+++ b/internal/engines/executor/executor.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import "context"
+
+// Executor defines how optimization tasks are executed.
+type Executor interface {
+	// Start begins execution and blocks until context is cancelled.
+	Start(ctx context.Context)
+}
+
+// OptimizeFunc is the function to be executed.
+type OptimizeFunc func(ctx context.Context) error
+
+// Config holds common executor configuration.
+type Config struct {
+	OptimizeFunc OptimizeFunc
+}

--- a/internal/engines/executor/polling.go
+++ b/internal/engines/executor/polling.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+)
+
+// PollingExecutor executes the optimization function at fixed intervals.
+type PollingExecutor struct {
+	config       Config
+	interval     time.Duration // polling interval
+	retryBackoff time.Duration // backoff duration between retries
+}
+
+// PollingConfig holds polling-specific configuration.
+type PollingConfig struct {
+	Config
+	Interval     time.Duration
+	RetryBackoff time.Duration
+}
+
+// NewPollingExecutor creates a new polling executor.
+func NewPollingExecutor(config PollingConfig) *PollingExecutor {
+	return &PollingExecutor{
+		config:       config.Config,
+		interval:     config.Interval,
+		retryBackoff: config.RetryBackoff,
+	}
+}
+
+func (e *PollingExecutor) Start(ctx context.Context) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		e.executeWithRetry(ctx)
+	}, e.interval)
+}
+
+func (e *PollingExecutor) executeWithRetry(ctx context.Context) {
+	backoff := e.retryBackoff
+	for { // infinite retry loop
+		select {
+		case <-ctx.Done():
+			logger.Log.Info("Context cancelled, stopping optimization loop")
+			return
+		default:
+		}
+
+		err := e.config.OptimizeFunc(ctx)
+		if err == nil {
+			return
+		}
+
+		logger.Log.Errorw("Optimization error", "error", err)
+
+		select {
+		case <-ctx.Done():
+			logger.Log.Info("Context cancelled during retry delay")
+			return
+		case <-time.After(backoff):
+			backoff *= 2
+
+			if backoff > 4*time.Second {
+				backoff = 4 * time.Second
+			}
+		}
+	}
+}

--- a/internal/engines/model/engine.go
+++ b/internal/engines/model/engine.go
@@ -35,6 +35,8 @@ type Engine struct {
 	executor executor.Executor
 
 	// Add fields as necessary for the engine's state and configuration.
+	// refer to this interface to add fields for optimizer and model analyzer
+	// https://github.com/llm-d-incubation/workload-variant-autoscaler/blob/main/internal/interfaces/interfaces.go
 }
 
 // NewEngine creates a new instance of the model engine.

--- a/internal/engines/model/engine.go
+++ b/internal/engines/model/engine.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
+)
+
+// NOTE: This is a placeholder for the model engine implementation.
+// The actual logic for the model engine should be implemented here.
+
+type Engine struct {
+	client client.Client
+	// Add fields as necessary for the engine's state and configuration.
+}
+
+// NewEngine creates a new instance of the model engine.
+func NewEngine(client client.Client) *Engine {
+	return &Engine{
+		client: client,
+		// Initialize fields as necessary.
+	}
+}
+
+// StartOptimizeLoop starts the optimization loop for the model engine.
+// It runs until the context is cancelled.
+func (e *Engine) StartOptimizeLoop(ctx context.Context) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		for { // Infinite retry loop in case of optimization errors.
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled, stopping optimization loop")
+				return
+			default:
+			}
+
+			err := e.optimize(ctx)
+			if err == nil {
+				break
+			}
+
+			logger.Log.Errorf("Optimization error: %v", err)
+
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled during retry delay")
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}, 30*time.Minute)
+}
+
+// optimize performs the optimization logic.
+func (e *Engine) optimize(ctx context.Context) error {
+	// Get all active VAs
+	activeVAs, err := utils.ActiveVariantAutoscalings(ctx, e.client)
+	if err != nil {
+		return err
+	}
+
+	logger.Log.Debugw("Found active VariantAutoscaling resources", "count", len(activeVAs))
+
+	// TODO: Implement optimization logic
+
+	return nil
+}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/executor"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
 )
@@ -31,51 +31,38 @@ import (
 // The actual logic for the saturation engine should be implemented here.
 
 type Engine struct {
-	client client.Client
+	client   client.Client
+	executor executor.Executor
 	// Add fields as necessary for the engine's state and configuration.
 }
 
 // NewEngine creates a new instance of the saturation engine.
 func NewEngine(client client.Client) *Engine {
-	return &Engine{
+	engine := Engine{
 		client: client,
-		// Initialize fields as necessary.
 	}
+
+	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
+		Config: executor.Config{
+			OptimizeFunc: engine.optimize,
+		},
+		Interval:     30 * time.Second,
+		RetryBackoff: 100 * time.Millisecond,
+	})
+
+	return &engine
 }
 
 // StartOptimizeLoop starts the optimization loop for the saturation engine.
 // It runs until the context is cancelled.
 func (e *Engine) StartOptimizeLoop(ctx context.Context) {
-	wait.UntilWithContext(ctx, func(ctx context.Context) {
-		for { // Infinite retry loop in case of optimization errors.
-			select {
-			case <-ctx.Done():
-				logger.Log.Info("Context cancelled, stopping optimization loop")
-				return
-			default:
-			}
-
-			err := e.optimize(ctx)
-			if err == nil {
-				break
-			}
-
-			logger.Log.Errorf("Optimization error: %v", err)
-
-			select {
-			case <-ctx.Done():
-				logger.Log.Info("Context cancelled during retry delay")
-				return
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-	}, 30*time.Minute)
+	e.executor.Start(ctx)
 }
 
 // optimize performs the optimization logic.
 func (e *Engine) optimize(ctx context.Context) error {
-	// Get all active VAs
-	activeVAs, err := utils.ActiveVariantAutoscalings(ctx, e.client)
+	// Get all active VAs grouped by model
+	activeVAs, err := utils.ActiveVariantAutoscalingByModel(ctx, e.client)
 	if err != nil {
 		return err
 	}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
+)
+
+// NOTE: This is a placeholder for the saturation engine implementation.
+// The actual logic for the saturation engine should be implemented here.
+
+type Engine struct {
+	client client.Client
+	// Add fields as necessary for the engine's state and configuration.
+}
+
+// NewEngine creates a new instance of the saturation engine.
+func NewEngine(client client.Client) *Engine {
+	return &Engine{
+		client: client,
+		// Initialize fields as necessary.
+	}
+}
+
+// StartOptimizeLoop starts the optimization loop for the saturation engine.
+// It runs until the context is cancelled.
+func (e *Engine) StartOptimizeLoop(ctx context.Context) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		for { // Infinite retry loop in case of optimization errors.
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled, stopping optimization loop")
+				return
+			default:
+			}
+
+			err := e.optimize(ctx)
+			if err == nil {
+				break
+			}
+
+			logger.Log.Errorf("Optimization error: %v", err)
+
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled during retry delay")
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}, 30*time.Minute)
+}
+
+// optimize performs the optimization logic.
+func (e *Engine) optimize(ctx context.Context) error {
+	// Get all active VAs
+	activeVAs, err := utils.ActiveVariantAutoscalings(ctx, e.client)
+	if err != nil {
+		return err
+	}
+
+	logger.Log.Debugw("Found active VariantAutoscaling resources", "count", len(activeVAs))
+	// TODO: Implement optimization logic
+
+	return nil
+}

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalefromzero
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
+)
+
+// NOTE: This is a placeholder for the scale-from-zero engine implementation.
+// The actual logic for the scale-from-zero engine should be implemented here.
+
+type Engine struct {
+	client client.Client
+	// Add fields as necessary for the engine's state and configuration.
+}
+
+// NewEngine creates a new instance of the scale-from-zero engine.
+func NewEngine(client client.Client) *Engine {
+	return &Engine{
+		client: client,
+		// Initialize fields as necessary.
+	}
+}
+
+// StartOptimizeLoop starts the optimization loop for the scale-from-zero engine.
+// It runs until the context is cancelled.
+func (e *Engine) StartOptimizeLoop(ctx context.Context) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		for { // Infinite retry loop in case of optimization errors.
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled, stopping optimization loop")
+				return
+			default:
+			}
+
+			err := e.optimize(ctx)
+			if err == nil {
+				break
+			}
+
+			logger.Log.Errorf("Optimization error: %v", err)
+
+			select {
+			case <-ctx.Done():
+				logger.Log.Info("Context cancelled during retry delay")
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}, 100*time.Millisecond)
+}
+
+// optimize performs the optimization logic.
+func (e *Engine) optimize(ctx context.Context) error {
+	// Get all inactive (replicas == 0) VAs
+	inactiveVAs, err := utils.InactiveVariantAutoscalings(ctx, e.client)
+	if err != nil {
+		return err
+	}
+
+	logger.Log.Debugw("Found inactive VariantAutoscaling resources", "count", len(inactiveVAs))
+	// TODO: Implement optimization logic
+
+	return nil
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -142,6 +142,8 @@ func UpdateStatusWithOptimisticLocking[T client.Object](
 	backoff wait.Backoff,
 	resourceType string,
 ) error {
+	// TODO: use retry.OnConflict from k8s.io/client-go/util/retry
+
 	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		// Fetch the latest version of the resource
 		err := c.Get(ctx, objKey, obj)

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -138,9 +138,11 @@ func readyVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav
 			continue
 		}
 
-		if wvav1alpha1.IsConditionTrue(&va, wvav1alpha1.TypeTargetResolved) { // TODO: add a Ready condition
-			readyVAs = append(readyVAs, va) // Shallow copy
-		}
+		// TODO: Uncomment when TypeTargetResolved condition is added
+
+		// if wvav1alpha1.IsConditionTrue(&va, wvav1alpha1.TypeTargetResolved) { // TODO: add a Ready condition
+		readyVAs = append(readyVAs, va) // Shallow copy
+		// }
 	}
 
 	logger.Log.Debugw("Found VariantAutoscaling resources ready for optimization", "count", len(readyVAs))

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+)
+
+// VariantFilter is a function that determines if a VA should be included.
+type VariantFilter func(deploy *appsv1.Deployment) bool
+
+// ActiveVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization
+// and have at least one target replica.
+func ActiveVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+	return filterVariantsByDeployment(ctx, client, isActive, "active")
+}
+
+// InactiveVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization
+// and have no target replicas.
+func InactiveVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+	return filterVariantsByDeployment(ctx, client, isInactive, "inactive")
+}
+
+// filterVariantsByDeployment is a generic function to filter VAs based on deployment state.
+func filterVariantsByDeployment(ctx context.Context,
+	client client.Client,
+	filter VariantFilter,
+	filterName string) ([]wvav1alpha1.VariantAutoscaling, error) {
+
+	readyVAs, err := readyVariantAutoscalings(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredVAs := make([]wvav1alpha1.VariantAutoscaling, 0, len(readyVAs))
+
+	for _, va := range readyVAs {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// TODO: Generalize to other scale target kinds in future
+		var deploy appsv1.Deployment
+		if err := GetDeploymentWithBackoff(ctx, client, va.Name, va.Namespace, &deploy); err != nil {
+			logger.Log.Errorw("Failed to get deployment", "namespace", va.Namespace, "name", va.Name, "error", err)
+			continue
+		}
+
+		// Skip deleted deployments
+		if !deploy.DeletionTimestamp.IsZero() {
+			logger.Log.Debugw("Skipping deleted deployment", "namespace", va.Namespace, "name", va.Name)
+			continue
+		}
+
+		// Apply the filter function
+		if filter(&deploy) {
+			filteredVAs = append(filteredVAs, va)
+		}
+	}
+	logger.Log.Debugw("Found filtered VariantAutoscaling resources",
+		"filterType", filterName,
+		"count", len(filteredVAs))
+	return filteredVAs, nil
+}
+
+// readyVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization.
+func readyVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+	// List all VariantAutoscaling resources
+	var variantAutoscalingList wvav1alpha1.VariantAutoscalingList
+	if err := client.List(ctx, &variantAutoscalingList); err != nil {
+		logger.Log.Errorw("unable to list variantAutoscaling resources", "error", err)
+		return nil, err
+	}
+
+	// Filter VAs that are ready for optimization
+	readyVAs := make([]wvav1alpha1.VariantAutoscaling, 0, len(variantAutoscalingList.Items))
+	for _, va := range variantAutoscalingList.Items {
+		// Skip deleted VAs
+		if !va.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		if wvav1alpha1.IsConditionTrue(&va, wvav1alpha1.TypeTargetResolved) { // TODO: add a Ready condition
+			readyVAs = append(readyVAs, va)
+		}
+	}
+
+	logger.Log.Debugw("Found VariantAutoscaling resources ready for optimization", "count", len(readyVAs))
+	return readyVAs, nil
+}
+
+// isActive explicitly requires that replicas > 0
+func isActive(deploy *appsv1.Deployment) bool {
+	return GetDesiredReplicas(deploy) > 0
+}
+
+// isInactive explicitly requires that replicas == 0
+func isInactive(deploy *appsv1.Deployment) bool {
+	return GetDesiredReplicas(deploy) == 0
+}
+
+// Helper function makes behavior explicit
+func GetDesiredReplicas(deploy *appsv1.Deployment) int32 {
+	if deploy == nil || deploy.Spec.Replicas == nil {
+		return 1 // Kubernetes default
+	}
+	return *deploy.Spec.Replicas
+}


### PR DESCRIPTION
Part of https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/379

This is the first step to extract optimizers into their own loop. 

This PR includes:

- Partial refactoring of the `VariantAutoscalingReconciler` to 
   - process one VA per reconciliation loop. (**Previous behavior, ie. global reconciliation, is still preserved in this PR**)
   - to include explicit logic for resolving the target deployment and updating the VA status condition (`TypeTargetResolved`)
- The beginning of an optimization engine management framework with clearer separation between per VA reconciliation and flexible global optimization logic.  
- Added 3 optimization engine placeholders. 
- A new executor package to allow various optimization execution strategies such as polling (periodic optimization) and reactive (not implemented) for scale-from-zero and eventually faster 1-N scaling. 

Remaining tasks (follow-on PRs):
- executor unit tests
- add reactive executor
- move existing engines as-is to `engines/...`
 
