### PR TITLE
Adding a function to obtain the API Version of a Scale Target Resource 

### DIFF
--- a/api/v1alpha1/variantautoscaling_types.go
+++ b/api/v1alpha1/variantautoscaling_types.go
@@ -227,6 +227,11 @@ const (
 	ReasonSkippedProcessing = "SkippedProcessing"
 )
 
+// GetScaleTargetAPI returns the API of the scale target resource.
+func (va *VariantAutoscaling) GetScaleTargetAPI() string {
+	return va.Spec.ScaleTargetRef.APIVersion
+}
+
 // GetScaleTargetName returns the name of the scale target resource.
 func (va *VariantAutoscaling) GetScaleTargetName() string {
 	return va.Spec.ScaleTargetRef.Name


### PR DESCRIPTION
This PR creates a function (`GetScaleTargetAPI()`) to obtain the API version of the scale target resource. 