### PR TITLE
update to support multi-ns deployment

### DIFF
--- a/charts/workload-variant-autoscaler/templates/vllm-servicemonitor.yaml
+++ b/charts/workload-variant-autoscaler/templates/vllm-servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: vllm-servicemonitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.llmd.namespace }}
   labels:
     llm-d.ai/model: {{ .Values.llmd.modelName }}
     openshift.io/user-monitoring: "true"


### PR DESCRIPTION
when the models are running in a diff ns than wva is installed in, the svc monitor needs to be in the workload ns, not the wva ns. fixes #429