### PR TITLE
Fix: update svc monitor to use the ns associated with the model workload

### DIFF
--- a/charts/workload-variant-autoscaler/templates/vllm-servicemonitor.yaml
+++ b/charts/workload-variant-autoscaler/templates/vllm-servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: vllm-servicemonitor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.llmd.namespace }}
   labels:
     llm-d.ai/model: {{ .Values.llmd.modelName }}
     openshift.io/user-monitoring: "true"


### PR DESCRIPTION
need to help benchmark team release - back porting this on top of v0.4.1 release