### PR TITLE
Remove configmap default thresholds for saturation mode

### DIFF
--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -53,6 +53,14 @@ var _ = Describe("Saturation Engine", func() {
 			_, err := engine.readOptimizationConfig(ctx)
 			Expect(err).To(HaveOccurred(), "Expected error when reading missing variant autoscaling optimization ConfigMap")
 		})
+
+		It("should fail on missing saturation scaling ConfigMap", func() {
+			By("Creating Engine without required ConfigMaps")
+			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, nil)
+
+			_, err := engine.readSaturationScalingConfig(ctx, "saturation-scaling-config", "workload-variant-autoscaler-system")
+			Expect(err).To(HaveOccurred(), "Expected error when reading missing saturation scaling ConfigMap")
+		})
 	})
 
 	Context("When validating configurations", func() {

--- a/internal/interfaces/saturation_scaling.go
+++ b/internal/interfaces/saturation_scaling.go
@@ -25,35 +25,6 @@ type SaturationScalingConfig struct {
 	QueueSpareTrigger float64 `yaml:"queueSpareTrigger"`
 }
 
-// DefaultSaturationScalingConfig returns hardcoded default configuration.
-// Used as fallback when ConfigMap is missing or has no 'default' entry.
-func DefaultSaturationScalingConfig() SaturationScalingConfig {
-	return SaturationScalingConfig{
-		KvCacheThreshold:     0.80,
-		QueueLengthThreshold: 5,
-		KvSpareTrigger:       0.10,
-		QueueSpareTrigger:    3,
-	}
-}
-
-// Merge applies non-zero values from override on top of base config.
-// This allows partial overrides where unspecified fields inherit from default.
-// Note: model_id and namespace are not merged (they're metadata fields).
-func (base *SaturationScalingConfig) Merge(override SaturationScalingConfig) {
-	if override.KvCacheThreshold != 0 {
-		base.KvCacheThreshold = override.KvCacheThreshold
-	}
-	if override.QueueLengthThreshold != 0 {
-		base.QueueLengthThreshold = override.QueueLengthThreshold
-	}
-	if override.KvSpareTrigger != 0 {
-		base.KvSpareTrigger = override.KvSpareTrigger
-	}
-	if override.QueueSpareTrigger != 0 {
-		base.QueueSpareTrigger = override.QueueSpareTrigger
-	}
-}
-
 // Validate checks for invalid threshold values.
 // Returns error with descriptive message if validation fails.
 func (c *SaturationScalingConfig) Validate() error {

--- a/internal/interfaces/saturation_scaling_test.go
+++ b/internal/interfaces/saturation_scaling_test.go
@@ -4,23 +4,6 @@ import (
 	"testing"
 )
 
-func TestDefaultSaturationScalingConfig(t *testing.T) {
-	config := DefaultSaturationScalingConfig()
-
-	if config.KvCacheThreshold != 0.80 {
-		t.Errorf("Expected KvCacheThreshold 0.80, got %.2f", config.KvCacheThreshold)
-	}
-	if config.QueueLengthThreshold != 5 {
-		t.Errorf("Expected QueueLengthThreshold 5, got %.1f", config.QueueLengthThreshold)
-	}
-	if config.KvSpareTrigger != 0.10 {
-		t.Errorf("Expected KvSpareTrigger 0.10, got %.2f", config.KvSpareTrigger)
-	}
-	if config.QueueSpareTrigger != 3 {
-		t.Errorf("Expected QueueSpareTrigger 3, got %.1f", config.QueueSpareTrigger)
-	}
-}
-
 func TestSaturationScalingConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -28,8 +11,13 @@ func TestSaturationScalingConfigValidate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid default config",
-			config:  DefaultSaturationScalingConfig(),
+			name: "valid default config",
+			config: SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+			},
 			wantErr: false,
 		},
 		{
@@ -139,85 +127,6 @@ func TestSaturationScalingConfigValidate(t *testing.T) {
 			err := tt.config.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestSaturationScalingConfigMerge(t *testing.T) {
-	tests := []struct {
-		name     string
-		base     SaturationScalingConfig
-		override SaturationScalingConfig
-		expected SaturationScalingConfig
-	}{
-		{
-			name: "full override",
-			base: DefaultSaturationScalingConfig(),
-			override: SaturationScalingConfig{
-				KvCacheThreshold:     0.75,
-				QueueLengthThreshold: 10,
-				KvSpareTrigger:       0.15,
-				QueueSpareTrigger:    5,
-			},
-			expected: SaturationScalingConfig{
-				KvCacheThreshold:     0.75,
-				QueueLengthThreshold: 10,
-				KvSpareTrigger:       0.15,
-				QueueSpareTrigger:    5,
-			},
-		},
-		{
-			name: "partial override - only KvCacheThreshold",
-			base: DefaultSaturationScalingConfig(),
-			override: SaturationScalingConfig{
-				KvCacheThreshold: 0.90,
-			},
-			expected: SaturationScalingConfig{
-				KvCacheThreshold:     0.90,
-				QueueLengthThreshold: 5,   // from default
-				KvSpareTrigger:       0.1, // from default
-				QueueSpareTrigger:    3,   // from default
-			},
-		},
-		{
-			name: "partial override - queue thresholds only",
-			base: DefaultSaturationScalingConfig(),
-			override: SaturationScalingConfig{
-				QueueLengthThreshold: 20,
-				QueueSpareTrigger:    10,
-			},
-			expected: SaturationScalingConfig{
-				KvCacheThreshold:     0.8, // from default
-				QueueLengthThreshold: 20,
-				KvSpareTrigger:       0.1, // from default
-				QueueSpareTrigger:    10,
-			},
-		},
-		{
-			name:     "empty override - base unchanged",
-			base:     DefaultSaturationScalingConfig(),
-			override: SaturationScalingConfig{},
-			expected: DefaultSaturationScalingConfig(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.base
-			result.Merge(tt.override)
-
-			if result.KvCacheThreshold != tt.expected.KvCacheThreshold {
-				t.Errorf("KvCacheThreshold = %.2f, want %.2f", result.KvCacheThreshold, tt.expected.KvCacheThreshold)
-			}
-			if result.QueueLengthThreshold != tt.expected.QueueLengthThreshold {
-				t.Errorf("QueueLengthThreshold = %.1f, want %.1f", result.QueueLengthThreshold, tt.expected.QueueLengthThreshold)
-			}
-			if result.KvSpareTrigger != tt.expected.KvSpareTrigger {
-				t.Errorf("KvSpareTrigger = %.2f, want %.2f", result.KvSpareTrigger, tt.expected.KvSpareTrigger)
-			}
-			if result.QueueSpareTrigger != tt.expected.QueueSpareTrigger {
-				t.Errorf("QueueSpareTrigger = %.1f, want %.1f", result.QueueSpareTrigger, tt.expected.QueueSpareTrigger)
 			}
 		})
 	}

--- a/internal/saturation/analyzer_test.go
+++ b/internal/saturation/analyzer_test.go
@@ -16,7 +16,12 @@ func init() {
 
 func TestAnalyzeModelSaturation_ScaleUp(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	tests := []struct {
 		name                string
@@ -74,7 +79,12 @@ func TestAnalyzeModelSaturation_ScaleUp(t *testing.T) {
 
 func TestAnalyzeModelSaturation_ScaleDownSafety(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	tests := []struct {
 		name                string
@@ -131,7 +141,12 @@ func TestAnalyzeModelSaturation_ScaleDownSafety(t *testing.T) {
 
 func TestAnalyzeModelSaturation_MultiVariant(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	// Test with metrics from multiple variants
 	replicaMetrics := []interfaces.ReplicaMetrics{
@@ -178,7 +193,12 @@ func TestAnalyzeModelSaturation_MultiVariant(t *testing.T) {
 
 func TestAnalyzeModelSaturation_EmptyMetrics(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	analysis, err := analyzer.AnalyzeModelSaturation(
 		context.Background(),
@@ -207,7 +227,12 @@ func TestAnalyzeModelSaturation_EmptyMetrics(t *testing.T) {
 
 func TestAnalyzeVariant_SaturatedReplicas(t *testing.T) {
 	analyzer := &Analyzer{}
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	metrics := []interfaces.ReplicaMetrics{
 		{PodName: "pod-1", VariantName: "v1", KvCacheUsage: 0.85, QueueLength: 2}, // Saturated (KV)
@@ -242,7 +267,12 @@ func TestAnalyzeVariant_SaturatedReplicas(t *testing.T) {
 
 func TestAnalyzeModelSaturation_AllSaturated(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	// All replicas are saturated
 	replicaMetrics := []interfaces.ReplicaMetrics{
@@ -294,7 +324,12 @@ func TestAnalyzeModelSaturation_AllSaturated(t *testing.T) {
 
 func TestAnalyzeModelSaturation_TimestampSet(t *testing.T) {
 	analyzer := NewAnalyzer()
-	config := interfaces.DefaultSaturationScalingConfig()
+	config := interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.80,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.10,
+		QueueSpareTrigger:    3,
+	}
 
 	before := time.Now()
 

--- a/test/e2e-openshift/sharegpt_scaleup_test.go
+++ b/test/e2e-openshift/sharegpt_scaleup_test.go
@@ -38,12 +38,12 @@ var lowLoad = numPrompts <= 2000 && requestRate <= 8
 
 // Load generation configuration constants
 const (
-	numLoadWorkers      = 10   // Number of parallel load generation workers
-	requestsPerWorker   = 500  // Requests each worker sends
-	batchSize           = 50   // Concurrent requests per batch
-	curlTimeoutSeconds  = 120  // Timeout for each curl request
-	maxTokens           = 150  // Max tokens for completion requests
-	batchSleepDuration  = "0.1" // Sleep duration between batches to control rate
+	numLoadWorkers     = 10    // Number of parallel load generation workers
+	requestsPerWorker  = 500   // Requests each worker sends
+	batchSize          = 50    // Concurrent requests per batch
+	curlTimeoutSeconds = 120   // Timeout for each curl request
+	maxTokens          = 150   // Max tokens for completion requests
+	batchSleepDuration = "0.1" // Sleep duration between batches to control rate
 )
 
 var _ = Describe("ShareGPT Scale-Up Test", Ordered, func() {


### PR DESCRIPTION
This PR removes the default thresholds for the saturation-based model from the codebase. Adding defaults seems incorrect; if we fail reading the configmap, we fall back to the default. This can cause incorrect scaling decisions for that iteration there by hampering system stability, instead we try to read configmap with retries and if we fail we skip the optimization loop for that iteraiton.