### PR TITLE
Add /ok-to-test gate for fork PRs and re-enable test-e2e

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -239,8 +239,6 @@ jobs:
       MAX_NUM_SEQS: ${{ github.event.inputs.max_num_seqs || '1' }}
       HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '30' }}
       SKIP_CLEANUP: ${{ github.event.inputs.skip_cleanup || 'false' }}
-      # PR number from gate (works for pull_request and issue_comment)
-      PR_NUMBER: ${{ needs.gate.outputs.pr_number || github.run_id }}
       # PR-specific namespaces for isolation between concurrent PR tests
       # Primary llm-d namespace (Model A1 + A2)
       LLMD_NAMESPACE: llm-d-inference-scheduler-pr-${{ needs.gate.outputs.pr_number || github.run_id }}

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -1,13 +1,14 @@
 name: CI - OpenShift E2E Tests
 
-# Permissions needed for the build-image job to push to GHCR
+# Permissions needed for various jobs
 permissions:
   contents: read
   packages: write
+  pull-requests: write  # For posting comments on PRs
 
 # Cancel previous runs on the same PR to avoid resource conflicts
 concurrency:
-  group: e2e-openshift-${{ github.event.pull_request.number || github.run_id }}
+  group: e2e-openshift-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 on:
@@ -15,6 +16,9 @@ on:
     branches:
       - main
       - dev
+  # Allow maintainers to trigger tests on fork PRs via /ok-to-test comment
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       model_id:
@@ -47,34 +51,137 @@ on:
         default: '30'
 
 jobs:
-  # Gate: Check if PR author is privileged (admin/maintain/write)
-  # External contributors need maintainer approval via /ok-to-test (handled by gate workflow after merge)
+  # Gate: Check permissions and handle /ok-to-test for fork PRs
+  # - Maintainers (write access): Tests run automatically
+  # - External contributors: Must wait for maintainer to comment /ok-to-test
   gate:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+      pr_head_sha: ${{ steps.check.outputs.pr_head_sha }}
     steps:
-      - name: Check permissions
+      - name: Check permissions and /ok-to-test
         id: check
         uses: actions/github-script@v7
         with:
           script: |
+            // Helper to check if user has write access
+            async function hasWriteAccess(username) {
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: username
+                });
+                const privilegedRoles = ['admin', 'maintain', 'write'];
+                return privilegedRoles.includes(permission.permission);
+              } catch (e) {
+                console.log(`Could not get permissions for ${username}: ${e.message}`);
+                return false;
+              }
+            }
+
             // Always run for workflow_dispatch
             if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('should_run', 'true');
+              core.setOutput('pr_number', '');
+              core.setOutput('pr_head_sha', context.sha);
+              return;
+            }
+
+            // Handle issue_comment event (/ok-to-test)
+            if (context.eventName === 'issue_comment') {
+              const comment = context.payload.comment.body.trim();
+              const issue = context.payload.issue;
+
+              // Only process /ok-to-test comments on PRs
+              if (!issue.pull_request) {
+                console.log('Comment is not on a PR, skipping');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+
+              if (comment !== '/ok-to-test') {
+                console.log(`Comment "${comment}" is not /ok-to-test, skipping`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+
+              // Check if commenter has write access
+              const commenter = context.payload.comment.user.login;
+              const hasAccess = await hasWriteAccess(commenter);
+              if (!hasAccess) {
+                console.log(`User ${commenter} does not have write access, ignoring /ok-to-test`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+
+              // Get PR details to get head SHA
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issue.number
+              });
+
+              console.log(`/ok-to-test approved by ${commenter} for PR #${issue.number}`);
+              console.log(`PR head SHA: ${pr.head.sha}`);
+              core.setOutput('should_run', 'true');
+              core.setOutput('pr_number', issue.number.toString());
+              core.setOutput('pr_head_sha', pr.head.sha);
+
+              // Add reaction to acknowledge
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'rocket'
+              });
+              return;
+            }
+
+            // Handle pull_request event
+            const pr = context.payload.pull_request;
+            const prAuthor = pr.user.login;
+            const prNumber = pr.number;
+            const prHeadSha = pr.head.sha;
+
+            core.setOutput('pr_number', prNumber.toString());
+            core.setOutput('pr_head_sha', prHeadSha);
+
+            // Check if PR author has write access
+            const isPrivileged = await hasWriteAccess(prAuthor);
+            console.log(`PR #${prNumber} author ${prAuthor}: privileged=${isPrivileged}`);
+
+            if (isPrivileged) {
               core.setOutput('should_run', 'true');
               return;
             }
 
-            // Check PR author permission
-            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+            // External contributor - post instructions and skip
+            console.log('External contributor PR - posting instructions');
+            core.setOutput('should_run', 'false');
+
+            // Check if we already posted instructions
+            const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: context.payload.pull_request.user.login
+              issue_number: prNumber
             });
-            const privilegedRoles = ['admin', 'maintain', 'write'];
-            const isPrivileged = privilegedRoles.includes(permission.permission);
-            console.log(`PR author ${context.payload.pull_request.user.login}: ${permission.permission}, privileged: ${isPrivileged}`);
-            core.setOutput('should_run', isPrivileged ? 'true' : 'false');
+
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('ok-to-test')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `👋 Thanks for your contribution!\n\nThis PR is from a fork, so the e2e tests require maintainer approval to run (they use GPU resources).\n\n**For maintainers:** After reviewing the code, comment \`/ok-to-test\` to trigger the e2e tests.\n\n**Note:** Please review the PR changes carefully before approving, as the tests will run with access to cluster resources.`
+              });
+            }
 
   # Build the WVA controller image on GitHub-hosted runner (has proper Docker setup)
   build-image:
@@ -87,8 +194,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
-          # Use PR head SHA for pull_request events, otherwise default
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Use PR head SHA from gate (works for both pull_request and issue_comment)
+          ref: ${{ needs.gate.outputs.pr_head_sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -102,8 +209,8 @@ jobs:
         env:
           REGISTRY: ghcr.io
           IMAGE_NAME: ${{ github.repository }}
-          # Use PR head SHA for pull_request events, otherwise github.sha
-          GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Use PR head SHA from gate
+          GIT_REF: ${{ needs.gate.outputs.pr_head_sha }}
         run: |
           # Build image with git ref tag for this PR
           # Use first 8 chars of the git ref (POSIX-compliant)
@@ -132,13 +239,15 @@ jobs:
       MAX_NUM_SEQS: ${{ github.event.inputs.max_num_seqs || '1' }}
       HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '30' }}
       SKIP_CLEANUP: ${{ github.event.inputs.skip_cleanup || 'false' }}
+      # PR number from gate (works for pull_request and issue_comment)
+      PR_NUMBER: ${{ needs.gate.outputs.pr_number || github.run_id }}
       # PR-specific namespaces for isolation between concurrent PR tests
       # Primary llm-d namespace (Model A1 + A2)
-      LLMD_NAMESPACE: llm-d-inference-scheduler-pr-${{ github.event.pull_request.number || github.run_id }}
+      LLMD_NAMESPACE: llm-d-inference-scheduler-pr-${{ needs.gate.outputs.pr_number || github.run_id }}
       # Secondary llm-d namespace (Model B)
-      LLMD_NAMESPACE_B: llm-d-inference-scheduler-pr-${{ github.event.pull_request.number || github.run_id }}-b
+      LLMD_NAMESPACE_B: llm-d-inference-scheduler-pr-${{ needs.gate.outputs.pr_number || github.run_id }}-b
       # WVA controller namespace (monitors all models)
-      WVA_NAMESPACE: llm-d-autoscaler-pr-${{ github.event.pull_request.number || github.run_id }}
+      WVA_NAMESPACE: llm-d-autoscaler-pr-${{ needs.gate.outputs.pr_number || github.run_id }}
       # Unique release names per run to avoid conflicts
       WVA_RELEASE_NAME: wva-e2e-${{ github.run_id }}
       # Model A1: Primary deployment in LLMD_NAMESPACE
@@ -151,8 +260,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
-          # Use PR head SHA for pull_request events, otherwise default
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Use PR head SHA from gate (works for both pull_request and issue_comment)
+          ref: ${{ needs.gate.outputs.pr_head_sha }}
 
       - name: Extract Go version from go.mod
         run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -179,7 +179,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body: `👋 Thanks for your contribution!\n\nThis PR is from a fork, so the e2e tests require maintainer approval to run (they use GPU resources).\n\n**For maintainers:** After reviewing the code, comment \`/ok-to-test\` to trigger the e2e tests.\n\n**Note:** Please review the PR changes carefully before approving, as the tests will run with access to cluster resources.`
+                body: `👋 Thanks for your contribution!\n\nThis PR is from a fork, so the e2e tests require maintainer approval to run (they use GPU resources).\n\n**For maintainers:** After reviewing the code, comment /ok-to-test to trigger the e2e tests.\n\n**Note:** Please review the PR changes carefully before approving, as the tests will run with access to cluster resources.`
               });
             }
 

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -34,12 +34,6 @@ jobs:
           version: v2.1.6
           args: ""
 
-      # - name: Run precommit checks
-      #   run: make precommit
-
-      # Note: test-e2e requires Kind and full cluster setup
-      # E2E tests run in separate ci-e2e-openshift workflow on self-hosted runner
-
       - name: Run make build
         shell: bash
         run: |
@@ -49,3 +43,15 @@ jobs:
         shell: bash
         run: |
           make test
+
+      - name: Install Kind
+        run: |
+          [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Run make test-e2e
+        shell: bash
+        run: |
+          make test-e2e

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -46,7 +46,13 @@ jobs:
 
       - name: Install Kind
         run: |
-          [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-amd64
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  KIND_ARCH="amd64" ;;
+            aarch64) KIND_ARCH="arm64" ;;
+            *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+          esac
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-${KIND_ARCH}"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind version

--- a/test/e2e-saturation-based/e2e_saturation_test.go
+++ b/test/e2e-saturation-based/e2e_saturation_test.go
@@ -700,7 +700,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Multiple 
 				// Initial replica count should be MinimumReplicas (typically 0 or 1)
 				g.Expect(vaA100.Status.CurrentAlloc.NumReplicas).To(BeNumerically("==", MinimumReplicas),
 					fmt.Sprintf("A100 VariantAutoscaling DesiredReplicas should be at %d replicas", MinimumReplicas))
-			}, 4*time.Minute, 5*time.Second).Should(Succeed())
+			}, 6*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("verifying H100 variant has expected initial replicas or scales down (before load)")
 			Eventually(func(g Gomega) {
@@ -713,7 +713,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Multiple 
 
 				g.Expect(vaH100.Status.CurrentAlloc.NumReplicas).To(BeNumerically("==", MinimumReplicas),
 					fmt.Sprintf("H100 VariantAutoscaling DesiredReplicas should be at %d replicas", MinimumReplicas))
-			}, 4*time.Minute, 5*time.Second).Should(Succeed())
+			}, 6*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("logging initial VariantAutoscaling statuses")
 			err := utils.LogVariantAutoscalingStatus(ctx, deployNameA100, namespace, crClient, GinkgoWriter)

--- a/test/e2e-saturation-based/e2e_saturation_test.go
+++ b/test/e2e-saturation-based/e2e_saturation_test.go
@@ -66,7 +66,7 @@ const (
 	llmDNamespace                 = "llm-d-sim"
 	gatewayName                   = "infra-sim-inference-gateway-istio"
 	WVAConfigMapName              = "workload-variant-autoscaler-variantautoscaling-config"
-	saturationConfigMapName       = "saturation-scaling-config"
+	saturationConfigMapName       = "workload-variant-autoscaler-saturation-scaling-config"
 )
 
 // Variant and Model constants
@@ -135,11 +135,8 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Single Va
 		initialReplicas int32
 		loadGenJob      *batchv1.Job
 		port            int
-		modelName       string
-		ctx             context.Context
-
-		// ConfigMap reference
-		saturationConfigMapName = "saturation-scaling-config"
+		modelName string
+		ctx       context.Context
 	)
 
 	BeforeAll(func() {


### PR DESCRIPTION
## Summary

- Add `/ok-to-test` gate for fork PRs to handle external contributors gracefully
- Re-enable `make test-e2e` in ci-pr-checks with Kind installation

## /ok-to-test Gate for Fork PRs

External contributors opening PRs from forks now see a helpful message instead of a failing CI run:

**For maintainers (write access):** Tests run automatically

**For external contributors:**
1. Gate detects they don't have write access
2. Posts a comment explaining how to get tests approved
3. Skips the workflow gracefully (no red failure)

**When maintainer reviews and comments `/ok-to-test`:**
1. `issue_comment` event triggers a new workflow run
2. Runs in base repo context (has secrets and self-hosted runner access)
3. Adds 🚀 reaction to acknowledge the command

### Security Model

- External contributor opens PR (untrusted code)
- Maintainer reviews the code manually
- Maintainer comments `/ok-to-test` (explicit approval after review)
- Workflow runs with secrets access

This is the standard pattern used by Kubernetes, Istio, and other large projects for running tests on external PRs.

## Re-enable test-e2e

Added Kind installation and `make test-e2e` to ci-pr-checks.yaml to run emulated e2e tests (saturation mode) on every PR.

## Test Plan

- [ ] Open a PR from a fork to verify the gate posts instructions
- [ ] Comment `/ok-to-test` to verify tests are triggered
- [ ] Verify maintainer PRs still run automatically
- [ ] Verify Kind e2e tests run in ci-pr-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)