### PR TITLE
fix(ci): skip build-image for fork PRs on pull_request event

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -773,7 +773,7 @@ jobs:
               state = 'success';
               description = 'E2E tests passed';
             } else if (e2eResult === 'skipped') {
-              state = 'success';
+              state = 'pending';
               description = 'E2E tests skipped';
             } else if (e2eResult === 'cancelled') {
               state = 'failure';
@@ -792,7 +792,7 @@ jobs:
               state: state,
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               description: description,
-              context: 'CI - OpenShift E2E Tests / e2e (/ok-to-test)'
+              context: '${{ github.workflow }} / e2e (/ok-to-test)'
             });
 
             console.log('Status reported successfully');


### PR DESCRIPTION
## Summary
- Fix fork PRs showing failed `build-image` checks by skipping the job on `pull_request` event (fork PRs don't have secrets access)
- Add `is_fork_pr` detection to gate job
- Add `report-status` job to update PR commit status after `/ok-to-test` triggered runs complete

## Context
Fork PRs don't have access to repository secrets when triggered by the `pull_request` event (GitHub security feature). This causes the `build-image` job to fail with "Username and password required" even though the job will succeed when triggered via `/ok-to-test` (which uses `issue_comment` event running in base repo context).

## Changes
- Gate job now outputs `is_fork_pr` to detect fork PRs
- `build-image` job skips when `is_fork_pr == true AND event == pull_request`
- New `report-status` job reports back to PR commit after `/ok-to-test` runs complete

## Test plan
- [x] Verify PR #457 (from fork) no longer shows failing `build-image` check on `pull_request` event
- [ ] Verify `/ok-to-test` still works correctly for fork PRs
- [ ] Verify status is reported back to PR after `/ok-to-test` run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)