### PR TITLE
feat(ci): post comment with link to e2e run on /ok-to-test

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -147,6 +147,15 @@ jobs:
                 comment_id: context.payload.comment.id,
                 content: 'rocket'
               });
+
+              // Post comment with link to the e2e workflow run
+              const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `🚀 **E2E tests triggered by /ok-to-test**\n\n[View the OpenShift E2E workflow run](${runUrl})`
+              });
               return;
             }
 


### PR DESCRIPTION
## Summary
- When `/ok-to-test` triggers e2e tests, post a comment with a direct link to the workflow run
- Makes it easy to find and monitor e2e tests since `issue_comment` triggered runs don't appear in PR checks

## Example output
When a maintainer comments `/ok-to-test`:

> 🚀 **E2E tests triggered by /ok-to-test**
>
> [View the OpenShift E2E workflow run](https://github.com/llm-d-incubation/workload-variant-autoscaler/actions/runs/123)

## Test plan
- [ ] Comment `/ok-to-test` on a fork PR and verify the comment with link is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)