### PR TITLE
Engine thread should not perform VA updates

### DIFF
--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -3,6 +3,8 @@ package interfaces
 import (
 	"context"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ReplicaMetrics holds capacity-related metrics for a single replica
@@ -77,10 +79,11 @@ type VariantDecision struct {
 	TargetReplicas     int // Suggested replica count
 	DesiredReplicas    int // Desired replicas from optimizer (from CRD status)
 	Reason             string
-	SaturationBased    bool // True if decision is primarily saturation-driven
-	ModelBasedDecision bool // True if decision considers model-based optimizer
-	SafetyOverride     bool // True if saturation veto overrode model-based decision
-	SaturationOnly     bool // True if operating in saturation-only mode (no model-based analysis)
+	SaturationBased    bool        // True if decision is primarily saturation-driven
+	ModelBasedDecision bool        // True if decision considers model-based optimizer
+	SafetyOverride     bool        // True if saturation veto overrode model-based decision
+	LastRunTime        metav1.Time // Time when decision was made (for status updates)
+	SaturationOnly     bool        // True if operating in saturation-only mode (no model-based analysis)
 }
 
 // SaturationAction represents the scaling action

--- a/internal/saturation/shared.go
+++ b/internal/saturation/shared.go
@@ -1,0 +1,53 @@
+package saturation
+
+import (
+	"sync"
+	"time"
+
+	interfaces "github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// InternalDecisionCache holds the latest saturation decisions for VAs.
+// This is used to pass decisions from the Engine to the Controller without API server interaction.
+type InternalDecisionCache struct {
+	sync.RWMutex
+	items map[string]interfaces.VariantDecision
+}
+
+// Key format: namespace/name
+func cacheKey(name, namespace string) string {
+	return namespace + "/" + name
+}
+
+func (c *InternalDecisionCache) Set(name, namespace string, d interfaces.VariantDecision) {
+	c.Lock()
+	defer c.Unlock()
+	key := cacheKey(name, namespace)
+	c.items[key] = d
+}
+
+func (c *InternalDecisionCache) Get(name, namespace string) (interfaces.VariantDecision, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	key := cacheKey(name, namespace)
+	val, ok := c.items[key]
+	return val, ok
+}
+
+// Global cache instance
+var DecisionCache = &InternalDecisionCache{
+	items: make(map[string]interfaces.VariantDecision),
+}
+
+// DecisionTrigger is a channel to trigger reconciliation for VAs.
+// Buffered to prevent blocking the engine loop.
+var DecisionTrigger = make(chan event.GenericEvent, 1000)
+
+// Helper to convert VariantDecision to OptimizedAlloc status
+func DecisionToOptimizedAlloc(d interfaces.VariantDecision) (int, string, metav1.Time) {
+	// If LastRunTime is adding to VariantDecision, use it, else Now
+	// For now we assume the consumer sets LastRunTime or uses Now
+	return d.TargetReplicas, d.AcceleratorName, metav1.NewTime(time.Now())
+}

--- a/test/e2e-openshift/e2e_suite_test.go
+++ b/test/e2e-openshift/e2e_suite_test.go
@@ -46,7 +46,7 @@ var (
 	// Secondary llm-d namespace for Model B (multi-model testing)
 	llmDNamespaceB = getEnvString("LLMD_NAMESPACE_B", "")
 	gatewayName    = getEnvString("GATEWAY_NAME", "infra-inference-scheduling-inference-gateway")
-	modelID     = getEnvString("MODEL_ID", "unsloth/Meta-Llama-3.1-8B")
+	modelID        = getEnvString("MODEL_ID", "unsloth/Meta-Llama-3.1-8B")
 	deployment     = getEnvString("DEPLOYMENT", "ms-inference-scheduling-llm-d-modelservice-decode")
 	requestRate    = getEnvInt("REQUEST_RATE", 20)
 	numPrompts     = getEnvInt("NUM_PROMPTS", 3000)

--- a/test/e2e-saturation-based/e2e_saturation_test.go
+++ b/test/e2e-saturation-based/e2e_saturation_test.go
@@ -135,8 +135,8 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Single Va
 		initialReplicas int32
 		loadGenJob      *batchv1.Job
 		port            int
-		modelName string
-		ctx       context.Context
+		modelName       string
+		ctx             context.Context
 	)
 
 	BeforeAll(func() {


### PR DESCRIPTION
Removed VA status updates from the engine.go thread; there is a shared cache implemented, which shares optimization updates to the reconciler thread to update VA status.