### PR TITLE
Add common cache layer for all engines

### DIFF
--- a/internal/engines/common/cache.go
+++ b/internal/engines/common/cache.go
@@ -1,4 +1,4 @@
-package saturation
+package common
 
 import (
 	"sync"

--- a/internal/engines/common/cache_test.go
+++ b/internal/engines/common/cache_test.go
@@ -1,0 +1,153 @@
+package common
+
+import (
+	"sync"
+	"testing"
+
+	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	interfaces "github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestInternalDecisionCache(t *testing.T) {
+	cache := &InternalDecisionCache{
+		items: make(map[string]interfaces.VariantDecision),
+	}
+
+	// Test Set and Get
+	decision := interfaces.VariantDecision{
+		VariantName:     "test-variant",
+		Namespace:       "test-ns",
+		TargetReplicas:  5,
+		AcceleratorName: "A100",
+		Action:          interfaces.ActionScaleUp,
+	}
+
+	cache.Set("test-variant", "test-ns", decision)
+
+	retrieved, ok := cache.Get("test-variant", "test-ns")
+	if !ok {
+		t.Error("Expected decision to be found in cache")
+	}
+	if retrieved.TargetReplicas != 5 {
+		t.Errorf("Expected TargetReplicas 5, got %d", retrieved.TargetReplicas)
+	}
+
+	_, ok = cache.Get("non-existent", "test-ns")
+	if ok {
+		t.Error("Expected non-existent item to not be found")
+	}
+
+	// Test Concurrency
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Set("test-variant", "test-ns", decision)
+			cache.Get("test-variant", "test-ns")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGlobalConfig(t *testing.T) {
+	config := &GlobalConfig{}
+
+	// Test Optimization Config
+	config.UpdateOptimizationConfig("60s")
+	if config.GetOptimizationInterval() != "60s" {
+		t.Errorf("Expected interval '60s', got '%s'", config.GetOptimizationInterval())
+	}
+
+	// Test Saturation Config
+	satConfig := map[string]interfaces.SaturationScalingConfig{
+		"default": {KvCacheThreshold: 0.8},
+	}
+	config.UpdateSaturationConfig(satConfig)
+	retrievedConfig := config.GetSaturationConfig()
+	if retrievedConfig["default"].KvCacheThreshold != 0.8 {
+		t.Errorf("Expected threshold 0.8, got %f", retrievedConfig["default"].KvCacheThreshold)
+	}
+
+	// Test Concurrency
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			config.UpdateOptimizationConfig("30s")
+			config.GetOptimizationInterval()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestVACache(t *testing.T) {
+	// Reset global cache for testing (since it's a global variable)
+	// Note: This might affect other parallel tests if any, but unit tests usually run sequentially pkg-wise
+	vaCacheLocks := &vaCacheLock
+	vaCacheLocks.Lock()
+	originalCache := vaCache
+	vaCache = make(map[client.ObjectKey]*wvav1alpha1.VariantAutoscaling)
+	vaCacheLocks.Unlock()
+
+	defer func() {
+		vaCacheLocks.Lock()
+		vaCache = originalCache
+		vaCacheLocks.Unlock()
+	}()
+
+	va := &wvav1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-va",
+			Namespace: "test-ns",
+		},
+	}
+
+	// Test Update
+	UpdateVACache(va)
+	key := client.ObjectKey{Name: "test-va", Namespace: "test-ns"}
+
+	// Verify via GetReadyVAs (implicitly tests Get)
+	readyVAs := GetReadyVAs()
+	if len(readyVAs) != 1 {
+		t.Errorf("Expected 1 ready VA, got %d", len(readyVAs))
+	} else if readyVAs[0].Name != "test-va" {
+		t.Errorf("Expected VA name 'test-va', got '%s'", readyVAs[0].Name)
+	}
+
+	// Test Remove
+	RemoveVACache(key)
+	readyVAs = GetReadyVAs()
+	if len(readyVAs) != 0 {
+		t.Errorf("Expected 0 ready VAs, got %d", len(readyVAs))
+	}
+
+	// Test Deleted VAs are skipped in GetReadyVAs
+	deletedVA := va.DeepCopy()
+	now := metav1.Now()
+	deletedVA.DeletionTimestamp = &now
+	UpdateVACache(deletedVA)
+	readyVAs = GetReadyVAs()
+	if len(readyVAs) != 0 {
+		t.Errorf("Expected 0 ready VAs (filtered deleted), got %d", len(readyVAs))
+	}
+}
+
+func TestDecisionToOptimizedAlloc(t *testing.T) {
+	d := interfaces.VariantDecision{
+		TargetReplicas:  3,
+		AcceleratorName: "H100",
+	}
+
+	replicas, acc, _ := DecisionToOptimizedAlloc(d)
+
+	if replicas != 3 {
+		t.Errorf("Expected 3 replicas, got %d", replicas)
+	}
+	if acc != "H100" {
+		t.Errorf("Expected H100 accelerator, got %s", acc)
+	}
+}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -36,6 +36,7 @@ import (
 	actuator "github.com/llm-d-incubation/workload-variant-autoscaler/internal/actuator"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector/prometheus"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/executor"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
@@ -85,7 +86,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 	//TODO: move interval to manager.yaml
 	logger := ctrl.LoggerFrom(ctx)
 
-	interval := saturation.Config.GetOptimizationInterval()
+	interval := common.Config.GetOptimizationInterval()
 
 	// Update the executor interval if changed
 	// Note: simple polling executor might not support dynamic interval update easily without restart,
@@ -126,7 +127,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 		logger.Info("Collected cluster accelerator inventory (Limited Mode)", "inventory", inventory)
 	}
 
-	saturationConfigMap := saturation.Config.GetSaturationConfig()
+	saturationConfigMap := common.Config.GetSaturationConfig()
 	if len(saturationConfigMap) == 0 {
 		logger.Info("Saturation scaling config not loaded yet, skipping optimization")
 		return nil
@@ -715,7 +716,7 @@ func (e *Engine) applySaturationDecisions(
 		// This avoids any API server interaction from the Engine.
 
 		// 1. Update Cache
-		saturation.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
+		common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
 			VariantName:     vaName,
 			Namespace:       va.Namespace,
 			TargetReplicas:  targetReplicas,
@@ -725,7 +726,7 @@ func (e *Engine) applySaturationDecisions(
 		})
 
 		// 2. Trigger Reconciler
-		saturation.DecisionTrigger <- event.GenericEvent{
+		common.DecisionTrigger <- event.GenericEvent{
 			Object: &updateVa,
 		}
 

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -33,9 +33,9 @@ import (
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
 	collector "github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/config"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/common"
 	interfaces "github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
-	saturationPkg "github.com/llm-d-incubation/workload-variant-autoscaler/internal/saturation"
 	utils "github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
 	testutils "github.com/llm-d-incubation/workload-variant-autoscaler/test/utils"
 )
@@ -404,7 +404,7 @@ data:
 			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, metricsCollector)
 
 			// Populate global config
-			saturationPkg.Config.UpdateSaturationConfig(map[string]interfaces.SaturationScalingConfig{
+			common.Config.UpdateSaturationConfig(map[string]interfaces.SaturationScalingConfig{
 				"default": {}, // Empty config is valid enough to proceed? Validate() might fail if not checked.
 			})
 

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -24,8 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
-	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/saturation"
 )
 
 // VariantFilter is a function that determines if a VA should be included.
@@ -166,7 +166,7 @@ func filterVariantsByDeployment(ctx context.Context, client client.Client, filte
 // (condition TargetResolved is true) using the shared cache.
 func readyVariantAutoscalings(ctx context.Context, _ client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
 	// Read VAs from shared cache instead of API server
-	readyVAs := saturation.GetReadyVAs()
+	readyVAs := common.GetReadyVAs()
 
 	ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("Found VariantAutoscaling resources ready for optimization", "count", len(readyVAs))
 	return readyVAs, nil


### PR DESCRIPTION
A cache layer has been added to load ConfigMaps and VAs that are consumed by multiple engines in the controller.