### PR TITLE
feat: trigger VA reconciliation on deployment delete events

### DIFF
--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -85,19 +85,22 @@ func EventFilter() predicate.Funcs {
 }
 
 // DeploymentPredicate returns a predicate that filters Deployment events.
-// It allows Create events for all Deployments (to trigger VA reconciliation when target is created).
-// This handles the race condition where VA is created before its target deployment.
+// It allows Create and Delete events for all Deployments to trigger VA reconciliation:
+// - Create: handles the race condition where VA is created before its target deployment
+// - Delete: allows VA to update status and clear metrics when target deployment is removed
 func DeploymentPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			// Controller-runtime guarantees e.Object is a Deployment since we watch that type
+			// Allow all Deployment create events to trigger reconciliation
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return false
+			// Allow all Deployment delete events to trigger reconciliation
+			// so VAs can update their status when target deployment is removed
+			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false


### PR DESCRIPTION
## Summary

- Trigger VA reconciliation when target deployment is deleted
- Allows VA to update status and clear metrics when deployment is removed

## Changes

Updated `DeploymentPredicate` in `internal/controller/predicates.go` to return `true` for Delete events in addition to Create events.

## Why

When a deployment is deleted:
1. The VA's status should be updated to reflect the missing deployment
2. Any associated metrics should be cleared or updated
3. The VA should be marked as not ready until the deployment is recreated

Previously, only Create events triggered reconciliation for deployments, leaving VAs in a stale state when their target deployment was deleted.

## Test plan

- [ ] Verify VA status updates when target deployment is deleted
- [ ] Verify VA recovers when deployment is recreated

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)