### PR TITLE
fix: apply controller-instance filter to VA list operations

### DIFF
--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -86,3 +86,11 @@ const (
 	LabelAcceleratorType    = "accelerator_type"
 	LabelControllerInstance = "controller_instance"
 )
+
+// Kubernetes Label Keys
+// Label keys used on Kubernetes resources for filtering and identification.
+const (
+	// ControllerInstanceLabelKey is the label key used to associate VAs with specific controller instances.
+	// Used for multi-controller isolation where each controller only manages VAs with matching labels.
+	ControllerInstanceLabelKey = "wva.llmd.ai/controller-instance"
+)

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -1,14 +1,12 @@
 package controller
 
 import (
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
-
-// controllerInstanceLabelKey is the label key used to associate VAs with specific controller instances
-const controllerInstanceLabelKey = "wva.llmd.ai/controller-instance"
 
 // ConfigMapPredicate returns a predicate that filters ConfigMap events to only the target ConfigMaps.
 // It matches the enqueue function logic - allows either configmap name if namespace matches.
@@ -137,7 +135,7 @@ func VariantAutoscalingPredicate() predicate.Predicate {
 			return false
 		}
 
-		vaInstance, hasLabel := labels[controllerInstanceLabelKey]
+		vaInstance, hasLabel := labels[constants.ControllerInstanceLabelKey]
 		return hasLabel && vaInstance == controllerInstance
 	})
 }

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -25,6 +25,7 @@ import (
 
 	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/metrics"
 )
 
 // VariantFilter is a function that determines if a VA should be included.
@@ -161,12 +162,31 @@ func filterVariantsByDeployment(ctx context.Context, client client.Client, filte
 	return filteredVAs, nil
 }
 
+// controllerInstanceLabelKey is the label key used to associate VAs with specific controller instances.
+// This must match the key used in predicates.go for consistent filtering.
+const controllerInstanceLabelKey = "wva.llmd.ai/controller-instance"
+
 // readyVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization
-// using the informer cache.
-func readyVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
-	// List all VAs using the informer cache
+// using the informer cache. When CONTROLLER_INSTANCE is configured, only VAs with matching
+// controller-instance labels are returned to enable multi-controller isolation.
+func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// Build list options based on controller instance configuration
+	listOpts := []client.ListOption{}
+	controllerInstance := metrics.GetControllerInstance()
+	if controllerInstance != "" {
+		// Filter by controller-instance label for multi-controller isolation
+		listOpts = append(listOpts, client.MatchingLabels{
+			controllerInstanceLabelKey: controllerInstance,
+		})
+		logger.V(logging.DEBUG).Info("Filtering VAs by controller instance",
+			"controllerInstance", controllerInstance)
+	}
+
+	// List VAs using the informer cache with optional label selector
 	var vaList wvav1alpha1.VariantAutoscalingList
-	if err := client.List(ctx, &vaList); err != nil {
+	if err := k8sClient.List(ctx, &vaList, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -180,7 +200,9 @@ func readyVariantAutoscalings(ctx context.Context, client client.Client) ([]wvav
 		readyVAs = append(readyVAs, va)
 	}
 
-	ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("Found VariantAutoscaling resources ready for optimization", "count", len(readyVAs))
+	logger.V(logging.DEBUG).Info("Found VariantAutoscaling resources ready for optimization",
+		"count", len(readyVAs),
+		"controllerInstance", controllerInstance)
 	return readyVAs, nil
 }
 

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/metrics"
 )
@@ -162,10 +163,6 @@ func filterVariantsByDeployment(ctx context.Context, client client.Client, filte
 	return filteredVAs, nil
 }
 
-// controllerInstanceLabelKey is the label key used to associate VAs with specific controller instances.
-// This must match the key used in predicates.go for consistent filtering.
-const controllerInstanceLabelKey = "wva.llmd.ai/controller-instance"
-
 // readyVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization
 // using the informer cache. When CONTROLLER_INSTANCE is configured, only VAs with matching
 // controller-instance labels are returned to enable multi-controller isolation.
@@ -178,7 +175,7 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 	if controllerInstance != "" {
 		// Filter by controller-instance label for multi-controller isolation
 		listOpts = append(listOpts, client.MatchingLabels{
-			controllerInstanceLabelKey: controllerInstance,
+			constants.ControllerInstanceLabelKey: controllerInstance,
 		})
 		logger.V(logging.DEBUG).Info("Filtering VAs by controller instance",
 			"controllerInstance", controllerInstance)


### PR DESCRIPTION
## Summary
- Fixes multi-controller isolation bug introduced in PR #495
- The saturation engine's polling loop was listing ALL VAs instead of only those assigned to the controller instance
- Adds label selector filtering to `readyVariantAutoscalings()` when `CONTROLLER_INSTANCE` is configured

## Problem
PR #495 added `VariantAutoscalingPredicate()` to filter watch events, but the saturation engine bypasses the watch:
- It runs on a 30-second polling loop
- Calls `ActiveVariantAutoscaling()` → `readyVariantAutoscalings()` → `client.List()`
- The List operation had no label selector, so it returned ALL VAs in the cluster
- This caused controllers to process VAs belonging to other controller instances

## Fix
When `CONTROLLER_INSTANCE` env var is set, the List operation now uses a `MatchingLabels` selector to filter by `wva.llmd.ai/controller-instance` label, matching the predicate behavior.

## Test plan
- [ ] Verify unit tests pass
- [ ] Verify lint passes
- [ ] E2E test with multiple concurrent PRs to confirm isolation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)