### PR TITLE
ci: scale down GPU workloads on e2e test failure

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -833,7 +833,7 @@ jobs:
               echo "=== Scaling down decode deployments in $ns ==="
               kubectl scale deployment -n "$ns" -l llm-d.ai/inferenceServing=true --replicas=0 || true
               # Also try by name pattern in case labels are missing
-              for deploy in $(kubectl get deployment -n "$ns" -o name 2>/dev/null | grep decode); do
+              kubectl get deployment -n "$ns" -o name 2>/dev/null | grep decode | while read -r deploy; do
                 echo "  Scaling down: $deploy"
                 kubectl scale "$deploy" -n "$ns" --replicas=0 || true
               done

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -819,6 +819,41 @@ jobs:
 
           echo "Cleanup complete"
 
+      - name: Scale down GPU workloads on failure
+        # On failure, scale down decode deployments to free GPUs while preserving
+        # other resources (VA, HPA, controller, gateway) for debugging
+        if: failure()
+        run: |
+          echo "Test failed - scaling down decode deployments to free GPUs..."
+          echo "Other resources (VA, HPA, controller logs) are preserved for debugging"
+          echo ""
+
+          for ns in "$LLMD_NAMESPACE" "$LLMD_NAMESPACE_B"; do
+            if kubectl get namespace "$ns" &>/dev/null; then
+              echo "=== Scaling down decode deployments in $ns ==="
+              kubectl scale deployment -n "$ns" -l llm-d.ai/inferenceServing=true --replicas=0 || true
+              # Also try by name pattern in case labels are missing
+              for deploy in $(kubectl get deployment -n "$ns" -o name 2>/dev/null | grep decode); do
+                echo "  Scaling down: $deploy"
+                kubectl scale "$deploy" -n "$ns" --replicas=0 || true
+              done
+            fi
+          done
+
+          echo ""
+          echo "GPU workloads scaled down. Remaining resources for debugging:"
+          echo ""
+          echo "=== VAs ==="
+          kubectl get va -n "$LLMD_NAMESPACE" 2>/dev/null || true
+          kubectl get va -n "$LLMD_NAMESPACE_B" 2>/dev/null || true
+          echo ""
+          echo "=== HPAs ==="
+          kubectl get hpa -n "$LLMD_NAMESPACE" 2>/dev/null || true
+          kubectl get hpa -n "$LLMD_NAMESPACE_B" 2>/dev/null || true
+          echo ""
+          echo "=== Controller pods ==="
+          kubectl get pods -n "$WVA_NAMESPACE" 2>/dev/null || true
+
   # Report status back to PR for issue_comment triggered runs
   # This ensures fork PRs show the correct status after /ok-to-test runs complete
   report-status:


### PR DESCRIPTION
## Summary
- Scale down decode deployments when e2e tests fail to free GPUs
- Preserves VA, HPA, controller, and gateway resources for debugging
- Outputs debugging info (VA status, HPA status, controller pods) after scale-down

## Why
When e2e tests fail, the full namespace is left for debugging. However, this means GPUs remain allocated and unavailable for other PRs. By scaling down only the decode deployments (the GPU consumers), we:

1. **Free GPUs immediately** - Other PRs can use them
2. **Keep debugging info** - VA status, HPA events, controller logs, events all remain
3. **No manual cleanup needed** - Failed tests auto-release GPUs

## Test plan
- [ ] Trigger a test failure and verify decode deployments scale to 0
- [ ] Verify VA, HPA, and controller pods remain accessible
- [ ] Verify GPUs become available for scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)