### PR TITLE
fix(e2e): increase max_tokens to sustain GPU load for scale-up

### DIFF
--- a/test/e2e-openshift/sharegpt_scaleup_test.go
+++ b/test/e2e-openshift/sharegpt_scaleup_test.go
@@ -58,8 +58,8 @@ const (
 	numLoadWorkers     = 10    // Number of parallel load generation workers
 	requestsPerWorker  = 500   // Requests each worker sends
 	batchSize          = 50    // Concurrent requests per batch
-	curlTimeoutSeconds = 120   // Timeout for each curl request
-	maxTokens          = 150   // Max tokens for completion requests
+	curlTimeoutSeconds = 180   // Timeout for each curl request (increased for longer outputs)
+	maxTokens          = 400   // Max tokens for completion requests (increased to sustain GPU load)
 	batchSleepDuration = "0.1" // Sleep duration between batches to control rate
 )
 


### PR DESCRIPTION
## Summary
- Increase `maxTokens` from 150 to 400 to generate longer outputs that keep GPU KV cache occupied
- Increase `curlTimeoutSeconds` from 120 to 180 to accommodate longer response times

## Problem
With A100 GPUs, the model responds very quickly (TTFT ~20ms) with shorter outputs. This causes:
1. Load generation completes before metrics are collected
2. Saturation engine sees 0 arrival rate/queue because traffic already finished
3. Scale-up is not triggered even under heavy load

## Solution
Longer max_tokens (400 vs 150) means:
- Each request takes ~2-3x longer to complete
- KV cache stays occupied longer
- Queue builds up under concurrent load
- Saturation engine properly detects load and recommends scale-up

## Testing
Manually verified with heavy load test on PR-521 cluster:
- OPTIMIZED increased from 1 → 2 → 3 under sustained load
- HPA correctly scaled deployment from 1 → 2 replicas

## Test plan
- [ ] Run e2e tests on PR to verify scale-up is triggered reliably
- [ ] Monitor VA and HPA metrics during test

🤖 Generated with [Claude Code](https://claude.com/claude-code)