### PR TITLE
fix(e2e): scale load generation based on initial replica count

### DIFF
--- a/test/e2e-openshift/sharegpt_scaleup_test.go
+++ b/test/e2e-openshift/sharegpt_scaleup_test.go
@@ -19,6 +19,7 @@ package e2eopenshift
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -154,7 +155,8 @@ var _ = Describe("ShareGPT Scale-Up Test", Ordered, func() {
 				// Scale load workers proportionally to initial replicas
 				// Formula: scaledWorkers = baseLoadWorkers * initialReplicas / baseReplicas
 				// This ensures consistent load pressure per replica
-				scaledLoadWorkers = int(baseLoadWorkers * initialReplicas / baseReplicas)
+				// Use floating-point with explicit rounding to avoid integer division truncation
+				scaledLoadWorkers = int(math.Round(float64(baseLoadWorkers*initialReplicas) / float64(baseReplicas)))
 				if scaledLoadWorkers < 1 {
 					scaledLoadWorkers = 1 // Minimum 1 worker
 				}


### PR DESCRIPTION
## Summary
Scale load generation workers proportionally to initial replica count to ensure consistent load pressure per replica and prevent excessive scaling on limited GPU clusters.

## Problem
When Model B started with 1 replica under full load (10 workers), it experienced:
- Massive queue buildup (131 second TTFT!)
- System scaled to 7 replicas to catch up
- Consumed excessive GPU resources

Meanwhile Model A with 2 replicas handled the same load with only scaling to 2.

## Solution
Scale load workers based on initial replicas:
- Base: 10 workers tuned for 2 replicas
- Formula: `scaledWorkers = baseWorkers * initialReplicas / baseReplicas`
- 1 replica → 5 workers
- 2 replicas → 10 workers

This ensures:
- Consistent load pressure per replica
- Predictable scaling behavior
- No runaway replica counts on limited GPU clusters

## Test plan
- [ ] Run e2e tests to verify consistent scaling across models
- [ ] Monitor that optimized replicas stay in reasonable range (2-3, not 7+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)