### PR TITLE
fix: remove stale PerfParms reference from controller test

### DIFF
--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -420,10 +420,6 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 								Acc:          "A100",
 								AccCount:     1,
 								MaxBatchSize: 4,
-								PerfParms: llmdVariantAutoscalingV1alpha1.PerfParms{
-									DecodeParms:  map[string]string{"alpha": "0.28", "beta": "0.72"},
-									PrefillParms: map[string]string{"gamma": "0", "delta": "0"},
-								},
 							},
 						},
 					},


### PR DESCRIPTION
## Summary
- Remove stale `PerfParms` reference from controller test that was breaking all CI runs
- PR 528 removed PerfParms from the CRD but missed this reference in the controller test

## Test plan
- [ ] Verify lint-and-test passes