### PR TITLE
test: Increase E2E load test token counts to 1500/1500

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,8 +55,8 @@ const (
 	llamaModelId        = "unsloth/Meta-Llama-3.1-8B"
 	a100Acc             = "A100"
 	h100Acc             = "H100"
-	inputTokens         = 64
-	outputTokens        = 64
+	inputTokens         = 1500
+	outputTokens        = 1500
 	maxExecutionTimeSec = 600
 	loadRateTolerance   = 10
 	avgITL              = 20


### PR DESCRIPTION
## Summary
- Increase input and output token counts from 64 to 1500 for E2E load tests
- Makes tests more realistic by simulating longer LLM inference requests
- Helps better test EPP routing behavior under load

## Changes
- `inputTokens`: 64 → 1500
- `outputTokens`: 64 → 1500

## Rationale
With 64 tokens, requests complete very quickly, making it harder to:
- Build up meaningful queue depth
- Observe EPP routing decisions under sustained load
- Test KV cache utilization patterns

1500 tokens better simulates production inference workloads.

## Test plan
- [ ] Run OpenShift E2E tests with new token configuration
- [ ] Verify load generation works correctly with longer requests
- [ ] Confirm scale-up behavior under sustained load

🤖 Generated with [Claude Code](https://claude.com/claude-code)