### PR TITLE
Metrics cleanup phase 1: do not collect model-based metrics

### DIFF
--- a/internal/collector/v2/noop_source.go
+++ b/internal/collector/v2/noop_source.go
@@ -1,0 +1,33 @@
+package collector
+
+import (
+	"context"
+)
+
+// NoOpSource is a minimal MetricsSource implementation with no queries.
+// Useful for testing or as a placeholder when no metrics collection is needed.
+type NoOpSource struct {
+	queryList *QueryList
+}
+
+// NewNoOpSource creates a new no-op metrics source with an empty query list.
+func NewNoOpSource() *NoOpSource {
+	return &NoOpSource{
+		queryList: newQueryList(),
+	}
+}
+
+// QueryList returns an empty, immutable query list.
+func (n *NoOpSource) QueryList() *QueryList {
+	return n.queryList
+}
+
+// Refresh always returns an empty result map.
+func (n *NoOpSource) Refresh(ctx context.Context, spec RefreshSpec) (map[string]*MetricResult, error) {
+	return make(map[string]*MetricResult), nil
+}
+
+// Get always returns nil since no values are cached.
+func (n *NoOpSource) Get(queryName string, params map[string]string) *CachedValue {
+	return nil
+}

--- a/internal/collector/v2/source.go
+++ b/internal/collector/v2/source.go
@@ -1,3 +1,7 @@
+// Package collector provides metrics collection functionality.
+//
+// This file defines the MetricsSource interface and related types for
+// collecting and caching metrics from various backends.
 package collector
 
 import (

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	yaml "gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,12 +50,6 @@ type VariantAutoscalingReconciler struct {
 	Scheme *runtime.Scheme
 
 	Recorder record.EventRecorder
-
-	PromAPI promv1.API
-
-	// MetricsCollector is the interface for collecting metrics from various backends
-	// Defaults to Prometheus collector, but can be swapped for other backends (e.g., EPP)
-	MetricsCollector interfaces.MetricsCollector
 }
 
 // +kubebuilder:rbac:groups=llmd.ai,resources=variantautoscalings,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/prometheus/common/model"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
-	collector "github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
 	testutils "github.com/llm-d-incubation/workload-variant-autoscaler/test/utils"
 )
@@ -137,17 +135,11 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			mockPromAPI := &testutils.MockPromAPI{
-				QueryResults: map[string]model.Value{},
-				QueryErrors:  map[string]error{},
-			}
+
 			// Initialize MetricsCollector with mock Prometheus API
-			metricsCollector := collector.NewPrometheusCollector(mockPromAPI)
 			controllerReconciler := &VariantAutoscalingReconciler{
-				Client:           k8sClient,
-				Scheme:           k8sClient.Scheme(),
-				PromAPI:          mockPromAPI,
-				MetricsCollector: metricsCollector,
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -345,13 +337,9 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			// Mock controller components
-			mockPromAPI := &testutils.MockPromAPI{}
-			metricsCollector := collector.NewPrometheusCollector(mockPromAPI)
 			controllerReconciler := &VariantAutoscalingReconciler{
-				Client:           k8sClient,
-				Scheme:           k8sClient.Scheme(),
-				PromAPI:          mockPromAPI,
-				MetricsCollector: metricsCollector,
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
 			}
 
 			By("Reconciling - expect TargetNotFound")

--- a/internal/engines/saturation/metrics/replica_metrics.go
+++ b/internal/engines/saturation/metrics/replica_metrics.go
@@ -44,14 +44,14 @@ const (
 // ReplicaMetricsCollector collects replica-level metrics for saturation analysis
 // using the v2 collector infrastructure.
 type ReplicaMetricsCollector struct {
-	source             *collector.PrometheusSource
+	source             collector.MetricsSource
 	k8sClient          client.Client
 	podVAMapper        *collector.PodVAMapper
 	stalenessThreshold time.Duration
 }
 
 // NewReplicaMetricsCollector creates a new replica metrics collector.
-func NewReplicaMetricsCollector(source *collector.PrometheusSource, k8sClient client.Client) *ReplicaMetricsCollector {
+func NewReplicaMetricsCollector(source collector.MetricsSource, k8sClient client.Client) *ReplicaMetricsCollector {
 	return &ReplicaMetricsCollector{
 		source:             source,
 		k8sClient:          k8sClient,
@@ -61,7 +61,7 @@ func NewReplicaMetricsCollector(source *collector.PrometheusSource, k8sClient cl
 }
 
 // NewReplicaMetricsCollectorWithThreshold creates a new replica metrics collector with a custom staleness threshold.
-func NewReplicaMetricsCollectorWithThreshold(source *collector.PrometheusSource, k8sClient client.Client, stalenessThreshold time.Duration) *ReplicaMetricsCollector {
+func NewReplicaMetricsCollectorWithThreshold(source collector.MetricsSource, k8sClient client.Client, stalenessThreshold time.Duration) *ReplicaMetricsCollector {
 	return &ReplicaMetricsCollector{
 		source:             source,
 		k8sClient:          k8sClient,

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -77,14 +77,9 @@ func GroupVariantAutoscalingByModel(
 
 // GetAcceleratorType extracts the accelerator type from a VariantAutoscaling.
 // It checks in order:
-// 1. The first accelerator in Spec.ModelProfile.Accelerators
-// 2. The inference.optimization/acceleratorName label
-// 3. Returns empty string if neither is available
+// 1. The inference.optimization/acceleratorName label
+// 2. Returns empty string if neither is available
 func GetAcceleratorType(va *wvav1alpha1.VariantAutoscaling) string {
-	// Try spec first (primary source of truth)
-	// Spec.ModelProfile is deprecated/removed, falling back to label
-
-	// Fall back to label
 	if va.Labels != nil {
 		if acc, exists := va.Labels[AcceleratorNameLabel]; exists {
 			return acc


### PR DESCRIPTION
Key Changes:
- start removing references to v1 collector (MetricCollector)
- Do not pro-actively invalidate cached entry, as this is handled by checking metric freshness already (and automatic cleanup)