### PR TITLE
fix: always set MetricsAvailable condition in VA status

### DIFF
--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -192,8 +192,9 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Note: We blindly apply for now, assuming the Engine acts as the source of truth for "Desired" state
 		numReplicas, accelerator, lastRunTime := common.DecisionToOptimizedAlloc(decision)
 
-		// Only update DesiredOptimizedAlloc if we have valid values (accelerator is required by CRD)
-		if accelerator != "" && numReplicas > 0 {
+		// Only update DesiredOptimizedAlloc if we have a valid accelerator (required by CRD).
+		// Note: numReplicas may legitimately be 0 for scale-to-zero scenarios.
+		if accelerator != "" {
 			va.Status.DesiredOptimizedAlloc.NumReplicas = numReplicas
 			va.Status.DesiredOptimizedAlloc.Accelerator = accelerator
 			va.Status.DesiredOptimizedAlloc.LastRunTime = lastRunTime

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -187,6 +187,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Process Engine Decisions from Shared Cache
 	// This mechanism allows the Engine to trigger updates without touching the API server directly.
 	if decision, ok := common.DecisionCache.Get(va.Name, va.Namespace); ok {
+		logger.Info("Found decision in cache", "va", va.Name, "namespace", va.Namespace, "metricsAvailable", decision.MetricsAvailable)
 		// Only apply if the decision is fresher than the last one applied or if we haven't applied it
 		// Note: We blindly apply for now, assuming the Engine acts as the source of truth for "Desired" state
 		numReplicas, accelerator, lastRunTime := common.DecisionToOptimizedAlloc(decision)
@@ -209,7 +210,7 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Note: CurrentAlloc is removed from Status.
 		// Internal allocation state is managed by the Engine and Actuator.
 	} else {
-		logger.V(logging.DEBUG).Info("No decision found in cache for VA", "variant", va.Name)
+		logger.Info("No decision found in cache for VA", "va", va.Name, "namespace", va.Namespace)
 	}
 
 	// Update Status if we have changes (Conditions or OptimizedAlloc)

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -192,11 +192,14 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Note: We blindly apply for now, assuming the Engine acts as the source of truth for "Desired" state
 		numReplicas, accelerator, lastRunTime := common.DecisionToOptimizedAlloc(decision)
 
-		va.Status.DesiredOptimizedAlloc.NumReplicas = numReplicas
-		va.Status.DesiredOptimizedAlloc.Accelerator = accelerator
-		va.Status.DesiredOptimizedAlloc.LastRunTime = lastRunTime
+		// Only update DesiredOptimizedAlloc if we have valid values (accelerator is required by CRD)
+		if accelerator != "" && numReplicas > 0 {
+			va.Status.DesiredOptimizedAlloc.NumReplicas = numReplicas
+			va.Status.DesiredOptimizedAlloc.Accelerator = accelerator
+			va.Status.DesiredOptimizedAlloc.LastRunTime = lastRunTime
+		}
 
-		// Apply MetricsAvailable condition from cache
+		// Always apply MetricsAvailable condition from cache
 		metricsStatus := metav1.ConditionFalse
 		if decision.MetricsAvailable {
 			metricsStatus = metav1.ConditionTrue

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -195,6 +195,17 @@ func (r *VariantAutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.R
 		va.Status.DesiredOptimizedAlloc.Accelerator = accelerator
 		va.Status.DesiredOptimizedAlloc.LastRunTime = lastRunTime
 
+		// Apply MetricsAvailable condition from cache
+		metricsStatus := metav1.ConditionFalse
+		if decision.MetricsAvailable {
+			metricsStatus = metav1.ConditionTrue
+		}
+		llmdVariantAutoscalingV1alpha1.SetCondition(&va,
+			llmdVariantAutoscalingV1alpha1.TypeMetricsAvailable,
+			metricsStatus,
+			decision.MetricsReason,
+			decision.MetricsMessage)
+
 		// Note: CurrentAlloc is removed from Status.
 		// Internal allocation state is managed by the Engine and Actuator.
 	} else {

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -553,7 +553,10 @@ func (e *Engine) applySaturationDecisions(
 		if acceleratorName == "" {
 			logger.Info("Skipping status update for VA without accelerator info, but setting MetricsAvailable=False",
 				"variant", vaName, "cacheKey.name", va.Name, "cacheKey.namespace", va.Namespace)
-			// Still set the cache entry so the controller can set MetricsAvailable=False
+			// Still set the cache entry so the controller can set MetricsAvailable=False.
+			// This is a partial decision for metrics status only - other fields like
+			// TargetReplicas and AcceleratorName are left at zero values since we don't
+			// have enough information to set them.
 			common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
 				VariantName:      vaName,
 				Namespace:        va.Namespace,

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -518,8 +518,8 @@ func (e *Engine) applySaturationDecisions(
 			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
 				llmdVariantAutoscalingV1alpha1.TypeMetricsAvailable,
 				metav1.ConditionTrue,
-				"MetricsCollected",
-				"Saturation metrics are being collected from Prometheus")
+				"MetricsAvailable",
+				"Saturation metrics data is available for scaling decisions")
 		} else {
 			llmdVariantAutoscalingV1alpha1.SetCondition(&updateVa,
 				llmdVariantAutoscalingV1alpha1.TypeMetricsAvailable,

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -544,7 +544,7 @@ func (e *Engine) applySaturationDecisions(
 		// But we still need to set MetricsAvailable condition via the cache
 		if acceleratorName == "" {
 			logger.Info("Skipping status update for VA without accelerator info, but setting MetricsAvailable=False",
-				"variant", vaName)
+				"variant", vaName, "cacheKey.name", va.Name, "cacheKey.namespace", va.Namespace)
 			// Still set the cache entry so the controller can set MetricsAvailable=False
 			common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
 				VariantName:      vaName,

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -87,9 +87,14 @@ type VariantDecision struct {
 
 	// CurrentAllocation carries the collected metrics/allocation state
 	// This helps the Controller update status without re-collecting metrics
-	// CurrentAllocation carries the collected metrics/allocation state
-	// This helps the Controller update status without re-collecting metrics
 	CurrentAllocation *Allocation
+
+	// MetricsAvailable indicates whether saturation metrics were available for this decision
+	MetricsAvailable bool
+	// MetricsReason is the reason for the MetricsAvailable condition
+	MetricsReason string
+	// MetricsMessage is the human-readable message for the MetricsAvailable condition
+	MetricsMessage string
 }
 
 // SaturationAction represents the scaling action


### PR DESCRIPTION
## Summary
  - Fix MetricsReady condition not showing in VA status
  - The condition was never being set because the code tried to copy from a local object where it didn't exist
  - Now directly sets the condition based on whether metrics data is available

  ## Test plan
  - Deploy and check `oc get variantautoscaling -A` shows MetricsReady column populated