### PR TITLE
ci: auto-label PRs, assign reviewers, and add approved label on /approve

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -37,7 +37,7 @@ area/ci:
 area/e2e:
   - changed-files:
       - any-glob-to-any-file:
-          - 'test/e2e**'
+          - 'test/e2e/**'
           - 'test/e2e-openshift/**'
           - 'test/e2e-saturation-based/**'
 

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -37,7 +37,7 @@ area/ci:
 area/e2e:
   - changed-files:
       - any-glob-to-any-file:
-          - 'test/e2e/**'
+          - 'test/e2e**'
           - 'test/e2e-openshift/**'
           - 'test/e2e-saturation-based/**'
 

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,59 @@
+# PR Labeler configuration
+# Maps file patterns to labels
+
+area/api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'api/**'
+          - 'config/crd/**'
+
+area/controller:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/controller/**'
+
+area/engine:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/engines/**'
+
+area/collector:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/collector/**'
+
+area/saturation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/saturation/**'
+
+area/ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/*.yml'
+          - '.github/*.yaml'
+
+area/e2e:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/e2e/**'
+          - 'test/e2e-openshift/**'
+          - 'test/e2e-saturation-based/**'
+
+area/charts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'charts/**'
+
+area/deploy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'deploy/**'
+
+kind/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+          - '**/*.mdx'

--- a/.github/workflows/pr-auto-label-assign.yaml
+++ b/.github/workflows/pr-auto-label-assign.yaml
@@ -50,15 +50,15 @@ jobs:
 
             // Define reviewers for each area (excluding PR author)
             const areaReviewers = {
-              'area/api': ['asm582', 'lionelvillard'],
-              'area/controller': ['asm582', 'lionelvillard'],
-              'area/engine': ['lionelvillard', 'asm582'],
-              'area/collector': ['lionelvillard', 'asm582'],
-              'area/saturation': ['ev-shindin', 'asm582'],
+              'area/api': ['asm582', 'lionelvillard', 'mamy-CS'],
+              'area/controller': ['asm582', 'lionelvillard', 'mamy-CS'],
+              'area/engine': ['lionelvillard', 'asm582', 'mamy-CS'],
+              'area/collector': ['lionelvillard', 'asm582', 'mamy-CS'],
+              'area/saturation': ['ev-shindin', 'asm582', 'mamy-CS'],
               'area/ci': ['clubanderson', 'asm582'],
-              'area/e2e': ['clubanderson', 'asm582'],
-              'area/charts': ['clubanderson', 'asm582'],
-              'area/deploy': ['clubanderson', 'asm582'],
+              'area/e2e': ['clubanderson', 'asm582', 'mamy-CS'],
+              'area/charts': ['clubanderson', 'asm582', 'mamy-CS'],
+              'area/deploy': ['clubanderson', 'asm582', 'mamy-CS'],
               'kind/docs': []  // Docs PRs don't need reviewers auto-assigned
             };
 

--- a/.github/workflows/pr-auto-label-assign.yaml
+++ b/.github/workflows/pr-auto-label-assign.yaml
@@ -50,12 +50,12 @@ jobs:
 
             // Define reviewers for each area (excluding PR author)
             const areaReviewers = {
-              'area/api': ['asm582', 'WheelyMcBones'],
-              'area/controller': ['asm582', 'WheelyMcBones'],
+              'area/api': ['asm582', 'lionelvillard'],
+              'area/controller': ['asm582', 'lionelvillard'],
               'area/engine': ['lionelvillard', 'asm582'],
               'area/collector': ['lionelvillard', 'asm582'],
               'area/saturation': ['ev-shindin', 'asm582'],
-              'area/ci': ['clubanderson'],
+              'area/ci': ['clubanderson', 'asm582'],
               'area/e2e': ['clubanderson', 'asm582'],
               'area/charts': ['clubanderson', 'asm582'],
               'area/deploy': ['clubanderson', 'asm582'],

--- a/.github/workflows/pr-auto-label-assign.yaml
+++ b/.github/workflows/pr-auto-label-assign.yaml
@@ -1,0 +1,116 @@
+# Automatically label PRs based on changed files and assign expert reviewers
+name: "PR Auto Label and Assign"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.labeler.outputs.all-labels }}
+    steps:
+      - name: Apply labels based on changed files
+        id: labeler
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/pr-labeler.yml
+          sync-labels: false
+
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    needs: label
+    # Don't assign reviewers to bot PRs or draft PRs
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Assign reviewers based on labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            // Get current labels on the PR
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const labelNames = labels.map(l => l.name);
+            console.log('PR labels:', labelNames);
+
+            // Define reviewers for each area (excluding PR author)
+            const areaReviewers = {
+              'area/api': ['asm582', 'WheelyMcBones'],
+              'area/controller': ['asm582', 'WheelyMcBones'],
+              'area/engine': ['lionelvillard', 'asm582'],
+              'area/collector': ['lionelvillard', 'asm582'],
+              'area/saturation': ['ev-shindin', 'asm582'],
+              'area/ci': ['clubanderson'],
+              'area/e2e': ['clubanderson', 'asm582'],
+              'area/charts': ['clubanderson', 'asm582'],
+              'area/deploy': ['clubanderson', 'asm582'],
+              'kind/docs': []  // Docs PRs don't need reviewers auto-assigned
+            };
+
+            // Collect unique reviewers based on labels
+            const reviewersSet = new Set();
+
+            for (const label of labelNames) {
+              const reviewers = areaReviewers[label] || [];
+              for (const reviewer of reviewers) {
+                // Don't add PR author as reviewer
+                if (reviewer.toLowerCase() !== prAuthor.toLowerCase()) {
+                  reviewersSet.add(reviewer);
+                }
+              }
+            }
+
+            // Convert to array and limit to 2 reviewers
+            let reviewers = Array.from(reviewersSet).slice(0, 2);
+
+            if (reviewers.length === 0) {
+              console.log('No reviewers to assign for these labels');
+              return;
+            }
+
+            console.log('Assigning reviewers:', reviewers);
+
+            // Get current reviewers to avoid re-requesting
+            const { data: currentReviewers } = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const currentReviewerLogins = currentReviewers.users.map(u => u.login.toLowerCase());
+
+            // Filter out already requested reviewers
+            reviewers = reviewers.filter(r => !currentReviewerLogins.includes(r.toLowerCase()));
+
+            if (reviewers.length === 0) {
+              console.log('All reviewers already requested');
+              return;
+            }
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                reviewers: reviewers
+              });
+              console.log('Successfully assigned reviewers:', reviewers);
+            } catch (error) {
+              console.log('Error assigning reviewers:', error.message);
+              // Don't fail the workflow if reviewer assignment fails
+            }

--- a/.github/workflows/prow-github.yaml
+++ b/.github/workflows/prow-github.yaml
@@ -39,7 +39,7 @@ jobs:
   # Add approved label when /approve is commented
   add-approved-label:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/approve')
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/approve')
     steps:
       - name: Add approved label
         uses: actions/github-script@v7

--- a/.github/workflows/prow-github.yaml
+++ b/.github/workflows/prow-github.yaml
@@ -35,3 +35,19 @@ jobs:
             /hold
             /cc
             /uncc"
+
+  # Add approved label when /approve is commented
+  add-approved-label:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/approve')
+    steps:
+      - name: Add approved label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['approved']
+            });


### PR DESCRIPTION
## Summary
- Adds GitHub Actions automation for PR workflow:
  - **Auto-labeling**: Labels PRs based on changed files (area/api, area/controller, etc.)
  - **Auto-assign reviewers**: Assigns 1-2 expert reviewers based on the category
  - **Approved label**: Adds `approved` label when `/approve` is commented

## Categories and Expert Reviewers

| Category | Files | Reviewers |
|----------|-------|-----------|
| area/api | `api/**`, `config/crd/**` | asm582, WheelyMcBones |
| area/controller | `internal/controller/**` | asm582, WheelyMcBones |
| area/engine | `internal/engines/**` | lionelvillard, asm582 |
| area/collector | `internal/collector/**` | lionelvillard, asm582 |
| area/saturation | `internal/saturation/**` | ev-shindin, asm582 |
| area/ci | `.github/workflows/**` | clubanderson |
| area/e2e | `test/e2e**` | clubanderson, asm582 |
| area/charts | `charts/**` | clubanderson, asm582 |
| area/deploy | `deploy/**` | clubanderson, asm582 |
| kind/docs | `docs/**`, `*.md` | *(no auto-assign)* |

## Test plan
- [x] Comment `/approve` on PR #548 - verified workflow triggers
- [ ] Merge this PR
- [ ] Open a new PR touching `internal/controller/` - verify `area/controller` label and reviewer assignment