### PR TITLE
🌱 Update golangci-lint to v2.8.0

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.8.0
           args: ""
 
       - name: Run make build


### PR DESCRIPTION
## Summary
- Updates golangci-lint from v2.1.6 to v2.8.0
- Fixes false positive "possible nil pointer dereference" warnings in test files
- The older staticcheck version didn't recognize that `t.Fatal()` terminates execution

## Context
PR #424 is blocked by these false positives in `pkg/core/system_test.go` and `pkg/core/allocation_test.go`. The code correctly checks for nil and calls `t.Fatal()` which stops execution, but the older linter version doesn't understand this control flow.

## Test plan
- [ ] CI passes with the updated linter version
- [ ] No new legitimate lint warnings introduced