### PR TITLE
Implement Direct Actuation to Scale Resources

### DIFF
--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -110,5 +110,11 @@ rules:
   - get
   - watch
   - list
-
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - get
+  - update
 {{- end }}

--- a/internal/actuator/direct_actuator.go
+++ b/internal/actuator/direct_actuator.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actuator
+
+import (
+	"context"
+
+	poolutil "github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/scalefromzero"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	cached "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/scale"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type DirectActuator struct {
+	scaleClient scale.ScalesGetter
+	Mapper      meta.RESTMapper
+}
+
+func NewDirectActuator(config *rest.Config) (*DirectActuator, error) {
+	scaleClient, mapper, err := initScaleClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DirectActuator{
+		scaleClient: scaleClient,
+		Mapper:      mapper,
+	}, nil
+}
+
+func (da *DirectActuator) ScaleTargetObject(ctx context.Context, scaledObject *unstructured.Unstructured, replicas int32) error {
+	logger := log.FromContext(ctx)
+	scale, gr, err := da.getScaleTargetScale(ctx, scaledObject)
+	if err != nil {
+		return err
+	}
+
+	if scale.Spec.Replicas == replicas {
+		logger.Info("Scale Object already has the desired number of replicas. Skipping scaling", "scaleName", scale.Name)
+		return nil
+	}
+
+	currentReplicas, err := da.updateScaleOnScaleTarget(ctx, scaledObject, scale, replicas, gr)
+	if err == nil {
+		logger.Info("Successfully updated ScaleTarget",
+			"Original Replicas Count", currentReplicas,
+			"New Replicas Count", replicas)
+	} else {
+		logger.Error(err, "Failed to scale Target", "kind", scaledObject.GetKind(), "namespace", scaledObject.GetNamespace(), "name", scaledObject.GetName())
+		return err
+	}
+	return nil
+}
+
+func (da *DirectActuator) getScaleTargetScale(ctx context.Context, scaledObject *unstructured.Unstructured) (*autoscalingv1.Scale, schema.GroupResource, error) {
+	// Get the scale subresource for the target Object
+	logger := log.FromContext(ctx)
+	gvr, err := poolutil.GetResourceForKind(da.Mapper, scaledObject.GetAPIVersion(), scaledObject.GetKind())
+	if err != nil {
+		msg := "Failed to parse Group, Version, Kind, Resource"
+		logger.Error(err, msg, "apiVersion", scaledObject.GetAPIVersion(), "kind", scaledObject.GetKind())
+		return nil, schema.GroupResource{}, err
+	}
+
+	gr := gvr.GroupResource()
+	scale, err := da.scaleClient.Scales(scaledObject.GetNamespace()).Get(ctx, gr, scaledObject.GetName(), metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "Error getting scale subresource object")
+		return nil, schema.GroupResource{}, err
+	}
+	return scale, gr, nil
+}
+
+func (da *DirectActuator) updateScaleOnScaleTarget(ctx context.Context, scaledObject *unstructured.Unstructured, scale *autoscalingv1.Scale, replicas int32, gr schema.GroupResource) (int32, error) {
+	// Update with requested replicas.
+	currentReplicas := scale.Spec.Replicas
+	scale.Spec.Replicas = replicas
+
+	_, err := da.scaleClient.Scales(scaledObject.GetNamespace()).Update(ctx, gr, scale, metav1.UpdateOptions{})
+	return currentReplicas, err
+}
+
+// initScaleClient initializes scale client
+func initScaleClient(config *rest.Config) (scale.ScalesGetter, meta.RESTMapper, error) {
+	clientset, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cachedDiscoveryClient := cached.NewMemCacheClient(clientset)
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+
+	return scale.New(
+		clientset.RESTClient(), restMapper,
+		dynamic.LegacyAPIPathResolverFunc,
+		scale.NewDiscoveryScaleKindResolver(clientset),
+	), restMapper, nil
+}

--- a/internal/actuator/direct_actuator_test.go
+++ b/internal/actuator/direct_actuator_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actuator
+
+import (
+	"context"
+	"testing"
+
+	unittestutil "github.com/llm-d-incubation/workload-variant-autoscaler/test/utils"
+	"github.com/stretchr/testify/require"
+	appsV1 "k8s.io/api/apps/v1"
+	autoscalingapi "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	scalefake "k8s.io/client-go/scale/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestDirectActuator(t *testing.T) {
+	testSelector := map[string]string{"app": "vllm_v1"}
+	gvr := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
+
+	tests := []struct {
+		name            string
+		objName         string
+		namespace       string
+		initialReplicas int32
+		desiredReplicas int32
+		wantErr         bool
+	}{
+		{
+			name:            "Scale from 0 to 1 replica",
+			objName:         "test-scale-object",
+			namespace:       "default",
+			initialReplicas: int32(0),
+			desiredReplicas: int32(1),
+			wantErr:         false,
+		},
+		{
+			name:            "Scale from 1 to 5 replicas",
+			objName:         "test-scale-object",
+			namespace:       "llm-d-sim",
+			initialReplicas: int32(1),
+			desiredReplicas: int32(5),
+			wantErr:         false,
+		},
+		{
+			name:            "Scale to same replica count (no-op)",
+			objName:         "test-scale-object",
+			namespace:       "default",
+			initialReplicas: int32(3),
+			desiredReplicas: int32(3),
+			wantErr:         false,
+		},
+		{
+			name:      "Error when deployment does not exist",
+			objName:   "non-existent-deployment",
+			namespace: "default",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create scheme and add types
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = appsV1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			// Create deployment
+			deployment := unittestutil.MakeDeployment(tt.objName, tt.namespace, tt.initialReplicas, testSelector)
+
+			// Create initial scale object
+			initialScale := &autoscalingapi.Scale{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.objName,
+					Namespace: tt.namespace,
+				},
+				Spec: autoscalingapi.ScaleSpec{
+					Replicas: tt.initialReplicas,
+				},
+				Status: autoscalingapi.ScaleStatus{
+					Replicas: tt.initialReplicas,
+				},
+			}
+
+			// Create fake dynamic client with deployment
+			var fakeDynamicClientObjects []runtime.Object
+			if !tt.wantErr {
+				fakeDynamicClientObjects = []runtime.Object{deployment}
+			}
+			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, fakeDynamicClientObjects...)
+
+			// Create fake scale client
+			fakeScaleClient := &scalefake.FakeScaleClient{}
+
+			// Add reactor to handle Get requests for scales
+			if !tt.wantErr {
+				fakeScaleClient.AddReactor("get", "deployments", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, initialScale, nil
+				})
+			}
+
+			// Add reactor to handle Update requests for scales
+			fakeScaleClient.AddReactor("update", "deployments", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+				updateAction := action.(clienttesting.UpdateAction)
+				updatedScale := updateAction.GetObject().(*autoscalingapi.Scale)
+				return true, updatedScale, nil
+			})
+
+			// Create REST mapper
+			mapper := testrestmapper.TestOnlyStaticRESTMapper(scheme, schema.GroupVersion{Group: "apps", Version: "v1"})
+
+			// Create DirectActuator with fake scale client
+			actuator := &DirectActuator{
+				scaleClient: fakeScaleClient,
+				Mapper:      mapper,
+			}
+
+			// Get the deployment as unstructured object
+			var deploy runtime.Object
+			var err error
+			if !tt.wantErr {
+				deploy, err = fakeDynamicClient.Resource(gvr).Namespace(tt.namespace).Get(ctx, tt.objName, metav1.GetOptions{})
+				require.NoError(t, err)
+			} else {
+				// For error case, create a minimal unstructured object
+				deploy = deployment
+			}
+
+			// Convert to unstructured
+			unstructuredDeploy, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+			require.NoError(t, err)
+			unstructuredObj := &unstructured.Unstructured{}
+			unstructuredObj.SetUnstructuredContent(unstructuredDeploy)
+
+			// Call the ScaleTargetObject function
+			err = actuator.ScaleTargetObject(ctx, unstructuredObj, tt.desiredReplicas)
+
+			// Verify results
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				// Verify the scale client received the correct actions
+				actions := fakeScaleClient.Actions()
+				require.NotEmpty(t, actions, "Expected at least one action on scale client")
+
+				// If replicas are different, we expect Get and Update actions
+				if tt.initialReplicas != tt.desiredReplicas {
+					require.GreaterOrEqual(t, len(actions), 2, "Expected Get and Update actions")
+
+					// Verify Get action
+					getAction := actions[0]
+					require.Equal(t, "get", getAction.GetVerb())
+					require.Equal(t, "deployments", getAction.GetResource().Resource)
+
+					// Verify Update action
+					updateAction := actions[1]
+					require.Equal(t, "update", updateAction.GetVerb())
+					require.Equal(t, "deployments", updateAction.GetResource().Resource)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR extends WVA to support direct actuation by directly changing the number of replicas in the scale object that corresponds to the scaleTargetRef object. This feature will allow WVA to support use-cases such as scale-from-zero. 


**Related Issue**:  https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/421