### PR TITLE
test: enable replica stability test

### DIFF
--- a/test/e2e-saturation-based/e2e_saturation_test.go
+++ b/test/e2e-saturation-based/e2e_saturation_test.go
@@ -831,9 +831,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Multiple 
 	})
 
 	Context("Replica stability under constant load", func() {
-		//TODO: Flaky - re-enable when controller is stable
 		It("should maintain stable replica count under constant load", func() {
-			Skip("Flaky - re-enable when controller is stable")
 			By("starting constant load generation")
 			loadGenJob, err := utils.CreateLoadGeneratorJob(
 


### PR DESCRIPTION
## Summary

  - Enable the "Replica stability under constant load" test that was previously skipped as flaky

  ## Test plan

  - [x] CI passes with the stability test enabled
  - [x] Verify the test runs successfully in the e2e-saturation-based suite