### PR TITLE
Final drop of the scale-from-zero implementation

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-configmap.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-configmap.yaml
@@ -27,6 +27,9 @@ data:
   # PROMETHEUS_BEARER_TOKEN: "your-token-here"           # Direct bearer token (development/testing)
   # PROMETHEUS_TOKEN_PATH: "/path/to/token/file"        # Path to bearer token file (production with mounted secrets)
 
+  # configuration from scalefromzero
+  EPP_METRIC_READER_BEARER_TOKEN: ""
+
   # Optimization configuration
   GLOBAL_OPT_INTERVAL: {{ .Values.wva.reconcileInterval | quote }}
 

--- a/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
@@ -64,6 +64,11 @@ spec:
         image: "{{ .Values.wva.image.repository }}:{{ .Values.wva.image.tag }}"
         imagePullPolicy: "{{ .Values.wva.imagePullPolicy }}"
         env:
+          - name: EPP_METRIC_READER_BEARER_TOKEN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-config
+                key: EPP_METRIC_READER_BEARER_TOKEN
           - name: LOG_LEVEL
             value: {{ if .Values.wva.logging }}{{ .Values.wva.logging.level | default "info" | quote }}{{ else }}"info"{{ end }}
           - name: CONFIG_MAP_NAME

--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -50,6 +50,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -117,4 +119,9 @@ rules:
   verbs:
   - get
   - update
+- nonResourceURLs:
+  - /metrics
+  - /debug/pprof/*
+  verbs:
+  - get
 {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -425,7 +425,7 @@ func main() {
 	// Create InferencePool reconciler
 	inferencePoolReconciler := &controller.InferencePoolReconciler{
 		Datastore: ds,
-		Reader:    mgr.GetClient(),
+		Client:    mgr.GetClient(),
 		PoolGKNN:  poolutil.DefaultPoolGKNN(),
 	}
 

--- a/internal/actuator/direct_actuator.go
+++ b/internal/actuator/direct_actuator.go
@@ -19,7 +19,7 @@ package actuator
 import (
 	"context"
 
-	poolutil "github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/scalefromzero"
+	poolutil "github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils/pool"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/inferencepool_reconciler.go
+++ b/internal/controller/inferencepool_reconciler.go
@@ -33,7 +33,7 @@ import (
 )
 
 type InferencePoolReconciler struct {
-	client.Reader
+	client.Client
 	Datastore datastore.Datastore
 	PoolGKNN  common.GKNN
 }
@@ -80,12 +80,12 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	switch pool := obj.(type) {
 	case *v1.InferencePool:
-		endpointPool, err = poolutils.InferencePoolToEndpointPool(ctx, c.Reader, pool)
+		endpointPool, err = poolutils.InferencePoolToEndpointPool(ctx, c.Client, pool)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to convert InferencePool v1 to EndPointPool - %w", err)
 		}
 	case *v1alpha2.InferencePool:
-		endpointPool, err = poolutils.AlphaInferencePoolToEndpointPool(ctx, c.Reader, pool)
+		endpointPool, err = poolutils.AlphaInferencePoolToEndpointPool(ctx, c.Client, pool)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to convert InferencePool v1alpha2 to EndPointPool - %w", err)
 		}
@@ -94,7 +94,7 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if endpointPool != nil {
-		if err := c.Datastore.PoolSet(endpointPool); err != nil {
+		if err := c.Datastore.PoolSet(ctx, c.Client, endpointPool); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add endpoint into the datastore: - %w", err)
 		}
 	}

--- a/internal/controller/inferencepool_reconciler_test.go
+++ b/internal/controller/inferencepool_reconciler_test.go
@@ -101,7 +101,7 @@ func TestInferencePoolReconcile(t *testing.T) {
 			ctx := context.Background()
 
 			ds := datastore.NewDatastore()
-			inferencePoolReconciler := &InferencePoolReconciler{Reader: fakeClient, Datastore: ds, PoolGKNN: gknn}
+			inferencePoolReconciler := &InferencePoolReconciler{Client: fakeClient, Datastore: ds, PoolGKNN: gknn}
 
 			if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
 				t.Errorf("Unexpected InferencePool reconcile error: %v", err)
@@ -222,7 +222,7 @@ func TestAlphaInferencePoolReconcile(t *testing.T) {
 			ctx := context.Background()
 
 			ds := datastore.NewDatastore()
-			inferencePoolReconciler := &InferencePoolReconciler{Reader: fakeClient, Datastore: ds, PoolGKNN: gknn}
+			inferencePoolReconciler := &InferencePoolReconciler{Client: fakeClient, Datastore: ds, PoolGKNN: gknn}
 
 			if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
 				t.Errorf("Unexpected InferencePool reconcile error: %v", err)

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -94,7 +94,7 @@ func TestDatastore(t *testing.T) {
 			}
 
 			// Test PoolSet
-			gotErr := ds.PoolSet(ep)
+			gotErr := ds.PoolSet(ctx, fakeClient, ep)
 			if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error diff (+got/-want): %s", diff)
 			}
@@ -136,7 +136,7 @@ func TestDatastore(t *testing.T) {
 				ds.PoolDelete(ep.Name)
 				assert.Equal(t, len(ds.PoolList()), tt.clearDeleteResultLen, "Pools map should have the expected length after item deleted")
 
-				if err := ds.PoolSet(ep); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, ep); err != nil {
 					t.Errorf("failed to add endpoint into the datastore: %v", err)
 				}
 				assert.Equal(t, len(ds.PoolList()), tt.listResultLen, "Pools map should have the expected length after item added")

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -19,6 +19,8 @@ package scalefromzero
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -27,39 +29,69 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/utils/env"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	wvav1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/actuator"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/datastore"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/executor"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
+	poolutil "github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils/pool"
 )
 
-// NOTE: This is a placeholder for the scale-from-zero engine implementation.
-// The actual logic for the scale-from-zero engine should be implemented here.
+// Constants for condition
+const (
+	MetricsReasonAvailable            = "ScaleFromZero"
+	MetricsMessageAvailable           = "Scaled from zero due to pending requests"
+	reason                            = "scalefromzero mode: pending request - scale-up"
+	targetEPPMetricName               = "inference_extension_flow_control_queue_size"
+	targetEPPMetricLabel              = "target_model_name"
+	scaleFromZeroEngineMaxConcurrency = "SCALE_FROM_ZERO_ENGINE_MAX_CONCURRENCY"
+)
 
 type Engine struct {
-	client        client.Client
-	executor      executor.Executor
-	Datastore     datastore.Datastore
-	DynamicClient dynamic.Interface
-	Mapper        meta.RESTMapper
+	client         client.Client
+	executor       executor.Executor
+	Datastore      datastore.Datastore
+	DynamicClient  dynamic.Interface
+	Actuator       *actuator.DirectActuator
+	Mapper         meta.RESTMapper
+	maxConcurrency int
 }
 
 // NewEngine creates a new instance of the scale-from-zero engine.
 func NewEngine(client client.Client, mapper meta.RESTMapper, config *rest.Config, ds datastore.Datastore) (*Engine, error) {
+
+	maxConcurrency, err := env.GetInt(scaleFromZeroEngineMaxConcurrency, 30)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value for %s: expected integer: %w", scaleFromZeroEngineMaxConcurrency, err)
+	}
+
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
+	actuator, err := actuator.NewDirectActuator(config)
+	if err != nil {
+		return nil, err
+	}
+
 	engine := Engine{
-		client:        client,
-		Datastore:     ds,
-		DynamicClient: dynamicClient,
-		Mapper:        mapper,
+		client:         client,
+		Datastore:      ds,
+		DynamicClient:  dynamicClient,
+		Actuator:       actuator,
+		Mapper:         mapper,
+		maxConcurrency: maxConcurrency,
 	}
 
 	// TODO: replace by an hybrid, polling and reactive executor when available
@@ -82,26 +114,27 @@ func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 
 // optimize performs the optimization logic.
 func (e *Engine) optimize(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
 	// Get all inactive (replicas == 0) VAs
 	inactiveVAs, err := utils.InactiveVariantAutoscaling(ctx, e.client)
 	if err != nil {
 		return err
 	}
 
-	ctrl.Log.V(logging.DEBUG).Info("Found inactive VariantAutoscaling resources", "count", len(inactiveVAs))
+	logger.V(logging.DEBUG).Info("Found inactive VariantAutoscaling resources", "count", len(inactiveVAs))
 
 	var wg sync.WaitGroup
-	const maxConcurrency = 20 // TO DO: Make this configurable via a flag or environment variable.
-	sem := make(chan struct{}, maxConcurrency)
-	errorCh := make(chan error, maxConcurrency)
+	sem := make(chan struct{}, e.maxConcurrency)
+	errorCh := make(chan error, e.maxConcurrency)
 
 	for _, va := range inactiveVAs {
 		select {
 		case <-ctx.Done():
-			ctrl.Log.V(logging.DEBUG).Info("Context cancelled, exiting optimize loop")
+			logger.V(logging.DEBUG).Info("Context cancelled, exiting optimize loop")
 			return ctx.Err()
 		default:
-			ctrl.Log.V(logging.DEBUG).Info("Processing variant", "name", va.Name)
+			logger.V(logging.DEBUG).Info("Processing variant", "name", va.Name)
 			wg.Add(1)
 
 			// This call blocks if the channel is full (concurrency limit reached)
@@ -110,9 +143,9 @@ func (e *Engine) optimize(ctx context.Context) error {
 				defer wg.Done()
 				defer func() { <-sem }()
 
-				err := e.processInactiveVariant(ctx, va)
+				err := e.processInactiveVariant(ctx, va, 1)
 				if err != nil {
-					ctrl.Log.V(logging.DEBUG).Error(err, "Error Processing variant", "name", va.Name)
+					logger.V(logging.DEBUG).Error(err, "Error Processing variant", "name", va.Name)
 					errorCh <- err
 				} else {
 					errorCh <- nil
@@ -122,10 +155,9 @@ func (e *Engine) optimize(ctx context.Context) error {
 
 	}
 
-	go func() {
-		wg.Wait()
-		close(errorCh)
-	}()
+	// Wait for all goroutines to complete
+	wg.Wait()
+	close(errorCh)
 
 	// Aggregate errors
 	var aggregatedErrors []error
@@ -141,13 +173,14 @@ func (e *Engine) optimize(ctx context.Context) error {
 }
 
 // ProcessInactiveVariant processes a single inactive VariantAutoscaling resource.
-func (e *Engine) processInactiveVariant(ctx context.Context, va wvav1alpha1.VariantAutoscaling) error {
+func (e *Engine) processInactiveVariant(ctx context.Context, va wvav1alpha1.VariantAutoscaling, targetWorkloadReplicas int) error {
+	logger := log.FromContext(ctx)
 	objAPI := va.GetScaleTargetAPI()
 	objKind := va.GetScaleTargetKind()
 	objName := va.GetScaleTargetName()
 
 	// Parse Group, Version, Kind, Resource
-	gvr, err := GetResourceForKind(e.Mapper, objAPI, objKind)
+	gvr, err := poolutil.GetResourceForKind(e.Mapper, objAPI, objKind)
 	if err != nil {
 		return err
 	}
@@ -167,22 +200,137 @@ func (e *Engine) processInactiveVariant(ctx context.Context, va wvav1alpha1.Vari
 		return errors.New("labels are missing for target workload object")
 	}
 
+	// Check if inferencepool datastore is empty: this can happen during bootstrapping
+	dsPoolList := e.Datastore.PoolList()
+	if len(dsPoolList) == 0 {
+		logger.Info("Inferencepool datastore is empty - skipping processing inactive variant", "value", va.Name)
+		return nil
+	}
+
 	// Find target EPP for metrics collection
 	pool, err := e.Datastore.PoolGetFromLabels(labels)
+	if err != nil {
+		logger.Error(err, "Error finding target EPP", "variant", va.Name, "target VA model", va.Spec.ModelID)
+		return err
+	}
+
+	// Use EPP source from registry
+	eppSource := e.Datastore.PoolGetMetricsSource(pool.Name)
+	if eppSource == nil {
+		return errors.New("endpointpicker metrics source not found in datastore")
+	}
+
+	results, err := eppSource.Refresh(ctx, source.RefreshSpec{})
 	if err != nil {
 		return err
 	}
 
-	epp := pool.EndpointPicker
+	// Check for pending requests using EPP flowcontrol queue size metrics
+	result := results["all_metrics"]
+	pendingRequestExist := false
+	for _, value := range result.Values {
+		metricName := value.Labels["__name__"]
+		if metricName == targetEPPMetricName && value.Value > 0 {
+			if value.Labels[targetEPPMetricLabel] == va.Spec.ModelID {
+				logger.Info(
+					"Target workload has pending requests, scaling up from zero", "metricName", metricName,
+					"metric", value.Labels, "value", value.Value)
+				pendingRequestExist = true
+				break
+			}
+		}
+	}
 
-	// For Tests only (REMOVE LATER)
-	ctrl.Log.V(logging.DEBUG).Info(
-		"Target EndpointPicker resolved for inactive variant",
-		"service", epp.ServiceName,
-		"namespace", epp.Namespace,
-		"metricsPort", epp.MetricsPortNumber,
-	)
+	if !pendingRequestExist {
+		logger.V(logging.DEBUG).Info("No pending requests found in the flowcontrol queue - skipping scaling up from zero")
+		return nil
+	}
 
-	// TODO: Create EPP source and query metrics port
+	// 1.  Scale up from zero to one
+	// TODO: Right now we are scaling all the VA for the same target model. We need to scale only the VA that has the lowest cost.
+	err = e.Actuator.ScaleTargetObject(ctx, unstructuredObj, int32(targetWorkloadReplicas))
+	if err != nil {
+		logger.Error(err, "Error scaling up Target Workload", "variant", va.Name, "target VA model", va.Spec.ModelID)
+		return err
+	}
+	logger.Info("Successfully scaled up Target Workload", "variant", va.Name, "target VA model", va.Spec.ModelID, "inferencepool", pool.EndpointPicker.ServiceName)
+
+	// 2. Create or update VariantDecision
+	va.Status.Actuation.Applied = false
+	// Determine accelerator - try status first, then labels
+	var accelerator string
+	accelerator = va.Status.DesiredOptimizedAlloc.Accelerator
+	if accelerator == "" {
+		// Try to get from VA labels as last resort
+		if val, ok := va.Labels["inference.optimization/acceleratorName"]; ok && val != "" {
+			accelerator = val
+		}
+	}
+
+	decision, hasDecision := common.DecisionCache.Get(va.Name, va.Namespace)
+	if !hasDecision {
+		cost, err := strconv.ParseFloat(va.Spec.VariantCost, 64)
+		if err != nil {
+			return err
+		}
+		common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
+			VariantName:        va.Name,
+			Namespace:          va.Namespace,
+			ModelID:            va.Spec.ModelID,
+			Cost:               cost,
+			TargetReplicas:     targetWorkloadReplicas, // Scale up to 1 replica
+			CurrentReplicas:    targetWorkloadReplicas,
+			DesiredReplicas:    targetWorkloadReplicas,
+			LastRunTime:        metav1.Now(),
+			SaturationBased:    false,
+			SafetyOverride:     false,
+			ModelBasedDecision: false,
+			AcceleratorName:    accelerator,
+			Reason:             reason, // Reason for scaling up
+			MetricsAvailable:   true,
+			MetricsReason:      MetricsReasonAvailable,
+			MetricsMessage:     MetricsMessageAvailable,
+		})
+	} else {
+		if decision.CurrentReplicas == 0 {
+			decision.TargetReplicas = targetWorkloadReplicas
+			decision.CurrentReplicas = targetWorkloadReplicas
+			decision.DesiredReplicas = targetWorkloadReplicas
+			decision.LastRunTime = metav1.Now()
+			decision.SaturationBased = false
+			decision.SafetyOverride = false
+			decision.ModelBasedDecision = false
+			decision.Reason = reason
+			decision.AcceleratorName = accelerator
+			decision.MetricsAvailable = true
+			decision.MetricsReason = MetricsReasonAvailable
+			decision.MetricsMessage = MetricsMessageAvailable
+			common.DecisionCache.Set(va.Name, va.Namespace, decision)
+		} else {
+			logger.Info("Target variant decision.CurrentReplicas is not zero", "value", decision.CurrentReplicas)
+		}
+	}
+
+	// 3. Updates VA status.
+	va.Status.DesiredOptimizedAlloc = wvav1alpha1.OptimizedAlloc{
+		NumReplicas: targetWorkloadReplicas,
+		LastRunTime: metav1.Now(),
+		Accelerator: accelerator,
+	}
+
+	// Set condition based on decision characteristics
+	wvav1alpha1.SetCondition(&va,
+		wvav1alpha1.TypeOptimizationReady,
+		metav1.ConditionTrue,
+		"ScaleFromZeroMode",
+		fmt.Sprintf("scalefromzero decision: %s", reason))
+
+	va.Status.Actuation.Applied = true
+
+	// 4. Trigger Reconciler
+	common.DecisionTrigger <- event.GenericEvent{
+		Object: &va,
+	}
+
 	return nil
 }

--- a/internal/utils/pool/gvr.go
+++ b/internal/utils/pool/gvr.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scalefromzero
+package pool
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/internal/utils/pool/pool.go
+++ b/internal/utils/pool/pool.go
@@ -48,12 +48,12 @@ type EndpointPicker struct {
 }
 
 // InferencePoolToEndpointPool converts an v1 InferencePool to an EndpointPool.
-func InferencePoolToEndpointPool(ctx context.Context, reader client.Reader, inferencePool *v1.InferencePool) (*EndpointPool, error) {
+func InferencePoolToEndpointPool(ctx context.Context, client client.Client, inferencePool *v1.InferencePool) (*EndpointPool, error) {
 	if inferencePool == nil {
 		return nil, nil
 	}
 
-	epp, err := generateEndpointPickerObject(ctx, string(inferencePool.Spec.EndpointPickerRef.Name), inferencePool.Namespace, reader)
+	epp, err := generateEndpointPickerObject(ctx, string(inferencePool.Spec.EndpointPickerRef.Name), inferencePool.Namespace, client)
 	if err != nil {
 		return nil, err
 	}
@@ -72,12 +72,12 @@ func InferencePoolToEndpointPool(ctx context.Context, reader client.Reader, infe
 }
 
 // AlphaInferencePoolToEndpointPool converts an v1alpha2 inferencePool to an EndpointPool.
-func AlphaInferencePoolToEndpointPool(ctx context.Context, reader client.Reader, inferencePool *v1alpha2.InferencePool) (*EndpointPool, error) {
+func AlphaInferencePoolToEndpointPool(ctx context.Context, client client.Client, inferencePool *v1alpha2.InferencePool) (*EndpointPool, error) {
 	if inferencePool == nil {
 		return nil, nil
 	}
 
-	epp, err := generateEndpointPickerObject(ctx, string(inferencePool.Spec.ExtensionRef.Name), inferencePool.Namespace, reader)
+	epp, err := generateEndpointPickerObject(ctx, string(inferencePool.Spec.ExtensionRef.Name), inferencePool.Namespace, client)
 	if err != nil {
 		return nil, err
 	}
@@ -95,9 +95,9 @@ func AlphaInferencePoolToEndpointPool(ctx context.Context, reader client.Reader,
 	return endpointPool, nil
 }
 
-func generateEndpointPickerObject(ctx context.Context, serviceName, namespace string, reader client.Reader) (*EndpointPicker, error) {
+func generateEndpointPickerObject(ctx context.Context, serviceName, namespace string, c client.Client) (*EndpointPicker, error) {
 	service := &corev1.Service{}
-	err := reader.Get(ctx, client.ObjectKey{
+	err := c.Get(ctx, client.ObjectKey{
 		Namespace: namespace,
 		Name:      serviceName,
 	}, service)

--- a/test/e2e-openshift/scale_from_zero_test.go
+++ b/test/e2e-openshift/scale_from_zero_test.go
@@ -1,0 +1,543 @@
+/*scaleFromZeroTestTimeout
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2eopenshift
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+)
+
+// Scale-from-zero test configuration
+const (
+	scaleFromZeroTestTimeout = 15 * time.Minute
+	// Time to wait for deployment to scale to zero after load stops
+	scaleDownTimeout = 10 * time.Minute
+	// Time to wait for scale-from-zero to detect pending requests and scale up
+	scaleUpFromZeroTimeout = 5 * time.Minute
+	// Number of requests to send to trigger scale-from-zero
+	scaleFromZeroRequestCount = 10
+)
+
+var _ = Describe("Scale-From-Zero Test", Ordered, func() {
+	var (
+		ctx                   context.Context
+		scaleToZeroEnabled    bool
+		hpaScaleToZeroEnabled bool
+		originalConfigExists  bool
+		originalConfigData    map[string]string
+		testDeploymentName    string
+		testNamespace         string
+		testGatewayService    string
+		testModelID           string
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+
+		// Use the primary llm-d namespace for testing
+		testNamespace = llmDNamespace
+		testDeploymentName = getDeploymentName()
+		testGatewayService = getGatewayName()
+		testModelID = modelID
+
+		// Check if scale-to-zero is enabled
+		scaleToZeroEnabled = true // Scale-from-zero requires scale-to-zero to be enabled
+
+		// Check if HPAScaleToZero feature gate is enabled
+		hpaScaleToZeroEnabled = isHPAScaleToZeroEnabled(ctx)
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n========================================\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Starting Scale-From-Zero Tests\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Scale-to-Zero Enabled: %v\n", scaleToZeroEnabled)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  HPA Scale-to-Zero Feature Gate: %v\n", hpaScaleToZeroEnabled)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Test Namespace: %s\n", testNamespace)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Test Deployment: %s\n", testDeploymentName)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Test Gateway: %s\n", testGatewayService)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Test Model ID: %s\n", testModelID)
+		_, _ = fmt.Fprintf(GinkgoWriter, "========================================\n\n")
+
+		if !hpaScaleToZeroEnabled {
+			Skip("HPAScaleToZero feature gate is not enabled - scale-from-zero requires this feature")
+		}
+
+		// Backup existing scale-to-zero ConfigMap if it exists
+		By("backing up existing scale-to-zero ConfigMap")
+		existingCM, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, scaleToZeroConfigMapName, metav1.GetOptions{})
+		if err == nil {
+			originalConfigExists = true
+			originalConfigData = existingCM.Data
+			_, _ = fmt.Fprintf(GinkgoWriter, "Backed up existing scale-to-zero ConfigMap\n")
+		} else {
+			originalConfigExists = false
+			_, _ = fmt.Fprintf(GinkgoWriter, "No existing scale-to-zero ConfigMap found\n")
+		}
+	})
+
+	Context("Scale-from-zero with pending requests", Ordered, func() {
+		var (
+			vaName               string
+			initialReplicas      int32
+			loadJobName          string
+			scaleFromZeroJobName string
+		)
+
+		BeforeAll(func() {
+			By("configuring scale-to-zero as enabled with short retention period")
+			scaleToZeroCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      scaleToZeroConfigMapName,
+					Namespace: controllerNamespace,
+				},
+				Data: map[string]string{
+					"default": `enable_scale_to_zero: true
+retention_period: 2m`,
+				},
+			}
+
+			// Delete existing ConfigMap if it exists
+			_ = k8sClient.CoreV1().ConfigMaps(controllerNamespace).Delete(ctx, scaleToZeroConfigMapName, metav1.DeleteOptions{})
+			time.Sleep(2 * time.Second)
+
+			_, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Create(ctx, scaleToZeroCM, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to create scale-to-zero ConfigMap")
+
+			By("finding VariantAutoscaling for the deployment")
+			vaList := &v1alpha1.VariantAutoscalingList{}
+			err = crClient.List(ctx, vaList, client.InNamespace(testNamespace))
+			Expect(err).NotTo(HaveOccurred(), "Should be able to list VariantAutoscalings")
+
+			// Find VA that targets our deployment
+			for _, va := range vaList.Items {
+				if va.GetScaleTargetName() == testDeploymentName {
+					vaName = va.Name
+					break
+				}
+			}
+
+			if vaName == "" {
+				Skip("No VariantAutoscaling found for deployment " + testDeploymentName)
+			}
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Found VariantAutoscaling: %s\n", vaName)
+
+			By("recording initial deployment state")
+			deploy, err := k8sClient.AppsV1().Deployments(testNamespace).Get(ctx, testDeploymentName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to get deployment")
+			initialReplicas = deploy.Status.ReadyReplicas
+			_, _ = fmt.Fprintf(GinkgoWriter, "Initial ready replicas: %d\n", initialReplicas)
+
+			loadJobName = fmt.Sprintf("scale-from-zero-load-%d", time.Now().Unix())
+			scaleFromZeroJobName = fmt.Sprintf("scale-from-zero-trigger-%d", time.Now().Unix())
+		})
+
+		It("should scale deployment to zero when idle", func() {
+			By("waiting for deployment to scale to zero (no load)")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(testNamespace).Get(ctx, testDeploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "Current deployment replicas: %d (waiting for 0)\n", deploy.Status.Replicas)
+
+				g.Expect(deploy.Status.Replicas).To(Equal(int32(0)),
+					"Deployment should have scaled to 0 replicas when idle")
+			}, scaleDownTimeout, 15*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deployment successfully scaled to zero\n")
+		})
+
+		It("should verify VariantAutoscaling recommends zero replicas", func() {
+			By("checking VA status shows zero replicas")
+			va := &v1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      vaName,
+			}, va)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "VA DesiredOptimizedAlloc.NumReplicas: %d\n",
+				va.Status.DesiredOptimizedAlloc.NumReplicas)
+
+			Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(Equal(0),
+				"VariantAutoscaling should recommend 0 replicas when idle")
+		})
+
+		It("should detect pending requests and trigger scale-from-zero", func() {
+			By("creating a job to send requests while deployment is at zero")
+			// This job will send requests that will queue up in EPP's flow control queue
+			// The scale-from-zero engine should detect these pending requests and scale up
+			job := createScaleFromZeroTriggerJob(scaleFromZeroJobName, testNamespace, testGatewayService, testModelID, scaleFromZeroRequestCount)
+
+			_, err := k8sClient.BatchV1().Jobs(testNamespace).Create(ctx, job, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to create scale-from-zero trigger job")
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Created scale-from-zero trigger job: %s\n", scaleFromZeroJobName)
+
+			By("waiting for job pod to be running and sending requests")
+			Eventually(func(g Gomega) {
+				podList, err := k8sClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("job-name=%s", scaleFromZeroJobName),
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(podList.Items)).To(BeNumerically(">", 0), "Job pod should exist")
+
+				pod := podList.Items[0]
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Job pod should be running")
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Job pod is running and sending requests\n")
+
+			By("monitoring VariantAutoscaling for scale-from-zero decision")
+			Eventually(func(g Gomega) {
+				va := &v1alpha1.VariantAutoscaling{}
+				err := crClient.Get(ctx, client.ObjectKey{
+					Namespace: testNamespace,
+					Name:      vaName,
+				}, va)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				optimized := int32(va.Status.DesiredOptimizedAlloc.NumReplicas)
+				_, _ = fmt.Fprintf(GinkgoWriter, "VA DesiredOptimizedAlloc.NumReplicas: %d (waiting for > 0)\n", optimized)
+
+				// Scale-from-zero engine should detect pending requests and recommend scaling up
+				g.Expect(optimized).To(BeNumerically(">", 0),
+					"VariantAutoscaling should recommend scaling up from zero due to pending requests")
+
+				// Check for scale-from-zero condition
+				condition := findCondition(va.Status.Conditions, v1alpha1.TypeOptimizationReady)
+				if condition != nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "OptimizationReady condition: status=%s, reason=%s, message=%s\n",
+						condition.Status, condition.Reason, condition.Message)
+
+					// Verify the condition indicates scale-from-zero mode
+					g.Expect(condition.Reason).To(Equal("ScaleFromZeroMode"),
+						"Condition reason should indicate scale-from-zero mode")
+				}
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero engine detected pending requests and recommended scale-up\n")
+		})
+
+		It("should scale deployment up from zero", func() {
+			By("monitoring deployment for actual scale-up from zero")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(testNamespace).Get(ctx, testDeploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				currentReplicas := deploy.Status.Replicas
+				readyReplicas := deploy.Status.ReadyReplicas
+				_, _ = fmt.Fprintf(GinkgoWriter, "Current replicas: %d, ready: %d (waiting for > 0)\n",
+					currentReplicas, readyReplicas)
+
+				g.Expect(currentReplicas).To(BeNumerically(">", 0),
+					"Deployment should have scaled up from zero")
+				g.Expect(readyReplicas).To(BeNumerically(">", 0),
+					"Deployment should have at least one ready replica")
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deployment successfully scaled up from zero\n")
+		})
+
+		It("should process the pending requests successfully", func() {
+			By("waiting for the trigger job to complete")
+			Eventually(func(g Gomega) {
+				job, err := k8sClient.BatchV1().Jobs(testNamespace).Get(ctx, scaleFromZeroJobName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "Job status: succeeded=%d, failed=%d, active=%d\n",
+					job.Status.Succeeded, job.Status.Failed, job.Status.Active)
+
+				// Job should complete successfully (requests were processed after scale-up)
+				g.Expect(job.Status.Succeeded).To(BeNumerically(">=", 1),
+					"Job should complete successfully after deployment scaled up")
+			}, scaleFromZeroTestTimeout, 15*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Pending requests were processed successfully after scale-up\n")
+		})
+
+		It("should verify scale-from-zero metrics in VariantAutoscaling status", func() {
+			By("checking VA status for scale-from-zero indicators")
+			va := &v1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      vaName,
+			}, va)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the decision was recorded
+			Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically(">", 0),
+				"VA should show scaled-up state")
+
+			// Check condition
+			condition := findCondition(va.Status.Conditions, v1alpha1.TypeOptimizationReady)
+			Expect(condition).NotTo(BeNil(), "OptimizationReady condition should exist")
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue), "Condition should be True")
+			Expect(condition.Reason).To(Equal("ScaleFromZeroMode"), "Reason should indicate scale-from-zero")
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "VA status correctly reflects scale-from-zero decision\n")
+		})
+
+		AfterAll(func() {
+			By("cleaning up test jobs")
+			propagationPolicy := metav1.DeletePropagationBackground
+
+			_ = k8sClient.BatchV1().Jobs(testNamespace).Delete(ctx, scaleFromZeroJobName, metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
+			_ = k8sClient.BatchV1().Jobs(testNamespace).Delete(ctx, loadJobName, metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero test completed\n")
+		})
+	})
+
+	Context("Scale-from-zero with multiple concurrent requests", Ordered, func() {
+		var (
+			vaName                string
+			concurrentJobBaseName string
+			numConcurrentJobs     = 3
+			requestsPerJob        = 5
+		)
+
+		BeforeAll(func() {
+			By("ensuring scale-to-zero is enabled")
+			// ConfigMap should already be set from previous context
+
+			By("finding VariantAutoscaling for the deployment")
+			vaList := &v1alpha1.VariantAutoscalingList{}
+			err := crClient.List(ctx, vaList, client.InNamespace(testNamespace))
+			Expect(err).NotTo(HaveOccurred(), "Should be able to list VariantAutoscalings")
+
+			for _, va := range vaList.Items {
+				if va.GetScaleTargetName() == testDeploymentName {
+					vaName = va.Name
+					break
+				}
+			}
+
+			Expect(vaName).NotTo(BeEmpty(), "VariantAutoscaling should exist")
+			concurrentJobBaseName = fmt.Sprintf("scale-from-zero-concurrent-%d", time.Now().Unix())
+		})
+
+		It("should wait for deployment to scale to zero again", func() {
+			By("waiting for deployment to scale back to zero")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(testNamespace).Get(ctx, testDeploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(deploy.Status.Replicas).To(Equal(int32(0)))
+			}, scaleDownTimeout, 15*time.Second).Should(Succeed())
+		})
+
+		It("should handle multiple concurrent requests triggering scale-from-zero", func() {
+			By("creating multiple concurrent jobs to trigger scale-from-zero")
+			for i := 1; i <= numConcurrentJobs; i++ {
+				jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+				job := createScaleFromZeroTriggerJob(jobName, testNamespace, testGatewayService, testModelID, requestsPerJob)
+
+				_, err := k8sClient.BatchV1().Jobs(testNamespace).Create(ctx, job, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, _ = fmt.Fprintf(GinkgoWriter, "Created concurrent job %d: %s\n", i, jobName)
+			}
+
+			By("verifying scale-from-zero handles concurrent load")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(testNamespace).Get(ctx, testDeploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(deploy.Status.ReadyReplicas).To(BeNumerically(">", 0),
+					"Deployment should scale up to handle concurrent requests")
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			By("waiting for all concurrent jobs to complete")
+			Eventually(func(g Gomega) {
+				completedCount := 0
+				for i := 1; i <= numConcurrentJobs; i++ {
+					jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+					job, err := k8sClient.BatchV1().Jobs(testNamespace).Get(ctx, jobName, metav1.GetOptions{})
+					if err == nil && job.Status.Succeeded >= 1 {
+						completedCount++
+					}
+				}
+				_, _ = fmt.Fprintf(GinkgoWriter, "Completed jobs: %d / %d\n", completedCount, numConcurrentJobs)
+				g.Expect(completedCount).To(Equal(numConcurrentJobs),
+					"All concurrent jobs should complete successfully")
+			}, scaleFromZeroTestTimeout, 15*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero successfully handled concurrent requests\n")
+		})
+
+		AfterAll(func() {
+			By("cleaning up concurrent test jobs")
+			propagationPolicy := metav1.DeletePropagationBackground
+			for i := 1; i <= numConcurrentJobs; i++ {
+				jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+				_ = k8sClient.BatchV1().Jobs(testNamespace).Delete(ctx, jobName, metav1.DeleteOptions{
+					PropagationPolicy: &propagationPolicy,
+				})
+			}
+		})
+	})
+
+	AfterAll(func() {
+		By("restoring original scale-to-zero ConfigMap state")
+		if originalConfigExists {
+			existingCM, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, scaleToZeroConfigMapName, metav1.GetOptions{})
+			if err == nil {
+				existingCM.Data = originalConfigData
+				_, err = k8sClient.CoreV1().ConfigMaps(controllerNamespace).Update(ctx, existingCM, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, _ = fmt.Fprintf(GinkgoWriter, "Restored original scale-to-zero ConfigMap\n")
+			}
+		} else {
+			_ = k8sClient.CoreV1().ConfigMaps(controllerNamespace).Delete(ctx, scaleToZeroConfigMapName, metav1.DeleteOptions{})
+		}
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n========================================\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Scale-From-Zero tests completed\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "========================================\n\n")
+	})
+})
+
+// createScaleFromZeroTriggerJob creates a job that sends requests to trigger scale-from-zero
+// The job sends requests slowly to allow time for the scale-from-zero engine to detect them
+func createScaleFromZeroTriggerJob(name, namespace, gatewayService, modelID string, numRequests int) *batchv1.Job {
+	backoffLimit := int32(3)
+
+	script := fmt.Sprintf(`#!/bin/sh
+echo "Scale-from-zero trigger job starting..."
+echo "Sending %d requests to gateway %s:80"
+echo "Model ID: %s"
+
+# Wait for gateway to be reachable
+MAX_RETRIES=30
+RETRY_DELAY=5
+CONNECTED=false
+
+for i in $(seq 1 $MAX_RETRIES); do
+  if curl -s -o /dev/null -w "%%{http_code}" http://%s:80/v1/models 2>/dev/null | grep -q 200; then
+    echo "Gateway is reachable on attempt $i"
+    CONNECTED=true
+    break
+  fi
+  echo "Attempt $i failed, retrying in ${RETRY_DELAY}s..."
+  sleep $RETRY_DELAY
+done
+
+if [ "$CONNECTED" != "true" ]; then
+  echo "ERROR: Cannot connect to gateway after $MAX_RETRIES attempts"
+  exit 1
+fi
+
+# Send requests with delays to allow scale-from-zero engine to detect them
+SENT=0
+SUCCESS=0
+FAILED=0
+
+while [ $SENT -lt %d ]; do
+  echo "Sending request $((SENT + 1)) / %d..."
+  
+  RESPONSE=$(curl -s -w "\n%%{http_code}" --max-time 180 -X POST http://%s:80/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"%s","prompt":"Test prompt for scale-from-zero","max_tokens":50}' 2>&1)
+  
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  
+  if [ "$HTTP_CODE" = "200" ]; then
+    SUCCESS=$((SUCCESS + 1))
+    echo "Request $((SENT + 1)) succeeded (HTTP $HTTP_CODE)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "Request $((SENT + 1)) failed (HTTP $HTTP_CODE)"
+  fi
+  
+  SENT=$((SENT + 1))
+  
+  # Small delay between requests to allow scale-from-zero engine to detect pending requests
+  sleep 2
+done
+
+echo "Job completed: sent=$SENT, success=$SUCCESS, failed=$FAILED"
+
+# Consider job successful if at least some requests succeeded
+if [ $SUCCESS -gt 0 ]; then
+  exit 0
+else
+  exit 1
+fi
+`, numRequests, gatewayService, modelID, gatewayService, numRequests, numRequests, gatewayService, modelID)
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"test-type": "scale-from-zero",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"test-type": "scale-from-zero",
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "scale-from-zero-trigger",
+							Image:   "quay.io/curl/curl:8.11.1",
+							Command: []string{"/bin/sh", "-c"},
+							Args:    []string{script},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// findCondition finds a condition by type in the conditions list
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/test/e2e-saturation-based/e2e_scale_from_zero_test.go
+++ b/test/e2e-saturation-based/e2e_scale_from_zero_test.go
@@ -1,0 +1,529 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2esaturation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"os/exec"
+	"strings"
+
+	v1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/test/utils"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/test/utils/resources"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Scale-from-zero test constants
+const (
+	scaleFromZeroTestTimeout   = 15 * time.Minute
+	scaleUpFromZeroTimeout     = 5 * time.Minute
+	scaleFromZeroRequestCount  = 10
+	scaleFromZeroConfigMapName = "workload-variant-autoscaler-variantautoscaling-config"
+)
+
+// Test workload-variant-autoscaler - Scale-From-Zero Feature
+// This test validates that the scale-from-zero engine correctly detects pending requests
+// in the EPP flow control queue and scales up deployments from zero replicas.
+// Note: This test assumes scale-to-zero is already configured and the deployment starts at 0 replicas.
+var _ = Describe("Test workload-variant-autoscaler - Scale-From-Zero Feature", Ordered, func() {
+	var (
+		name            string
+		namespace       string
+		deployName      string
+		serviceName     string
+		gatewayService  string
+		appLabel        string
+		initialReplicas int32
+		port            int
+		modelName       string
+		ctx             context.Context
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+		name = "llm-d-sim-sfz" // Scale-from-zero test
+		deployName = name + "-deployment"
+		serviceName = name + "-service"
+
+		appLabel = name
+		namespace = llmDNamespace
+		port = 8000
+		modelName = llamaModelId + "-sfz"
+		gatewayService = "infra-sim-inference-gateway"
+
+		// Start with 0 replicas to test scale-from-zero
+		initialReplicas = 0
+
+		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+		// Skip scalefromzero test if feature gate is not enabled
+		if !utils.IsHPAScaleToZeroEnabled(ctx, k8sClient, GinkgoWriter) {
+			Skip("HPAScaleToZero feature gate is not enabled; skipping scale from zero test")
+		}
+
+		By("verifying saturation-scaling ConfigMap exists before creating VA")
+		Eventually(func(g Gomega) {
+			cm, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, saturationConfigMapName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("saturation ConfigMap %s should exist in namespace %s", saturationConfigMapName, controllerNamespace))
+			g.Expect(cm.Data).To(HaveKey("default"), "saturation ConfigMap should have 'default' configuration")
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("updating scale-from-zero ConfigMap with BearerToken for EPP metrics collection")
+		// Execute the exact shell command to get the token
+		cmd := exec.Command("bash", "-c",
+			`kubectl -n workload-variant-autoscaler-system get secret workload-variant-autoscaler-controller-manager-token -o jsonpath='{.data.token}' | base64 --decode`)
+
+		output, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "Failed to get and decode token")
+
+		bearerToken := strings.TrimSpace(string(output))
+		Expect(bearerToken).NotTo(BeEmpty(), "Token should not be empty")
+
+		// Get the existing ConfigMap
+		scaleFromZeroCM, err := k8sClient.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, scaleFromZeroConfigMapName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to get ConfigMap: %s", scaleFromZeroConfigMapName))
+
+		// Update the bearer token key
+		scaleFromZeroCM.Data["EPP_METRIC_READER_BEARER_TOKEN"] = bearerToken
+
+		// Update the ConfigMap
+		_, err = k8sClient.CoreV1().ConfigMaps(controllerNamespace).Update(ctx, scaleFromZeroCM, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to update scale-from-zero ConfigMap: %s", scaleFromZeroConfigMapName))
+
+		// Start the scale-from-zero deployment
+		By("deleting pods using kubectl command")
+		cmd = exec.Command("kubectl", "delete", "pods",
+			"-n", controllerNamespace,
+			"-l", "control-plane=controller-manager",
+			"--wait=false")
+		output, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("kubectl delete failed: %s", string(output)))
+
+		By("ensuring unique app label for deployment and service")
+		utils.ValidateAppLabelUniqueness(namespace, appLabel, k8sClient, crClient)
+		utils.ValidateVariantAutoscalingUniqueness(namespace, modelName, a100Acc, crClient)
+
+		By("creating llm-d-sim deployment with 0 replicas")
+		deployment := resources.CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, fmt.Sprintf("%d", port), avgTTFT, avgITL, initialReplicas)
+		_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to create Deployment: %s", deployName))
+
+		By("creating service to expose llm-d-sim deployment")
+		service := resources.CreateLlmdSimService(namespace, serviceName, appLabel, 30005, port)
+		_, err = k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to create Service: %s", serviceName))
+
+		By("creating VariantAutoscaling resource (deployment starts at 0 replicas)")
+		variantAutoscaling := utils.CreateVariantAutoscalingResource(namespace, deployName, modelName, a100Acc, 10.0)
+		err = crClient.Create(ctx, variantAutoscaling)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to create VariantAutoscaling for: %s", deployName))
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero test setup complete\n")
+	})
+
+	Context("Initial state verification", func() {
+		It("should have VariantAutoscaling resource created", func() {
+			By("verifying VariantAutoscaling exists")
+			va := &v1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{
+				Namespace: namespace,
+				Name:      deployName,
+			}, va)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to get VariantAutoscaling: %s", deployName))
+			Expect(va.Spec.ModelID).To(Equal(modelName))
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "VariantAutoscaling resource verified: %s\n", deployName)
+		})
+
+		It("should verify deployment starts at zero replicas", func() {
+			By("checking deployment has 0 replicas")
+			deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			specReplicas := int32(1)
+			if deploy.Spec.Replicas != nil {
+				specReplicas = *deploy.Spec.Replicas
+			}
+
+			Expect(specReplicas).To(Equal(int32(0)), "Deployment should start with 0 replicas")
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deployment verified at 0 replicas\n")
+		})
+	})
+
+	Context("Scale-from-zero with pending requests", func() {
+		var scaleFromZeroJobName string
+
+		BeforeAll(func() {
+			scaleFromZeroJobName = fmt.Sprintf("scale-from-zero-trigger-%d", time.Now().Unix())
+		})
+
+		It("should detect pending requests and trigger scale-from-zero", func() {
+			By("creating a job to send requests while deployment is at zero")
+			job := createScaleFromZeroTriggerJob(scaleFromZeroJobName, namespace, gatewayService, modelName, scaleFromZeroRequestCount)
+
+			_, err := k8sClient.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to create scale-from-zero trigger job")
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Created scale-from-zero trigger job: %s\n", scaleFromZeroJobName)
+
+			By("waiting for job pod to be running and sending requests")
+			Eventually(func(g Gomega) {
+				podList, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("job-name=%s", scaleFromZeroJobName),
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(podList.Items)).To(BeNumerically(">", 0), "Job pod should exist")
+
+				pod := podList.Items[0]
+				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Job pod should be running")
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Job pod is running and sending requests\n")
+
+			By("monitoring VariantAutoscaling for scale-from-zero decision")
+			Eventually(func(g Gomega) {
+				va := &v1alpha1.VariantAutoscaling{}
+				err := crClient.Get(ctx, client.ObjectKey{
+					Namespace: namespace,
+					Name:      deployName,
+				}, va)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				optimized := int32(va.Status.DesiredOptimizedAlloc.NumReplicas)
+				_, _ = fmt.Fprintf(GinkgoWriter, "VA DesiredOptimizedAlloc.NumReplicas: %d (waiting for > 0)\n", optimized)
+
+				// Scale-from-zero engine should detect pending requests and recommend scaling up
+				g.Expect(optimized).To(BeNumerically(">", 0),
+					"VariantAutoscaling should recommend scaling up from zero due to pending requests")
+
+				// // Check for scale-from-zero condition
+				// condition := findCondition(va.Status.Conditions, v1alpha1.TypeOptimizationReady)
+				// if condition != nil {
+				// 	_, _ = fmt.Fprintf(GinkgoWriter, "OptimizationReady condition: status=%s, reason=%s, message=%s\n",
+				// 		condition.Status, condition.Reason, condition.Message)
+
+				// 	// Verify the condition indicates scale-from-zero mode
+				// 	g.Expect(condition.Reason).To(Equal("ScaleFromZero"),
+				// 		"Condition reason should indicate scale-from-zero mode")
+				// }
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero engine detected pending requests and recommended scale-up\n")
+		})
+
+		It("should scale deployment up from zero", func() {
+			By("monitoring deployment for actual scale-up from zero")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				currentReplicas := deploy.Status.Replicas
+				readyReplicas := deploy.Status.ReadyReplicas
+				_, _ = fmt.Fprintf(GinkgoWriter, "Current replicas: %d, ready: %d (waiting for > 0)\n",
+					currentReplicas, readyReplicas)
+
+				g.Expect(currentReplicas).To(BeNumerically(">", 0),
+					"Deployment should have scaled up from zero")
+				g.Expect(readyReplicas).To(BeNumerically(">", 0),
+					"Deployment should have at least one ready replica")
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deployment successfully scaled up from zero\n")
+		})
+
+		It("should process the pending requests successfully", func() {
+			By("waiting for the trigger job to complete")
+			Eventually(func(g Gomega) {
+				job, err := k8sClient.BatchV1().Jobs(namespace).Get(ctx, scaleFromZeroJobName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "Job status: succeeded=%d, failed=%d, active=%d\n",
+					job.Status.Succeeded, job.Status.Failed, job.Status.Active)
+
+				// Job should complete successfully (requests were processed after scale-up)
+				g.Expect(job.Status.Succeeded).To(BeNumerically(">=", 1),
+					"Job should complete successfully after deployment scaled up")
+			}, scaleFromZeroTestTimeout, 15*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Pending requests were processed successfully after scale-up\n")
+		})
+
+		It("should verify scale-from-zero metrics in VariantAutoscaling status", func() {
+			By("checking VA status for scale-from-zero indicators")
+			va := &v1alpha1.VariantAutoscaling{}
+			err := crClient.Get(ctx, client.ObjectKey{
+				Namespace: namespace,
+				Name:      deployName,
+			}, va)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the decision was recorded
+			Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically(">", 0),
+				"VA should show scaled-up state")
+
+			// condition := findCondition(va.Status.Conditions, v1alpha1.TypeOptimizationReady)
+			// Expect(condition).NotTo(BeNil(), "OptimizationReady condition should exist")
+			// Expect(condition.Status).To(Equal(metav1.ConditionTrue), "Condition should be True")
+			// Expect(condition.Reason).To(Equal("ScaleFromZero"), "Reason should indicate scale-from-zero")
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "VA status correctly reflects scale-from-zero decision\n")
+		})
+
+		AfterAll(func() {
+			By("cleaning up scale-from-zero trigger job")
+			propagationPolicy := metav1.DeletePropagationBackground
+			_ = k8sClient.BatchV1().Jobs(namespace).Delete(ctx, scaleFromZeroJobName, metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
+		})
+	})
+
+	Context("Multiple concurrent scale-from-zero requests", func() {
+		var (
+			concurrentJobBaseName string
+			numConcurrentJobs     = 3
+			requestsPerJob        = 5
+		)
+
+		BeforeAll(func() {
+			concurrentJobBaseName = fmt.Sprintf("scale-from-zero-concurrent-%d", time.Now().Unix())
+		})
+
+		It("should handle multiple concurrent requests triggering scale-from-zero", func() {
+			By("manually scaling deployment back to 0 for concurrent test")
+			deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			replicas := int32(0)
+			deploy.Spec.Replicas = &replicas
+			_, err = k8sClient.AppsV1().Deployments(namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to reach 0 replicas")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(deploy.Status.Replicas).To(Equal(int32(0)))
+			}, 2*time.Minute, 10*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deployment at 0 replicas, starting concurrent test\n")
+
+			By("creating multiple concurrent jobs to trigger scale-from-zero")
+			for i := 1; i <= numConcurrentJobs; i++ {
+				jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+				job := createScaleFromZeroTriggerJob(jobName, namespace, gatewayService, modelName, requestsPerJob)
+
+				_, err := k8sClient.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, _ = fmt.Fprintf(GinkgoWriter, "Created concurrent job %d: %s\n", i, jobName)
+			}
+
+			By("verifying scale-from-zero handles concurrent load")
+			Eventually(func(g Gomega) {
+				deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "Current ready replicas: %d (waiting for > 0)\n", deploy.Status.ReadyReplicas)
+
+				g.Expect(deploy.Status.ReadyReplicas).To(BeNumerically(">", 0),
+					"Deployment should scale up to handle concurrent requests")
+			}, scaleUpFromZeroTimeout, 10*time.Second).Should(Succeed())
+
+			By("waiting for all concurrent jobs to complete")
+			Eventually(func(g Gomega) {
+				completedCount := 0
+				for i := 1; i <= numConcurrentJobs; i++ {
+					jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+					job, err := k8sClient.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+					if err == nil && job.Status.Succeeded >= 1 {
+						completedCount++
+					}
+				}
+				_, _ = fmt.Fprintf(GinkgoWriter, "Completed jobs: %d / %d\n", completedCount, numConcurrentJobs)
+				g.Expect(completedCount).To(Equal(numConcurrentJobs),
+					"All concurrent jobs should complete successfully")
+			}, scaleFromZeroTestTimeout, 15*time.Second).Should(Succeed())
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Scale-from-zero successfully handled concurrent requests\n")
+		})
+
+		AfterAll(func() {
+			By("cleaning up concurrent test jobs")
+			propagationPolicy := metav1.DeletePropagationBackground
+			for i := 1; i <= numConcurrentJobs; i++ {
+				jobName := fmt.Sprintf("%s-%d", concurrentJobBaseName, i)
+				_ = k8sClient.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{
+					PropagationPolicy: &propagationPolicy,
+				})
+			}
+		})
+	})
+
+	AfterAll(func() {
+		By("cleaning up scale-from-zero test resources")
+
+		// Delete VariantAutoscaling resource
+		va := &v1alpha1.VariantAutoscaling{}
+		err := crClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deployName}, va)
+		if err == nil {
+			err = crClient.Delete(ctx, va)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to delete VariantAutoscaling: %s", deployName))
+		}
+
+		// Delete Service
+		err = k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to delete Service: %s", serviceName))
+
+		// Delete Deployment
+		err = k8sClient.AppsV1().Deployments(namespace).Delete(ctx, deployName, metav1.DeleteOptions{})
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to delete Deployment: %s", deployName))
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "Cleanup completed for scale-from-zero test\n")
+	})
+})
+
+// createScaleFromZeroTriggerJob creates a job that sends requests to trigger scale-from-zero
+// The job sends requests slowly to allow time for the scale-from-zero engine to detect them
+func createScaleFromZeroTriggerJob(name, namespace, gatewayService, modelID string, numRequests int) *batchv1.Job {
+	backoffLimit := int32(3)
+
+	script := fmt.Sprintf(`#!/bin/sh
+echo "Scale-from-zero trigger job starting..."
+echo "Sending %d requests to gateway %s:80"
+echo "Model ID: %s"
+
+# Wait for gateway to be reachable
+MAX_RETRIES=30
+RETRY_DELAY=5
+CONNECTED=false
+
+# for i in $(seq 1 $MAX_RETRIES); do
+#   if curl -s -o /dev/null -w "%%{http_code}" http://%s:80/v1/models 2>/dev/null | grep -q 200; then
+#     echo "Gateway is reachable on attempt $i"
+#     CONNECTED=true
+#     break
+#   fi
+#   echo "Attempt $i failed, retrying in ${RETRY_DELAY}s..."
+#   echo "Gateway address: http://%s-istio:80/v1/models"
+#   sleep $RETRY_DELAY
+# done
+
+# if [ "$CONNECTED" != "true" ]; then
+#   echo "ERROR: Cannot connect to gateway after $MAX_RETRIES attempts"
+#   exit 1
+# fi
+
+# Send requests with delays to allow scale-from-zero engine to detect them
+SENT=0
+SUCCESS=0
+FAILED=0
+
+while [ $SENT -lt %d ]; do
+	 echo "Sending request $((SENT + 1)) / %d..."
+	 
+	 RESPONSE=$(curl -s -w "\n%%{http_code}" --max-time 180 -X POST http://%s-istio:80/v1/completions \
+	   -H "Content-Type: application/json" \
+	   -d '{"model":"%s","prompt":"Test prompt for scale-from-zero","max_tokens":50}' 2>&1)
+	 
+	 HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+	 
+	 if [ "$HTTP_CODE" = "200" ]; then
+	   SUCCESS=$((SUCCESS + 1))
+	   echo "Request $((SENT + 1)) succeeded (HTTP $HTTP_CODE)"
+	 else
+	   FAILED=$((FAILED + 1))
+	   echo "Request $((SENT + 1)) failed (HTTP $HTTP_CODE)"
+	 fi
+	 
+	 SENT=$((SENT + 1))
+	 
+	 # Small delay between requests to allow scale-from-zero engine to detect pending requests
+	 sleep 2
+done
+
+echo "Job completed: sent=$SENT, success=$SUCCESS, failed=$FAILED"
+
+# Consider job successful if at least some requests succeeded
+if [ $SUCCESS -gt 0 ]; then
+	 exit 0
+else
+	 exit 1
+fi
+`, numRequests, gatewayService, modelID, gatewayService, gatewayService, numRequests, numRequests, gatewayService, modelID)
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"test-type": "scale-from-zero",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"test-type": "scale-from-zero",
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "scale-from-zero-trigger",
+							Image:   "quay.io/curl/curl:8.11.1",
+							Command: []string{"/bin/sh", "-c"},
+							Args:    []string{script},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// // findCondition finds a condition by type in the conditions list
+// func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+// 	for i := range conditions {
+// 		if conditions[i].Type == conditionType {
+// 			return &conditions[i]
+// 		}
+// 	}
+// 	return nil
+// }


### PR DESCRIPTION
This PR starts the implementation of the logic to support scale from zero outlined in the design doc [here](https://docs.google.com/document/d/1jEhbz3UcDNJcYRpaIdhtnAPwBXvDP-YwI4yY6V3ZVqc/edit?tab=t.0) 

**This PR is responsible for the following:**

- Use PodScrapingSource to get metrics from EPP
- Use direct actuation to scale from zero (see PR https://github.com/llm-d-incubation/workload-variant-autoscaler/pull/602)
- Build E2E test scripts


**Related Issue:** https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/372