### PR TITLE
update inferno metrics naming to wva

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ kubectl logs -n workload-variant-autoscaler-system \
 kubectl describe variantautoscaling <name> -n <namespace>
 
 # Check emitted metrics
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/wva_desired_replicas" | jq
 ```
 
 ### Cleaning Up

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -300,5 +300,5 @@ kubectl logs pod prometheus-adapter-xxxxx -n openshift-user-workload-monitoring 
 ```
 3. Check, after a few minutes following installation, for metric collection
 ```
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" | jq
 ```

--- a/charts/workload-variant-autoscaler/templates/hpa.yaml
+++ b/charts/workload-variant-autoscaler/templates/hpa.yaml
@@ -36,7 +36,7 @@ spec:
   - type: External
     external:
       metric:
-        name: inferno_desired_replicas
+        name: wva_desired_replicas
         selector:
           matchLabels:
             variant_name: {{ printf "%s-decode" .Values.llmd.modelName }}

--- a/config/samples/hpa-integration.yaml
+++ b/config/samples/hpa-integration.yaml
@@ -27,7 +27,7 @@ spec:
   - type: External
     external:
       metric:
-        name: inferno_desired_replicas
+        name: wva_desired_replicas
         selector:
           matchLabels:
             variant_name: vllme-deployment

--- a/config/samples/prometheus-adapter-values-ocp.yaml
+++ b/config/samples/prometheus-adapter-values-ocp.yaml
@@ -4,15 +4,15 @@ prometheus:
 
 rules:
   external:
-  - seriesQuery: 'inferno_desired_replicas{variant_name!="",exported_namespace!=""}'
+  - seriesQuery: 'wva_desired_replicas{variant_name!="",exported_namespace!=""}'
     resources:
       overrides:
         exported_namespace: {resource: "namespace"}
         variant_name: {resource: "deployment"}
     name:
-      matches: "^inferno_desired_replicas"
-      as: "inferno_desired_replicas"
-    metricsQuery: 'inferno_desired_replicas{<<.LabelMatchers>>}'
+      matches: "^wva_desired_replicas"
+      as: "wva_desired_replicas"
+    metricsQuery: 'wva_desired_replicas{<<.LabelMatchers>>}'
 
 replicas: 2
 logLevel: 4

--- a/config/samples/prometheus-adapter-values.yaml
+++ b/config/samples/prometheus-adapter-values.yaml
@@ -4,15 +4,15 @@ prometheus:
 
 rules:
   external:
-  - seriesQuery: 'inferno_desired_replicas{variant_name!="",exported_namespace!=""}'
+  - seriesQuery: 'wva_desired_replicas{variant_name!="",exported_namespace!=""}'
     resources:
       overrides:
         exported_namespace: {resource: "namespace"}
         variant_name: {resource: "deployment"}  
     name:
-      matches: "^inferno_desired_replicas"
-      as: "inferno_desired_replicas"
-    metricsQuery: 'inferno_desired_replicas{<<.LabelMatchers>>}'
+      matches: "^wva_desired_replicas"
+      as: "wva_desired_replicas"
+    metricsQuery: 'wva_desired_replicas{<<.LabelMatchers>>}'
 
 replicas: 2
 logLevel: 4

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -538,7 +538,7 @@ spec:
   - type: External
     external:
       metric:
-        name: inferno_desired_replicas
+        name: wva_desired_replicas
         selector:
           matchLabels:
             variant_name: my-vllm-deployment-decode
@@ -717,7 +717,7 @@ kubectl port-forward -n <monitoring-namespace> svc/prometheus-k8s 9090:9090
 kubectl logs -n workload-variant-autoscaler-system -l app.kubernetes.io/name=workload-variant-autoscaler | grep "Collected metrics"
 
 # 4. Verify external metrics API (if using HPA)
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/wva_desired_replicas" | jq
 ```
 
 ### Monitoring WVA
@@ -807,7 +807,7 @@ watch kubectl get hpa -n <namespace>
 watch kubectl get pods -n <namespace>
 
 # Watch external metrics
-watch 'kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/inferno_desired_replicas" | jq'
+watch 'kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/wva_desired_replicas" | jq'
 ```
 
 ## Troubleshooting
@@ -913,14 +913,14 @@ my-hpa     Deployment/vllm    <unknown>/1(avg)   1         10        1
 kubectl describe hpa <name> -n <namespace>
 
 # Check external metrics API on the specified namespace
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<your-namespace>/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<your-namespace>/wva_desired_replicas" | jq
 
 # Check Prometheus Adapter logs
 kubectl logs -n <monitoring-namespace> deployment/prometheus-adapter
 
 # Check if WVA is emitting the metric
 kubectl logs -n workload-variant-autoscaler-system -l app.kubernetes.io/name=workload-variant-autoscaler | \
-  grep "inferno_desired_replicas"
+  grep "wva_desired_replicas"
 ```
 
 **Common causes**:
@@ -941,7 +941,7 @@ kubectl get configmap prometheus-adapter -n <monitoring-namespace> -o yaml
 
 # Verify metric exists in Prometheus
 kubectl port-forward -n <monitoring-namespace> svc/prometheus-k8s 9090:9090
-# Query: inferno_desired_replicas{variant_name="<name>"}
+# Query: wva_desired_replicas{variant_name="<name>"}
 ```
 
 ### Getting Help

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -732,7 +732,7 @@ print_summary() {
     echo "   kubectl logs -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler -f"
     echo ""
     echo "4. Check external metrics API:"
-    echo "   kubectl get --raw \"/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NS/inferno_desired_replicas\" | jq"
+    echo "   kubectl get --raw \"/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NS/wva_desired_replicas\" | jq"
     echo ""
     echo "5. Port-forward Prometheus to view metrics:"
     echo "   kubectl port-forward -n $MONITORING_NAMESPACE svc/${PROMETHEUS_SVC_NAME} ${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -445,7 +445,7 @@ kubectl describe variantautoscaling ms-inference-scheduling-llm-d-modelservice-d
 kubectl get hpa -n llm-d-inference-scheduling
 
 # Check external metrics
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduling/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduling/wva_desired_replicas" | jq
 ```
 
 ### Monitor WVA Logs (See Metrics Validation!)
@@ -470,7 +470,7 @@ kubectl port-forward -n workload-variant-autoscaler-monitoring \
 
 # Visit http://localhost:9090
 # Query: vllm:request_success_total
-# Query: inferno_desired_replicas
+# Query: wva_desired_replicas
 ```
 
 ### Access Grafana Dashboards

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -311,7 +311,7 @@ export HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxx"
 
 ```bash
 kubectl get pods -n openshift-user-workload-monitoring | grep prometheus-adapter
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduler/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduler/wva_desired_replicas" | jq
 ```
 
 ### vLLM Pods Not Starting
@@ -344,7 +344,7 @@ kubectl get variantautoscaling -n llm-d-inference-scheduler
 kubectl get hpa -n llm-d-inference-scheduler
 
 # Check external metrics
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduler/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduler/wva_desired_replicas" | jq
 ```
 
 ### Monitor WVA Logs

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -155,7 +155,7 @@ make test-e2e FOCUS="should scale up when saturation is detected"
 
 - ✅ Saturation detection via KV cache and queue metrics
 - ✅ Scale-up recommendations based on thresholds
-- ✅ HPA integration with `inferno_desired_replicas` metric
+- ✅ HPA integration with `wva_desired_replicas` metric
 - ✅ Multi-variant scaling with cost optimization
 - ✅ Deployment scaling and replica stabilization
 
@@ -558,11 +558,11 @@ kubectl logs -n workload-variant-autoscaler-system deployment/workload-variant-a
 **Debugging steps**:
 ```bash
 # Check external metrics API
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/wva_desired_replicas" | jq
 
 # Check Prometheus
 kubectl port-forward -n workload-variant-autoscaler-monitoring svc/prometheus-operated 9090:9090
-# Query: inferno_desired_replicas{variant_name="..."}
+# Query: wva_desired_replicas{variant_name="..."}
 ```
 
 #### Deployment Not Scaling

--- a/docs/integrations/hpa-integration.md
+++ b/docs/integrations/hpa-integration.md
@@ -6,13 +6,13 @@ This guide shows how to integrate Kubernetes HorizontalPodAutoscaler (HPA) with 
 
 After deploying the workload-variant-autoscaler following the provided guides, this guide allows the integration of the following components:
 
-1. **WVA controller**: processes VariantAutoscaling objects and emits the `inferno_current_replicas`, the `inferno_desired_replicas` and the `inferno_desired_ratio` metrics
+1. **WVA controller**: processes VariantAutoscaling objects and emits the `wva_current_replicas`, the `wva_desired_replicas` and the `wva_desired_ratio` metrics
 
 2. **Prometheus**: scrapes these metrics from the workload-variant-autoscaler `/metrics` endpoint using TLS
 
 3. **Prometheus Adapter**: exposes the metrics to Kubernetes external metrics API
 
-4. **HPA** example configuration: reads the value for the `inferno_desired_replicas` metrics and adjusts Deployment replicas accordingly, using an `AverageValue` target
+4. **HPA** example configuration: reads the value for the `wva_desired_replicas` metrics and adjusts Deployment replicas accordingly, using an `AverageValue` target
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ After deploying the workload-variant-autoscaler following the provided guides, t
 
 ## Quick Setup
 
-> **Note**: The required RBAC permissions for Prometheus to access Inferno's secure HTTPS metrics endpoint are automatically deployed via `config/rbac/prometheus_metrics_auth_role_binding.yaml`.
+> **Note**: The required RBAC permissions for Prometheus to access WVA's secure HTTPS metrics endpoint are automatically deployed via `config/rbac/prometheus_metrics_auth_role_binding.yaml`.
 
 ### 1. Create Prometheus CA ConfigMap
 
@@ -101,7 +101,7 @@ kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" | jq
   "groupVersion": "external.metrics.k8s.io/v1beta1",
   "resources": [
     {
-      "name": "inferno_desired_replicas",
+      "name": "wva_desired_replicas",
       "singularName": "",
       "namespaced": true,
       "kind": "ExternalMetricValueList",
@@ -113,19 +113,19 @@ kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" | jq
 }
 ```
 
-- Get the latest value for the `inferno_desired_replicas` metric:
+- Get the latest value for the `wva_desired_replicas` metric:
 
 ```sh
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/inferno_desired_replicas?labelSelector=variant_name%3Dvllme-deployment" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/wva_desired_replicas?labelSelector=variant_name%3Dvllme-deployment" | jq
 {
   "kind": "ExternalMetricValueList",
   "apiVersion": "external.metrics.k8s.io/v1beta1",
   "metadata": {},
   "items": [
     {
-      "metricName": "inferno_desired_replicas",
+      "metricName": "wva_desired_replicas",
       "metricLabels": {
-        "__name__": "inferno_desired_replicas",
+        "__name__": "wva_desired_replicas",
         "accelerator_type": "A100",
         "endpoint": "https",
         "exported_namespace": "llm-d-sim",
@@ -456,15 +456,15 @@ prometheus:
 
 rules:
   external:
-  - seriesQuery: 'inferno_desired_replicas{variant_name!="",exported_namespace!=""}'
+  - seriesQuery: 'wva_desired_replicas{variant_name!="",exported_namespace!=""}'
     resources:
       overrides:
         exported_namespace: {resource: "namespace"}
         variant_name: {resource: "deployment"}  
     name:
-      matches: "^inferno_desired_replicas"
-      as: "inferno_desired_replicas"
-    metricsQuery: 'inferno_desired_replicas{<<.LabelMatchers>>}'
+      matches: "^wva_desired_replicas"
+      as: "wva_desired_replicas"
+    metricsQuery: 'wva_desired_replicas{<<.LabelMatchers>>}'
 
 replicas: 2
 logLevel: 4
@@ -518,7 +518,7 @@ spec:
   - type: External
     external:
       metric:
-        name: inferno_desired_replicas
+        name: wva_desired_replicas
         selector:
           matchLabels:
             variant_name: vllme-deployment

--- a/docs/integrations/keda-integration.md
+++ b/docs/integrations/keda-integration.md
@@ -6,7 +6,7 @@ This document describes how to integrate the Kubernetes Event-driven Autoscaler 
 
 After deploying the Workload-Variant-Autoscaler following the provided guides, this guide allows the integration of the following components:
 
-1. **WVA Controller**: processes VariantAutoscaling objects and emits the `inferno_current_replicas`, the `inferno_desired_replicas` and the `inferno_desired_ratio` metrics
+1. **WVA Controller**: processes VariantAutoscaling objects and emits the `wva_current_replicas`, the `wva_desired_replicas` and the `wva_desired_ratio` metrics
 
 2. **Prometheus**: scrapes these metrics from the Workload-Variant-Autoscaler `/metrics` endpoint using TLS
 
@@ -14,7 +14,7 @@ After deploying the Workload-Variant-Autoscaler following the provided guides, t
 
 - Deploys a `ScaledObject` and configures the underlying HPA for the Deployment.
 
-- Reads the values for the `inferno_desired_replicas` metrics and adjusts Deployment replicas accordingly, using an `AverageValue` target.
+- Reads the values for the `wva_desired_replicas` metrics and adjusts Deployment replicas accordingly, using an `AverageValue` target.
 
 - Natively supports scale to zero.
 
@@ -127,7 +127,7 @@ kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/s0
 }
 ```
 
-**Note**: KEDA creates its own external metric names based on the trigger configuration. The original Prometheus metric `inferno_desired_replicas` is therefore used to emit  the `s0-prometheus` metric in KEDA's external metrics API, where:
+**Note**: KEDA creates its own external metric names based on the trigger configuration. The original Prometheus metric `wva_desired_replicas` is therefore used to emit  the `s0-prometheus` metric in KEDA's external metrics API, where:
 
 - `s0` = Scaler index (first scaler = 0)
 - `prometheus` = Scaler type
@@ -148,7 +148,7 @@ kubectl get events -n llm-d-sim --field-selector type=Normal -w
 37m         Normal   KEDAScalersStarted           scaledobject/vllme-deployment-scaler                      Started scalers watch
 37m         Normal   ScaledObjectReady            scaledobject/vllme-deployment-scaler                      ScaledObject is ready for scaling
 36m         Normal   KEDAScaleTargetDeactivated   scaledobject/vllme-deployment-scaler                      Deactivated apps/v1.Deployment llm-d-sim/vllme-deployment from 1 to 0
-3m37s       Normal   KEDAScaleTargetActivated     scaledobject/vllme-deployment-scaler                      Scaled apps/v1.Deployment llm-d-sim/vllme-deployment from 0 to 1, triggered by inferno-desired-replicas
+3m37s       Normal   KEDAScaleTargetActivated     scaledobject/vllme-deployment-scaler                      Scaled apps/v1.Deployment llm-d-sim/vllme-deployment from 0 to 1, triggered by wva-desired-replicas
 3m37s       Normal   ScalingReplicaSet            deployment/vllme-deployment                               Scaled up replica set vllme-deployment-64f7cd79f5 from 0 to 1
 ```
 
@@ -165,7 +165,7 @@ kubectl get events -n llm-d-sim | grep -i keda
 38m         Normal    KEDAScalersStarted           scaledobject/vllme-deployment-scaler                      Scaler prometheus is built
 38m         Normal    KEDAScalersStarted           scaledobject/vllme-deployment-scaler                      Started scalers watch
 38m         Normal    KEDAScaleTargetDeactivated   scaledobject/vllme-deployment-scaler                      Deactivated apps/v1.Deployment llm-d-sim/vllme-deployment from 1 to 0
-4m55s       Normal    KEDAScaleTargetActivated     scaledobject/vllme-deployment-scaler                      Scaled apps/v1.Deployment llm-d-sim/vllme-deployment from 0 to 1, triggered by inferno-desired-replicas
+4m55s       Normal    KEDAScaleTargetActivated     scaledobject/vllme-deployment-scaler                      Scaled apps/v1.Deployment llm-d-sim/vllme-deployment from 0 to 1, triggered by wva-desired-replicas
 ```
 
 ## Example: scale-up scenario
@@ -289,22 +289,22 @@ spec:
             value: 5                          # Scale up by max 5 pods at a time
             periodSeconds: 15
 
-  # Prometheus trigger using inferno metrics
+  # Prometheus trigger using wva metrics
   triggers:
   - type: prometheus
-    name: inferno-desired-replicas
+    name: wva-desired-replicas
     metadata:
       # Prometheus server address
       serverAddress: https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090
       
-      # Use inferno_desired_replicas as the scaling metric
+      # Use wva_desired_replicas as the scaling metric
       query: |
-        inferno_desired_replicas{
+        wva_desired_replicas{
           variant_name="vllme-deployment",
           exported_namespace="llm-d-sim"
         }
 
-      # Scaling configuration for inferno_desired_replicas metric (integer values)
+      # Scaling configuration for wva_desired_replicas metric (integer values)
       threshold: '1'                       
       activationThreshold: '0'             # Activation: scale out from 0 when the metric is above 0
       metricType: "AverageValue"           

--- a/docs/integrations/prometheus.md
+++ b/docs/integrations/prometheus.md
@@ -152,6 +152,8 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
 *No optimization metrics are currently exposed. Optimization timing is logged at DEBUG level.*
 
 ### Replica Management Metrics
+
+### `wva_current_replicas`
 - **Type**: Gauge
 - **Description**: Current number of replicas for each variant
 - **Labels**:
@@ -160,7 +162,7 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
   - `accelerator_type`: Type of accelerator being used
 - **Use Case**: Monitor current number of replicas per variant
 
-### `inferno_desired_replicas`
+### `wva_desired_replicas`
 - **Type**: Gauge
 - **Description**: Desired number of replicas for each variant
 - **Labels**:
@@ -169,7 +171,7 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
   - `accelerator_type`: Type of accelerator being used
 - **Use Case**: Expose the desired optimized number of replicas per variant
 
-### `inferno_desired_ratio`
+### `wva_desired_ratio`
 - **Type**: Gauge
 - **Description**: Ratio of the desired number of replicas and the current number of replicas for each variant
 - **Labels**:
@@ -178,7 +180,7 @@ All custom metrics are prefixed with `inferno_` and include labels for `variant_
   - `accelerator_type`: Type of accelerator being used
 - **Use Case**: Compare the desired and current number of replicas per variant, for scaling purposes
 
-### `inferno_replica_scaling_total`
+### `wva_replica_scaling_total`
 - **Type**: Counter
 - **Description**: Total number of replica scaling operations
 - **Labels**:
@@ -220,23 +222,23 @@ spec:
 ### Basic Queries
 ```promql
 # Current replicas by variant
-inferno_current_replicas
+wva_current_replicas
 
 # Scaling frequency
-rate(inferno_replica_scaling_total[5m])
+rate(wva_replica_scaling_total[5m])
 
 # Desired replicas by variant
-inferno_desired_replicas
+wva_desired_replicas
 ```
 
 ### Advanced Queries
 ```promql
 # Scaling frequency by direction
-rate(inferno_replica_scaling_total{direction="scale_up"}[5m])
+rate(wva_replica_scaling_total{direction="scale_up"}[5m])
 
 # Replica count mismatch
-abs(inferno_desired_replicas - inferno_current_replicas)
+abs(wva_desired_replicas - wva_current_replicas)
 
 # Scaling frequency by reason
-rate(inferno_replica_scaling_total[5m]) by (reason)
+rate(wva_replica_scaling_total[5m]) by (reason)
 ```

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -325,7 +325,7 @@ WVA exposes metrics for monitoring and integrates with HPA for automatic scaling
 
 WVA includes a **safety net** that prevents HPA from using stale metrics during failures:
 
-1. **Normal Operation**: Emits `inferno_desired_replicas` with optimized targets
+1. **Normal Operation**: Emits `wva_desired_replicas` with optimized targets
 2. **Capacity Analysis Fails**:
    - Uses previous desired replicas (from last successful run)
    - If unavailable, uses current replicas (safe no-op)

--- a/docs/user-guide/multi-controller-isolation.md
+++ b/docs/user-guide/multi-controller-isolation.md
@@ -125,17 +125,17 @@ When `CONTROLLER_INSTANCE` is set, all emitted metrics include a `controller_ins
 
 ```promql
 # Without controller instance isolation
-inferno_desired_replicas{variant_name="llama-8b",namespace="llm-d",accelerator_type="H100"}
+wva_desired_replicas{variant_name="llama-8b",namespace="llm-d",accelerator_type="H100"}
 
 # With controller instance isolation  
-inferno_desired_replicas{variant_name="llama-8b",namespace="llm-d",accelerator_type="H100",controller_instance="my-instance-id"}
+wva_desired_replicas{variant_name="llama-8b",namespace="llm-d",accelerator_type="H100",controller_instance="my-instance-id"}
 ```
 
 Affected metrics:
-- `inferno_replica_scaling_total`
-- `inferno_desired_replicas`
-- `inferno_current_replicas`
-- `inferno_desired_ratio`
+- `wva_replica_scaling_total`
+- `wva_desired_replicas`
+- `wva_current_replicas`
+- `wva_desired_ratio`
 
 ### VA Resource Filtering
 
@@ -162,7 +162,7 @@ spec:
   - type: Pods
     pods:
       metric:
-        name: inferno_desired_replicas
+        name: wva_desired_replicas
         selector:
           matchLabels:
             variant_name: "llama-8b"
@@ -224,15 +224,15 @@ Query metrics for specific controller instances:
 
 ```promql
 # Check desired replicas for specific controller instance
-inferno_desired_replicas{controller_instance="prod"}
+wva_desired_replicas{controller_instance="prod"}
 
 # Compare scaling events across instances
 sum by (controller_instance, direction) (
-  rate(inferno_replica_scaling_total[5m])
+  rate(wva_replica_scaling_total[5m])
 )
 
 # Alert on missing controller instance metrics
-absent(inferno_current_replicas{controller_instance="prod"})
+absent(wva_current_replicas{controller_instance="prod"})
 ```
 
 ### Cleanup
@@ -292,7 +292,7 @@ kubectl delete hpa -l wva.llmd.ai/controller-instance=instance-a
 
 2. Verify metrics exist with expected labels:
    ```promql
-   inferno_desired_replicas{
+   wva_desired_replicas{
      variant_name="llama-8b",
      controller_instance="my-instance-id"
    }

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -54,25 +54,25 @@ const (
 	VLLMNumRequestsWaiting = "vllm:num_requests_waiting"
 )
 
-// Inferno Output Metrics
-// These metric names are used to emit Inferno autoscaler metrics to Prometheus.
+// WVA Output Metrics
+// These metric names are used to emit WVA (Workload Variant Autoscaler) metrics to Prometheus.
 // The metrics expose scaling decisions and current state for monitoring and alerting.
 const (
-	// InfernoReplicaScalingTotal is a counter that tracks the total number of scaling operations.
+	// WVAReplicaScalingTotal is a counter that tracks the total number of scaling operations.
 	// Labels: variant_name, namespace, direction (up/down), reason, accelerator_type
-	InfernoReplicaScalingTotal = "inferno_replica_scaling_total"
+	WVAReplicaScalingTotal = "wva_replica_scaling_total"
 
-	// InfernoDesiredReplicas is a gauge that tracks the desired number of replicas.
+	// WVADesiredReplicas is a gauge that tracks the desired number of replicas.
 	// Labels: variant_name, namespace, accelerator_type
-	InfernoDesiredReplicas = "inferno_desired_replicas"
+	WVADesiredReplicas = "wva_desired_replicas"
 
-	// InfernoCurrentReplicas is a gauge that tracks the current number of replicas.
+	// WVACurrentReplicas is a gauge that tracks the current number of replicas.
 	// Labels: variant_name, namespace, accelerator_type
-	InfernoCurrentReplicas = "inferno_current_replicas"
+	WVACurrentReplicas = "wva_current_replicas"
 
-	// InfernoDesiredRatio is a gauge that tracks the ratio of desired to current replicas.
+	// WVADesiredRatio is a gauge that tracks the ratio of desired to current replicas.
 	// Labels: variant_name, namespace, accelerator_type
-	InfernoDesiredRatio = "inferno_desired_ratio"
+	WVADesiredRatio = "wva_desired_ratio"
 )
 
 // Metric Label Names

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -39,10 +39,10 @@ import (
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/executor"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/saturation"
-	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -49,28 +49,28 @@ func InitMetrics(registry prometheus.Registerer) error {
 
 	replicaScalingTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: constants.InfernoReplicaScalingTotal,
+			Name: constants.WVAReplicaScalingTotal,
 			Help: "Total number of replica scaling operations",
 		},
 		scalingLabels,
 	)
 	desiredReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: constants.InfernoDesiredReplicas,
+			Name: constants.WVADesiredReplicas,
 			Help: "Desired number of replicas for each variant",
 		},
 		baseLabels,
 	)
 	currentReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: constants.InfernoCurrentReplicas,
+			Name: constants.WVACurrentReplicas,
 			Help: "Current number of replicas for each variant",
 		},
 		baseLabels,
 	)
 	desiredRatio = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: constants.InfernoDesiredRatio,
+			Name: constants.WVADesiredRatio,
 			Help: "Ratio of the desired number of replicas and the current number of replicas for each variant",
 		},
 		baseLabels,

--- a/test/e2e-openshift/README.md
+++ b/test/e2e-openshift/README.md
@@ -19,7 +19,7 @@ The tests assume the following infrastructure is already deployed on the OpenShi
    - vLLM deployment (ms-inference-scheduling-llm-d-modelservice-decode)
 3. **Prometheus** and **Thanos** for metrics collection
 4. **Prometheus Adapter** for exposing external metrics to HPA
-5. **HPA** configured to read `inferno_desired_replicas` metric
+5. **HPA** configured to read `wva_desired_replicas` metric
 6. **VariantAutoscaling** resource created for the vLLM deployment
 
 ### Environment Setup
@@ -83,7 +83,7 @@ The `sharegpt_scaleup_test.go` test performs the following steps:
 
 4. **HPA Scale-Up Trigger**
    - Monitors HPA for metric processing
-   - Verifies HPA reads the updated `inferno_desired_replicas` metric
+   - Verifies HPA reads the updated `wva_desired_replicas` metric
    - Confirms HPA desires more replicas
 
 5. **Deployment Scaling**
@@ -310,7 +310,7 @@ oc get hpa -n llm-d-inference-scheduling
 oc logs -n openshift-user-workload-monitoring deployment/prometheus-adapter
 
 # Query external metrics API directly
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduling/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-inference-scheduling/wva_desired_replicas" | jq
 ```
 
 ### Test Fails: No Scale-Up Detected

--- a/test/e2e-openshift/scale_to_zero_test.go
+++ b/test/e2e-openshift/scale_to_zero_test.go
@@ -41,11 +41,11 @@ const (
 
 var _ = Describe("Scale-to-Zero Test", Ordered, func() {
 	var (
-		ctx                      context.Context
-		scaleToZeroEnabled       bool
-		hpaScaleToZeroEnabled    bool
-		originalConfigExists     bool
-		originalConfigData       map[string]string
+		ctx                   context.Context
+		scaleToZeroEnabled    bool
+		hpaScaleToZeroEnabled bool
+		originalConfigExists  bool
+		originalConfigData    map[string]string
 	)
 
 	BeforeAll(func() {

--- a/test/e2e-openshift/sharegpt_scaleup_test.go
+++ b/test/e2e-openshift/sharegpt_scaleup_test.go
@@ -230,7 +230,7 @@ var _ = Describe("ShareGPT Scale-Up Test", Ordered, func() {
 
 				Expect(hpa.Spec.Metrics).To(HaveLen(1), "HPA should have one metric")
 				Expect(hpa.Spec.Metrics[0].Type).To(Equal(autoscalingv2.ExternalMetricSourceType), "HPA should use external metrics")
-				Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.InfernoDesiredReplicas), "HPA should use inferno_desired_replicas metric")
+				Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.WVADesiredReplicas), "HPA should use wva_desired_replicas metric")
 
 				By("verifying gateway service exists for load routing")
 				// Traffic goes through the Istio gateway to be properly routed via InferencePool/EPP
@@ -309,14 +309,14 @@ var _ = Describe("ShareGPT Scale-Up Test", Ordered, func() {
 			})
 
 			It("should verify external metrics API is accessible", func() {
-				By("querying external metrics API for inferno_desired_replicas")
+				By("querying external metrics API for wva_desired_replicas")
 				Eventually(func(g Gomega) {
 					result, err := k8sClient.RESTClient().
 						Get().
-						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + model.namespace + "/" + constants.InfernoDesiredReplicas).
+						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + model.namespace + "/" + constants.WVADesiredReplicas).
 						DoRaw(ctx)
 					g.Expect(err).NotTo(HaveOccurred(), "Should be able to query external metrics API")
-					g.Expect(string(result)).To(ContainSubstring(constants.InfernoDesiredReplicas), "Metric should be available")
+					g.Expect(string(result)).To(ContainSubstring(constants.WVADesiredReplicas), "Metric should be available")
 					g.Expect(string(result)).To(ContainSubstring(model.deployment), "Metric should be for the correct variant")
 				}, 5*time.Minute, 5*time.Second).Should(Succeed())
 			})

--- a/test/e2e-saturation-based/README.md
+++ b/test/e2e-saturation-based/README.md
@@ -23,7 +23,7 @@ The test suite creates a complete testing environment:
    - Gateway for request routing
    - Emulated vLLM deployments (llm-d-sim) with configurable accelerators
    - Prometheus and monitoring stack
-4. **HPA** configured to scale based on WVA recommendations via `inferno_desired_replicas` metric
+4. **HPA** configured to scale based on WVA recommendations via `wva_desired_replicas` metric
 5. **VariantAutoscaling** resources for test model deployments
 
 ## Prerequisites
@@ -172,7 +172,7 @@ make test-e2e
 1. **BeforeSuite**: Build controller image, create Kind cluster, deploy infrastructure
 2. **ConfigMap Validation**: Verify saturation-scaling ConfigMap exists with default thresholds
 3. **Resource Creation**: Create VariantAutoscaling resource for test deployment
-4. **HPA Validation**: Verify HPA is configured with `inferno_desired_replicas` external metric
+4. **HPA Validation**: Verify HPA is configured with `wva_desired_replicas` external metric
 5. **Initial State**: Wait for deployment to reach minimum replica count (typically 1)
 6. **Load Generation**: Start load generation job with configurable request rate
 7. **Saturation Detection**: Monitor VariantAutoscaling status for saturation indicators:
@@ -202,7 +202,7 @@ Creating Kind cluster with 3 nodes and 4 GPUs per node...
 Deploying WVA and llm-d infrastructure...
 ✓ Saturation ConfigMap created with default thresholds
 ✓ VariantAutoscaling resource created
-✓ HPA configured with inferno_desired_replicas metric
+✓ HPA configured with wva_desired_replicas metric
 ✓ Deployment scaled to 1 replica (initial state)
 ✓ Load generation started (8 req/s)
 ✓ Saturation detected (KV cache: 75%, Queue: 12)
@@ -259,7 +259,7 @@ kubectl describe hpa -n llm-d-sim
 kubectl logs -n workload-variant-autoscaler-system deployment/workload-variant-autoscaler-controller-manager -f
 
 # Query external metrics API
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/inferno_desired_replicas" | jq
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/wva_desired_replicas" | jq
 ```
 
 ### Prometheus Metrics
@@ -271,7 +271,7 @@ kubectl port-forward -n workload-variant-autoscaler-monitoring svc/prometheus-op
 ```
 
 Key metrics to monitor:
-- `inferno_desired_replicas{variant_name="..."}` - WVA replica recommendations
+- `wva_desired_replicas{variant_name="..."}` - WVA replica recommendations
 - `vllm_cache_utilization{variant_name="..."}` - KV cache utilization
 - `vllm_queue_length{variant_name="..."}` - Request queue depth
 
@@ -325,7 +325,7 @@ make deploy-wva-emulated-on-kind
 kubectl get va -n llm-d-sim -o yaml
 
 # Verify metrics are being collected
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/inferno_desired_replicas"
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/llm-d-sim/wva_desired_replicas"
 
 # Check load generation job
 kubectl get jobs -n llm-d-sim

--- a/test/e2e-saturation-based/e2e_saturation_test.go
+++ b/test/e2e-saturation-based/e2e_saturation_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Single Va
 			By("verifying HPA uses external metrics")
 			Expect(hpa.Spec.Metrics).To(HaveLen(1), "HPA should have one metric")
 			Expect(hpa.Spec.Metrics[0].Type).To(Equal(autoscalingv2.ExternalMetricSourceType), "HPA should use external metrics")
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.InfernoDesiredReplicas), "HPA should use inferno_desired_replicas metric")
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.WVADesiredReplicas), "HPA should use wva_desired_replicas metric")
 			Expect(hpa.Spec.Metrics[0].External.Metric.Selector.MatchLabels["variant_name"]).To(Equal(deployName), "HPA metric should filter by variant_name")
 
 			_, _ = fmt.Fprintf(GinkgoWriter, "HPA %s verified and configured correctly\n", hpaName)
@@ -282,10 +282,10 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Single Va
 			Eventually(func(g Gomega) {
 				result, err := k8sClient.RESTClient().
 					Get().
-					AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + namespace + "/" + constants.InfernoDesiredReplicas).
+					AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + namespace + "/" + constants.WVADesiredReplicas).
 					DoRaw(ctx)
 				g.Expect(err).NotTo(HaveOccurred(), "Should be able to query external metrics API")
-				g.Expect(string(result)).To(ContainSubstring(constants.InfernoDesiredReplicas), "Metric should be available")
+				g.Expect(string(result)).To(ContainSubstring(constants.WVADesiredReplicas), "Metric should be available")
 				g.Expect(string(result)).To(ContainSubstring(deployName), "Metric should be for the correct variant")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
@@ -677,7 +677,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Multiple 
 			Expect(hpaA100.Spec.ScaleTargetRef.Name).To(Equal(deployNameA100), "A100 HPA should target correct deployment")
 			Expect(hpaA100.Spec.Metrics).To(HaveLen(1), "A100 HPA should have one metric")
 			Expect(hpaA100.Spec.Metrics[0].Type).To(Equal(autoscalingv2.ExternalMetricSourceType), "A100 HPA should use external metrics")
-			Expect(hpaA100.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.InfernoDesiredReplicas), "A100 HPA should use inferno_desired_replicas")
+			Expect(hpaA100.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.WVADesiredReplicas), "A100 HPA should use wva_desired_replicas")
 
 			By("verifying H100 HPA exists and is configured")
 			hpaH100, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(ctx, hpaNameH100, metav1.GetOptions{})
@@ -685,7 +685,7 @@ var _ = Describe("Test workload-variant-autoscaler - Saturation Mode - Multiple 
 			Expect(hpaH100.Spec.ScaleTargetRef.Name).To(Equal(deployNameH100), "H100 HPA should target correct deployment")
 			Expect(hpaH100.Spec.Metrics).To(HaveLen(1), "H100 HPA should have one metric")
 			Expect(hpaH100.Spec.Metrics[0].Type).To(Equal(autoscalingv2.ExternalMetricSourceType), "H100 HPA should use external metrics")
-			Expect(hpaH100.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.InfernoDesiredReplicas), "H100 HPA should use inferno_desired_replicas")
+			Expect(hpaH100.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.WVADesiredReplicas), "H100 HPA should use wva_desired_replicas")
 
 			_, _ = fmt.Fprintf(GinkgoWriter, "Both HPAs verified and configured correctly\n")
 		})

--- a/test/e2e-saturation-based/e2e_scale_to_zero_test.go
+++ b/test/e2e-saturation-based/e2e_scale_to_zero_test.go
@@ -155,7 +155,6 @@ retention_period: %s`, modelName, retentionPeriodShort),
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to create HPA: %s", hpaName))
 	})
 
-
 	// ConfigMap and VA existence checks - same as saturation test + scale-to-zero ConfigMap check
 	Context("ConfigMap and VA existence checks", func() {
 		It("should have saturation-scaling ConfigMap with default configuration spawned", func() {
@@ -208,7 +207,7 @@ retention_period: %s`, modelName, retentionPeriodShort),
 			By("verifying HPA uses external metrics")
 			Expect(hpa.Spec.Metrics).To(HaveLen(1), "HPA should have one metric")
 			Expect(hpa.Spec.Metrics[0].Type).To(Equal(autoscalingv2.ExternalMetricSourceType), "HPA should use external metrics")
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.InfernoDesiredReplicas), "HPA should use inferno_desired_replicas metric")
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal(constants.WVADesiredReplicas), "HPA should use wva_desired_replicas metric")
 
 			_, _ = fmt.Fprintf(GinkgoWriter, "HPA %s verified and configured correctly\n", hpaName)
 		})
@@ -237,10 +236,10 @@ retention_period: %s`, modelName, retentionPeriodShort),
 			Eventually(func(g Gomega) {
 				result, err := k8sClient.RESTClient().
 					Get().
-					AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + namespace + "/" + constants.InfernoDesiredReplicas).
+					AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + namespace + "/" + constants.WVADesiredReplicas).
 					DoRaw(ctx)
 				g.Expect(err).NotTo(HaveOccurred(), "Should be able to query external metrics API")
-				g.Expect(string(result)).To(ContainSubstring(constants.InfernoDesiredReplicas), "Metric should be available")
+				g.Expect(string(result)).To(ContainSubstring(constants.WVADesiredReplicas), "Metric should be available")
 				g.Expect(string(result)).To(ContainSubstring(deployName), "Metric should be for the correct variant")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
@@ -770,4 +769,3 @@ enable_scale_to_zero: false`, modelName),
 		_, _ = fmt.Fprintf(GinkgoWriter, "Cleanup completed for scale-to-zero disabled test\n")
 	})
 })
-

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -420,13 +420,13 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - sin
 
 			// Verify Prometheus replica metrics
 			// Use DesiredOptimizedAlloc.Accelerator as CurrentAlloc is removed
-			currentReplicasProm, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.DesiredOptimizedAlloc.Accelerator)
+			currentReplicasProm, desiredReplicasProm, _, err = utils.GetWVAReplicaMetrics(va.Name, namespace, va.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			g.Expect(desiredReplicasProm).To(BeNumerically(">", 1),
-				fmt.Sprintf("Prometheus `inferno_desired_replicas` query should show scale-up for VA: %s - actual: %.2f", va.Name, desiredReplicasProm))
+				fmt.Sprintf("Prometheus `wva_desired_replicas` query should show scale-up for VA: %s - actual: %.2f", va.Name, desiredReplicasProm))
 			g.Expect(currentReplicasProm).To(BeNumerically(">=", 1),
-				fmt.Sprintf("Prometheus `inferno_current_replicas` query should show at least 1 replica for VA: %s - actual: %.2f", va.Name, currentReplicasProm))
+				fmt.Sprintf("Prometheus `wva_current_replicas` query should show at least 1 replica for VA: %s - actual: %.2f", va.Name, currentReplicasProm))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
 			g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically("==", desiredReplicasProm),
@@ -460,7 +460,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - sin
 				fmt.Sprintf("DesiredOptimizedAlloc for VA %s should stay at %d replicas with constant load", deployName, initialDesiredReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, va.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicasProm, _, err = utils.GetWVAReplicaMetrics(va.Name, namespace, va.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -538,7 +538,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - sin
 				accelerator = "A100" // Fallback for test if needed, or rely on labels
 			}
 
-			_, desiredReplicasProm, _, err = utils.GetInfernoReplicaMetrics(va.Name, namespace, accelerator)
+			_, desiredReplicasProm, _, err = utils.GetWVAReplicaMetrics(va.Name, namespace, accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -940,7 +940,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s", va1.Name))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetWVAReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -986,7 +986,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 			if acc2 == "" {
 				acc2 = "H100"
 			} // fallback/assumed
-			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, acc2)
+			_, desiredReplicas2, _, err = utils.GetWVAReplicaMetrics(va2.Name, namespace, acc2)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1126,7 +1126,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", firstDeployName, va1.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetWVAReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1145,7 +1145,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 				fmt.Sprintf("High load should trigger scale-up recommendation for VA: %s - actual replicas: %d", secondDeployName, va2.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicas2, _, err = utils.GetWVAReplicaMetrics(va2.Name, namespace, va2.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1198,7 +1198,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 				fmt.Sprintf("No load should trigger scale-down recommendation to %d for VA: %s", MinimumReplicas, firstDeployName))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas1, _, err = utils.GetInfernoReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicas1, _, err = utils.GetWVAReplicaMetrics(va1.Name, namespace, va1.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va1.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result
@@ -1217,7 +1217,7 @@ var _ = Describe("Test workload-variant-autoscaler in emulated environment - mul
 				fmt.Sprintf("High load should trigger scale-up recommendation to %d for VA: %s - actual replicas: %d", MinimumReplicas, secondDeployName, va2.Status.DesiredOptimizedAlloc.NumReplicas))
 
 			// Verify Prometheus replica metrics
-			_, desiredReplicas2, _, err = utils.GetInfernoReplicaMetrics(va2.Name, namespace, va2.Status.DesiredOptimizedAlloc.Accelerator)
+			_, desiredReplicas2, _, err = utils.GetWVAReplicaMetrics(va2.Name, namespace, va2.Status.DesiredOptimizedAlloc.Accelerator)
 			g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Should be able to query Prometheus metrics for: %s - got error: %v", va2.Name, err))
 
 			// Verify that the desired number of replicas has same value as Prometheus result

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -900,7 +900,7 @@ func CreateVariantAutoscalingResource(namespace, resourceName, modelId, acc stri
 	}
 }
 
-// CreateHPAOnDesiredReplicaMetrics creates a HorizontalPodAutoscaler for a deployment that scales based on the inferno_desired_replicas metric
+// CreateHPAOnDesiredReplicaMetrics creates a HorizontalPodAutoscaler for a deployment that scales based on the wva_desired_replicas metric
 // Needs the Prometheus Adapter to be installed and configured in the cluster to correctly map the external metric.
 func CreateHPAOnDesiredReplicaMetrics(name, namespace, deploymentName, variantName string, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
 	stabilizationWindowSeconds := int32(0)
@@ -947,7 +947,7 @@ func CreateHPAOnDesiredReplicaMetrics(name, namespace, deploymentName, variantNa
 					Type: autoscalingv2.ExternalMetricSourceType,
 					External: &autoscalingv2.ExternalMetricSource{
 						Metric: autoscalingv2.MetricIdentifier{
-							Name: constants.InfernoDesiredReplicas,
+							Name: constants.WVADesiredReplicas,
 							Selector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"variant_name": variantName,
@@ -1100,8 +1100,8 @@ func isPermanentPrometheusError(err error) bool {
 	return false
 }
 
-// GetInfernoReplicaMetrics queries Prometheus for metrics emitted by the Inferno autoscaler
-func GetInfernoReplicaMetrics(variantName, namespace, acceleratorType string) (currentReplicas, desiredReplicas, desiredRatio float64, err error) {
+// GetWVAReplicaMetrics queries Prometheus for metrics emitted by the WVA autoscaler
+func GetWVAReplicaMetrics(variantName, namespace, acceleratorType string) (currentReplicas, desiredReplicas, desiredRatio float64, err error) {
 
 	client, err := NewPrometheusClient("https://localhost:9090", true)
 	if err != nil {
@@ -1114,19 +1114,19 @@ func GetInfernoReplicaMetrics(variantName, namespace, acceleratorType string) (c
 	labels := fmt.Sprintf(`variant_name="%s",exported_namespace="%s",accelerator_type="%s"`, variantName, namespace, acceleratorType)
 
 	// Query both metrics with retries
-	currentQuery := fmt.Sprintf(`%s{%s}`, constants.InfernoCurrentReplicas, labels)
+	currentQuery := fmt.Sprintf(`%s{%s}`, constants.WVACurrentReplicas, labels)
 	currentReplicas, err = client.QueryWithRetry(ctx, currentQuery)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("failed to query current replicas: %w", err)
 	}
 
-	desiredQuery := fmt.Sprintf(`%s{%s}`, constants.InfernoDesiredReplicas, labels)
+	desiredQuery := fmt.Sprintf(`%s{%s}`, constants.WVADesiredReplicas, labels)
 	desiredReplicas, err = client.QueryWithRetry(ctx, desiredQuery)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("failed to query desired replicas: %w", err)
 	}
 
-	desiredRatioQuery := fmt.Sprintf(`%s{%s}`, constants.InfernoDesiredRatio, labels)
+	desiredRatioQuery := fmt.Sprintf(`%s{%s}`, constants.WVADesiredRatio, labels)
 	desiredRatio, err = client.QueryWithRetry(ctx, desiredRatioQuery)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("failed to query desired ratio: %w", err)
@@ -1249,4 +1249,3 @@ func SetupTestEnvironment(image string, numNodes, gpusPerNode int, gpuTypes stri
 	gom.Expect(os.Setenv("DEPLOY_HPA", "false")).To(gom.Succeed())                 // tests create their own HPAs if needed
 	gom.Expect(os.Setenv("VLLM_SVC_ENABLED", "false")).To(gom.Succeed())           // tests deploy their own Service
 }
-


### PR DESCRIPTION
Replace all metric names that used the "inferno" legacy prefix with "wva" (Workload Variant Autoscaler) to align with the project's naming convention. Updated metric constants, code references, test files, configuration files, and documentation to use the new naming: `wva_desired_replicas`, `wva_current_replicas`, `wva_desired_ratio`, and `wva_replica_scaling_total`. This ensures consistency across the codebase and makes the metrics clearly identifiable as WVA metrics.