### PR TITLE
Fix: OpenShift E2E Workflow Not Running

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -475,8 +475,6 @@ jobs:
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
           # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
-          # Disable benchmark mode - istioBench environment not available in llm-d helmfile
-          BENCHMARK_MODE: "false"
         run: |
           echo "Deploying WVA and llm-d infrastructure..."
           echo "  MODEL_ID: $MODEL_ID"
@@ -532,8 +530,6 @@ jobs:
           DEPLOY_HPA: "false"
           # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
-          # Disable benchmark mode - istioBench environment not available in llm-d helmfile
-          BENCHMARK_MODE: "false"
         run: |
           echo "Deploying Model B infrastructure in $LLMD_NAMESPACE_B..."
           echo "  MODEL_ID: $MODEL_ID"


### PR DESCRIPTION
## Summary

Fixes the `CI - OpenShift E2E Tests` workflow which was completely broken due to duplicate environment variable definitions causing GitHub Actions to reject the workflow file.

## Problem

The OpenShift E2E workflow (`.github/workflows/ci-e2e-openshift.yaml`) was not running on any PRs. GitHub Actions was rejecting the workflow file with the error:

```
Invalid workflow file: .github/workflows/ci-e2e-openshift.yaml#L1
(Line: 479, Col: 11): 'BENCHMARK_MODE' is already defined
(Line: 536, Col: 11): 'BENCHMARK_MODE' is already defined
```

This prevented the entire workflow from executing, which is why:
- No OpenShift E2E checks appeared in PR status
- `/ok-to-test` comments had no effect
- The workflow appeared to be completely inactive

## Root Cause

Two `env` blocks in the workflow had duplicate `BENCHMARK_MODE` definitions:

1. **"Deploy WVA and llm-d infrastructure" step** (lines 462-491):
   - Line 468: `BENCHMARK_MODE: "false"` (original)
   - Line 479: `BENCHMARK_MODE: "false"` (duplicate)

2. **"Deploy Model B infrastructure" step** (lines 515-548):
   - Line 521: `BENCHMARK_MODE: "false"` (original)
   - Line 536: `BENCHMARK_MODE: "false"` (duplicate)

YAML does not allow duplicate keys in the same mapping, and GitHub Actions enforces this validation.

## Fix

Removed the duplicate `BENCHMARK_MODE` definitions at lines 479 and 536, keeping the original definitions at lines 468 and 521.