### PR TITLE
fix(e2e): pin llm-d-inference-sim to v0.6.1 for stable metrics

### DIFF
--- a/test/utils/resources/llmdsim.go
+++ b/test/utils/resources/llmdsim.go
@@ -40,7 +40,7 @@ func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port st
 					Containers: []corev1.Container{
 						{
 							Name:            appLabel,
-							Image:           "ghcr.io/llm-d/llm-d-inference-sim:latest",
+							Image:           "ghcr.io/llm-d/llm-d-inference-sim:v0.6.1",
 							ImagePullPolicy: corev1.PullAlways,
 							Args: []string{
 								"--model",
@@ -92,7 +92,7 @@ func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, 
 
 	container := corev1.Container{
 		Name:            appLabel,
-		Image:           "ghcr.io/llm-d/llm-d-inference-sim:latest",
+		Image:           "ghcr.io/llm-d/llm-d-inference-sim:v0.6.1",
 		ImagePullPolicy: corev1.PullAlways,
 		Args: []string{
 			"--model",


### PR DESCRIPTION
Pin llm-d-inference-sim image from :latest to :v0.6.1 to ensure consistent metric availability in e2e tests. The :latest tag may point to different versions over time, causing test flakiness.