### PR TITLE
🐛 Fix e2e tests by adding DECODE_REPLICAS override

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -475,6 +475,8 @@ jobs:
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
           # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
+          # Decode replicas for e2e testing (start with 1 replica, let HPA scale)
+          DECODE_REPLICAS: "1"
         run: |
           echo "Deploying WVA and llm-d infrastructure..."
           echo "  MODEL_ID: $MODEL_ID"
@@ -485,6 +487,7 @@ jobs:
           echo "  WVA_IMAGE_TAG: $WVA_IMAGE_TAG"
           echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
           echo "  VLLM_MAX_NUM_SEQS: $VLLM_MAX_NUM_SEQS"
+          echo "  DECODE_REPLICAS: $DECODE_REPLICAS"
           echo "  HF token configuration: ✓"
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
 
@@ -530,11 +533,14 @@ jobs:
           DEPLOY_HPA: "false"
           # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
+          # Decode replicas for e2e testing (start with 1 replica, let HPA scale)
+          DECODE_REPLICAS: "1"
         run: |
           echo "Deploying Model B infrastructure in $LLMD_NAMESPACE_B..."
           echo "  MODEL_ID: $MODEL_ID"
           echo "  ACCELERATOR_TYPE: $ACCELERATOR_TYPE"
           echo "  VLLM_MAX_NUM_SEQS: $VLLM_MAX_NUM_SEQS"
+          echo "  DECODE_REPLICAS: $DECODE_REPLICAS"
 
           # Deploy llm-d infrastructure only (no WVA controller, no VA/HPA)
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --environment openshift


### PR DESCRIPTION
## Summary
- Add `DECODE_REPLICAS` environment variable support to `install.sh`
- Set `DECODE_REPLICAS=1` in OpenShift e2e workflow

## Problem
PR [llm-d/llm-d#619](https://github.com/llm-d/llm-d/pull/619) changed `decode.replicas` from 2 to 8, requiring 16 GPUs (8 pods × 2 GPUs each). This breaks e2e tests which don't have enough GPU resources available on the cluster.

## Solution
Add a `DECODE_REPLICAS` environment variable override in `deploy/install.sh`, similar to the existing `VLLM_MAX_NUM_SEQS` pattern. This allows e2e tests to start with 1 replica (2 GPUs) and let the HPA scale as needed based on WVA metrics.

## Test plan
- [ ] Run `/ok-to-test` on PR #644 after this is merged
- [ ] Verify deployment starts with 1 replica (2 GPUs)
- [ ] Verify HPA can scale based on WVA metrics