### PR TITLE
🐛 Increase HPA stabilization window to fix flaky e2e test

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -68,7 +68,7 @@ on:
       hpa_stabilization_seconds:
         description: 'HPA stabilization window in seconds'
         required: false
-        default: '30'
+        default: '240'
 
 jobs:
   # Gate: Check permissions and handle /ok-to-test for fork PRs
@@ -319,7 +319,7 @@ jobs:
       REQUEST_RATE: ${{ github.event.inputs.request_rate || '20' }}
       NUM_PROMPTS: ${{ github.event.inputs.num_prompts || '3000' }}
       MAX_NUM_SEQS: ${{ github.event.inputs.max_num_seqs || '1' }}
-      HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '30' }}
+      HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       SKIP_CLEANUP: ${{ github.event.inputs.skip_cleanup || 'false' }}
       # Use main branch of llm-d/llm-d for inferencepool chart v1.2.1 (GA API support)
       LLM_D_RELEASE: main


### PR DESCRIPTION
## Summary
- Increase `HPA_STABILIZATION_SECONDS` from 30 to 240 in the CI workflow

## Problem
The "should maintain scaled state while load is active" test was flaky because:
- HPA `scaleDown.stabilizationWindowSeconds` = 30 seconds
- Test's `Consistently()` check = 30 seconds
- Same duration creates a race condition where scale-down can occur just as the stability check completes

## Solution
Increase the stabilization window to 240s, ensuring replicas stay stable throughout the entire 30s test period plus buffer time.

## Test plan
- [x] Review CI workflow changes
- [ ] Run `/ok-to-test` to trigger e2e tests