### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ kubectl get crd variantautoscalings.llmd.ai -o jsonpath='{.spec.versions[0].sche
 
 We welcome contributions! See the llm-d Contributing Guide for guidelines.
 
-Join the [llm-d autoscaling community meetings](https://join.slack.com/share/enQtOTg1MzkwODExNDI5Mi02NWQwOWEwOWM4Y2Y3MTc4OTQyY2Y1ZDVlZmU2MjBmZDUwNjJhZGM3MjY4ZTQ5OTdjZjgzMmI0NjI0ZTBhZTM4) to get involved.
+Join the [llm-d autoscaling community meetings](https://llm-d.ai/slack) to get involved.
 
 ## License
 
@@ -201,7 +201,7 @@ Apache 2.0 - see [LICENSE](LICENSE) for details.
 ## Related Projects
 
 - [llm-d infrastructure](https://github.com/llm-d-incubation/llm-d-infra)
-- [llm-d main repository](https://github.com/llm-d-incubation/llm-d)
+- [llm-d main repository](https://github.com/llm-d/llm-d)
 
 ## References
 


### PR DESCRIPTION
- Point to the llm-d.ai slack redirect page in case we change the URL 
- Fix the llm-d main website.