### PR TITLE
feat: add saturation_v2 package foundation

### DIFF
--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -1,0 +1,518 @@
+package saturation_v2
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
+)
+
+// SaturationAnalyzer implements the interfaces.Analyzer interface using a
+// token-based capacity model with memory-bound (k1) and compute-bound (k2)
+// constraints. It replaces the V1 percentage-based analyzer when
+// analyzerName is set to "saturation".
+type SaturationAnalyzer struct {
+	// mu protects computeCapacityHistory from concurrent access.
+	mu sync.Mutex
+	// computeCapacityHistory stores rolling averages of observed k2 values,
+	// keyed by "modelID|accelerator|outputBucket".
+	computeCapacityHistory map[string]*rollingAverage
+	capacityStore          *CapacityKnowledgeStore
+}
+
+// NewSaturationAnalyzer creates a new V2 saturation analyzer backed by the
+// given capacity store.
+func NewSaturationAnalyzer(store *CapacityKnowledgeStore) *SaturationAnalyzer {
+	return &SaturationAnalyzer{
+		computeCapacityHistory: make(map[string]*rollingAverage),
+		capacityStore:          store,
+	}
+}
+
+// Name returns the analyzer identifier.
+func (a *SaturationAnalyzer) Name() string {
+	return "saturation"
+}
+
+// EvictStaleHistory removes k2 history entries that have not been updated
+// within the given timeout. This prevents unbounded memory growth from
+// deleted models or workload buckets that are no longer active.
+func (a *SaturationAnalyzer) EvictStaleHistory(timeout time.Duration) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	evicted := 0
+	for key, ra := range a.computeCapacityHistory {
+		if time.Since(ra.lastUpdated) > timeout {
+			delete(a.computeCapacityHistory, key)
+			evicted++
+		}
+	}
+	return evicted
+}
+
+// Analyze computes capacity signals for a model across all its variants.
+func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+	satConfig, ok := input.Config.(*interfaces.SaturationScalingConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected *SaturationScalingConfig, got %T", input.Config)
+	}
+
+	// Build GPU count lookup from variant states
+	gpusByVariant := make(map[string]int, len(input.VariantStates))
+	for _, vs := range input.VariantStates {
+		gpusByVariant[vs.VariantName] = vs.GPUsPerReplica
+	}
+
+	// Phase 1: Per-replica capacity computation
+	replicaCapacities := make([]ReplicaCapacity, 0, len(input.ReplicaMetrics))
+	for _, rm := range input.ReplicaMetrics {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		gpuCount := gpusByVariant[rm.VariantName]
+		rc := a.computeReplicaCapacity(rm, satConfig, input.ModelID, input.Namespace, gpuCount)
+		if rc != nil {
+			replicaCapacities = append(replicaCapacities, *rc)
+		}
+	}
+
+	// Phase 2: Per-variant aggregation
+	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
+
+	// Phase 3: Model-level aggregation
+	var totalSupply, totalAnticipatedSupply, totalDemand float64
+	for _, vc := range variantCapacities {
+		totalSupply += vc.TotalCapacity
+		totalDemand += vc.TotalDemand
+		// Anticipated supply includes pending replicas
+		anticipatedCapacity := float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
+		totalAnticipatedSupply += anticipatedCapacity
+	}
+
+	// Add scheduler queue demand (requests queued upstream in llm-d flow control)
+	totalDemand += estimateSchedulerQueueDemand(input.SchedulerQueue, input.ReplicaMetrics)
+
+	var utilization float64
+	if totalSupply > 0 {
+		utilization = totalDemand / totalSupply
+	}
+
+	// Phase 4: Scaling signals
+	var requiredCapacity, spareCapacity float64
+	if satConfig.ScaleUpThreshold > 0 {
+		requiredCapacity = totalDemand/satConfig.ScaleUpThreshold - totalAnticipatedSupply
+	}
+	if requiredCapacity < 0 {
+		requiredCapacity = 0
+	}
+
+	if satConfig.ScaleDownBoundary > 0 {
+		spareCapacity = totalSupply - totalDemand/satConfig.ScaleDownBoundary
+	}
+	if spareCapacity < 0 {
+		spareCapacity = 0
+	}
+
+	// Phase 5: Build result
+	result := &interfaces.AnalyzerResult{
+		AnalyzerName:     a.Name(),
+		ModelID:          input.ModelID,
+		Namespace:        input.Namespace,
+		AnalyzedAt:       time.Now(),
+		VariantCapacities: variantCapacities,
+		TotalSupply:      totalSupply,
+		TotalDemand:      totalDemand,
+		Utilization:      utilization,
+		RequiredCapacity: requiredCapacity,
+		SpareCapacity:    spareCapacity,
+	}
+
+	return result, nil
+}
+
+// computeReplicaCapacity computes the capacity breakdown for a single replica.
+// Returns nil if the replica has no V2 capacity data (TotalKvCapacityTokens == 0).
+func (a *SaturationAnalyzer) computeReplicaCapacity(
+	rm interfaces.ReplicaMetrics,
+	config *interfaces.SaturationScalingConfig,
+	modelID, namespace string,
+	gpuCount int,
+) *ReplicaCapacity {
+	if rm.TotalKvCapacityTokens <= 0 {
+		return nil
+	}
+
+	// Compute demand
+	replicaDemand := rm.TokensInUse
+	if rm.AvgInputTokens > 0 {
+		replicaDemand += int64(rm.QueueLength) * int64(rm.AvgInputTokens)
+	}
+
+	// k1: memory-bound capacity
+	k1 := int64(float64(rm.TotalKvCapacityTokens) * config.KvCacheThreshold)
+
+	// k2: compute-bound capacity
+	var vllmParams *VLLMEngineParams
+	if rec := a.capacityStore.Get(namespace, modelID, rm.VariantName); rec != nil {
+		vllmParams = rec.VLLMParams
+	}
+	k2 := a.computeK2(
+		modelID, rm.AcceleratorName,
+		rm.QueueLength, rm.TokensInUse,
+		rm.AvgOutputTokens, rm.AvgInputTokens,
+		config.QueueLengthThreshold,
+		vllmParams,
+		k1,
+	)
+
+	effectiveCapacity := k1
+	if k2 < k1 {
+		effectiveCapacity = k2
+	}
+
+	isSaturated := replicaDemand >= effectiveCapacity
+
+	// Update capacity store with live data, preserving VLLMParams from any
+	// existing record (parsed from deployment args and needed for FindCompatible).
+	var existingParams *VLLMEngineParams
+	if existing := a.capacityStore.Get(namespace, modelID, rm.VariantName); existing != nil && existing.VLLMParams != nil {
+		existingParams = existing.VLLMParams
+	}
+	a.capacityStore.Update(namespace, modelID, rm.VariantName, CapacityRecord{
+		AcceleratorName:       rm.AcceleratorName,
+		GpuCount:              gpuCount,
+		NumGpuBlocks:          rm.NumGpuBlocks,
+		BlockSize:             rm.BlockSize,
+		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
+		EffectiveCapacity:     effectiveCapacity,
+		VLLMParams:            existingParams,
+		LearnedFrom:           "live",
+	})
+
+	return &ReplicaCapacity{
+		PodName:               rm.PodName,
+		VariantName:           rm.VariantName,
+		AcceleratorName:       rm.AcceleratorName,
+		TokensInUse:           rm.TokensInUse,
+		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
+		MemoryBoundCapacity:   k1,
+		ComputeBoundCapacity:  k2,
+		EffectiveCapacity:     effectiveCapacity,
+		IsSaturated:           isSaturated,
+		ReplicaDemand:         replicaDemand,
+	}
+}
+
+// computeK2 determines the compute-bound capacity using a priority chain:
+// 1. Observed (queue saturated) → use tokensInUse as k2
+// 2. Historical → rolling average from previous observations
+// 3. Derived (from deployment args) → formula-based estimate
+// 4. Fallback → k1 (memory-bound only)
+func (a *SaturationAnalyzer) computeK2(
+	modelID, accelerator string,
+	queueLen int, tokensInUse int64,
+	avgOutput, avgInput float64,
+	queueThreshold float64,
+	vllmParams *VLLMEngineParams,
+	k1 int64,
+) int64 {
+	outputBucket := classifyOutputLength(avgOutput)
+	historyKey := fmt.Sprintf("%s|%s|%s", modelID, accelerator, outputBucket)
+
+	// Priority 1: Observed (queue saturated)
+	if queueLen >= int(queueThreshold) && tokensInUse > 0 {
+		k2Observed := tokensInUse
+		a.mu.Lock()
+		ra, ok := a.computeCapacityHistory[historyKey]
+		if !ok {
+			ra = newRollingAverage(RollingAverageWindowSize)
+			a.computeCapacityHistory[historyKey] = ra
+		}
+		ra.Add(float64(k2Observed))
+		a.mu.Unlock()
+		return k2Observed
+	}
+
+	// Priority 2: Historical — lock must cover Average() since Add() mutates
+	// the same slice from Priority 1 under the same lock.
+	a.mu.Lock()
+	var histAvg float64
+	if ra, ok := a.computeCapacityHistory[historyKey]; ok {
+		histAvg = ra.Average()
+	}
+	a.mu.Unlock()
+	if histAvg > 0 {
+		return int64(histAvg)
+	}
+
+	// Priority 3: Derived from deployment args
+	if k2Derived := estimateCapacityFromParams(vllmParams, avgInput, avgOutput); k2Derived > 0 {
+		return k2Derived
+	}
+
+	// Priority 4: Fallback to k1
+	return k1
+}
+
+// aggregateByVariant groups replica capacities by variant and computes
+// per-variant capacity metrics.
+func (a *SaturationAnalyzer) aggregateByVariant(
+	replicaCapacities []ReplicaCapacity,
+	inputMetrics []interfaces.ReplicaMetrics,
+	variantStates []interfaces.VariantReplicaState,
+	modelID, namespace string,
+	kvCacheThreshold float64,
+) []interfaces.VariantCapacity {
+	// Group replicas by variant
+	byVariant := make(map[string][]ReplicaCapacity)
+	for _, rc := range replicaCapacities {
+		byVariant[rc.VariantName] = append(byVariant[rc.VariantName], rc)
+	}
+
+	// Build cost and accelerator lookup from input metrics
+	variantCost := make(map[string]float64)
+	variantAccel := make(map[string]string)
+	for _, rm := range inputMetrics {
+		if _, ok := variantCost[rm.VariantName]; !ok {
+			variantCost[rm.VariantName] = rm.Cost
+			variantAccel[rm.VariantName] = rm.AcceleratorName
+		}
+	}
+
+	// Compute model-level workload averages from live replica metrics.
+	// Used for capacity estimation of zero-replica variants with deployment-derived params.
+	modelAvgInput, modelAvgOutput, _ := computeModelWorkloadAverages(inputMetrics)
+
+	result := make([]interfaces.VariantCapacity, 0, len(variantStates))
+	for _, vs := range variantStates {
+		replicas := byVariant[vs.VariantName]
+
+		var perReplicaCapacity float64
+		var totalDemand float64
+		accelerator := variantAccel[vs.VariantName]
+		cost := variantCost[vs.VariantName]
+
+		readyCount := vs.CurrentReplicas - vs.PendingReplicas
+		if readyCount < 0 {
+			readyCount = 0
+		}
+
+		if len(replicas) > 0 {
+			// Use median effective capacity from ready pods
+			capacities := make([]int64, 0, len(replicas))
+			for _, rc := range replicas {
+				capacities = append(capacities, rc.EffectiveCapacity)
+				totalDemand += float64(rc.ReplicaDemand)
+			}
+			perReplicaCapacity = float64(median(capacities))
+			if accelerator == "" {
+				accelerator = replicas[0].AcceleratorName
+			}
+		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
+			// No ready replicas — use stored capacity, enhanced with k2 derivation
+			// for deployment-derived records when workload data is available.
+			perReplicaCapacity = a.estimateStoredCapacity(rec, modelID, kvCacheThreshold, modelAvgInput, modelAvgOutput)
+		} else if rec := a.lookupCompatibleCapacity(namespace, modelID, vs.VariantName, accelerator, vs.GPUsPerReplica); rec != nil {
+			// No own record — try cross-variant estimation from a compatible variant
+			perReplicaCapacity = float64(rec.EffectiveCapacity)
+		}
+
+		totalCapacity := float64(readyCount) * perReplicaCapacity
+
+		var utilization float64
+		if totalCapacity > 0 {
+			utilization = totalDemand / totalCapacity
+		}
+
+		vc := interfaces.VariantCapacity{
+			VariantName:        vs.VariantName,
+			AcceleratorName:    accelerator,
+			Cost:               cost,
+			ReplicaCount:       readyCount,
+			PendingReplicas:    vs.PendingReplicas,
+			PerReplicaCapacity: perReplicaCapacity,
+			TotalCapacity:      totalCapacity,
+			TotalDemand:        totalDemand,
+			Utilization:        utilization,
+		}
+		result = append(result, vc)
+	}
+
+	return result
+}
+
+// lookupCompatibleCapacity searches the capacity store for a record from
+// another variant with matching hardware and vLLM parameters. This enables
+// capacity estimation for zero-replica variants that have no prior data.
+// The search is cross-namespace since capacity depends on hardware + config,
+// not namespace.
+func (a *SaturationAnalyzer) lookupCompatibleCapacity(namespace, modelID, variantName, accelerator string, gpuCount int) *CapacityRecord {
+	// Get VLLMParams for this variant (from deployment-derived record)
+	rec := a.capacityStore.Get(namespace, modelID, variantName)
+	if rec == nil || rec.VLLMParams == nil {
+		return nil
+	}
+	return a.capacityStore.FindCompatible(modelID, accelerator, gpuCount, rec.VLLMParams)
+}
+
+// estimateStoredCapacity returns a capacity estimate for a zero-replica variant
+// using its stored CapacityRecord. For "live" records (from a previously running
+// pod), the stored EffectiveCapacity is authoritative. For "deployment" records,
+// it tries to compute a better estimate using the k2 derivation formula with
+// model-level workload averages, bounded by:
+//  1. A compatible variant's live EffectiveCapacity (already min(k1,k2))
+//  2. Own k1 if TotalKvCapacityTokens is known (from num_gpu_blocks_override)
+//
+// Falls back to stored EffectiveCapacity (EffectiveMaxBatchedTokens) when no
+// workload data is available.
+func (a *SaturationAnalyzer) estimateStoredCapacity(rec *CapacityRecord, modelID string, kvCacheThreshold float64, modelAvgInput, modelAvgOutput float64) float64 {
+	if rec == nil {
+		return 0
+	}
+
+	// Live records have observed capacity — use directly
+	if rec.LearnedFrom == "live" {
+		return float64(rec.EffectiveCapacity)
+	}
+
+	// For deployment-derived records, try k2 derivation with workload data
+	if rec.VLLMParams != nil && modelAvgOutput > 0 {
+		if derived := estimateCapacityFromParams(rec.VLLMParams, modelAvgInput, modelAvgOutput); derived > 0 {
+			bounded := derived
+
+			// Bound by own k1 if TotalKvCapacityTokens is known (num_gpu_blocks_override)
+			if rec.TotalKvCapacityTokens > 0 && kvCacheThreshold > 0 {
+				k1 := int64(float64(rec.TotalKvCapacityTokens) * kvCacheThreshold)
+				if k1 > 0 && k1 < bounded {
+					bounded = k1
+				}
+			}
+
+			// Bound by compatible variant's live EffectiveCapacity (already min(k1,k2))
+			if compatible := a.capacityStore.FindCompatible(modelID, rec.AcceleratorName, rec.GpuCount, rec.VLLMParams); compatible != nil && compatible.LearnedFrom == "live" && compatible.EffectiveCapacity > 0 {
+				if compatible.EffectiveCapacity < bounded {
+					bounded = compatible.EffectiveCapacity
+				}
+			}
+
+			return float64(bounded)
+		}
+	}
+
+	// Fallback: stored EffectiveCapacity (EffectiveMaxBatchedTokens from LoadFromDeployment)
+	return float64(rec.EffectiveCapacity)
+}
+
+// estimateCapacityFromParams computes a capacity estimate using the k2 derivation
+// formula: N_steady = min(B * O / (I + O), S), capacity = N_steady * (I + O/2).
+// Used by computeK2 (Priority 3) for per-replica estimation and by
+// estimateStoredCapacity for zero-replica variants with model-level workload averages.
+// Returns 0 if estimation is not possible.
+func estimateCapacityFromParams(params *VLLMEngineParams, avgInput, avgOutput float64) int64 {
+	if params == nil || params.EffectiveMaxBatchedTokens <= 0 || avgOutput <= 0 {
+		return 0
+	}
+
+	B := float64(params.EffectiveMaxBatchedTokens)
+	S := float64(params.MaxNumSeqs)
+	I := avgInput
+	O := avgOutput
+
+	nSteady := B * O / (I + O)
+	if nSteady > S {
+		nSteady = S
+	}
+	k2Derived := int64(nSteady * (I + O/2))
+	if k2Derived > 0 {
+		return k2Derived
+	}
+	return 0
+}
+
+// computeModelWorkloadAverages computes the model-level average input tokens,
+// output tokens, and prefix cache hit rate from replica metrics across all
+// variants. These averages enable capacity estimation for zero-replica variants
+// using the k2 derivation formula, and scheduler queue demand estimation.
+func computeModelWorkloadAverages(replicaMetrics []interfaces.ReplicaMetrics) (avgInput, avgOutput, avgHitRate float64) {
+	var count int
+	for _, rm := range replicaMetrics {
+		if rm.AvgInputTokens > 0 || rm.AvgOutputTokens > 0 {
+			avgInput += rm.AvgInputTokens
+			avgOutput += rm.AvgOutputTokens
+			avgHitRate += rm.PrefixCacheHitRate
+			count++
+		}
+	}
+	if count > 0 {
+		avgInput /= float64(count)
+		avgOutput /= float64(count)
+		avgHitRate /= float64(count)
+	}
+	return avgInput, avgOutput, avgHitRate
+}
+
+// estimateSchedulerQueueDemand estimates the token demand from requests queued
+// in the llm-d inference scheduler's flow control layer.
+//
+// These requests have not yet reached any vLLM pod, so we estimate their
+// token footprint using two independent signals:
+//
+//	inputTokens = max(queueBytes / BytesPerToken, queueSize * avgInputTokens)
+//	             * (1 - prefixCacheHitRate)
+//	outputTokens = queueSize * avgOutputTokens
+//	demand = inputTokens + outputTokens
+//
+// The prefix cache hit rate reduces expected input token KV demand because
+// a fraction of prompt tokens will hit the prefix cache and reuse existing
+// KV blocks. This does NOT apply to the local vLLM queue (num_requests_waiting)
+// because those requests have not yet had prefix cache lookup performed.
+func estimateSchedulerQueueDemand(
+	sq *interfaces.SchedulerQueueMetrics,
+	replicaMetrics []interfaces.ReplicaMetrics,
+) float64 {
+	if sq == nil || (sq.QueueSize == 0 && sq.QueueBytes == 0) {
+		return 0
+	}
+
+	// Compute model-level averages from replica metrics
+	avgInput, avgOutput, avgHitRate := computeModelWorkloadAverages(replicaMetrics)
+
+	// Estimate input tokens from two signals, take the max for robustness
+	tokensFromBytes := float64(sq.QueueBytes) / BytesPerToken
+	tokensFromCount := float64(sq.QueueSize) * avgInput
+	inputTokens := tokensFromBytes
+	if tokensFromCount > inputTokens {
+		inputTokens = tokensFromCount
+	}
+
+	// Apply prefix cache hit rate reduction to input tokens only
+	inputTokens *= (1 - avgHitRate)
+
+	// Estimate output tokens (no cache reduction — output must be generated)
+	outputTokens := float64(sq.QueueSize) * avgOutput
+
+	return inputTokens + outputTokens
+}
+
+// median returns the median value from a sorted slice of int64 values.
+// Returns 0 if the slice is empty.
+func median(values []int64) int64 {
+	n := len(values)
+	if n == 0 {
+		return 0
+	}
+
+	sorted := make([]int64, n)
+	copy(sorted, values)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	if n%2 == 0 {
+		return (sorted[n/2-1] + sorted[n/2]) / 2
+	}
+	return sorted[n/2]
+}

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -1,0 +1,723 @@
+package saturation_v2
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
+)
+
+var _ = Describe("SaturationAnalyzer", func() {
+	var (
+		analyzer *SaturationAnalyzer
+		store    *CapacityKnowledgeStore
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		store = NewCapacityKnowledgeStore()
+		analyzer = NewSaturationAnalyzer(store)
+		ctx = context.Background()
+	})
+
+	Describe("Name", func() {
+		It("should return 'saturation'", func() {
+			Expect(analyzer.Name()).To(Equal("saturation"))
+		})
+	})
+
+	Describe("k1/k2 interaction", func() {
+		It("should use k1 (memory-bound) when k2 is unknown", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			// k1 = 16000 * 0.8 = 12800, k2 = k1 (fallback, queue < threshold)
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(12800)))
+		})
+
+		It("should use k2 (compute-bound) when queue is saturated", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					// Queue >= threshold (5), tokensInUse = 8000
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						8000, 16000, 6, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// k1 = 12800, k2 = 8000 (observed: tokensInUse when queue saturated)
+			// effective = min(12800, 8000) = 8000
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(8000)))
+		})
+
+		It("should detect compute-bound when k2 < k1 with high queue and low KV", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					// Low KV usage but saturated queue
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						4000, 16000, 10, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// k1 = 12800, k2 = 4000 (observed), effective = 4000
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(4000)))
+		})
+	})
+
+	Describe("k2 history", func() {
+		It("should store k2 observation in rolling average", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						8000, 16000, 6, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			_, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify k2 was stored in history
+			histKey := "test-model|H100|short"
+			ra, ok := analyzer.computeCapacityHistory[histKey]
+			Expect(ok).To(BeTrue())
+			Expect(ra.Average()).To(Equal(float64(8000)))
+		})
+
+		It("should use historical k2 when queue drops below threshold", func() {
+			// First call: queue saturated → observes k2
+			input1 := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						8000, 16000, 6, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			_, err := analyzer.Analyze(ctx, input1)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second call: queue below threshold → uses historical k2
+			input2 := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						6000, 16000, 2, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			result, err := analyzer.Analyze(ctx, input2)
+			Expect(err).NotTo(HaveOccurred())
+			// Should use historical k2=8000, not fallback to k1=12800
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(8000)))
+		})
+	})
+
+	Describe("Output-length bucketing", func() {
+		It("should use different k2 history buckets for different output lengths", func() {
+			// Short output workload: k2 observation
+			input1 := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						8000, 16000, 6, 100, 50), // avgOutput=50 → "short"
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			_, _ = analyzer.Analyze(ctx, input1)
+
+			// Long output workload: no history yet
+			input2 := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						6000, 16000, 2, 100, 600), // avgOutput=600 → "long"
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			result, err := analyzer.Analyze(ctx, input2)
+			Expect(err).NotTo(HaveOccurred())
+			// No "long" history → falls back to k1=12800 (not the "short" k2=8000)
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(12800)))
+		})
+	})
+
+	Describe("k2 derivation from deployment params", func() {
+		It("should derive k2 from chunked prefill params", func() {
+			// Pre-populate store with deployment params for this variant
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName: "H100",
+				GpuCount:        1,
+				VLLMParams: &VLLMEngineParams{
+					EffectiveMaxBatchedTokens: 2048,
+					MaxNumSeqs:                256,
+					ChunkedPrefillEnabled:     true,
+				},
+				LearnedFrom: "deployment",
+			})
+
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					// Queue below threshold, no history → uses derived k2
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 2, 500, 100), // I=500, O=100
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// B=2048, S=256, I=500, O=100
+			// N_steady = min(2048*100/(500+100), 256) = min(341.3, 256) = 256
+			// k2 = 256 * (500 + 100/2) = 256 * 550 = 140800
+			// k1 = 12800, effective = min(12800, 140800) = 12800
+			// k2 > k1, so memory-bound
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(12800)))
+		})
+
+		It("should fall back to k1 when no batch/queue/history data exists", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 0, 0), // no avg tokens
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// k2 derivation needs avgOutput > 0, falls back to k1
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(12800)))
+		})
+	})
+
+	Describe("Pending replicas", func() {
+		It("should include pending replicas in anticipated supply for scale-up", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						10000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 2, PendingReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// readyCount = 2 - 1 = 1
+			// anticipated = (1 + 1) * perReplicaCapacity
+			// This suppresses scale-up signal since anticipated > ready
+			Expect(result.RequiredCapacity).To(BeNumerically(">=", 0))
+		})
+
+		It("should NOT include pending replicas in scale-down calculation", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						1000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 3, PendingReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// spareCapacity uses totalSupply (ready only, not pending)
+			// readyCount = 2, totalSupply = 2 * capacity
+			Expect(result.SpareCapacity).To(BeNumerically(">=", 0))
+		})
+	})
+
+	Describe("Zero-replica variants", func() {
+		It("should use stored live capacity directly when variant has zero replicas", func() {
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName:   "H100",
+				GpuCount:          1,
+				EffectiveCapacity: 12000,
+				LearnedFrom:       "live",
+			})
+
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{}, // no pods
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			// Live record → uses stored EffectiveCapacity directly
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(12000)))
+		})
+
+		It("should derive capacity from params + workload for deployment-derived records", func() {
+			// Zero-replica variant with deployment-derived params only
+			store.Update("test-ns", "test-model", "variant-b", CapacityRecord{
+				AcceleratorName:   "A100",
+				GpuCount:          1,
+				EffectiveCapacity: 8192, // conservative fallback from LoadFromDeployment
+				VLLMParams: &VLLMEngineParams{
+					EffectiveMaxBatchedTokens: 8192,
+					MaxNumSeqs:                256,
+				},
+				LearnedFrom: "deployment",
+			})
+
+			// Another variant has live pods providing workload data
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 500, 100), // I=500, O=100
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+					{VariantName: "variant-b", CurrentReplicas: 0, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(2))
+
+			// variant-b: deployment-derived with workload data available
+			// B=8192, S=256, I=500, O=100
+			// N_steady = min(8192*100/(500+100), 256) = min(1365.3, 256) = 256
+			// k2_derived = 256 * (500 + 100/2) = 256 * 550 = 140800
+			// Much better than the 8192 fallback!
+			varB := result.VariantCapacities[1]
+			Expect(varB.VariantName).To(Equal("variant-b"))
+			Expect(varB.PerReplicaCapacity).To(Equal(float64(140800)))
+		})
+
+		It("should bound k2 estimate by compatible variant's live EffectiveCapacity", func() {
+			// variant-b is a new deployment on the same H100 hardware as variant-a
+			defaultParams := &VLLMEngineParams{
+				GpuMemoryUtilization:      0.9,
+				BlockSize:                 16,
+				KvCacheDtype:              "auto",
+				TensorParallelSize:        1,
+				MaxNumSeqs:                256,
+				EffectiveMaxBatchedTokens: 8192,
+			}
+			store.Update("test-ns", "test-model", "variant-b", CapacityRecord{
+				AcceleratorName:   "H100",
+				GpuCount:          1,
+				EffectiveCapacity: 8192,
+				VLLMParams:        defaultParams,
+				LearnedFrom:       "deployment",
+			})
+
+			// variant-a has a compatible live record (same accel, GPU count, params)
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 50000,
+				EffectiveCapacity:     40000, // observed min(k1, k2) = 40000
+				VLLMParams:            defaultParams,
+				LearnedFrom:           "live",
+			})
+
+			// variant-a provides workload data
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 50000, 0, 500, 100), // I=500, O=100
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+					{VariantName: "variant-b", CurrentReplicas: 0, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// k2_derived = 256 * 550 = 140800, but bounded by variant-a's live
+			// EffectiveCapacity = 40000 → result = min(140800, 40000) = 40000
+			varB := result.VariantCapacities[1]
+			Expect(varB.VariantName).To(Equal("variant-b"))
+			Expect(varB.PerReplicaCapacity).To(Equal(float64(40000)))
+		})
+
+		It("should bound k2 estimate by own k1 when TotalKvCapacityTokens is known", func() {
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName:       "A100",
+				GpuCount:              1,
+				EffectiveCapacity:     8192,
+				TotalKvCapacityTokens: 30000, // from num_gpu_blocks_override
+				VLLMParams: &VLLMEngineParams{
+					EffectiveMaxBatchedTokens: 8192,
+					MaxNumSeqs:                256,
+					NumGpuBlocksOverride:      1875,
+					BlockSize:                 16,
+				},
+				LearnedFrom: "deployment",
+			})
+
+			// Another variant provides workload data (different accelerator, won't be compatible)
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-x", "L40S", 5.0,
+						5000, 16000, 0, 500, 100),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-x", CurrentReplicas: 1, GPUsPerReplica: 1},
+					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// k2_derived = 256 * 550 = 140800
+			// k1 = 30000 * 0.8 (KvCacheThreshold) = 24000
+			// No compatible live record (A100 vs L40S) → bounded by k1 only
+			// result = min(140800, 24000) = 24000
+			varA := result.VariantCapacities[1]
+			Expect(varA.VariantName).To(Equal("variant-a"))
+			Expect(varA.PerReplicaCapacity).To(Equal(float64(24000)))
+		})
+
+		It("should use EffectiveMaxBatchedTokens fallback when no workload data exists", func() {
+			// Zero-replica variant with deployment-derived params, no other live pods
+			store.Update("test-ns", "test-model", "variant-a", CapacityRecord{
+				AcceleratorName:   "H100",
+				GpuCount:          1,
+				EffectiveCapacity: 8192,
+				VLLMParams: &VLLMEngineParams{
+					EffectiveMaxBatchedTokens: 8192,
+					MaxNumSeqs:                256,
+				},
+				LearnedFrom: "deployment",
+			})
+
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{}, // no live pods at all
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 0, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.VariantCapacities).To(HaveLen(1))
+			// No workload data → falls back to stored EffectiveCapacity (8192)
+			Expect(result.VariantCapacities[0].PerReplicaCapacity).To(Equal(float64(8192)))
+		})
+	})
+
+	Describe("estimateCapacityFromParams", func() {
+		It("should compute k2 from B, S, I, O", func() {
+			params := &VLLMEngineParams{
+				EffectiveMaxBatchedTokens: 4096,
+				MaxNumSeqs:                256,
+			}
+			// B=4096, S=256, I=500, O=100
+			// N_steady = min(4096*100/600, 256) = min(682.6, 256) = 256
+			// k2 = 256 * (500 + 50) = 256 * 550 = 140800
+			Expect(estimateCapacityFromParams(params, 500, 100)).To(Equal(int64(140800)))
+		})
+
+		It("should cap N_steady at MaxNumSeqs", func() {
+			params := &VLLMEngineParams{
+				EffectiveMaxBatchedTokens: 8192,
+				MaxNumSeqs:                64,
+			}
+			// B=8192, S=64, I=100, O=200
+			// N_steady = min(8192*200/300, 64) = min(5461, 64) = 64
+			// k2 = 64 * (100 + 100) = 64 * 200 = 12800
+			Expect(estimateCapacityFromParams(params, 100, 200)).To(Equal(int64(12800)))
+		})
+
+		It("should return 0 when avgOutput is 0", func() {
+			params := &VLLMEngineParams{
+				EffectiveMaxBatchedTokens: 8192,
+				MaxNumSeqs:                256,
+			}
+			Expect(estimateCapacityFromParams(params, 500, 0)).To(Equal(int64(0)))
+		})
+
+		It("should return 0 when params is nil", func() {
+			Expect(estimateCapacityFromParams(nil, 500, 100)).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("Scaling signals", func() {
+		It("should signal scale-up when demand exceeds threshold", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						11000, 16000, 3, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// demand is high relative to supply → requiredCapacity > 0
+			Expect(result.RequiredCapacity).To(BeNumerically(">", 0))
+		})
+
+		It("should signal scale-down when utilization is below boundary", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						1000, 16000, 0, 100, 50),
+					makeReplicaMetrics("pod-2", "variant-a", "H100", 10.0,
+						1000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 2, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// Very low utilization → spareCapacity > 0
+			Expect(result.SpareCapacity).To(BeNumerically(">", 0))
+			Expect(result.RequiredCapacity).To(Equal(float64(0)))
+		})
+
+		It("should signal steady state when utilization is between thresholds", func() {
+			// Supply ~ demand / 0.77 (between 0.70 boundary and 0.85 threshold)
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						10000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// utilization = 10000/12800 = 0.78 — between 0.70 and 0.85
+			Expect(result.RequiredCapacity).To(Equal(float64(0)))
+			Expect(result.SpareCapacity).To(Equal(float64(0)))
+		})
+	})
+
+	Describe("Scheduler queue demand", func() {
+		It("should add scheduler queue demand to total demand", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+				QueueSize:  10,
+				QueueBytes: 8000,
+			}
+
+			resultWithQueue, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Without scheduler queue
+			input.SchedulerQueue = nil
+			// Reset analyzer for clean comparison
+			analyzer2 := NewSaturationAnalyzer(store)
+			resultWithout, err := analyzer2.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resultWithQueue.TotalDemand).To(BeNumerically(">", resultWithout.TotalDemand))
+		})
+
+		It("should not add demand when scheduler queue is nil", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			// Total demand = just the replica demand (tokensInUse)
+			Expect(result.TotalDemand).To(Equal(float64(5000)))
+		})
+
+		It("should reduce input tokens by prefix cache hit rate", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					{
+						PodName: "pod-1", VariantName: "variant-a",
+						AcceleratorName: "H100", Cost: 10.0,
+						TokensInUse: 5000, TotalKvCapacityTokens: 16000,
+						NumGpuBlocks: 1000, BlockSize: 16,
+						AvgInputTokens: 100, AvgOutputTokens: 50,
+						PrefixCacheHitRate: 0.5, // 50% cache hit rate
+					},
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+				QueueSize:  10,
+				QueueBytes: 4000, // 4000/4 = 1000 tokens from bytes
+			}
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Input from count: 10 * 100 = 1000 tokens
+			// Input from bytes: 4000 / 4 = 1000 tokens
+			// max(1000, 1000) = 1000
+			// After cache hit: 1000 * (1 - 0.5) = 500
+			// Output: 10 * 50 = 500
+			// Scheduler demand = 500 + 500 = 1000
+			// Replica demand = 5000
+			// Total = 5000 + 1000 = 6000
+			Expect(result.TotalDemand).To(Equal(float64(6000)))
+		})
+
+		It("should use max of bytes and count estimates for input tokens", func() {
+			input := makeAnalyzerInput(
+				[]interfaces.ReplicaMetrics{
+					makeReplicaMetrics("pod-1", "variant-a", "H100", 10.0,
+						5000, 16000, 0, 100, 50),
+				},
+				[]interfaces.VariantReplicaState{
+					{VariantName: "variant-a", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			)
+			input.SchedulerQueue = &interfaces.SchedulerQueueMetrics{
+				QueueSize:  10,
+				QueueBytes: 20000, // 20000/4 = 5000 >> 10*100=1000
+			}
+
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Bytes estimate (5000) > count estimate (1000), so bytes wins
+			// Input = 5000 * (1-0) = 5000 (no cache hit)
+			// Output = 10 * 50 = 500
+			// Scheduler demand = 5500
+			// Total = 5000 + 5500 = 10500
+			Expect(result.TotalDemand).To(Equal(float64(10500)))
+		})
+	})
+
+	Describe("median helper", func() {
+		It("should return 0 for empty slice", func() {
+			Expect(median([]int64{})).To(Equal(int64(0)))
+		})
+
+		It("should return the value for single element", func() {
+			Expect(median([]int64{42})).To(Equal(int64(42)))
+		})
+
+		It("should return middle value for odd count", func() {
+			Expect(median([]int64{1, 3, 5})).To(Equal(int64(3)))
+		})
+
+		It("should return average of middle two for even count", func() {
+			Expect(median([]int64{1, 3, 5, 7})).To(Equal(int64(4)))
+		})
+
+		It("should handle unsorted input", func() {
+			Expect(median([]int64{5, 1, 3})).To(Equal(int64(3)))
+		})
+	})
+})
+
+// makeAnalyzerInput creates a standard AnalyzerInput with default config.
+func makeAnalyzerInput(
+	metrics []interfaces.ReplicaMetrics,
+	states []interfaces.VariantReplicaState,
+) interfaces.AnalyzerInput {
+	config := &interfaces.SaturationScalingConfig{
+		KvCacheThreshold:     0.8,
+		QueueLengthThreshold: 5,
+		KvSpareTrigger:       0.1,
+		QueueSpareTrigger:    3,
+		AnalyzerName:         "saturation",
+		ScaleUpThreshold:     0.85,
+		ScaleDownBoundary:    0.70,
+	}
+	return interfaces.AnalyzerInput{
+		ModelID:        "test-model",
+		Namespace:      "test-ns",
+		ReplicaMetrics: metrics,
+		VariantStates:  states,
+		Config:         config,
+	}
+}
+
+// makeReplicaMetrics creates a ReplicaMetrics with the given parameters.
+func makeReplicaMetrics(
+	podName, variantName, accelerator string,
+	cost float64,
+	tokensInUse, totalCapacity int64,
+	queueLen int,
+	avgInput, avgOutput float64,
+) interfaces.ReplicaMetrics {
+	var kvUsage float64
+	if totalCapacity > 0 {
+		kvUsage = float64(tokensInUse) / float64(totalCapacity)
+	}
+	blockSize := int64(16)
+	numBlocks := totalCapacity / blockSize
+
+	return interfaces.ReplicaMetrics{
+		PodName:               podName,
+		VariantName:           variantName,
+		AcceleratorName:       accelerator,
+		Cost:                  cost,
+		KvCacheUsage:          kvUsage,
+		QueueLength:           queueLen,
+		NumGpuBlocks:          numBlocks,
+		BlockSize:             blockSize,
+		TotalKvCapacityTokens: totalCapacity,
+		TokensInUse:           tokensInUse,
+		AvgInputTokens:        avgInput,
+		AvgOutputTokens:       avgOutput,
+		ModelID:               "test-model",
+		Namespace:             "test-ns",
+	}
+}

--- a/internal/engines/analyzers/saturation_v2/capacity_store.go
+++ b/internal/engines/analyzers/saturation_v2/capacity_store.go
@@ -1,0 +1,187 @@
+package saturation_v2
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// CapacityRecord holds cached capacity knowledge for a specific variant.
+// This allows the analyzer to make capacity estimates for variants that
+// currently have zero replicas, either from their own prior data or from
+// a compatible variant via FindCompatible.
+type CapacityRecord struct {
+	AcceleratorName       string
+	GpuCount              int
+	NumGpuBlocks          int64
+	BlockSize             int64
+	TotalKvCapacityTokens int64
+	EffectiveCapacity     int64
+	VLLMParams            *VLLMEngineParams // parsed deployment params for k2 derivation
+	LearnedFrom           string            // "live", "deployment", "annotation"
+	LearnedAt             time.Time
+}
+
+// CapacityKnowledgeStore is a thread-safe in-memory cache of capacity
+// records keyed by "namespace|modelID|variantName". It enables the analyzer
+// to estimate capacity for zero-replica variants and newly created
+// deployments before any live metrics are available.
+//
+// For cross-variant estimation, use FindCompatible which searches for records
+// from other variants with matching hardware and vLLM parameters.
+type CapacityKnowledgeStore struct {
+	mu      sync.RWMutex
+	records map[string]*CapacityRecord
+}
+
+// NewCapacityKnowledgeStore creates an empty capacity store.
+func NewCapacityKnowledgeStore() *CapacityKnowledgeStore {
+	return &CapacityKnowledgeStore{
+		records: make(map[string]*CapacityRecord),
+	}
+}
+
+// storeKey builds the map key for a given namespace, model, and variant.
+// The pipe delimiter is safe because Kubernetes resource names follow DNS
+// naming rules and cannot contain the "|" character.
+func storeKey(namespace, modelID, variantName string) string {
+	return fmt.Sprintf("%s|%s|%s", namespace, modelID, variantName)
+}
+
+// Update stores or overwrites a capacity record for a specific variant.
+// Live data is always authoritative and should always be written via Update.
+func (s *CapacityKnowledgeStore) Update(namespace, modelID, variantName string, record CapacityRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record.LearnedAt = time.Now()
+	s.records[storeKey(namespace, modelID, variantName)] = &record
+}
+
+// Get returns the stored capacity record for a specific variant, or nil
+// if none exists. For cross-variant lookup, use FindCompatible instead.
+func (s *CapacityKnowledgeStore) Get(namespace, modelID, variantName string) *CapacityRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.records[storeKey(namespace, modelID, variantName)]
+}
+
+// IsStale returns true if the record for the given variant is older than
+// CapacityStalenessTimeout, or if no record exists.
+func (s *CapacityKnowledgeStore) IsStale(namespace, modelID, variantName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.records[storeKey(namespace, modelID, variantName)]
+	if !ok {
+		return true
+	}
+	return time.Since(rec.LearnedAt) > CapacityStalenessTimeout
+}
+
+// LoadFromDeployment parses vLLM args from a Deployment and stores an
+// estimated capacity record for the variant. It does NOT overwrite an
+// existing "live" record — deployment-derived data is a fallback only.
+func (s *CapacityKnowledgeStore) LoadFromDeployment(namespace, modelID, variantName, accelerator string, gpuCount int, deploy *appsv1.Deployment) {
+	if deploy == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := storeKey(namespace, modelID, variantName)
+
+	// Don't overwrite live data
+	if existing, ok := s.records[key]; ok && existing.LearnedFrom == "live" {
+		return
+	}
+
+	params := ParseVLLMArgs(deploy)
+	record := &CapacityRecord{
+		AcceleratorName: accelerator,
+		GpuCount:        gpuCount,
+		VLLMParams:      &params,
+		LearnedFrom:     "deployment",
+		LearnedAt:       time.Now(),
+	}
+
+	// If num_gpu_blocks_override is set, we can estimate k1
+	if params.NumGpuBlocksOverride > 0 {
+		record.NumGpuBlocks = params.NumGpuBlocksOverride
+		record.BlockSize = params.BlockSize
+		record.TotalKvCapacityTokens = params.NumGpuBlocksOverride * params.BlockSize
+	}
+
+	// Provide a conservative capacity estimate so that brand-new variants
+	// with no live data or compatible siblings can still be considered for
+	// scale-up. EffectiveMaxBatchedTokens (the per-step token budget) is a
+	// safe lower bound — real capacity is almost always much higher.
+	if record.EffectiveCapacity <= 0 && params.EffectiveMaxBatchedTokens > 0 {
+		record.EffectiveCapacity = params.EffectiveMaxBatchedTokens
+	}
+
+	s.records[key] = record
+}
+
+// EvictStale removes capacity records that have not been updated within the
+// given timeout. This prevents unbounded memory growth from deleted or
+// long-unused variants. Use a long timeout (e.g. EvictionTimeout = 24h)
+// since historical capacity data is valuable for zero-replica estimation.
+func (s *CapacityKnowledgeStore) EvictStale(timeout time.Duration) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	evicted := 0
+	for key, rec := range s.records {
+		if time.Since(rec.LearnedAt) > timeout {
+			delete(s.records, key)
+			evicted++
+		}
+	}
+	return evicted
+}
+
+// FindCompatible searches across all namespaces for a capacity record from
+// another variant with matching configuration: same model, accelerator type,
+// GPU count, and compatible vLLM parameters (as defined by IsCapacityCompatible).
+// Capacity is a property of hardware + vLLM config, not namespace, so
+// cross-namespace matching is intentional.
+//
+// Returns the best match (preferring "live" records over "deployment" records),
+// or nil if no compatible record exists.
+func (s *CapacityKnowledgeStore) FindCompatible(modelID, accelerator string, gpuCount int, params *VLLMEngineParams) *CapacityRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var best *CapacityRecord
+	for key, rec := range s.records {
+		// Parse key: "namespace|modelID|variantName"
+		parts := strings.SplitN(key, "|", 3)
+		if len(parts) < 3 || parts[1] != modelID {
+			continue
+		}
+
+		// Must match accelerator type and GPU count
+		if rec.AcceleratorName != accelerator || rec.GpuCount != gpuCount {
+			continue
+		}
+
+		// Must have compatible vLLM parameters
+		if rec.VLLMParams == nil || !rec.VLLMParams.IsCapacityCompatible(params) {
+			continue
+		}
+
+		// Must have useful capacity data
+		if rec.EffectiveCapacity <= 0 && rec.TotalKvCapacityTokens <= 0 {
+			continue
+		}
+
+		// Prefer live data over deployment-derived
+		if best == nil || (best.LearnedFrom != "live" && rec.LearnedFrom == "live") {
+			best = rec
+		}
+	}
+
+	return best
+}

--- a/internal/engines/analyzers/saturation_v2/capacity_store_test.go
+++ b/internal/engines/analyzers/saturation_v2/capacity_store_test.go
@@ -1,0 +1,378 @@
+package saturation_v2
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("CapacityKnowledgeStore", func() {
+
+	var store *CapacityKnowledgeStore
+
+	BeforeEach(func() {
+		store = NewCapacityKnowledgeStore()
+	})
+
+	Describe("Store and retrieve", func() {
+		It("should store and retrieve a capacity record by namespace/model/variant", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				NumGpuBlocks:          1000,
+				BlockSize:             16,
+				TotalKvCapacityTokens: 16000,
+				EffectiveCapacity:     14000,
+				LearnedFrom:           "live",
+			})
+
+			got := store.Get("ns-1", "model-a", "variant-h100")
+			Expect(got).NotTo(BeNil())
+			Expect(got.TotalKvCapacityTokens).To(Equal(int64(16000)))
+			Expect(got.AcceleratorName).To(Equal("H100"))
+			Expect(got.GpuCount).To(Equal(1))
+			Expect(got.LearnedFrom).To(Equal("live"))
+		})
+
+		It("should keep records separate across namespaces", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				TotalKvCapacityTokens: 16000,
+				LearnedFrom:           "live",
+			})
+			store.Update("ns-2", "model-a", "variant-h100", CapacityRecord{
+				TotalKvCapacityTokens: 32000,
+				LearnedFrom:           "live",
+			})
+
+			Expect(store.Get("ns-1", "model-a", "variant-h100").TotalKvCapacityTokens).To(Equal(int64(16000)))
+			Expect(store.Get("ns-2", "model-a", "variant-h100").TotalKvCapacityTokens).To(Equal(int64(32000)))
+		})
+	})
+
+	Describe("Get missing key", func() {
+		It("should return nil for a key that does not exist", func() {
+			Expect(store.Get("ns-1", "nonexistent", "variant")).To(BeNil())
+		})
+	})
+
+	Describe("LoadFromDeployment", func() {
+		It("should populate VLLMParams from deployment args", func() {
+			deploy := makeTestDeployment("--gpu-memory-utilization=0.85", "--max-num-batched-tokens=4096")
+			store.LoadFromDeployment("ns-1", "model-a", "variant-a100", "A100", 2, deploy)
+
+			got := store.Get("ns-1", "model-a", "variant-a100")
+			Expect(got).NotTo(BeNil())
+			Expect(got.VLLMParams).NotTo(BeNil())
+			Expect(got.VLLMParams.GpuMemoryUtilization).To(Equal(0.85))
+			Expect(got.VLLMParams.MaxNumBatchedTokens).To(Equal(int64(4096)))
+			Expect(got.AcceleratorName).To(Equal("A100"))
+			Expect(got.GpuCount).To(Equal(2))
+			Expect(got.LearnedFrom).To(Equal("deployment"))
+		})
+
+		It("should not overwrite live data with deployment data", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				TotalKvCapacityTokens: 16000,
+				LearnedFrom:           "live",
+			})
+
+			deploy := makeTestDeployment("--gpu-memory-utilization=0.85")
+			store.LoadFromDeployment("ns-1", "model-a", "variant-h100", "H100", 1, deploy)
+
+			got := store.Get("ns-1", "model-a", "variant-h100")
+			Expect(got.LearnedFrom).To(Equal("live"))
+			Expect(got.TotalKvCapacityTokens).To(Equal(int64(16000)))
+		})
+
+		It("should handle nil deployment gracefully", func() {
+			store.LoadFromDeployment("ns-1", "model-a", "variant-h100", "H100", 1, nil)
+			Expect(store.Get("ns-1", "model-a", "variant-h100")).To(BeNil())
+		})
+
+		It("should set conservative EffectiveCapacity from EffectiveMaxBatchedTokens", func() {
+			// Default vLLM V1 deployment (no overrides)
+			deploy := makeTestDeployment()
+			store.LoadFromDeployment("ns-1", "model-a", "variant-h100", "H100", 1, deploy)
+
+			got := store.Get("ns-1", "model-a", "variant-h100")
+			Expect(got).NotTo(BeNil())
+			// V1 engine default EffectiveMaxBatchedTokens = 8192
+			Expect(got.EffectiveCapacity).To(Equal(int64(8192)))
+			Expect(got.LearnedFrom).To(Equal("deployment"))
+		})
+
+		It("should use num_gpu_blocks_override for k1 without overriding EffectiveCapacity", func() {
+			deploy := makeTestDeployment("--num-gpu-blocks-override=5000", "--block-size=16")
+			store.LoadFromDeployment("ns-1", "model-a", "variant-h100", "H100", 1, deploy)
+
+			got := store.Get("ns-1", "model-a", "variant-h100")
+			Expect(got).NotTo(BeNil())
+			Expect(got.TotalKvCapacityTokens).To(Equal(int64(80000))) // 5000 * 16
+			// EffectiveCapacity should NOT be overwritten since TotalKvCapacityTokens is set
+			// but LoadFromDeployment doesn't compute k1 from TotalKvCapacityTokens directly,
+			// it only sets EffectiveCapacity from EffectiveMaxBatchedTokens as a fallback
+			// Since num_gpu_blocks_override doesn't set EffectiveCapacity,
+			// the fallback EffectiveMaxBatchedTokens (8192) is used
+			Expect(got.EffectiveCapacity).To(Equal(int64(8192)))
+		})
+	})
+
+	Describe("Staleness", func() {
+		It("should report missing keys as stale", func() {
+			Expect(store.IsStale("ns-1", "x", "y")).To(BeTrue())
+		})
+
+		It("should report fresh records as not stale", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{LearnedFrom: "live"})
+			Expect(store.IsStale("ns-1", "model-a", "variant-h100")).To(BeFalse())
+		})
+
+		It("should report old records as stale", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{LearnedFrom: "live"})
+
+			// Manually age the record
+			store.mu.Lock()
+			rec := store.records[storeKey("ns-1", "model-a", "variant-h100")]
+			rec.LearnedAt = time.Now().Add(-CapacityStalenessTimeout - time.Minute)
+			store.mu.Unlock()
+
+			Expect(store.IsStale("ns-1", "model-a", "variant-h100")).To(BeTrue())
+		})
+	})
+
+	Describe("Concurrent access", func() {
+		It("should handle concurrent reads and writes without panicking", func() {
+			var wg sync.WaitGroup
+
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+						TotalKvCapacityTokens: int64(i * 1000),
+						LearnedFrom:           "live",
+					})
+				}(i)
+			}
+
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_ = store.Get("ns-1", "model-a", "variant-h100")
+					_ = store.IsStale("ns-1", "model-a", "variant-h100")
+				}()
+			}
+
+			wg.Wait()
+
+			got := store.Get("ns-1", "model-a", "variant-h100")
+			Expect(got).NotTo(BeNil())
+		})
+	})
+
+	Describe("Cross-variant lookup", func() {
+		It("should keep separate records for the same model on different variants", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				TotalKvCapacityTokens: 32000,
+				LearnedFrom:           "live",
+			})
+			store.Update("ns-1", "model-a", "variant-a100", CapacityRecord{
+				AcceleratorName:       "A100",
+				TotalKvCapacityTokens: 16000,
+				LearnedFrom:           "live",
+			})
+
+			Expect(store.Get("ns-1", "model-a", "variant-h100").TotalKvCapacityTokens).To(Equal(int64(32000)))
+			Expect(store.Get("ns-1", "model-a", "variant-a100").TotalKvCapacityTokens).To(Equal(int64(16000)))
+		})
+	})
+
+	Describe("FindCompatible", func() {
+		defaultParams := func() *VLLMEngineParams {
+			p := defaultVLLMEngineParams()
+			resolveEffectiveMaxBatchedTokens(&p)
+			return &p
+		}
+
+		It("should find a compatible record from another variant", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100-1", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			// Search for a compatible record for a different H100 variant
+			found := store.FindCompatible("model-a", "H100", 1, params)
+			Expect(found).NotTo(BeNil())
+			Expect(found.EffectiveCapacity).To(Equal(int64(28000)))
+		})
+
+		It("should not match across different accelerator types", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			// Search for A100 — should not match H100 record
+			found := store.FindCompatible("model-a", "A100", 1, params)
+			Expect(found).To(BeNil())
+		})
+
+		It("should not match across different GPU counts", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100-1gpu", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			// Search for 2-GPU H100 — should not match 1-GPU record
+			found := store.FindCompatible("model-a", "H100", 2, params)
+			Expect(found).To(BeNil())
+		})
+
+		It("should not match across different vLLM parameters", func() {
+			params1 := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100-high-util", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params1,
+				LearnedFrom:           "live",
+			})
+
+			// Search with different gpu_memory_utilization
+			params2 := defaultParams()
+			params2.GpuMemoryUtilization = 0.5
+			found := store.FindCompatible("model-a", "H100", 1, params2)
+			Expect(found).To(BeNil())
+		})
+
+		It("should match across different namespaces (capacity is hardware-dependent)", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			// Record in ns-1 should be found when searching for model-a
+			found := store.FindCompatible("model-a", "H100", 1, params)
+			Expect(found).NotTo(BeNil())
+			Expect(found.EffectiveCapacity).To(Equal(int64(28000)))
+		})
+
+		It("should not match across different models", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			// Different model should not match
+			found := store.FindCompatible("model-b", "H100", 1, params)
+			Expect(found).To(BeNil())
+		})
+
+		It("should prefer live records over deployment-derived records", func() {
+			params := defaultParams()
+
+			store.Update("ns-1", "model-a", "variant-h100-deploy", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 30000,
+				EffectiveCapacity:     25000,
+				VLLMParams:            params,
+				LearnedFrom:           "deployment",
+			})
+			store.Update("ns-1", "model-a", "variant-h100-live", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            params,
+				LearnedFrom:           "live",
+			})
+
+			found := store.FindCompatible("model-a", "H100", 1, params)
+			Expect(found).NotTo(BeNil())
+			Expect(found.LearnedFrom).To(Equal("live"))
+			Expect(found.EffectiveCapacity).To(Equal(int64(28000)))
+		})
+
+		It("should skip records with no useful capacity data", func() {
+			params := defaultParams()
+			store.Update("ns-1", "model-a", "variant-h100-empty", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				VLLMParams:            params,
+				EffectiveCapacity:     0,
+				TotalKvCapacityTokens: 0,
+				LearnedFrom:           "deployment",
+			})
+
+			found := store.FindCompatible("model-a", "H100", 1, params)
+			Expect(found).To(BeNil())
+		})
+
+		It("should return nil when nil params are provided", func() {
+			store.Update("ns-1", "model-a", "variant-h100", CapacityRecord{
+				AcceleratorName:       "H100",
+				GpuCount:              1,
+				TotalKvCapacityTokens: 32000,
+				EffectiveCapacity:     28000,
+				VLLMParams:            defaultParams(),
+				LearnedFrom:           "live",
+			})
+
+			found := store.FindCompatible("model-a", "H100", 1, nil)
+			Expect(found).To(BeNil())
+		})
+	})
+})
+
+// makeTestDeployment creates a minimal Deployment with the given vLLM args.
+func makeTestDeployment(args ...string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "vllm",
+							Command: []string{"vllm", "serve", "model-name"},
+							Args:    args,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/engines/analyzers/saturation_v2/constants.go
+++ b/internal/engines/analyzers/saturation_v2/constants.go
@@ -1,0 +1,41 @@
+package saturation_v2
+
+import "time"
+
+const (
+	// RollingAverageWindowSize is the number of samples retained for compute
+	// capacity (k2) history per workload bucket.
+	RollingAverageWindowSize = 10
+
+	// CapacityStalenessTimeout is the duration after which a stored capacity
+	// record is considered stale and should be refreshed from live data.
+	CapacityStalenessTimeout = 30 * time.Minute
+
+	// CapacityEvictionTimeout is the duration after which unused capacity
+	// store records are eligible for removal. This is intentionally long
+	// because historical capacity knowledge is valuable for zero-replica
+	// estimation and cross-variant matching (e.g., a variant may be at
+	// zero replicas over a weekend and scale back up Monday).
+	CapacityEvictionTimeout = 7 * 24 * time.Hour
+
+	// HistoryEvictionTimeout is the duration after which unused k2 history
+	// entries are eligible for removal. Shorter than capacity eviction
+	// because workload patterns shift and stale k2 observations from a
+	// very different workload can mislead scaling decisions.
+	HistoryEvictionTimeout = 24 * time.Hour
+
+	// BytesPerToken is the approximate number of bytes per LLM token.
+	// Used to convert scheduler queue bytes to estimated token count.
+	// Based on the OpenAI tiktoken observation that each token corresponds
+	// to roughly 4 bytes of text. This is conservative (yields an upper
+	// bound on token count) since modern tokenizers achieve 5-6 chars/token.
+	BytesPerToken = 4
+
+	// ShortOutputThreshold is the upper bound (exclusive) for the "short"
+	// output-length bucket used for k2 history keying.
+	ShortOutputThreshold = 100
+
+	// MediumOutputThreshold is the upper bound (exclusive) for the "medium"
+	// output-length bucket used for k2 history keying.
+	MediumOutputThreshold = 500
+)

--- a/internal/engines/analyzers/saturation_v2/deployment_parser.go
+++ b/internal/engines/analyzers/saturation_v2/deployment_parser.go
@@ -1,0 +1,268 @@
+package saturation_v2
+
+import (
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// VLLMEngineParams holds vLLM configuration parameters parsed from a
+// Deployment's container args and environment variables. These are used
+// to derive compute-bound capacity (k2) when no live metrics are available.
+type VLLMEngineParams struct {
+	GpuMemoryUtilization  float64 // default: 0.9
+	BlockSize             int64   // default: 16
+	KvCacheDtype          string  // default: "auto"
+	TensorParallelSize    int     // default: 1
+	NumGpuBlocksOverride  int64   // default: 0 (not set)
+	MaxNumBatchedTokens   int64   // default: 0 (auto)
+	MaxNumSeqs            int64   // default: 256
+	MaxModelLen           int64   // default: 0 (auto)
+	EnforceEager          bool    // default: false
+	IsV1Engine            bool    // VLLM_USE_V1 env detection (default: true since v0.8)
+	ChunkedPrefillEnabled bool    // true for V1, or --enable-chunked-prefill
+
+	// EffectiveMaxBatchedTokens is the resolved per-step token budget used
+	// for k2 derivation. It is computed after parsing all other fields.
+	EffectiveMaxBatchedTokens int64
+}
+
+// defaultVLLMEngineParams returns VLLMEngineParams with vLLM defaults
+// as of vLLM v0.8+. If vLLM changes its defaults in a future version,
+// these values should be updated accordingly.
+func defaultVLLMEngineParams() VLLMEngineParams {
+	return VLLMEngineParams{
+		GpuMemoryUtilization:  0.9,
+		BlockSize:             16,
+		KvCacheDtype:          "auto",
+		TensorParallelSize:    1,
+		MaxNumSeqs:            256,
+		IsV1Engine:            true,  // default since vLLM v0.8
+		ChunkedPrefillEnabled: true,  // V1 engine uses chunked prefill by default
+	}
+}
+
+// ParseVLLMArgs scans a Deployment's containers for vLLM CLI arguments
+// and environment variables, returning the parsed parameters.
+//
+// It handles:
+//   - --key=value and --key value argument formats
+//   - Hyphen/underscore normalization (--gpu-memory-utilization = --gpu_memory_utilization)
+//   - Shell commands: ["/bin/sh", "-c", "vllm serve model --arg=val"]
+//   - Boolean flags: --enforce-eager (no value)
+//   - VLLM_USE_V1 environment variable for V1 engine detection
+func ParseVLLMArgs(deploy *appsv1.Deployment) VLLMEngineParams {
+	params := defaultVLLMEngineParams()
+	if deploy == nil || len(deploy.Spec.Template.Spec.Containers) == 0 {
+		resolveEffectiveMaxBatchedTokens(&params)
+		return params
+	}
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		// Check environment variables first
+		for _, env := range container.Env {
+			if env.Name == "VLLM_USE_V1" {
+				if env.Value == "0" {
+					params.IsV1Engine = false
+					params.ChunkedPrefillEnabled = false // V0 default
+				}
+				// Any other value (including "1", empty) keeps V1 = true
+			}
+		}
+
+		// Collect all args from Command + Args, handling shell commands
+		allArgs := collectArgs(container.Command, container.Args)
+
+		// Parse the collected arguments
+		parseArgs(allArgs, &params)
+	}
+
+	// V1 engine always enables chunked prefill regardless of flag
+	if params.IsV1Engine {
+		params.ChunkedPrefillEnabled = true
+	}
+
+	resolveEffectiveMaxBatchedTokens(&params)
+	return params
+}
+
+// collectArgs merges container Command and Args, expanding shell commands.
+// If the command is a shell invocation (e.g. ["/bin/sh", "-c", "..."]),
+// the shell string is split into tokens.
+func collectArgs(command, args []string) []string {
+	all := make([]string, 0, len(command)+len(args))
+	all = append(all, command...)
+	all = append(all, args...)
+
+	// Detect shell invocation: ["/bin/sh", "-c", "cmd ..."] or similar
+	for i := 0; i < len(all)-1; i++ {
+		base := all[i]
+		if (base == "/bin/sh" || base == "/bin/bash" || base == "sh" || base == "bash") && i+1 < len(all) && all[i+1] == "-c" && i+2 < len(all) {
+			// Split the shell command string
+			shellTokens := splitShellString(all[i+2])
+			return shellTokens
+		}
+	}
+
+	return all
+}
+
+// splitShellString performs basic shell-like splitting on a command string.
+// It handles simple single/double quoting but is not a full shell parser:
+// escape sequences (\"), variable expansion ($VAR), and command substitution
+// are not supported. This is sufficient for typical vLLM deployment commands.
+func splitShellString(s string) []string {
+	var tokens []string
+	var current strings.Builder
+	inSingleQuote := false
+	inDoubleQuote := false
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch == '\'' && !inDoubleQuote:
+			inSingleQuote = !inSingleQuote
+		case ch == '"' && !inSingleQuote:
+			inDoubleQuote = !inDoubleQuote
+		case ch == ' ' && !inSingleQuote && !inDoubleQuote:
+			if current.Len() > 0 {
+				tokens = append(tokens, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens
+}
+
+// normalizeKey replaces hyphens with underscores and strips the leading
+// dashes so that --gpu-memory-utilization and --gpu_memory_utilization
+// both normalize to "gpu_memory_utilization".
+func normalizeKey(key string) string {
+	key = strings.TrimLeft(key, "-")
+	return strings.ReplaceAll(key, "-", "_")
+}
+
+// parseArgs walks the argument list and populates params.
+func parseArgs(args []string, params *VLLMEngineParams) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			continue
+		}
+
+		var key, value string
+		if idx := strings.Index(arg, "="); idx >= 0 {
+			// --key=value format
+			key = normalizeKey(arg[:idx])
+			value = arg[idx+1:]
+		} else {
+			key = normalizeKey(arg)
+			// Check if next token is the value (not another flag)
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
+				value = args[i+1]
+				i++ // consume the value
+			}
+			// Otherwise it's a boolean flag (no value)
+		}
+
+		applyParam(key, value, params)
+	}
+}
+
+// applyParam sets the corresponding VLLMEngineParams field from a
+// normalized key and its string value. Parse errors are silently ignored
+// and the default value is preserved — this is intentional graceful
+// degradation since deployment args are operator-controlled.
+func applyParam(key, value string, params *VLLMEngineParams) {
+	switch key {
+	case "gpu_memory_utilization":
+		if v, err := strconv.ParseFloat(value, 64); err == nil {
+			params.GpuMemoryUtilization = v
+		}
+	case "block_size":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.BlockSize = v
+		}
+	case "kv_cache_dtype":
+		params.KvCacheDtype = value
+	case "tensor_parallel_size":
+		if v, err := strconv.Atoi(value); err == nil {
+			params.TensorParallelSize = v
+		}
+	case "num_gpu_blocks_override":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.NumGpuBlocksOverride = v
+		}
+	case "max_num_batched_tokens":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxNumBatchedTokens = v
+		}
+	case "max_num_seqs":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxNumSeqs = v
+		}
+	case "max_model_len":
+		if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+			params.MaxModelLen = v
+		}
+	case "enforce_eager":
+		params.EnforceEager = true
+	case "enable_chunked_prefill":
+		params.ChunkedPrefillEnabled = true
+	}
+}
+
+// IsCapacityCompatible checks whether two VLLMEngineParams configurations
+// would produce equivalent per-replica capacity (both k1 and k2).
+// Used by CapacityKnowledgeStore.FindCompatible to identify variants
+// whose stored capacity can be reused for zero-replica estimation.
+func (p *VLLMEngineParams) IsCapacityCompatible(other *VLLMEngineParams) bool {
+	if p == nil || other == nil {
+		return false
+	}
+	return p.GpuMemoryUtilization == other.GpuMemoryUtilization &&
+		p.BlockSize == other.BlockSize &&
+		p.KvCacheDtype == other.KvCacheDtype &&
+		p.TensorParallelSize == other.TensorParallelSize &&
+		p.NumGpuBlocksOverride == other.NumGpuBlocksOverride &&
+		p.EffectiveMaxBatchedTokens == other.EffectiveMaxBatchedTokens
+}
+
+// resolveEffectiveMaxBatchedTokens computes the per-step token budget
+// based on parsed parameters. This is the value used for k2 derivation.
+//
+// Priority:
+//  1. Explicitly set --max-num-batched-tokens → use that
+//  2. V1 engine with chunked prefill → 8192 (vLLM V1 default since v0.8)
+//  3. V0 engine with chunked prefill → 2048 (vLLM V0 default since v0.6.5)
+//  4. Unchunked prefill → max(MaxModelLen, 2048)
+//  5. Fallback → 2048
+func resolveEffectiveMaxBatchedTokens(params *VLLMEngineParams) {
+	if params.MaxNumBatchedTokens > 0 {
+		params.EffectiveMaxBatchedTokens = params.MaxNumBatchedTokens
+		return
+	}
+
+	if params.ChunkedPrefillEnabled {
+		if params.IsV1Engine {
+			params.EffectiveMaxBatchedTokens = 8192
+		} else {
+			params.EffectiveMaxBatchedTokens = 2048
+		}
+		return
+	}
+
+	// Unchunked prefill
+	if params.MaxModelLen > 2048 {
+		params.EffectiveMaxBatchedTokens = params.MaxModelLen
+		return
+	}
+
+	params.EffectiveMaxBatchedTokens = 2048
+}

--- a/internal/engines/analyzers/saturation_v2/deployment_parser_test.go
+++ b/internal/engines/analyzers/saturation_v2/deployment_parser_test.go
@@ -1,0 +1,340 @@
+package saturation_v2
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("ParseVLLMArgs", func() {
+
+	Describe("Argument formats", func() {
+		It("should parse hyphen format (--gpu-memory-utilization=0.85)", func() {
+			deploy := makeTestDeployment("--gpu-memory-utilization=0.85")
+			params := ParseVLLMArgs(deploy)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+		})
+
+		It("should parse underscore format (--gpu_memory_utilization=0.85)", func() {
+			deploy := makeTestDeployment("--gpu_memory_utilization=0.85")
+			params := ParseVLLMArgs(deploy)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+		})
+
+		It("should parse space-separated format (--gpu-memory-utilization 0.85)", func() {
+			deploy := makeTestDeployment("--gpu-memory-utilization", "0.85")
+			params := ParseVLLMArgs(deploy)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+		})
+	})
+
+	Describe("Shell command parsing", func() {
+		It("should parse args from shell command string", func() {
+			deploy := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "vllm",
+									Command: []string{"/bin/sh", "-c", "vllm serve model-name --gpu-memory-utilization=0.85 --max-num-seqs=128"},
+								},
+							},
+						},
+					},
+				},
+			}
+			params := ParseVLLMArgs(deploy)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+			Expect(params.MaxNumSeqs).To(Equal(int64(128)))
+		})
+	})
+
+	Describe("Default values", func() {
+		It("should return vLLM defaults when no args are provided", func() {
+			deploy := makeTestDeployment() // no args
+			params := ParseVLLMArgs(deploy)
+
+			Expect(params.GpuMemoryUtilization).To(Equal(0.9))
+			Expect(params.BlockSize).To(Equal(int64(16)))
+			Expect(params.KvCacheDtype).To(Equal("auto"))
+			Expect(params.TensorParallelSize).To(Equal(1))
+			Expect(params.MaxNumSeqs).To(Equal(int64(256)))
+			Expect(params.NumGpuBlocksOverride).To(Equal(int64(0)))
+			Expect(params.MaxNumBatchedTokens).To(Equal(int64(0)))
+			Expect(params.MaxModelLen).To(Equal(int64(0)))
+			Expect(params.EnforceEager).To(BeFalse())
+			Expect(params.IsV1Engine).To(BeTrue())
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+			// V1 engine default: 8192 (since vLLM v0.8)
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(8192)))
+		})
+	})
+
+	Describe("All capacity-related params", func() {
+		It("should parse all known capacity parameters", func() {
+			deploy := makeTestDeployment(
+				"--gpu-memory-utilization=0.85",
+				"--block-size=32",
+				"--kv-cache-dtype=fp8",
+				"--tensor-parallel-size=4",
+				"--max-num-batched-tokens=4096",
+				"--max-num-seqs=128",
+				"--max-model-len=8192",
+			)
+			params := ParseVLLMArgs(deploy)
+
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+			Expect(params.BlockSize).To(Equal(int64(32)))
+			Expect(params.KvCacheDtype).To(Equal("fp8"))
+			Expect(params.TensorParallelSize).To(Equal(4))
+			Expect(params.MaxNumBatchedTokens).To(Equal(int64(4096)))
+			Expect(params.MaxNumSeqs).To(Equal(int64(128)))
+			Expect(params.MaxModelLen).To(Equal(int64(8192)))
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(4096)))
+		})
+	})
+
+	Describe("Boolean flag detection", func() {
+		It("should detect --enforce-eager as a boolean flag", func() {
+			deploy := makeTestDeployment("--enforce-eager", "--gpu-memory-utilization=0.85")
+			params := ParseVLLMArgs(deploy)
+
+			Expect(params.EnforceEager).To(BeTrue())
+			Expect(params.GpuMemoryUtilization).To(Equal(0.85))
+		})
+	})
+
+	Describe("NumGpuBlocksOverride", func() {
+		It("should parse --num-gpu-blocks-override", func() {
+			deploy := makeTestDeployment("--num-gpu-blocks-override=5000")
+			params := ParseVLLMArgs(deploy)
+			Expect(params.NumGpuBlocksOverride).To(Equal(int64(5000)))
+		})
+	})
+
+	Describe("V1 engine detection", func() {
+		It("should default to V1 engine when no VLLM_USE_V1 env var is set", func() {
+			deploy := makeTestDeployment()
+			params := ParseVLLMArgs(deploy)
+			Expect(params.IsV1Engine).To(BeTrue())
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+		})
+
+		It("should detect V1 engine when VLLM_USE_V1=1", func() {
+			deploy := makeDeploymentWithEnv(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "1"}},
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.IsV1Engine).To(BeTrue())
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+		})
+
+		It("should detect V0 engine when VLLM_USE_V1=0", func() {
+			deploy := makeDeploymentWithEnv(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "0"}},
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.IsV1Engine).To(BeFalse())
+			Expect(params.ChunkedPrefillEnabled).To(BeFalse())
+		})
+
+		It("should enable chunked prefill on V0 engine with --enable-chunked-prefill", func() {
+			deploy := makeDeploymentWithEnvAndArgs(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "0"}},
+				"--enable-chunked-prefill",
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.IsV1Engine).To(BeFalse())
+			Expect(params.ChunkedPrefillEnabled).To(BeTrue())
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(2048)))
+		})
+	})
+
+	Describe("EffectiveMaxBatchedTokens resolution", func() {
+		It("should use explicit --max-num-batched-tokens when set", func() {
+			deploy := makeTestDeployment("--max-num-batched-tokens=4096")
+			params := ParseVLLMArgs(deploy)
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(4096)))
+		})
+
+		It("should default to 8192 for V1 engine chunked prefill", func() {
+			deploy := makeTestDeployment() // V1 default → chunked
+			params := ParseVLLMArgs(deploy)
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(8192)))
+		})
+
+		It("should default to 2048 for V0 engine chunked prefill", func() {
+			deploy := makeDeploymentWithEnvAndArgs(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "0"}},
+				"--enable-chunked-prefill",
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(2048)))
+		})
+
+		It("should use max_model_len for unchunked prefill when larger than 2048", func() {
+			deploy := makeDeploymentWithEnvAndArgs(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "0"}},
+				"--max-model-len=8192",
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.ChunkedPrefillEnabled).To(BeFalse())
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(8192)))
+		})
+
+		It("should fallback to 2048 for unchunked prefill with small model len", func() {
+			deploy := makeDeploymentWithEnvAndArgs(
+				[]corev1.EnvVar{{Name: "VLLM_USE_V1", Value: "0"}},
+				"--max-model-len=1024",
+			)
+			params := ParseVLLMArgs(deploy)
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(2048)))
+		})
+	})
+
+	Describe("Nil deployment", func() {
+		It("should return defaults for nil deployment", func() {
+			params := ParseVLLMArgs(nil)
+			Expect(params.GpuMemoryUtilization).To(Equal(0.9))
+			Expect(params.IsV1Engine).To(BeTrue())
+			// V1 engine default: 8192
+			Expect(params.EffectiveMaxBatchedTokens).To(Equal(int64(8192)))
+		})
+	})
+})
+
+var _ = Describe("IsCapacityCompatible", func() {
+	It("should return true for identical default params", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeTrue())
+	})
+
+	It("should return false when GpuMemoryUtilization differs", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.GpuMemoryUtilization = 0.5
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should return false when BlockSize differs", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.BlockSize = 32
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should return false when KvCacheDtype differs", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.KvCacheDtype = "fp8"
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should return false when TensorParallelSize differs", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.TensorParallelSize = 4
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should return false when EffectiveMaxBatchedTokens differs", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.EffectiveMaxBatchedTokens = 4096
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeFalse())
+	})
+
+	It("should return false when either param is nil", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		Expect(p1.IsCapacityCompatible(nil)).To(BeFalse())
+
+		var p2 *VLLMEngineParams
+		Expect(p2.IsCapacityCompatible(&p1)).To(BeFalse())
+	})
+
+	It("should ignore non-capacity fields like MaxNumSeqs and MaxModelLen", func() {
+		p1 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p1)
+		p2 := defaultVLLMEngineParams()
+		resolveEffectiveMaxBatchedTokens(&p2)
+		p2.MaxNumSeqs = 512
+		p2.MaxModelLen = 16384
+		p2.EnforceEager = true
+		Expect(p1.IsCapacityCompatible(&p2)).To(BeTrue())
+	})
+})
+
+var _ = Describe("classifyOutputLength", func() {
+	It("should classify short output (< 100)", func() {
+		Expect(classifyOutputLength(50)).To(Equal("short"))
+		Expect(classifyOutputLength(0)).To(Equal("short"))
+		Expect(classifyOutputLength(99.9)).To(Equal("short"))
+	})
+
+	It("should classify medium output (100-500)", func() {
+		Expect(classifyOutputLength(100)).To(Equal("medium"))
+		Expect(classifyOutputLength(300)).To(Equal("medium"))
+		Expect(classifyOutputLength(499.9)).To(Equal("medium"))
+	})
+
+	It("should classify long output (>= 500)", func() {
+		Expect(classifyOutputLength(500)).To(Equal("long"))
+		Expect(classifyOutputLength(1000)).To(Equal("long"))
+	})
+})
+
+// makeDeploymentWithEnv creates a deployment with the given env vars and no extra args.
+func makeDeploymentWithEnv(envVars []corev1.EnvVar) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "vllm",
+							Command: []string{"vllm", "serve", "model-name"},
+							Env:     envVars,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// makeDeploymentWithEnvAndArgs creates a deployment with env vars and CLI args.
+func makeDeploymentWithEnvAndArgs(envVars []corev1.EnvVar, args ...string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "vllm",
+							Command: []string{"vllm", "serve", "model-name"},
+							Args:    args,
+							Env:     envVars,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/engines/analyzers/saturation_v2/history.go
+++ b/internal/engines/analyzers/saturation_v2/history.go
@@ -1,0 +1,47 @@
+package saturation_v2
+
+import "time"
+
+// rollingAverage maintains a fixed-size sliding window of float64 values
+// and computes their arithmetic mean. Used to smooth noisy compute-capacity
+// (k2) observations over time.
+type rollingAverage struct {
+	values      []float64
+	maxSize     int
+	lastUpdated time.Time
+}
+
+// newRollingAverage creates a rollingAverage with the given window size.
+func newRollingAverage(maxSize int) *rollingAverage {
+	return &rollingAverage{
+		values:      make([]float64, 0, maxSize),
+		maxSize:     maxSize,
+		lastUpdated: time.Now(),
+	}
+}
+
+// Add appends a value, evicting the oldest entry if the window is full.
+func (r *rollingAverage) Add(value float64) {
+	if len(r.values) >= r.maxSize {
+		r.values = r.values[1:]
+	}
+	r.values = append(r.values, value)
+	r.lastUpdated = time.Now()
+}
+
+// Average returns the arithmetic mean of all stored values, or 0 if empty.
+func (r *rollingAverage) Average() float64 {
+	if len(r.values) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range r.values {
+		sum += v
+	}
+	return sum / float64(len(r.values))
+}
+
+// Len returns the number of values currently stored.
+func (r *rollingAverage) Len() int {
+	return len(r.values)
+}

--- a/internal/engines/analyzers/saturation_v2/history_test.go
+++ b/internal/engines/analyzers/saturation_v2/history_test.go
@@ -1,0 +1,66 @@
+package saturation_v2
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Rolling Average", func() {
+
+	Describe("Add and Average", func() {
+		It("should compute the mean of added values", func() {
+			ra := newRollingAverage(5)
+			ra.Add(10)
+			ra.Add(20)
+			ra.Add(30)
+
+			Expect(ra.Average()).To(Equal(20.0))
+			Expect(ra.Len()).To(Equal(3))
+		})
+	})
+
+	Describe("Window eviction", func() {
+		It("should evict oldest values when window is full", func() {
+			ra := newRollingAverage(3)
+			ra.Add(1)
+			ra.Add(2)
+			ra.Add(3)
+			ra.Add(4) // evicts 1
+			ra.Add(5) // evicts 2
+
+			Expect(ra.Average()).To(Equal(4.0)) // (3+4+5)/3
+			Expect(ra.Len()).To(Equal(3))
+		})
+	})
+
+	Describe("Empty average", func() {
+		It("should return 0 for an empty rolling average", func() {
+			ra := newRollingAverage(5)
+			Expect(ra.Average()).To(Equal(0.0))
+			Expect(ra.Len()).To(Equal(0))
+		})
+	})
+
+	Describe("Single value", func() {
+		It("should return the value itself as the average", func() {
+			ra := newRollingAverage(5)
+			ra.Add(42)
+
+			Expect(ra.Average()).To(Equal(42.0))
+			Expect(ra.Len()).To(Equal(1))
+		})
+	})
+
+	Describe("Large window with overflow", func() {
+		It("should retain only the last maxSize values", func() {
+			ra := newRollingAverage(RollingAverageWindowSize)
+			for i := 1; i <= 15; i++ {
+				ra.Add(float64(i))
+			}
+
+			Expect(ra.Len()).To(Equal(RollingAverageWindowSize))
+			// Window contains 6..15, average = 10.5
+			Expect(ra.Average()).To(BeNumerically("~", 10.5, 0.001))
+		})
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/suite_test.go
+++ b/internal/engines/analyzers/saturation_v2/suite_test.go
@@ -1,0 +1,13 @@
+package saturation_v2
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSaturationV2(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Saturation V2 Suite")
+}

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -1,0 +1,37 @@
+package saturation_v2
+
+// ReplicaCapacity holds the per-replica capacity breakdown computed by
+// the V2 saturation analyzer. It is internal to the analyzer and not
+// part of the public interfaces package.
+type ReplicaCapacity struct {
+	PodName               string
+	VariantName           string
+	AcceleratorName       string
+	TokensInUse           int64
+	TotalKvCapacityTokens int64
+	MemoryBoundCapacity   int64 // k1: KV-cache-limited capacity
+	ComputeBoundCapacity  int64 // k2: compute/scheduling-limited capacity
+	EffectiveCapacity     int64 // min(k1, k2)
+	IsSaturated           bool
+	ReplicaDemand         int64 // tokensInUse + queueLength * avgInputTokens
+}
+
+// classifyOutputLength returns a workload bucket name based on average
+// output token length. The buckets are used to key compute-capacity (k2)
+// history, since k2 depends heavily on generation length.
+//
+// Buckets:
+//
+//	"short"  — avgOutput in [0, 100)
+//	"medium" — avgOutput in [100, 500)
+//	"long"   — avgOutput >= 500
+func classifyOutputLength(avgOutputTokens float64) string {
+	switch {
+	case avgOutputTokens < ShortOutputThreshold:
+		return "short"
+	case avgOutputTokens < MediumOutputThreshold:
+		return "medium"
+	default:
+		return "long"
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the `internal/saturation_v2` package with self-contained types and helpers for the V2 saturation analyzer — no engine dependency
- Implements `CapacityKnowledgeStore` for zero-replica capacity estimation, `ParseVLLMArgs` for deployment arg parsing, and supporting utilities (rolling average, output-length bucketing)
- This is the first of a stacked PR series implementing the V2 saturation analyzer

## What's included

### Types & Constants
- `ReplicaCapacity` — per-replica capacity breakdown with k1 (memory-bound), k2 (compute-bound), effective = min(k1,k2)
- `classifyOutputLength` — workload bucketing by average output tokens (short/medium/long) for k2 history keying
- `RollingAverageWindowSize`, `CapacityStalenessTimeout` constants

### Rolling Average (`history.go`)
- Fixed-size sliding window for smoothing noisy k2 observations over time

### Deployment Parser (`deployment_parser.go`)
- `ParseVLLMArgs(deploy)` extracts capacity-affecting vLLM CLI parameters from Deployment specs
- Handles `--key=value`, `--key value`, hyphen/underscore normalization, shell command splitting (`/bin/sh -c "..."`)
- Detects V1 engine via `VLLM_USE_V1` env var, resolves `EffectiveMaxBatchedTokens` (chunked vs unchunked prefill defaults)
- `VLLMEngineParams` struct with `IsCapacityCompatible()` for cross-variant matching

### Capacity Knowledge Store (`capacity_store.go`)
- Thread-safe in-memory cache keyed by `namespace|modelID|variantName`
- `Update` / `Get` / `IsStale` for live data management
- `LoadFromDeployment` — parses deployment args as fallback capacity estimate (never overwrites live data); uses `EffectiveMaxBatchedTokens` as conservative lower bound, `num_gpu_blocks_override` for k1 estimation
- `FindCompatible` — cross-namespace search for a compatible variant (same model, accelerator, GPU count, vLLM params) to enable capacity estimation for zero-replica variants; prefers live records over deployment-derived

## Test plan

- [x] 56 Ginkgo specs covering all components
- [x] Deployment parser: hyphen/underscore/space-separated formats, shell commands, boolean flags, V1/V0 engine detection, EffectiveMaxBatchedTokens resolution
- [x] Capacity store: CRUD, staleness, LoadFromDeployment (preserves live data, conservative estimates, num_gpu_blocks_override), FindCompatible (accelerator/GPU count/params matching, cross-namespace, live preference, nil safety)
- [x] Rolling average: window eviction, empty state, single value
- [x] Concurrent access safety
- [x] `go build ./...` clean