### PR TITLE
✨ Add nightly E2E test workflow for OpenShift

### DIFF
--- a/.github/workflows/nightly-e2e-openshift.yaml
+++ b/.github/workflows/nightly-e2e-openshift.yaml
@@ -1,0 +1,71 @@
+name: Nightly - OpenShift E2E Tests
+
+# Nightly regression test for WVA on OpenShift.
+# Calls the reusable workflow from llm-d/llm-d-infra to deploy the
+# workload-autoscaling guide stack and run the e2e test suite.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Midnight UTC daily
+  workflow_dispatch:
+    inputs:
+      model_id:
+        description: 'Model ID'
+        required: false
+        default: 'unsloth/Meta-Llama-3.1-8B'
+      accelerator_type:
+        description: 'Accelerator type (H100, A100, L40S)'
+        required: false
+        default: 'A100'
+      image_tag:
+        description: 'WVA image tag — "latest" auto-resolves to newest release'
+        required: false
+        default: 'latest'
+      request_rate:
+        description: 'Request rate (req/s)'
+        required: false
+        default: '20'
+      num_prompts:
+        description: 'Number of prompts'
+        required: false
+        default: '3000'
+      max_num_seqs:
+        description: 'vLLM max batch size (lower = easier to saturate)'
+        required: false
+        default: '1'
+      hpa_stabilization_seconds:
+        description: 'HPA stabilization window in seconds'
+        required: false
+        default: '240'
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-openshift
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    with:
+      guide_name: workload-autoscaling
+      namespace_suffix: nightly-wva
+      caller_repo: ${{ github.repository }}
+      deploy_wva: true
+      model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
+      accelerator_type: ${{ github.event.inputs.accelerator_type || 'A100' }}
+      wva_image_tag: ${{ github.event.inputs.image_tag || 'latest' }}
+      request_rate: ${{ github.event.inputs.request_rate || '20' }}
+      num_prompts: ${{ github.event.inputs.num_prompts || '3000' }}
+      max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}
+      hpa_stabilization_seconds: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      required_gpus: 2
+      recommended_gpus: 4
+      test_target: test-e2e-openshift
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow that runs the full WVA + llm-d e2e test suite nightly at midnight UTC
- Uses released images (not built from PR branches) to catch regressions from upstream `llm-d/llm-d` changes, OpenShift upgrades, and infrastructure drift
- Adapted from `ci-e2e-openshift.yaml` with simplifications: no gate job, no image build, no multi-model, always cleanup

## Key Features
- **Cron schedule** (midnight UTC) + manual `workflow_dispatch` with configurable inputs
- **GPU pre-flight check** with resource reporting in step summary
- **Full deploy** via `install.sh` with fixed nightly namespaces (`llm-d-nightly-wva`)
- **Always-cleanup** to free GPUs even on failure (unlike CI e2e which preserves for debugging)
- **Configurable** model, accelerator type, WVA image tag, request rate, and test parameters

## Differences from CI E2E
| Aspect | CI E2E (PR) | Nightly |
|--------|------------|---------|
| Trigger | PR / issue_comment | cron + workflow_dispatch |
| Gate job | Yes (fork PR security) | No |
| Build image | Yes (PR branch) | No (uses released tag) |
| Namespaces | PR-specific (`pr-123`) | Fixed (`nightly-wva`) |
| Multi-model | Yes (Model A1 + B) | No (single model) |
| Cleanup on failure | No (preserve for debug) | Yes (always clean up) |

## Test plan
- [ ] Trigger manually via `workflow_dispatch` and verify all steps pass
- [ ] Verify GPU check, deployment, e2e tests, and cleanup work end-to-end
- [ ] Verify namespace cleanup removes all nightly resources
- [ ] Verify cron schedule triggers at midnight UTC after merge