### PR TITLE
🐛 fix: link GHCR packages to repository and use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]  # Also runs when a GitHub release is published
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
@@ -42,7 +46,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build and push multi-arch image
         run: |

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -70,7 +70,11 @@ jobs:
       # 4. Log in to GHCR for Docker push
       # -----------------------------------------
       - name: Docker login GHCR
-        run: echo "${{ secrets.CR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       # -----------------------------------------
       # 5. Build and push multi-arch Docker image
@@ -121,12 +125,10 @@ jobs:
       # 8. Login to GHCR for chart publishing
       # -----------------------------------------
       - name: Login to GHCR (Helm)
-        env:
-          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
         run: |
           helm registry login ghcr.io \
-            --username ${{ secrets.CR_USER }} \
-            --password "$GITHUB_TOKEN"
+            --username ${{ github.actor }} \
+            --password "${{ github.token }}"
           echo "Helm registry login successful"
 
       # -----------------------------------------
@@ -140,8 +142,6 @@ jobs:
       # 10. Push chart to GHCR
       # -----------------------------------------
       - name: Push Helm chart
-        env:
-          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           CHART_FILE="workload-variant-autoscaler-${VERSION}.tgz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/llm-d/llm-d-workload-variant-autoscaler"
+LABEL org.opencontainers.image.description="Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Apache 2.0 - see [LICENSE](LICENSE) for details.
 
 ## Related Projects
 
-- [llm-d infrastructure](https://github.com/llm-d-incubation/llm-d-infra)
+- [llm-d infrastructure](https://github.com/llm-d/llm-d-infra)
 - [llm-d main repository](https://github.com/llm-d/llm-d)
 
 ## References

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Contributing to WVA:
 ## Additional Resources
 
 - [Community Proposal](https://docs.google.com/document/d/1n6SAhloQaoSyF2k3EveIOerT-f97HuWXTLFm07xcvqk/edit)
-- [llm-d Infrastructure](https://github.com/llm-d-incubation/llm-d-infra)
+- [llm-d Infrastructure](https://github.com/llm-d/llm-d-infra)
 - [API Proposal](https://docs.google.com/document/d/1j2KRAT68_FYxq1iVzG0xVL-DHQhGVUZBqiM22Hd_0hc/edit)
 
 ## Need Help?


### PR DESCRIPTION
## Summary
- Add OCI labels (`org.opencontainers.image.source`) to Dockerfile so GHCR auto-links container packages to this repository
- Switch `ci-release.yaml` and `helm-release.yaml` from personal access tokens (`secrets.GHCR_TOKEN` / `secrets.CR_TOKEN`) to `GITHUB_TOKEN` — PATs don't trigger automatic package-to-repo linking
- Fix remaining `llm-d-incubation` org references in README.md and docs/README.md

## Why packages aren't showing

The repo's Packages sidebar shows "No packages published" despite the release workflows succeeding because:

1. **No OCI labels** — GitHub requires `org.opencontainers.image.source` in the container image to auto-link it to the source repository
2. **PAT-based auth** — When workflows authenticate with personal access tokens instead of `GITHUB_TOKEN`, GitHub cannot associate the pushed package with the repository

## What this fixes

After merging + a new release:
- Container images will appear in the repo's Packages sidebar
- Helm charts will be linked to the repo
- `docker pull ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest` will work without auth (public visibility)
- No more `denied` errors for unauthenticated pulls

## Test plan
- [ ] Merge this PR
- [ ] Create a new release (or re-run the helm-release workflow via `workflow_dispatch`)
- [ ] Verify packages appear on the repo page sidebar
- [ ] Verify `docker pull ghcr.io/llm-d/llm-d-workload-variant-autoscaler:<new-tag>` works without auth
- [ ] Verify `helm pull oci://ghcr.io/llm-d/llm-d-workload-variant-autoscaler/workload-variant-autoscaler` works

> **Note:** Existing packages pushed with PATs will need to be manually linked to the repo via GitHub package settings (Settings → Packages → Connect repository), or they'll auto-link on the next release after this PR merges.