### PR TITLE
🐛 fix: revert GHCR auth to PAT-based secrets

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -7,10 +7,6 @@ on:
   release:
     types: [published]  # Also runs when a GitHub release is published
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
@@ -46,11 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push multi-arch image
         run: |

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -70,11 +70,7 @@ jobs:
       # 4. Log in to GHCR for Docker push
       # -----------------------------------------
       - name: Docker login GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+        run: echo "${{ secrets.CR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
 
       # -----------------------------------------
       # 5. Build and push multi-arch Docker image
@@ -125,10 +121,12 @@ jobs:
       # 8. Login to GHCR for chart publishing
       # -----------------------------------------
       - name: Login to GHCR (Helm)
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
         run: |
           helm registry login ghcr.io \
-            --username ${{ github.actor }} \
-            --password "${{ github.token }}"
+            --username ${{ secrets.CR_USER }} \
+            --password "$GITHUB_TOKEN"
           echo "Helm registry login successful"
 
       # -----------------------------------------
@@ -142,6 +140,8 @@ jobs:
       # 10. Push chart to GHCR
       # -----------------------------------------
       - name: Push Helm chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           CHART_FILE="workload-variant-autoscaler-${VERSION}.tgz"


### PR DESCRIPTION
## Summary

- Reverts the GHCR authentication change from PR #698 that broke release workflows
- `ci-release.yaml`: Back to `secrets.GHCR_TOKEN` for Docker push
- `helm-release.yaml`: Back to `secrets.CR_TOKEN` / `secrets.CR_USER` for Docker + Helm push
- OCI labels in Dockerfile are **kept** (those are good and unrelated to auth)

## Root Cause

PR #698 switched from PAT-based secrets (`GHCR_TOKEN`, `CR_TOKEN`) to `github.token` (the built-in GITHUB_TOKEN). However, the GHCR package `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` doesn't grant the repository's GITHUB_TOKEN write access, resulting in:

```
ERROR: failed to push ghcr.io/llm-d/llm-d-workload-variant-autoscaler:v0.5.1-rc.1: denied: permission_denied: write_package
```

All three release workflows for v0.5.1-rc.1 failed with this error.

## Test plan

- [ ] Merge this PR
- [ ] Re-create v0.5.1-rc.1 release (or create v0.5.1-rc.2)
- [ ] Verify `ci-release` and `helm-release` workflows complete successfully
- [ ] Verify Docker image appears at `ghcr.io/llm-d/llm-d-workload-variant-autoscaler:v0.5.1-rc.X`