### PR TITLE
🌱 Add typos config, Dependabot, and pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,5 @@
-# Canonical Dependabot configuration for llm-d repos
-# Copy this file to .github/dependabot.yml in your repo
-#
-# Covers: Go modules, GitHub Actions, Docker base images
-# Remove sections that don't apply to your repo
+# Dependabot configuration for llm-d-workload-variant-autoscaler
+# Based on canonical config from llm-d/llm-d-infra
 
 version: 2
 updates:
@@ -19,25 +16,22 @@ updates:
       - "dependencies"
       - "release-note-none"
     ignore:
-      # Ignore major and minor updates to Go toolchain
       - dependency-name: "go"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major and minor version updates to k8s packages
       - dependency-name: "k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major updates for all packages
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      go-dependencies:
-        patterns:
-          - "*"
       kubernetes:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      go-dependencies:
+        patterns:
+          - "*"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
@@ -59,13 +53,3 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps(docker)"
-
-  # Python dependencies (uncomment if repo uses pip/requirements.txt)
-  # - package-ecosystem: "pip"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   labels:
-  #     - "dependencies"
-  #   commit-message:
-  #     prefix: "deps(pip)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Canonical pre-commit configuration for llm-d repos
-# Copy this file to the root of your repo
+# Based on template from llm-d/llm-d-infra
 #
 # Install: pip install pre-commit && pre-commit install
 # Run all: pre-commit run --all-files

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,18 @@
+# Typos configuration for llm-d-workload-variant-autoscaler
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Intentional Go struct field names (ServiceParms, PrefillParms, DecodeParms)
+Parms = "Parms"
+parms = "parms"
+# Short code fragments / false positives
+ot = "ot"
+vas = "vas"
+
+# Pre-existing typos in codebase (to be fixed separately)
+accelarator = "accelarator"
+correcly = "correcly"
+coule = "coule"
+preformance = "preformance"
+servive = "servive"
+throughtput = "throughtput"


### PR DESCRIPTION
## Summary
- Add `_typos.toml` to suppress false positives (Parms struct names, pre-existing typos) so the org-wide typos check passes cleanly
- Add Dependabot config for Go modules, GitHub Actions, and Docker base images
- Add canonical `.pre-commit-config.yaml` from [llm-d/llm-d-infra](https://github.com/llm-d/llm-d-infra)

Part of the org-wide effort to standardize CI tooling across all llm-d repos.

## Test plan
- [ ] Verify typos check passes in CI
- [ ] Verify Dependabot creates dependency update PRs on schedule
- [ ] Verify pre-commit hooks work locally: `pip install pre-commit && pre-commit run --all-files`

cc @diegocastanibm @maugustosilva