### PR TITLE
🌱 chore: add OCI manifest annotations for GHCR auto-linking

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]  # Also runs when a GitHub release is published
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
@@ -52,6 +56,9 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --push \
+            --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.description=Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads" \
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
             -t $IMAGE:$VERSION_TAG \
             -t $IMAGE:latest .
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -83,6 +83,9 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --push \
+            --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.description=Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads" \
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
             -t $IMAGE:$TAG \
             -t $IMAGE:latest .
 


### PR DESCRIPTION
## Summary

- Adds `--annotation` flags to `docker buildx build` in both `ci-release.yaml` and `helm-release.yaml`
- For multi-arch images, Dockerfile `LABEL`s only apply to individual platform images (amd64, arm64) — GHCR reads **manifest index annotations** for auto-linking and metadata display
- This ensures GHCR automatically links the package to the repository and shows description/license without manual configuration

### Annotations added
- `org.opencontainers.image.source` — auto-links package to repo
- `org.opencontainers.image.description` — shows on GHCR package page
- `org.opencontainers.image.licenses` — displays license info

## Test plan

- [ ] Merge and create a new release (or re-tag)
- [ ] Verify GHCR package page shows description instead of "No description provided"
- [ ] Verify package stays linked to repository