### PR TITLE
🐛 Fix Helm chart GHCR package visibility (401 on anonymous pull)

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -149,8 +149,22 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           CHART_FILE="workload-variant-autoscaler-${VERSION}.tgz"
 
+          # Push to org-level path to avoid nested sub-package (slashes in
+          # GHCR package names prevent visibility changes via API/UI).
           helm push "$CHART_FILE" \
-            oci://ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+            oci://ghcr.io/llm-d
+
+      # -----------------------------------------
+      # 10b. Ensure Helm chart package is public
+      # -----------------------------------------
+      - name: Set Helm chart package visibility to public
+        env:
+          GH_TOKEN: ${{ secrets.CR_TOKEN }}
+        run: |
+          gh api --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/${{ github.repository_owner }}/packages/container/workload-variant-autoscaler" \
+            -f visibility='public' || echo "::warning::Could not set chart package to public — may need manual update"
 
       # -----------------------------------------
       # 11. Commit updated chart files


### PR DESCRIPTION
## Summary
- Helm chart pushed to `oci://ghcr.io/llm-d/llm-d-workload-variant-autoscaler` creates a nested GHCR package with a slash in its name (`llm-d-workload-variant-autoscaler/workload-variant-autoscaler`)
- GHCR packages with slashes **cannot** have their visibility changed via the GitHub REST API or UI settings page — they stay permanently private
- This causes `401 unauthorized` on anonymous `helm pull` even though the parent Docker image package is public
- **Fix**: Push chart to `oci://ghcr.io/llm-d` instead, creating a flat package `workload-variant-autoscaler` at org level
- Adds a post-push step to explicitly set the package visibility to public via the GitHub API

## New chart reference
```
# Before (broken - private, no way to change)
oci://ghcr.io/llm-d/llm-d-workload-variant-autoscaler/workload-variant-autoscaler

# After (public, manageable)
oci://ghcr.io/llm-d/workload-variant-autoscaler
```

## Test plan
- [ ] Merge and create a test release (or manual workflow dispatch with a test tag)
- [ ] Verify `helm pull oci://ghcr.io/llm-d/workload-variant-autoscaler --version 0.5.1-rc.1` works without auth
- [ ] Update any downstream references to the new chart path