### PR TITLE
🐛 Fix CI E2E: clean up orphaned cluster-scoped WVA resources

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -559,6 +559,27 @@ jobs:
             fi
           done
 
+          # The helmfile uses a generic release name "workload-variant-autoscaler" which
+          # produces non-unique ClusterRole names. On shared clusters, these resources
+          # may be owned by another namespace's release, causing Helm ownership conflicts.
+          # Fix: adopt them for our namespace so helmfile can proceed. Post-cleanup will
+          # delete them, and the next user's helmfile run will recreate them fresh.
+          echo "Adopting shared WVA cluster-scoped resources for namespace $LLMD_NAMESPACE..."
+          for kind in clusterrole clusterrolebinding; do
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | select(.metadata.annotations["meta.helm.sh/release-namespace"] != null) | .metadata.name' 2>/dev/null | \
+              while read -r name; do
+                current_ns=$(kubectl get "$kind" "$name" -o json 2>/dev/null | jq -r '.metadata.annotations["meta.helm.sh/release-namespace"] // ""')
+                if [ "$current_ns" != "$LLMD_NAMESPACE" ]; then
+                  echo "  Adopting $kind/$name (was owned by '$current_ns')"
+                  kubectl annotate "$kind" "$name" \
+                    "meta.helm.sh/release-name=workload-variant-autoscaler" \
+                    "meta.helm.sh/release-namespace=$LLMD_NAMESPACE" \
+                    --overwrite || true
+                fi
+              done
+          done
+
           echo ""
           echo "Cleanup complete for this PR's namespaces"
 
@@ -780,6 +801,19 @@ jobs:
           # Use both name and instance labels to avoid deleting resources from other PRs
           echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
           kubectl delete clusterrole,clusterrolebinding -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" --ignore-not-found || true
+
+          # Also clean up cluster-scoped resources owned by this PR's namespaces
+          # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
+          for kind in clusterrole clusterrolebinding; do
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+              while IFS=$'\t' read -r name ns; do
+                if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$LLMD_NAMESPACE_B" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                  echo "  Deleting $kind/$name (owned by PR namespace '$ns')"
+                  kubectl delete "$kind" "$name" --ignore-not-found || true
+                fi
+              done
+          done
 
           echo "Cleanup complete"
 


### PR DESCRIPTION
## Summary
- Adds orphan detection for cluster-scoped WVA resources (ClusterRoles, ClusterRoleBindings) whose owning namespace no longer exists
- These stale resources block fresh helm installs because Helm refuses to adopt resources owned by a different release
- Same fix as [llm-d/llm-d-infra#10](https://github.com/llm-d/llm-d-infra/pull/10) (nightly workflow), applied to the CI E2E workflow

## Root Cause
When a WVA installation's namespace is deleted (e.g., failed CI run cleanup, manual deletion), cluster-scoped resources like ClusterRoles are left behind. The next CI run tries to create the same ClusterRole, but Helm rejects it:

```
ClusterRole "workload-variant-autoscaler-metrics-auth-role" exists and cannot be imported
into the current release: invalid ownership metadata; key "meta.helm.sh/release-namespace"
must equal "llm-d-nightly-wva": current value is "llm-d-autoscaler"
```

## Changes

**Pre-cleanup** (before deploy):
- Scans all WVA-labeled ClusterRoles/ClusterRoleBindings
- For each, checks if the owning namespace (from `meta.helm.sh/release-namespace`) still exists
- Deletes only orphans where the namespace is gone — active installations are never touched

**Post-cleanup** (after tests):
- Existing: deletes cluster-scoped resources by `app.kubernetes.io/instance` label (matches WVA controller release)
- New: also deletes cluster-scoped resources owned by this PR's namespaces (covers helmfile-created resources with different instance labels)

## Test plan
- [ ] CI E2E passes on this PR
- [ ] Verify other WVA installations on the cluster are not affected
- [ ] Verify orphaned resources from deleted namespaces are cleaned up