### PR TITLE
🐛 Fix Helm chart: make ClusterRole names unique per namespace

### DIFF
--- a/.github/workflows/nightly-e2e-openshift.yaml
+++ b/.github/workflows/nightly-e2e-openshift.yaml
@@ -56,6 +56,7 @@ jobs:
       guide_name: workload-autoscaling
       namespace_suffix: nightly-wva
       caller_repo: ${{ github.repository }}
+      caller_ref: ${{ github.ref_name }}
       deploy_wva: true
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'A100' }}

--- a/charts/workload-variant-autoscaler/templates/_helpers.tpl
+++ b/charts/workload-variant-autoscaler/templates/_helpers.tpl
@@ -51,6 +51,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create a name for cluster-scoped resources (ClusterRole, ClusterRoleBinding).
+Appends the release namespace to the fullname to ensure uniqueness when multiple
+installations exist on the same cluster in different namespaces.
+*/}}
+{{- define "workload-variant-autoscaler.clusterResourceName" -}}
+{{- printf "%s-%s" (include "workload-variant-autoscaler.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "workload-variant-autoscaler.serviceAccountName" -}}

--- a/charts/workload-variant-autoscaler/templates/manager/prometheus-clusterrolebinding.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/prometheus-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-prometheus-adapter-monitoring
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-prometheus-adapter-monitoring
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:

--- a/charts/workload-variant-autoscaler/templates/manager/wva-clusterrolebinding.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-monitoring
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-monitoring
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/prometheus_metrics_auth_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/prometheus_metrics_auth_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-prometheus-metrics-auth-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-prometheus-metrics-auth-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
 subjects:
 # Bind the Prometheus service account to the metrics auth role
 # This allows Prometheus to access WVA's secure HTTPS metrics endpoint

--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-admin-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-admin-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-editor-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-editor-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-viewer-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-viewer-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
## Summary
- Adds `clusterResourceName` helper to `_helpers.tpl` that appends `.Release.Namespace` to the fullname
- Updates all 6 ClusterRoles and 6 ClusterRoleBindings to use namespace-scoped names
- Prevents Helm ownership conflicts when multiple WVA installations share a cluster

## Problem
When multiple WVA installations exist on the same cluster (e.g., `llm-d-nightly-wva`, `llm-d-vezio`), the chart produces identical ClusterRole names like `workload-variant-autoscaler-manager-role`. Helm stamps these with `meta.helm.sh/release-namespace` annotations, and subsequent installations fail with:

```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists.
Unable to continue with install: ClusterRole "workload-variant-autoscaler-manager-role"
already exists and cannot be imported into the current release
```

## Fix
New helper `clusterResourceName` produces names like:
- `workload-variant-autoscaler-llm-d-nightly-wva-manager-role`
- `workload-variant-autoscaler-llm-d-vezio-manager-role`

Each installation gets its own unique set of ClusterRoles/ClusterRoleBindings.

Namespace-scoped resources (Role, RoleBinding, ServiceAccount, etc.) are unchanged since they are already isolated by namespace.

## Test plan
- [ ] `helm template` renders correctly with namespace suffix in ClusterRole names
- [ ] Two renders with different `--namespace` values produce different ClusterRole names
- [ ] roleRef names in ClusterRoleBindings match corresponding ClusterRole names
- [ ] Namespace-scoped resources (Role, RoleBinding) are NOT affected
- [ ] Existing deployments: need coordinated upgrade (delete old ClusterRoles first, or use `helm upgrade --force`)