### PR TITLE
🐛 Fix ClusterRole cleanup, unique names, and workflow references

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   typos:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -559,6 +559,27 @@ jobs:
             fi
           done
 
+          # The helmfile uses a generic release name "workload-variant-autoscaler" which
+          # produces non-unique ClusterRole names. On shared clusters, these resources
+          # may be owned by another namespace's release, causing Helm ownership conflicts.
+          # Fix: adopt them for our namespace so helmfile can proceed. Post-cleanup will
+          # delete them, and the next user's helmfile run will recreate them fresh.
+          echo "Adopting shared WVA cluster-scoped resources for namespace $LLMD_NAMESPACE..."
+          for kind in clusterrole clusterrolebinding; do
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | select(.metadata.annotations["meta.helm.sh/release-namespace"] != null) | .metadata.name' 2>/dev/null | \
+              while read -r name; do
+                current_ns=$(kubectl get "$kind" "$name" -o json 2>/dev/null | jq -r '.metadata.annotations["meta.helm.sh/release-namespace"] // ""')
+                if [ "$current_ns" != "$LLMD_NAMESPACE" ]; then
+                  echo "  Adopting $kind/$name (was owned by '$current_ns')"
+                  kubectl annotate "$kind" "$name" \
+                    "meta.helm.sh/release-name=workload-variant-autoscaler" \
+                    "meta.helm.sh/release-namespace=$LLMD_NAMESPACE" \
+                    --overwrite || true
+                fi
+              done
+          done
+
           echo ""
           echo "Cleanup complete for this PR's namespaces"
 
@@ -780,6 +801,19 @@ jobs:
           # Use both name and instance labels to avoid deleting resources from other PRs
           echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
           kubectl delete clusterrole,clusterrolebinding -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" --ignore-not-found || true
+
+          # Also clean up cluster-scoped resources owned by this PR's namespaces
+          # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
+          for kind in clusterrole clusterrolebinding; do
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+              while IFS=$'\t' read -r name ns; do
+                if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$LLMD_NAMESPACE_B" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                  echo "  Deleting $kind/$name (owned by PR namespace '$ns')"
+                  kubectl delete "$kind" "$name" --ignore-not-found || true
+                fi
+              done
+          done
 
           echo "Cleanup complete"
 

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   links:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main

--- a/.github/workflows/nightly-e2e-openshift.yaml
+++ b/.github/workflows/nightly-e2e-openshift.yaml
@@ -56,6 +56,7 @@ jobs:
       guide_name: workload-autoscaling
       namespace_suffix: nightly-wva
       caller_repo: ${{ github.repository }}
+      caller_ref: ${{ github.ref_name }}
       deploy_wva: true
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'A100' }}

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   gatekeeper:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   prow:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   auto-merge:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -3,4 +3,4 @@ on: pull_request
 
 jobs:
   remove-lgtm:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   unstale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
     permissions:
       issues: write

--- a/charts/workload-variant-autoscaler/templates/_helpers.tpl
+++ b/charts/workload-variant-autoscaler/templates/_helpers.tpl
@@ -51,6 +51,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create a name for cluster-scoped resources (ClusterRole, ClusterRoleBinding).
+Appends the release namespace to the fullname to ensure uniqueness when multiple
+installations exist on the same cluster in different namespaces.
+*/}}
+{{- define "workload-variant-autoscaler.clusterResourceName" -}}
+{{- printf "%s-%s" (include "workload-variant-autoscaler.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "workload-variant-autoscaler.serviceAccountName" -}}

--- a/charts/workload-variant-autoscaler/templates/manager/prometheus-clusterrolebinding.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/prometheus-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-prometheus-adapter-monitoring
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-prometheus-adapter-monitoring
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:

--- a/charts/workload-variant-autoscaler/templates/manager/wva-clusterrolebinding.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-monitoring
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-monitoring
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_auth_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/metrics_reader_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-reader
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-reader
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/prometheus_metrics_auth_role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/prometheus_metrics_auth_role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-prometheus-metrics-auth-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-prometheus-metrics-auth-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-metrics-auth-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-metrics-auth-role
 subjects:
 # Bind the Prometheus service account to the metrics auth role
 # This allows Prometheus to access WVA's secure HTTPS metrics endpoint

--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/role_binding.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role_binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-rolebinding
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-rolebinding
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-manager-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "workload-variant-autoscaler.fullname" . }}-controller-manager

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-admin-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-admin-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-editor-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-editor-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-viewer-role
+  name: {{ include "workload-variant-autoscaler.clusterResourceName" . }}-variantautoscaling-viewer-role
   labels:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
## Summary
- Fix CI E2E: clean up orphaned cluster-scoped WVA resources
- Fix Helm chart: make ClusterRole names unique per namespace
- Fix broken reusable workflow references (@2b273d6 → @main)

Consolidates #715, #716, and #718.

## Test plan
- [ ] Verify ClusterRole cleanup works in CI E2E
- [ ] Verify Helm chart generates unique ClusterRole names
- [ ] Verify reusable workflow references resolve correctly