### PR TITLE
🐛 Fix nightly E2E: update DEFAULT_MODEL_ID and add WVA_METRICS_SECURE

### DIFF
--- a/.github/workflows/nightly-e2e-openshift.yaml
+++ b/.github/workflows/nightly-e2e-openshift.yaml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   nightly:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@fix/nightly-metrics-secure
     with:
       guide_name: workload-autoscaling
       namespace_suffix: nightly-wva

--- a/.github/workflows/nightly-e2e-openshift.yaml
+++ b/.github/workflows/nightly-e2e-openshift.yaml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   nightly:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@fix/nightly-metrics-secure
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: workload-autoscaling
       namespace_suffix: nightly-wva

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -68,7 +68,7 @@ INSTALL_GATEWAY_CTRLPLANE_ORIGINAL="${INSTALL_GATEWAY_CTRLPLANE:-}"
 INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-false}"
 
 # Model and SLO Configuration
-DEFAULT_MODEL_ID=${DEFAULT_MODEL_ID:-"Qwen/Qwen3-32B"}
+DEFAULT_MODEL_ID=${DEFAULT_MODEL_ID:-"Qwen/Qwen3-0.6B"}
 MODEL_ID=${MODEL_ID:-"unsloth/Meta-Llama-3.1-8B"}
 ACCELERATOR_TYPE=${ACCELERATOR_TYPE:-"H100"}
 SLO_TPOT=${SLO_TPOT:-10}  # Target time-per-output-token SLO (in ms)
@@ -96,6 +96,8 @@ HPA_STABILIZATION_SECONDS=${HPA_STABILIZATION_SECONDS:-240}
 HPA_MIN_REPLICAS=${HPA_MIN_REPLICAS:-1}
 SKIP_CHECKS=${SKIP_CHECKS:-false}
 E2E_TESTS_ENABLED=${E2E_TESTS_ENABLED:-false}
+# WVA metrics endpoint security (set false to disable bearer token auth on /metrics)
+WVA_METRICS_SECURE=${WVA_METRICS_SECURE:-true}
 # vLLM max-num-seqs (max concurrent sequences per replica, lower = easier to saturate for testing)
 VLLM_MAX_NUM_SEQS=${VLLM_MAX_NUM_SEQS:-""}
 # Decode replicas override (useful for e2e testing with limited GPUs)
@@ -454,6 +456,7 @@ deploy_wva_controller() {
         --set wva.logging.level=$WVA_LOG_LEVEL \
         --set wva.prometheus.tls.insecureSkipVerify=$SKIP_TLS_VERIFY \
         --set wva.namespaceScoped=$NAMESPACE_SCOPED \
+        --set wva.metrics.secure=$WVA_METRICS_SECURE \
         ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE}
     
     # Wait for WVA to be ready


### PR DESCRIPTION
## Summary
Two fixes for the nightly E2E tests on OpenShift:

1. **Update DEFAULT_MODEL_ID** from `Qwen/Qwen3-32B` to `Qwen/Qwen3-0.6B`
   - The llm-d repo changed its default model, but install.sh still had the old value
   - The yq model replacement silently failed — vLLM served `Qwen/Qwen3-0.6B` while WVA queried for `unsloth/Meta-Llama-3.1-8B` metrics
   - Result: `MetricsAvailable=False`, `DesiredOptimizedAlloc` empty, Scale-to-Zero tests fail

2. **Add `WVA_METRICS_SECURE` env var** (default: `true`) wired to `wva.metrics.secure` Helm value
   - When set to `false`, disables bearer token auth on the WVA `/metrics` endpoint
   - Needed for OpenShift user-workload-monitoring where the controller-manager SA token auth fails with "Token does not match server's copy"
   - Without this, Prometheus can't scrape `wva_desired_replicas` → external metrics API empty → ShareGPT test fails

**Before fix**: 1 Passed, 2 Failed, 22 Skipped
**After model ID fix only**: 3 Passed, 1 Failed, 21 Skipped
**Expected after both fixes**: 4+ Passed, 0 Failed

Companion PR: llm-d/llm-d-infra#20 (sets `WVA_METRICS_SECURE=false` in reusable workflow)

> **Note**: Nightly workflow temporarily points to `llm-d-infra@fix/nightly-metrics-secure`. Will revert to `@main` after llm-d-infra#20 merges.

## Test plan
- [ ] Trigger nightly from this branch — all core tests should pass
- [ ] Verify `MetricsAvailable=True` in metrics pipeline verification step
- [ ] Verify `wva_desired_replicas` is accessible via external metrics API