### PR TITLE
Enhance queueing model used by queue analyzer

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -67,20 +67,14 @@ type ModelAcceleratorPerfData struct {
 	AccCount     int          `json:"accCount"`     // number of accelerator units used by model
 	MaxBatchSize int          `json:"maxBatchSize"` // max batch size based on average number of tokens per request
 	AtTokens     int          `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
-	DecodeParms  DecodeParms  `json:"decodeParms"`  // parameters for estimating decode time
-	PrefillParms PrefillParms `json:"prefillParms"` // parameters for estimating prefill time
+	ServiceParms ServiceParms `json:"serviceParms"` // parameters for estimating service time
 }
 
-// Parameters for estimating decode time = alpha + beta * batchSize (msec); batchSize > 0
-type DecodeParms struct {
+// Parameters for estimating TTFT and ITL
+type ServiceParms struct {
 	Alpha float32 `json:"alpha"` // base
-	Beta  float32 `json:"beta"`  // slope
-}
-
-// Parameters for estimating prefill time = gamma + delta * inputTokens * batchSize (msec); inputTokens, batchSize > 0
-type PrefillParms struct {
-	Gamma float32 `json:"gamma"` // base
-	Delta float32 `json:"delta"` // slope
+	Beta  float32 `json:"beta"`  // slope for compute time
+	Gamma float32 `json:"gamma"` // slope for memory access time
 }
 
 // Data related to a service class SLOs

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -91,20 +91,15 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		MaxBatchSize: N,
 		MaxQueueSize: maxQueue,
 		ServiceParms: &analyzer.ServiceParms{
-			Prefill: &analyzer.PrefillParms{
-				Gamma: perf.PrefillParms.Gamma,
-				Delta: perf.PrefillParms.Delta,
-			},
-			Decode: &analyzer.DecodeParms{
-				Alpha: perf.DecodeParms.Alpha,
-				Beta:  perf.DecodeParms.Beta,
-			},
+			Alpha: perf.ServiceParms.Alpha,
+			Beta:  perf.ServiceParms.Beta,
+			Gamma: perf.ServiceParms.Gamma,
 		},
 	}
 
 	requestData := &analyzer.RequestSize{
-		AvgInputTokens:  load.AvgInTokens,
-		AvgOutputTokens: K,
+		AvgInputTokens:  float32(load.AvgInTokens),
+		AvgOutputTokens: float32(K),
 	}
 
 	queueAnalyzer, err := analyzer.NewQueueAnalyzer(qConfig, requestData)
@@ -112,9 +107,6 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		fmt.Println(err)
 		return nil
 	}
-
-	// TODO: do we need this?
-	// waitTimeLimit := target.TTFT / config.SLOMargin // distribution of waiting time assumed exponential
 
 	targetPerf := &analyzer.TargetPerf{
 		TargetTTFT: target.TTFT,
@@ -275,9 +267,9 @@ func zeroLoadAllocation(server *Server, model *Model, acc *Accelerator, perf *co
 	cost := acc.Cost() * float32(totalNumInstances)
 
 	//TODO: maxArrvRatePerReplica seems to be meaningless
-	decodeTime := perf.DecodeParms.Alpha + perf.DecodeParms.Beta
-	maxDecodeTime := perf.DecodeParms.Alpha + perf.DecodeParms.Beta*float32(maxBatchSize)
-	prefillTime := perf.PrefillParms.Gamma + perf.PrefillParms.Delta
+	decodeTime := perf.ServiceParms.Alpha + perf.ServiceParms.Beta
+	maxDecodeTime := perf.ServiceParms.Alpha + perf.ServiceParms.Beta*float32(maxBatchSize)
+	prefillTime := perf.ServiceParms.Alpha + perf.ServiceParms.Beta
 	maxServTime := prefillTime + maxDecodeTime
 	maxArrvRatePerReplica := float32(maxBatchSize) / maxServTime
 

--- a/pkg/core/server_test.go
+++ b/pkg/core/server_test.go
@@ -491,13 +491,10 @@ func TestServer_Calculate(t *testing.T) {
 			AccCount:     1,
 			MaxBatchSize: 16,
 			AtTokens:     200,
-			DecodeParms: config.DecodeParms{
+			ServiceParms: config.ServiceParms{
 				Alpha: 5.0,
-				Beta:  2.0,
-			},
-			PrefillParms: config.PrefillParms{
-				Gamma: 10.0,
-				Delta: 1.5,
+				Beta:  0.2,
+				Gamma: 0.015,
 			},
 		}
 		model.AddPerfDataFromSpec(perfData)
@@ -554,7 +551,7 @@ func TestServer_Calculate(t *testing.T) {
 				Class: "default",
 				CurrentAlloc: config.AllocationData{
 					Load: config.ServerLoadSpec{
-						ArrivalRate:  60,
+						ArrivalRate:  6,
 						AvgInTokens:  100,
 						AvgOutTokens: 200,
 					},

--- a/pkg/core/system_test.go
+++ b/pkg/core/system_test.go
@@ -68,13 +68,10 @@ func TestSystem_SetFromSpec(t *testing.T) {
 					AccCount:     1,
 					MaxBatchSize: 16,
 					AtTokens:     100,
-					DecodeParms: config.DecodeParms{
+					ServiceParms: config.ServiceParms{
 						Alpha: 10.0,
 						Beta:  2.0,
-					},
-					PrefillParms: config.PrefillParms{
-						Gamma: 5.0,
-						Delta: 0.1,
+						Gamma: 0.1,
 					},
 				},
 			},
@@ -443,13 +440,10 @@ func TestSystem_SetModelsFromSpec(t *testing.T) {
 				AccCount:     1,
 				MaxBatchSize: 16,
 				AtTokens:     100,
-				DecodeParms: config.DecodeParms{
+				ServiceParms: config.ServiceParms{
 					Alpha: 10.0,
 					Beta:  2.0,
-				},
-				PrefillParms: config.PrefillParms{
-					Gamma: 5.0,
-					Delta: 0.1,
+					Gamma: 0.1,
 				},
 			},
 			{
@@ -458,13 +452,10 @@ func TestSystem_SetModelsFromSpec(t *testing.T) {
 				AccCount:     2,
 				MaxBatchSize: 8,
 				AtTokens:     150,
-				DecodeParms: config.DecodeParms{
+				ServiceParms: config.ServiceParms{
 					Alpha: 15.0,
 					Beta:  3.0,
-				},
-				PrefillParms: config.PrefillParms{
-					Gamma: 8.0,
-					Delta: 0.15,
+					Gamma: 0.15,
 				},
 			},
 		},
@@ -497,17 +488,14 @@ func TestSystem_SetModelsFromSpec(t *testing.T) {
 	if perfData7b.AtTokens != 100 {
 		t.Errorf("Expected AtTokens 100 for llama-7b, got %d", perfData7b.AtTokens)
 	}
-	if perfData7b.DecodeParms.Alpha != 10.0 {
-		t.Errorf("Expected DecodeParms.Alpha 10.0 for llama-7b, got %f", perfData7b.DecodeParms.Alpha)
+	if perfData7b.ServiceParms.Alpha != 10.0 {
+		t.Errorf("Expected ServiceParms.Alpha 10.0 for llama-7b, got %f", perfData7b.ServiceParms.Alpha)
 	}
-	if perfData7b.DecodeParms.Beta != 2.0 {
-		t.Errorf("Expected DecodeParms.Beta 2.0 for llama-7b, got %f", perfData7b.DecodeParms.Beta)
+	if perfData7b.ServiceParms.Beta != 2.0 {
+		t.Errorf("Expected ServiceParms.Beta 2.0 for llama-7b, got %f", perfData7b.ServiceParms.Beta)
 	}
-	if perfData7b.PrefillParms.Gamma != 5.0 {
-		t.Errorf("Expected PrefillParms.Gamma 5.0 for llama-7b, got %f", perfData7b.PrefillParms.Gamma)
-	}
-	if perfData7b.PrefillParms.Delta != 0.1 {
-		t.Errorf("Expected PrefillParms.Delta 0.1 for llama-7b, got %f", perfData7b.PrefillParms.Delta)
+	if perfData7b.ServiceParms.Gamma != 0.1 {
+		t.Errorf("Expected ServiceParms.Gamma 0.1 for llama-7b, got %f", perfData7b.ServiceParms.Gamma)
 	}
 
 	// Validate llama-13b model
@@ -531,17 +519,14 @@ func TestSystem_SetModelsFromSpec(t *testing.T) {
 	if perfData13b.AtTokens != 150 {
 		t.Errorf("Expected AtTokens 150 for llama-13b, got %d", perfData13b.AtTokens)
 	}
-	if perfData13b.DecodeParms.Alpha != 15.0 {
-		t.Errorf("Expected DecodeParms.Alpha 15.0 for llama-13b, got %f", perfData13b.DecodeParms.Alpha)
+	if perfData13b.ServiceParms.Alpha != 15.0 {
+		t.Errorf("Expected ServiceParms.Alpha 15.0 for llama-13b, got %f", perfData13b.ServiceParms.Alpha)
 	}
-	if perfData13b.DecodeParms.Beta != 3.0 {
-		t.Errorf("Expected DecodeParms.Beta 3.0 for llama-13b, got %f", perfData13b.DecodeParms.Beta)
+	if perfData13b.ServiceParms.Beta != 3.0 {
+		t.Errorf("Expected ServiceParms.Beta 3.0 for llama-13b, got %f", perfData13b.ServiceParms.Beta)
 	}
-	if perfData13b.PrefillParms.Gamma != 8.0 {
-		t.Errorf("Expected PrefillParms.Gamma 8.0 for llama-13b, got %f", perfData13b.PrefillParms.Gamma)
-	}
-	if perfData13b.PrefillParms.Delta != 0.15 {
-		t.Errorf("Expected PrefillParms.Delta 0.15 for llama-13b, got %f", perfData13b.PrefillParms.Delta)
+	if perfData13b.ServiceParms.Gamma != 0.15 {
+		t.Errorf("Expected ServiceParms.Gamma 0.15 for llama-13b, got %f", perfData13b.ServiceParms.Gamma)
 	}
 }
 
@@ -1225,13 +1210,10 @@ func TestSystem_Calculate(t *testing.T) {
 		AccCount:     1,
 		MaxBatchSize: 16,
 		AtTokens:     100,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 10.0,
 			Beta:  2.0,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 5.0,
-			Delta: 0.1,
+			Gamma: 0.1,
 		},
 	})
 
@@ -1326,13 +1308,10 @@ func TestSystem_AllocateByType(t *testing.T) {
 		AccCount:     1,
 		MaxBatchSize: 16,
 		AtTokens:     100,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 10.0,
 			Beta:  2.0,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 5.0,
-			Delta: 0.1,
+			Gamma: 0.1,
 		},
 	})
 
@@ -1437,13 +1416,10 @@ func TestSystem_GenerateSolution(t *testing.T) {
 		AccCount:     1,
 		MaxBatchSize: 16,
 		AtTokens:     100,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 10.0,
 			Beta:  2.0,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 5.0,
-			Delta: 0.1,
+			Gamma: 0.1,
 		},
 	})
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -88,13 +88,10 @@ func TestManager_Optimize(t *testing.T) {
 			AccCount:     1,
 			MaxBatchSize: 16,
 			AtTokens:     200,
-			PrefillParms: config.PrefillParms{
-				Gamma: 10.0,
-				Delta: 1.5,
-			},
-			DecodeParms: config.DecodeParms{
+			ServiceParms: config.ServiceParms{
 				Alpha: 5.0,
-				Beta:  2.0,
+				Beta:  0.2,
+				Gamma: 0.015,
 			},
 		}
 		model.AddPerfDataFromSpec(perfData)
@@ -120,7 +117,7 @@ func TestManager_Optimize(t *testing.T) {
 			MinNumReplicas: 1,
 			CurrentAlloc: config.AllocationData{
 				Load: config.ServerLoadSpec{
-					ArrivalRate:  120.0, // Non-zero arrival rate (2 req/sec)
+					ArrivalRate:  60.0, // Non-zero arrival rate (1 req/sec)
 					AvgInTokens:  100,
 					AvgOutTokens: 200,
 				},

--- a/pkg/solver/greedy_test.go
+++ b/pkg/solver/greedy_test.go
@@ -51,13 +51,10 @@ func setupTestSystemForGreedy() {
 		AccCount:     1,
 		MaxBatchSize: 16,
 		AtTokens:     100,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 10.0,
-			Beta:  2.0,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 5.0,
-			Delta: 0.1,
+			Beta:  0.2,
+			Gamma: 0.01,
 		},
 	})
 	model1.AddPerfDataFromSpec(&config.ModelAcceleratorPerfData{
@@ -66,13 +63,10 @@ func setupTestSystemForGreedy() {
 		AccCount:     1,
 		MaxBatchSize: 32,
 		AtTokens:     100,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 8.0,
-			Beta:  1.5,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 3.0,
-			Delta: 0.08,
+			Beta:  0.15,
+			Gamma: 0.008,
 		},
 	})
 
@@ -83,13 +77,10 @@ func setupTestSystemForGreedy() {
 		AccCount:     2,
 		MaxBatchSize: 8,
 		AtTokens:     150,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 15.0,
-			Beta:  3.0,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 8.0,
-			Delta: 0.15,
+			Beta:  0.3,
+			Gamma: 0.01,
 		},
 	})
 	model2.AddPerfDataFromSpec(&config.ModelAcceleratorPerfData{
@@ -98,13 +89,10 @@ func setupTestSystemForGreedy() {
 		AccCount:     1,
 		MaxBatchSize: 16,
 		AtTokens:     150,
-		DecodeParms: config.DecodeParms{
+		ServiceParms: config.ServiceParms{
 			Alpha: 12.0,
-			Beta:  2.5,
-		},
-		PrefillParms: config.PrefillParms{
-			Gamma: 6.0,
-			Delta: 0.12,
+			Beta:  0.25,
+			Gamma: 0.012,
 		},
 	})
 
@@ -115,13 +103,13 @@ func setupTestSystemForGreedy() {
 		highPriorityClass.AddModelTarget(&config.ModelTarget{
 			Model:    "llama-7b",
 			SLO_ITL:  400,
-			SLO_TTFT: 20,
+			SLO_TTFT: 2000,
 			SLO_TPS:  15,
 		})
 		highPriorityClass.AddModelTarget(&config.ModelTarget{
 			Model:    "llama-13b",
 			SLO_ITL:  500,
-			SLO_TTFT: 25,
+			SLO_TTFT: 2500,
 			SLO_TPS:  12,
 		})
 	}
@@ -132,13 +120,13 @@ func setupTestSystemForGreedy() {
 		mediumPriorityClass.AddModelTarget(&config.ModelTarget{
 			Model:    "llama-7b",
 			SLO_ITL:  450,
-			SLO_TTFT: 22,
+			SLO_TTFT: 2200,
 			SLO_TPS:  13,
 		})
 		mediumPriorityClass.AddModelTarget(&config.ModelTarget{
 			Model:    "llama-13b",
 			SLO_ITL:  550,
-			SLO_TTFT: 28,
+			SLO_TTFT: 2800,
 			SLO_TPS:  10,
 		})
 	}
@@ -149,7 +137,7 @@ func setupTestSystemForGreedy() {
 		lowPriorityClass.AddModelTarget(&config.ModelTarget{
 			Model:    "llama-7b",
 			SLO_ITL:  500,
-			SLO_TTFT: 25,
+			SLO_TTFT: 2500,
 			SLO_TPS:  10,
 		})
 	}


### PR DESCRIPTION
Improve LLM queue analyzer model to handle simultaneous processing of prefill and decode in an iteration. The model uses three parameters which may be estimated either offline or online through a model tuner.
The model is used to

1. predict performance (TTFT and ITL) given a request load (requests/secs and average input and output tokens) and server configuration (max batch size); and/or
2. calculate the maximum throughput that attains a given performance (TTFT and/or ITL target values).