### PR TITLE
feat: add pdrole package for P/D role discovery and detection

### DIFF
--- a/internal/utils/pdrole/detect.go
+++ b/internal/utils/pdrole/detect.go
@@ -1,0 +1,63 @@
+package pdrole
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// GetDeploymentPDRole determines the P/D role of a deployment by checking
+// pod template labels against the provided labelConfig.
+//
+// This is label-only detection, matching how the EPP's filter plugins work:
+// the EPP's prefill-filter and decode-filter (and by-label) plugins route
+// traffic based solely on pod labels, never deployment names.
+//
+// Returns RoleUnknown if the deployment has no matching label. Callers should
+// use the PDDiscoveryResult.Disaggregated flag to interpret RoleUnknown:
+//   - If Disaggregated=false, skip detection entirely and treat all deployments as RoleBoth
+//   - If Disaggregated=true and RoleUnknown, the deployment has no P/D label set
+func GetDeploymentPDRole(deploy *appsv1.Deployment, labelConfig PDRoleLabelConfig) PDRole {
+	if deploy == nil {
+		return RoleUnknown
+	}
+
+	return detectFromLabels(deploy, labelConfig)
+}
+
+// detectFromLabels checks pod template labels against the label config.
+func detectFromLabels(deploy *appsv1.Deployment, config PDRoleLabelConfig) PDRole {
+	if config.LabelKey == "" {
+		return RoleUnknown
+	}
+
+	labels := deploy.Spec.Template.Labels
+	if labels == nil {
+		return RoleUnknown
+	}
+
+	value, exists := labels[config.LabelKey]
+	if !exists {
+		return RoleUnknown
+	}
+
+	return matchLabelValue(value, config)
+}
+
+// matchLabelValue matches a label value against the config's role value lists.
+func matchLabelValue(value string, config PDRoleLabelConfig) PDRole {
+	for _, v := range config.PrefillValues {
+		if value == v {
+			return RolePrefill
+		}
+	}
+	for _, v := range config.DecodeValues {
+		if value == v {
+			return RoleDecode
+		}
+	}
+	for _, v := range config.BothValues {
+		if value == v {
+			return RoleBoth
+		}
+	}
+	return RoleUnknown
+}

--- a/internal/utils/pdrole/detect_test.go
+++ b/internal/utils/pdrole/detect_test.go
@@ -1,0 +1,130 @@
+package pdrole
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeDeployment(name string, labels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			},
+		},
+	}
+}
+
+var _ = Describe("GetDeploymentPDRole", func() {
+	var defaultConfig PDRoleLabelConfig
+
+	BeforeEach(func() {
+		defaultConfig = DefaultPDRoleLabelConfig()
+	})
+
+	Context("with nil deployment", func() {
+		It("should return RoleUnknown", func() {
+			Expect(GetDeploymentPDRole(nil, defaultConfig)).To(Equal(RoleUnknown))
+		})
+	})
+
+	Context("with label-based detection", func() {
+		It("should detect prefill from label", func() {
+			deploy := makeDeployment("vllm-llama", map[string]string{DefaultRoleLabel: "prefill"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RolePrefill))
+		})
+
+		It("should detect decode from label", func() {
+			deploy := makeDeployment("vllm-llama", map[string]string{DefaultRoleLabel: "decode"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleDecode))
+		})
+
+		It("should detect both from label", func() {
+			deploy := makeDeployment("vllm-llama", map[string]string{DefaultRoleLabel: "both"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleBoth))
+		})
+
+		It("should return unknown for unrecognized label value", func() {
+			deploy := makeDeployment("vllm-llama", map[string]string{DefaultRoleLabel: "invalid"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleUnknown))
+		})
+	})
+
+	Context("without P/D label", func() {
+		It("should return unknown even if name contains prefill", func() {
+			deploy := makeDeployment("llama-prefill-a100", map[string]string{"app": "vllm"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleUnknown))
+		})
+
+		It("should return unknown even if name contains decode", func() {
+			deploy := makeDeployment("llama-decode-h100", map[string]string{"app": "vllm"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleUnknown))
+		})
+
+		It("should return unknown with no labels at all", func() {
+			deploy := makeDeployment("llama-prefill", nil)
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleUnknown))
+		})
+
+		It("should return unknown with generic name and no P/D label", func() {
+			deploy := makeDeployment("vllm-llama", map[string]string{"app": "vllm"})
+			Expect(GetDeploymentPDRole(deploy, defaultConfig)).To(Equal(RoleUnknown))
+		})
+	})
+
+	Context("with custom label config", func() {
+		It("should detect prefill with custom label key and values", func() {
+			config := PDRoleLabelConfig{
+				LabelKey:      "my.org/pd-role",
+				PrefillValues: []string{"p"},
+				DecodeValues:  []string{"d"},
+				BothValues:    []string{"pd"},
+			}
+			deploy := makeDeployment("vllm-llama", map[string]string{"my.org/pd-role": "p"})
+			Expect(GetDeploymentPDRole(deploy, config)).To(Equal(RolePrefill))
+		})
+
+		It("should detect decode with custom label key and values", func() {
+			config := PDRoleLabelConfig{
+				LabelKey:      "my.org/pd-role",
+				PrefillValues: []string{"p"},
+				DecodeValues:  []string{"d"},
+				BothValues:    []string{"pd"},
+			}
+			deploy := makeDeployment("vllm-llama", map[string]string{"my.org/pd-role": "d"})
+			Expect(GetDeploymentPDRole(deploy, config)).To(Equal(RoleDecode))
+		})
+
+		It("should detect both with custom label key and values", func() {
+			config := PDRoleLabelConfig{
+				LabelKey:      "my.org/pd-role",
+				PrefillValues: []string{"p"},
+				DecodeValues:  []string{"d"},
+				BothValues:    []string{"pd"},
+			}
+			deploy := makeDeployment("vllm-llama", map[string]string{"my.org/pd-role": "pd"})
+			Expect(GetDeploymentPDRole(deploy, config)).To(Equal(RoleBoth))
+		})
+
+		It("should return unknown when label key is empty", func() {
+			config := PDRoleLabelConfig{LabelKey: ""}
+			deploy := makeDeployment("vllm-llama", map[string]string{DefaultRoleLabel: "prefill"})
+			Expect(GetDeploymentPDRole(deploy, config)).To(Equal(RoleUnknown))
+		})
+	})
+})
+
+var _ = Describe("DefaultPDRoleLabelConfig", func() {
+	It("should return standard configuration", func() {
+		config := DefaultPDRoleLabelConfig()
+		Expect(config.LabelKey).To(Equal(DefaultRoleLabel))
+		Expect(config.PrefillValues).To(Equal([]string{"prefill"}))
+		Expect(config.DecodeValues).To(Equal([]string{"decode"}))
+		Expect(config.BothValues).To(Equal([]string{"both"}))
+	})
+})

--- a/internal/utils/pdrole/discover.go
+++ b/internal/utils/pdrole/discover.go
@@ -1,0 +1,348 @@
+package pdrole
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	epconfigv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	poolutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/pool"
+)
+
+// byLabelParams mirrors the by-label plugin parameter structure from llm-d-inference-scheduler.
+// We define it locally since we don't import the inference-scheduler module.
+type byLabelParams struct {
+	Label         string   `json:"label"`
+	ValidValues   []string `json:"validValues"`
+	AllowsNoLabel bool     `json:"allowsNoLabel"`
+}
+
+// DiscoverPDRoleLabelConfig discovers the P/D role label configuration by inspecting
+// the EPP's EndpointPickerConfig from its mounted ConfigMap.
+//
+// The pool parameter connects the discovery to a specific EPP instance, enabling
+// per-pool P/D label configuration when multiple EPPs exist with different settings.
+//
+// Returns a PDDiscoveryResult where:
+//   - Disaggregated=true means P/D filter plugins were found in the EPP config.
+//     The EPP uses INCLUSION-based filters (from llm-d-inference-scheduler):
+//     prefill-filter accepts only pods labeled "prefill" (allowsNoLabel=false),
+//     decode-filter accepts pods labeled "decode" or "both" plus unlabeled pods
+//     (allowsNoLabel=true). Use LabelConfig with GetDeploymentPDRole to determine
+//     each deployment's role.
+//   - Disaggregated=false means no P/D plugins exist. The EPP routes to all pods
+//     equally — all deployments effectively serve both prefill and decode.
+//     Callers should treat all deployments as RoleBoth.
+//
+// Discovery chain:
+//  1. Extract EPP service name and namespace from the pool's EndpointPicker
+//  2. Find EPP deployment via service selector matching
+//  3. Find ConfigMaps mounted as volumes in EPP deployment
+//  4. Parse ConfigMap data as EndpointPickerConfig (YAML/JSON)
+//  5. Extract P/D label config from filter plugins
+//  6. If any step fails, return Disaggregated=false with DefaultPDRoleLabelConfig()
+func DiscoverPDRoleLabelConfig(
+	ctx context.Context,
+	k8sClient client.Client,
+	pool *poolutil.EndpointPool,
+) PDDiscoveryResult {
+	logger := ctrl.LoggerFrom(ctx)
+
+	notDisaggregated := PDDiscoveryResult{
+		LabelConfig:   DefaultPDRoleLabelConfig(),
+		Disaggregated: false,
+	}
+
+	if pool == nil || pool.EndpointPicker == nil {
+		logger.V(logging.DEBUG).Info("No pool or EndpointPicker provided, P/D disaggregation not detected")
+		return notDisaggregated
+	}
+
+	eppServiceName := pool.EndpointPicker.ServiceName
+	namespace := pool.EndpointPicker.Namespace
+
+	// Step 1: Find EPP deployment from service
+	deploy, err := findEPPDeployment(ctx, k8sClient, namespace, eppServiceName)
+	if err != nil {
+		logger.V(logging.DEBUG).Info("Could not find EPP deployment, P/D disaggregation not detected",
+			"pool", pool.Name,
+			"eppService", eppServiceName,
+			"namespace", namespace,
+			"error", err)
+		return notDisaggregated
+	}
+
+	// Step 2: Find ConfigMap from deployment volumes
+	configData, err := findConfigDataFromDeployment(ctx, k8sClient, deploy)
+	if err != nil {
+		logger.V(logging.DEBUG).Info("Could not find EPP config from deployment, P/D disaggregation not detected",
+			"pool", pool.Name,
+			"deployment", deploy.Name,
+			"namespace", namespace,
+			"error", err)
+		return notDisaggregated
+	}
+
+	// Step 3: Parse EndpointPickerConfig
+	epc, err := parseEndpointPickerConfig(configData)
+	if err != nil {
+		logger.V(logging.DEBUG).Info("Could not parse EndpointPickerConfig, P/D disaggregation not detected",
+			"pool", pool.Name,
+			"deployment", deploy.Name,
+			"namespace", namespace,
+			"error", err)
+		return notDisaggregated
+	}
+
+	// Step 4: Extract P/D label config from plugins
+	config, found := extractPDRoleLabelConfig(epc)
+	if !found {
+		logger.V(logging.DEBUG).Info("No P/D filter plugins found in EndpointPickerConfig, P/D disaggregation not detected",
+			"pool", pool.Name,
+			"deployment", deploy.Name,
+			"namespace", namespace)
+		return notDisaggregated
+	}
+
+	logger.V(logging.DEBUG).Info("Discovered P/D label config from EndpointPickerConfig",
+		"pool", pool.Name,
+		"labelKey", config.LabelKey,
+		"prefillValues", config.PrefillValues,
+		"decodeValues", config.DecodeValues,
+		"bothValues", config.BothValues)
+	return PDDiscoveryResult{
+		LabelConfig:   config,
+		Disaggregated: true,
+	}
+}
+
+// findEPPDeployment finds the EPP deployment by looking up the service and matching
+// deployments by the service's selector labels.
+func findEPPDeployment(ctx context.Context, k8sClient client.Client, namespace, serviceName string) (*appsv1.Deployment, error) {
+	// Get the service
+	svc := &corev1.Service{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: serviceName}, svc); err != nil {
+		return nil, err
+	}
+
+	if len(svc.Spec.Selector) == 0 {
+		return nil, errNoServiceSelector
+	}
+
+	// List deployments matching the service selector
+	deployList := &appsv1.DeploymentList{}
+	if err := k8sClient.List(ctx, deployList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(svc.Spec.Selector),
+	); err != nil {
+		return nil, err
+	}
+
+	if len(deployList.Items) == 0 {
+		return nil, errNoDeploymentFound
+	}
+
+	return &deployList.Items[0], nil
+}
+
+// findConfigDataFromDeployment finds and returns the config data from ConfigMap volumes
+// mounted in the deployment.
+func findConfigDataFromDeployment(ctx context.Context, k8sClient client.Client, deploy *appsv1.Deployment) ([]byte, error) {
+	for _, vol := range deploy.Spec.Template.Spec.Volumes {
+		if vol.ConfigMap == nil {
+			continue
+		}
+
+		// Get the ConfigMap
+		cm := &corev1.ConfigMap{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: deploy.Namespace,
+			Name:      vol.ConfigMap.Name,
+		}, cm); err != nil {
+			continue // Try next volume
+		}
+
+		// Look for config data in the ConfigMap
+		for key, data := range cm.Data {
+			if isConfigKey(key) {
+				return []byte(data), nil
+			}
+		}
+	}
+
+	return nil, errNoConfigMapFound
+}
+
+// isConfigKey checks if a ConfigMap data key likely contains an EndpointPickerConfig.
+func isConfigKey(key string) bool {
+	lower := strings.ToLower(key)
+	return strings.HasSuffix(lower, ".yaml") ||
+		strings.HasSuffix(lower, ".yml") ||
+		strings.HasSuffix(lower, ".json") ||
+		lower == "config" ||
+		lower == "epp-config" ||
+		lower == "endpointpickerconfig"
+}
+
+// parseEndpointPickerConfig parses raw config data as an EndpointPickerConfig.
+// Supports both YAML and JSON formats.
+func parseEndpointPickerConfig(data []byte) (*epconfigv1alpha1.EndpointPickerConfig, error) {
+	var epc epconfigv1alpha1.EndpointPickerConfig
+
+	// sigs.k8s.io/yaml handles both YAML and JSON
+	if err := yaml.Unmarshal(data, &epc); err != nil {
+		return nil, err
+	}
+
+	// Validate that we got meaningful data
+	if len(epc.Plugins) == 0 && len(epc.SchedulingProfiles) == 0 {
+		return nil, errInvalidConfig
+	}
+
+	return &epc, nil
+}
+
+// extractPDRoleLabelConfig extracts P/D role label configuration from EndpointPickerConfig plugins.
+//
+// Detection logic:
+//  1. If prefill-filter or decode-filter plugin types exist → well-known label is used
+//  2. If by-label plugins exist and are referenced by "prefill"/"decode" scheduling profiles
+//     → extract custom label key and values from plugin parameters
+func extractPDRoleLabelConfig(epc *epconfigv1alpha1.EndpointPickerConfig) (PDRoleLabelConfig, bool) {
+	// Build plugin index by name for scheduling profile lookups
+	pluginsByName := make(map[string]epconfigv1alpha1.PluginSpec, len(epc.Plugins))
+	for _, p := range epc.Plugins {
+		name := p.Name
+		if name == "" {
+			name = p.Type
+		}
+		pluginsByName[name] = p
+	}
+
+	// Check for dedicated prefill-filter / decode-filter plugin types
+	hasDedicatedFilter := false
+	for _, p := range epc.Plugins {
+		if p.Type == PluginTypePrefillFilter || p.Type == PluginTypeDecodeFilter {
+			hasDedicatedFilter = true
+			break
+		}
+	}
+
+	if hasDedicatedFilter {
+		// Dedicated filter types use the well-known label
+		return DefaultPDRoleLabelConfig(), true
+	}
+
+	// Check for by-label plugins referenced by prefill/decode scheduling profiles
+	return extractByLabelConfig(epc, pluginsByName)
+}
+
+// extractByLabelConfig attempts to extract P/D role config from by-label plugins
+// that are referenced by scheduling profiles named "prefill" or "decode".
+//
+// Values that appear in both prefill and decode profiles' validValues are classified
+// as BothValues (pods with these labels pass both filters). Remaining values are
+// exclusive to their respective profile.
+func extractByLabelConfig(
+	epc *epconfigv1alpha1.EndpointPickerConfig,
+	pluginsByName map[string]epconfigv1alpha1.PluginSpec,
+) (PDRoleLabelConfig, bool) {
+	// Collect raw values from each profile type
+	var labelKey string
+	var rawPrefill, rawDecode []string
+	found := false
+
+	for _, profile := range epc.SchedulingProfiles {
+		profileName := strings.ToLower(profile.Name)
+		isPrefill := strings.Contains(profileName, "prefill")
+		isDecode := strings.Contains(profileName, "decode")
+
+		if !isPrefill && !isDecode {
+			continue
+		}
+
+		// Look for by-label plugin references in this profile
+		for _, sp := range profile.Plugins {
+			plugin, exists := pluginsByName[sp.PluginRef]
+			if !exists || plugin.Type != PluginTypeByLabel {
+				continue
+			}
+
+			// Parse the by-label parameters
+			var params byLabelParams
+			if err := json.Unmarshal(plugin.Parameters, &params); err != nil {
+				continue
+			}
+
+			if params.Label == "" {
+				continue
+			}
+
+			// Set the label key (should be same across all P/D plugins)
+			labelKey = params.Label
+			found = true
+
+			if isPrefill {
+				rawPrefill = append(rawPrefill, params.ValidValues...)
+			}
+			if isDecode {
+				rawDecode = append(rawDecode, params.ValidValues...)
+			}
+		}
+	}
+
+	if !found {
+		return PDRoleLabelConfig{}, false
+	}
+
+	// Compute intersection: values accepted by both profiles are "both" values.
+	// A pod with such a label passes both prefill and decode filters,
+	// meaning it can serve both roles.
+	prefillSet := toStringSet(rawPrefill)
+	decodeSet := toStringSet(rawDecode)
+
+	config := PDRoleLabelConfig{LabelKey: labelKey}
+
+	for _, v := range rawPrefill {
+		if _, inDecode := decodeSet[v]; inDecode {
+			config.BothValues = appendUnique(config.BothValues, v)
+		} else {
+			config.PrefillValues = append(config.PrefillValues, v)
+		}
+	}
+	for _, v := range rawDecode {
+		if _, inPrefill := prefillSet[v]; inPrefill {
+			// already added to BothValues above
+			continue
+		}
+		config.DecodeValues = append(config.DecodeValues, v)
+	}
+
+	return config, true
+}
+
+// toStringSet converts a slice to a set for O(1) lookups.
+func toStringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		set[v] = struct{}{}
+	}
+	return set
+}
+
+// appendUnique appends a value to a slice only if it's not already present.
+func appendUnique(slice []string, val string) []string {
+	for _, v := range slice {
+		if v == val {
+			return slice
+		}
+	}
+	return append(slice, val)
+}

--- a/internal/utils/pdrole/discover_test.go
+++ b/internal/utils/pdrole/discover_test.go
@@ -1,0 +1,424 @@
+package pdrole
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	epconfigv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
+
+	poolutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/pool"
+)
+
+const testNamespace = "test-ns"
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	return scheme
+}
+
+func makePool(name, namespace, serviceName string) *poolutil.EndpointPool {
+	return &poolutil.EndpointPool{
+		Name:      name,
+		Namespace: namespace,
+		EndpointPicker: &poolutil.EndpointPicker{
+			ServiceName:       serviceName,
+			Namespace:         namespace,
+			MetricsPortNumber: 9090,
+		},
+	}
+}
+
+func makeService(name, namespace string, selector map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Selector: selector,
+			Ports:    []corev1.ServicePort{{Name: "metrics", Port: 9090}},
+		},
+	}
+}
+
+func makeEPPDeployment(name, namespace string, labels map[string]string, configMapName string) *appsv1.Deployment {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec:       corev1.PodSpec{},
+			},
+		},
+	}
+	if configMapName != "" {
+		deploy.Spec.Template.Spec.Volumes = []corev1.Volume{{
+			Name: "config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				},
+			},
+		}}
+	}
+	return deploy
+}
+
+func makeConfigMap(name, namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       data,
+	}
+}
+
+func buildConfigJSON(plugins []epconfigv1alpha1.PluginSpec, profiles []epconfigv1alpha1.SchedulingProfile) string {
+	epc := epconfigv1alpha1.EndpointPickerConfig{
+		Plugins:            plugins,
+		SchedulingProfiles: profiles,
+	}
+	data, _ := json.Marshal(epc)
+	return string(data)
+}
+
+var _ = Describe("DiscoverPDRoleLabelConfig", func() {
+	var (
+		ctx       context.Context
+		eppLabels map[string]string
+		pool      *poolutil.EndpointPool
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		eppLabels = map[string]string{"app": "epp"}
+		pool = makePool("test-pool", testNamespace, "epp-svc")
+	})
+
+	Context("full chain with prefill-filter/decode-filter plugins", func() {
+		It("should return disaggregated=true with default label config", func() {
+			configJSON := buildConfigJSON(
+				[]epconfigv1alpha1.PluginSpec{
+					{Name: "pf", Type: PluginTypePrefillFilter},
+					{Name: "df", Type: PluginTypeDecodeFilter},
+				},
+				[]epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf"}}},
+					{Name: "decode", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "df"}}},
+				},
+			)
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": configJSON}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+
+			Expect(result.Disaggregated).To(BeTrue())
+			expected := DefaultPDRoleLabelConfig()
+			Expect(result.LabelConfig.LabelKey).To(Equal(expected.LabelKey))
+			Expect(result.LabelConfig.PrefillValues).To(Equal(expected.PrefillValues))
+			Expect(result.LabelConfig.DecodeValues).To(Equal(expected.DecodeValues))
+		})
+	})
+
+	Context("full chain with by-label plugins", func() {
+		It("should return disaggregated=true with custom label config", func() {
+			prefillParams, _ := json.Marshal(byLabelParams{Label: "custom.io/role", ValidValues: []string{"pf"}})
+			decodeParams, _ := json.Marshal(byLabelParams{Label: "custom.io/role", ValidValues: []string{"dc", "mixed"}})
+
+			configJSON := buildConfigJSON(
+				[]epconfigv1alpha1.PluginSpec{
+					{Name: "pf-filter", Type: PluginTypeByLabel, Parameters: prefillParams},
+					{Name: "dc-filter", Type: PluginTypeByLabel, Parameters: decodeParams},
+				},
+				[]epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf-filter"}}},
+					{Name: "decode", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "dc-filter"}}},
+				},
+			)
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": configJSON}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+
+			Expect(result.Disaggregated).To(BeTrue())
+			Expect(result.LabelConfig.LabelKey).To(Equal("custom.io/role"))
+			Expect(result.LabelConfig.PrefillValues).To(Equal([]string{"pf"}))
+			Expect(result.LabelConfig.DecodeValues).To(Equal([]string{"dc", "mixed"}))
+			Expect(result.LabelConfig.BothValues).To(BeNil())
+		})
+
+		It("should classify overlapping values as BothValues", func() {
+			// "all" appears in both prefill and decode profiles → should be BothValues
+			prefillParams, _ := json.Marshal(byLabelParams{Label: "custom.io/role", ValidValues: []string{"pf", "all"}})
+			decodeParams, _ := json.Marshal(byLabelParams{Label: "custom.io/role", ValidValues: []string{"dc", "all"}})
+
+			configJSON := buildConfigJSON(
+				[]epconfigv1alpha1.PluginSpec{
+					{Name: "pf-filter", Type: PluginTypeByLabel, Parameters: prefillParams},
+					{Name: "dc-filter", Type: PluginTypeByLabel, Parameters: decodeParams},
+				},
+				[]epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf-filter"}}},
+					{Name: "decode", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "dc-filter"}}},
+				},
+			)
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": configJSON}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+
+			Expect(result.Disaggregated).To(BeTrue())
+			Expect(result.LabelConfig.LabelKey).To(Equal("custom.io/role"))
+			Expect(result.LabelConfig.PrefillValues).To(Equal([]string{"pf"}))
+			Expect(result.LabelConfig.DecodeValues).To(Equal([]string{"dc"}))
+			Expect(result.LabelConfig.BothValues).To(Equal([]string{"all"}))
+		})
+	})
+
+	Context("fallback scenarios (disaggregated=false)", func() {
+		It("should return disaggregated=false when pool is nil", func() {
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, nil)
+			Expect(result.Disaggregated).To(BeFalse())
+			Expect(result.LabelConfig).To(Equal(DefaultPDRoleLabelConfig()))
+		})
+
+		It("should return disaggregated=false when pool has nil EndpointPicker", func() {
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+			poolNoEPP := &poolutil.EndpointPool{Name: "no-epp", Namespace: testNamespace}
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, poolNoEPP)
+			Expect(result.Disaggregated).To(BeFalse())
+			Expect(result.LabelConfig).To(Equal(DefaultPDRoleLabelConfig()))
+		})
+
+		It("should return disaggregated=false when service not found", func() {
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+			poolMissing := makePool("missing-pool", testNamespace, "nonexistent")
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, poolMissing)
+			Expect(result.Disaggregated).To(BeFalse())
+			Expect(result.LabelConfig).To(Equal(DefaultPDRoleLabelConfig()))
+		})
+
+		It("should return disaggregated=false when no deployment matches service selector", func() {
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+
+		It("should return disaggregated=false when no ConfigMap is mounted", func() {
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, ""),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+
+		It("should return disaggregated=false when ConfigMap has invalid data", func() {
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": "not valid yaml {{{"}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+
+		It("should return disaggregated=false when config has no plugins or profiles", func() {
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": `{}`}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+
+		It("should return disaggregated=false when config has no P/D plugins", func() {
+			configJSON := buildConfigJSON(
+				[]epconfigv1alpha1.PluginSpec{{Name: "scorer", Type: "kv-cache-scorer"}},
+				[]epconfigv1alpha1.SchedulingProfile{
+					{Name: "default", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "scorer"}}},
+				},
+			)
+			objects := []client.Object{
+				makeService("epp-svc", testNamespace, eppLabels),
+				makeEPPDeployment("epp", testNamespace, eppLabels, "epp-config"),
+				makeConfigMap("epp-config", testNamespace, map[string]string{"config.yaml": configJSON}),
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+
+		It("should return disaggregated=false when service has no selector", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "epp-svc", Namespace: testNamespace},
+				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "metrics", Port: 9090}}},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(svc).Build()
+			result := DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
+			Expect(result.Disaggregated).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("parseEndpointPickerConfig", func() {
+	It("should parse valid JSON", func() {
+		data := `{"plugins":[{"name":"p","type":"prefill-filter"}],"schedulingProfiles":[{"name":"prefill","plugins":[{"pluginRef":"p"}]}]}`
+		epc, err := parseEndpointPickerConfig([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(epc).NotTo(BeNil())
+		Expect(epc.Plugins).To(HaveLen(1))
+	})
+
+	It("should parse valid YAML", func() {
+		data := `
+plugins:
+  - name: p
+    type: prefill-filter
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: p
+`
+		epc, err := parseEndpointPickerConfig([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(epc).NotTo(BeNil())
+		Expect(epc.Plugins).To(HaveLen(1))
+	})
+
+	It("should reject invalid data", func() {
+		_, err := parseEndpointPickerConfig([]byte("not valid {{"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should reject empty plugins and profiles", func() {
+		_, err := parseEndpointPickerConfig([]byte(`{}`))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("extractPDRoleLabelConfig", func() {
+	Context("with dedicated filter types", func() {
+		It("should return default label config", func() {
+			epc := &epconfigv1alpha1.EndpointPickerConfig{
+				Plugins: []epconfigv1alpha1.PluginSpec{
+					{Name: "pf", Type: PluginTypePrefillFilter},
+					{Name: "df", Type: PluginTypeDecodeFilter},
+				},
+				SchedulingProfiles: []epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf"}}},
+				},
+			}
+			config, found := extractPDRoleLabelConfig(epc)
+			Expect(found).To(BeTrue())
+			Expect(config.LabelKey).To(Equal(DefaultRoleLabel))
+		})
+	})
+
+	Context("with by-label plugins", func() {
+		It("should extract custom label config from scheduling profiles", func() {
+			params, _ := json.Marshal(byLabelParams{Label: "custom/role", ValidValues: []string{"serve-prefill"}})
+			decodeParams, _ := json.Marshal(byLabelParams{Label: "custom/role", ValidValues: []string{"serve-decode"}})
+
+			epc := &epconfigv1alpha1.EndpointPickerConfig{
+				Plugins: []epconfigv1alpha1.PluginSpec{
+					{Name: "pf-label", Type: PluginTypeByLabel, Parameters: params},
+					{Name: "dc-label", Type: PluginTypeByLabel, Parameters: decodeParams},
+				},
+				SchedulingProfiles: []epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill-profile", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf-label"}}},
+					{Name: "decode-profile", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "dc-label"}}},
+				},
+			}
+			config, found := extractPDRoleLabelConfig(epc)
+			Expect(found).To(BeTrue())
+			Expect(config.LabelKey).To(Equal("custom/role"))
+			Expect(config.PrefillValues).To(Equal([]string{"serve-prefill"}))
+			Expect(config.DecodeValues).To(Equal([]string{"serve-decode"}))
+			Expect(config.BothValues).To(BeNil())
+		})
+
+		It("should classify overlapping values as BothValues", func() {
+			params, _ := json.Marshal(byLabelParams{Label: "custom/role", ValidValues: []string{"pf", "shared"}})
+			decodeParams, _ := json.Marshal(byLabelParams{Label: "custom/role", ValidValues: []string{"dc", "shared"}})
+
+			epc := &epconfigv1alpha1.EndpointPickerConfig{
+				Plugins: []epconfigv1alpha1.PluginSpec{
+					{Name: "pf-label", Type: PluginTypeByLabel, Parameters: params},
+					{Name: "dc-label", Type: PluginTypeByLabel, Parameters: decodeParams},
+				},
+				SchedulingProfiles: []epconfigv1alpha1.SchedulingProfile{
+					{Name: "prefill-profile", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "pf-label"}}},
+					{Name: "decode-profile", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "dc-label"}}},
+				},
+			}
+			config, found := extractPDRoleLabelConfig(epc)
+			Expect(found).To(BeTrue())
+			Expect(config.LabelKey).To(Equal("custom/role"))
+			Expect(config.PrefillValues).To(Equal([]string{"pf"}))
+			Expect(config.DecodeValues).To(Equal([]string{"dc"}))
+			Expect(config.BothValues).To(Equal([]string{"shared"}))
+		})
+	})
+
+	Context("with no P/D plugins", func() {
+		It("should return not found", func() {
+			epc := &epconfigv1alpha1.EndpointPickerConfig{
+				Plugins: []epconfigv1alpha1.PluginSpec{{Name: "scorer", Type: "kv-cache-scorer"}},
+				SchedulingProfiles: []epconfigv1alpha1.SchedulingProfile{
+					{Name: "default", Plugins: []epconfigv1alpha1.SchedulingPlugin{{PluginRef: "scorer"}}},
+				},
+			}
+			_, found := extractPDRoleLabelConfig(epc)
+			Expect(found).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("isConfigKey", func() {
+	DescribeTable("should correctly identify config keys",
+		func(key string, expected bool) {
+			Expect(isConfigKey(key)).To(Equal(expected))
+		},
+		Entry("config.yaml", "config.yaml", true),
+		Entry("config.yml", "config.yml", true),
+		Entry("config.json", "config.json", true),
+		Entry("config", "config", true),
+		Entry("epp-config", "epp-config", true),
+		Entry("endpointpickerconfig", "endpointpickerconfig", true),
+		Entry("random-key", "random-key", false),
+		Entry("data.txt", "data.txt", false),
+		Entry("CONFIG.YAML", "CONFIG.YAML", true),
+	)
+})

--- a/internal/utils/pdrole/suite_test.go
+++ b/internal/utils/pdrole/suite_test.go
@@ -1,0 +1,16 @@
+package pdrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+func TestPDRole(t *testing.T) {
+	logging.NewTestLogger()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PDRole Suite")
+}

--- a/internal/utils/pdrole/types.go
+++ b/internal/utils/pdrole/types.go
@@ -13,23 +13,34 @@ var (
 )
 
 // PDRole represents the Prefill/Decode role of a deployment in a P/D disaggregation setup.
+//
+// Role values and label key are aligned with llm-d-inference-scheduler
+// (pkg/plugins/filter/pd_role.go). We redefine them locally as typed constants
+// to avoid importing that module (heavyweight dependency not otherwise needed)
+// and to add RoleUnknown which the scheduler doesn't define.
 type PDRole string
 
 const (
 	// RolePrefill indicates a prefill-only deployment (KV cache producer).
+	// Matches filter.RolePrefill in llm-d-inference-scheduler.
 	RolePrefill PDRole = "prefill"
 	// RoleDecode indicates a decode-only deployment (KV cache consumer).
+	// Matches filter.RoleDecode in llm-d-inference-scheduler.
 	RoleDecode PDRole = "decode"
 	// RoleBoth indicates a deployment serving both prefill and decode.
+	// Matches filter.RoleBoth in llm-d-inference-scheduler.
 	RoleBoth PDRole = "both"
 	// RoleUnknown indicates the P/D role could not be determined.
+	// Not defined in llm-d-inference-scheduler (WVA-specific).
 	RoleUnknown PDRole = "unknown"
 
 	// DefaultRoleLabel is the well-known label key used by llm-d-inference-scheduler
 	// to identify P/D roles on pods.
+	// Matches filter.RoleLabel in llm-d-inference-scheduler.
 	DefaultRoleLabel = "llm-d.ai/role"
 
 	// Plugin types from llm-d-inference-scheduler used in EndpointPickerConfig.
+	// Match filter.PrefillRoleType and filter.DecodeRoleType respectively.
 	PluginTypePrefillFilter = "prefill-filter"
 	PluginTypeDecodeFilter  = "decode-filter"
 	PluginTypeByLabel       = "by-label"

--- a/internal/utils/pdrole/types.go
+++ b/internal/utils/pdrole/types.go
@@ -1,0 +1,74 @@
+// Package pdrole provides utilities for detecting Prefill/Decode (P/D) disaggregation
+// roles of deployments. Discovery inspects the EPP's EndpointPickerConfig for P/D
+// filter plugins; detection checks pod template labels against the discovered config.
+package pdrole
+
+import "errors"
+
+var (
+	errNoServiceSelector = errors.New("EPP service has no selector labels")
+	errNoDeploymentFound = errors.New("no deployment found matching EPP service selector")
+	errNoConfigMapFound  = errors.New("no ConfigMap with valid config found in EPP deployment volumes")
+	errInvalidConfig     = errors.New("parsed config has no plugins or scheduling profiles")
+)
+
+// PDRole represents the Prefill/Decode role of a deployment in a P/D disaggregation setup.
+type PDRole string
+
+const (
+	// RolePrefill indicates a prefill-only deployment (KV cache producer).
+	RolePrefill PDRole = "prefill"
+	// RoleDecode indicates a decode-only deployment (KV cache consumer).
+	RoleDecode PDRole = "decode"
+	// RoleBoth indicates a deployment serving both prefill and decode.
+	RoleBoth PDRole = "both"
+	// RoleUnknown indicates the P/D role could not be determined.
+	RoleUnknown PDRole = "unknown"
+
+	// DefaultRoleLabel is the well-known label key used by llm-d-inference-scheduler
+	// to identify P/D roles on pods.
+	DefaultRoleLabel = "llm-d.ai/role"
+
+	// Plugin types from llm-d-inference-scheduler used in EndpointPickerConfig.
+	PluginTypePrefillFilter = "prefill-filter"
+	PluginTypeDecodeFilter  = "decode-filter"
+	PluginTypeByLabel       = "by-label"
+)
+
+// PDRoleLabelConfig describes how to detect P/D roles from pod template labels.
+// The LabelKey specifies which label to inspect, and the value slices define
+// which label values correspond to which role.
+type PDRoleLabelConfig struct {
+	// LabelKey is the pod label key to check for P/D role (e.g., "llm-d.ai/role").
+	LabelKey string
+	// PrefillValues are label values that indicate a prefill role.
+	PrefillValues []string
+	// DecodeValues are label values that indicate a decode role.
+	DecodeValues []string
+	// BothValues are label values that indicate both prefill and decode roles.
+	BothValues []string
+}
+
+// PDDiscoveryResult holds the result of P/D role label config discovery.
+// Callers should check Disaggregated to determine whether P/D disaggregation
+// is configured for this pool:
+//   - Disaggregated=true: P/D filter plugins found, use LabelConfig with GetDeploymentPDRole
+//   - Disaggregated=false: no P/D plugins, all deployments serve both roles (RoleBoth)
+type PDDiscoveryResult struct {
+	// LabelConfig is the discovered or default P/D label configuration.
+	LabelConfig PDRoleLabelConfig
+	// Disaggregated indicates whether P/D disaggregation is configured.
+	// When false, all deployments should be treated as RoleBoth.
+	Disaggregated bool
+}
+
+// DefaultPDRoleLabelConfig returns the standard P/D role label configuration
+// using the well-known llm-d.ai/role label with standard values.
+func DefaultPDRoleLabelConfig() PDRoleLabelConfig {
+	return PDRoleLabelConfig{
+		LabelKey:      DefaultRoleLabel,
+		PrefillValues: []string{"prefill"},
+		DecodeValues:  []string{"decode"},
+		BothValues:    []string{"both"},
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/utils/pdrole` package that discovers P/D disaggregation configuration from the EPP's `EndpointPickerConfig` and detects each deployment's P/D role from pod template labels
- Discovery is per-pool (accepts `*pool.EndpointPool`), enabling correct behavior when multiple EPPs exist with different P/D label settings
- Returns `PDDiscoveryResult` with `Disaggregated` flag so callers can distinguish "no P/D plugins" (all pods serve both roles) from "P/D plugins found, use label config"

## Design decisions

**Label-only detection (no deployment name fallback).**
The EPP's filter plugins (`prefill-filter`, `decode-filter`, `by-label` from [llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler)) route traffic based solely on pod labels. A deployment named `llama-prefill` without a `llm-d.ai/role` label would still receive decode traffic from EPP (`decode-filter` has `allowsNoLabel=true`). Name-based guessing would misclassify it.

**BothValues from intersection, not hardcoded.**
For `by-label` custom plugins, values appearing in both prefill and decode profiles' `validValues` are classified as `BothValues`. This ensures `GetDeploymentPDRole` returns `RoleBoth` (not `RolePrefill` or `RoleDecode`) for pods that pass both filters.

**Aligned with EPP's actual filter semantics:**
| EPP filter | Label | Valid values | `allowsNoLabel` |
|---|---|---|---|
| `prefill-filter` | `llm-d.ai/role` | `"prefill"` | `false` |
| `decode-filter` | `llm-d.ai/role` | `"decode"`, `"both"` | `true` |

## Package structure

| File | Purpose |
|---|---|
| `types.go` | `PDRole`, `PDRoleLabelConfig`, `PDDiscoveryResult`, constants |
| `detect.go` | `GetDeploymentPDRole` — label-based role detection |
| `discover.go` | `DiscoverPDRoleLabelConfig` — EPP config discovery chain |
| `*_test.go` | 43 Ginkgo specs |

## Discovery chain

1. Pool -> EPP service name/namespace
2. Service selector -> EPP deployment
3. Deployment volumes -> mounted ConfigMap
4. ConfigMap data -> parse `EndpointPickerConfig` (YAML/JSON)
5. Plugins -> detect `prefill-filter`/`decode-filter` (well-known label) or `by-label` (custom label from parameters)
6. Any step fails -> `Disaggregated=false`, default config

## Intended caller pattern (not wired yet)

```go
pool, _ := datastore.PoolGetFromLabels(deploy.Spec.Template.Labels)
result := pdrole.DiscoverPDRoleLabelConfig(ctx, k8sClient, pool)
if !result.Disaggregated {
    // no P/D plugins — all deployments serve both roles
    role = pdrole.RoleBoth
} else {
    role = pdrole.GetDeploymentPDRole(deploy, result.LabelConfig)
}
```

## Test plan

- [x] `go build ./internal/utils/pdrole/...` — clean
- [x] `go vet ./internal/utils/pdrole/...` — clean
- [x] `go test ./internal/utils/pdrole/... -v -count=1` — 43/43 specs pass
- [ ] No callers yet (infrastructure-only PR), wiring comes in follow-up
