### PR TITLE
doc: update wva version in install doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,7 @@ The Workload Variant Autoscaler (WVA) is a Kubernetes-based global autoscaler fo
 - kubectl
 
 ### Install with Helm (Recommended)
-
-```bash
-# Add the WVA Helm repository (when published)
-helm upgrade -i workload-variant-autoscaler ./charts/workload-variant-autoscaler \
-  --namespace workload-variant-autoscaler-system \
-  --set-file prometheus.caCert=/tmp/prometheus-ca.crt \
-  --set variantAutoscaling.accelerator=L40S \
-  --set variantAutoscaling.modelID=unsloth/Meta-Llama-3.1-8B \
-  --set vllmService.enabled=true \
-  --set vllmService.nodePort=30000
-  --create-namespace
-```
+Go to the **INSTALL (on OpenShift)** section [here](charts/workload-variant-autoscaler/README.md) for detailed steps.
 
 ### Try it Locally with Kind (No GPU Required!)
 

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -59,7 +59,7 @@ helm ls -A
 ```
 export OWNER="llm-d"
 export WVA_PROJECT="llm-d-workload-variant-autoscaler"
-export WVA_RELEASE="v0.4.1"
+export WVA_RELEASE="v0.5.0"
 export WVA_NS="workload-variant-autoscaler-system"
 export MON_NS="openshift-user-workload-monitoring"
 


### PR DESCRIPTION
- In README.md, I'd suggest to point users to proper steps for helm method. If users just run the helm command as currently shown then it won't work since there are steps must be done before to be able to run helm command successfully.
- Update wva release to v0.5.0.