### PR TITLE
🐛 Fix kube-prometheus-stack timeout on busy clusters

### DIFF
--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -229,6 +229,8 @@ deploy_prometheus_stack() {
     rm -f /tmp/prometheus-tls.{key,crt}
     
     # Install kube-prometheus-stack with TLS enabled
+    # Disable Grafana and Alertmanager — WVA only needs Prometheus for metrics collection.
+    # Use a 10m timeout — 5m is insufficient on busy clusters (e.g. CKS with preemption).
     log_info "Installing kube-prometheus-stack with TLS configuration"
     helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
         -n $MONITORING_NAMESPACE \
@@ -240,7 +242,9 @@ deploy_prometheus_stack() {
         --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.key=tls.crt \
         --set prometheus.prometheusSpec.web.tlsConfig.keySecret.name=$PROMETHEUS_SECRET_NAME \
         --set prometheus.prometheusSpec.web.tlsConfig.keySecret.key=tls.key \
-        --timeout=5m \
+        --set grafana.enabled=false \
+        --set alertmanager.enabled=false \
+        --timeout=10m \
         --wait
     
     log_success "kube-prometheus-stack deployed with TLS"

--- a/deploy/kubernetes/install.sh
+++ b/deploy/kubernetes/install.sh
@@ -108,6 +108,8 @@ deploy_prometheus_stack() {
     rm -f /tmp/prometheus-tls.{key,crt}
     
     # Install kube-prometheus-stack with TLS enabled
+    # Disable Grafana and Alertmanager — WVA only needs Prometheus for metrics collection.
+    # Use a 10m timeout — 5m is insufficient on busy clusters (e.g. CKS with preemption).
     log_info "Installing kube-prometheus-stack with TLS configuration"
     helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
         -n $MONITORING_NAMESPACE \
@@ -119,7 +121,9 @@ deploy_prometheus_stack() {
         --set prometheus.prometheusSpec.web.tlsConfig.cert.secret.key=tls.crt \
         --set prometheus.prometheusSpec.web.tlsConfig.keySecret.name=$PROMETHEUS_SECRET_NAME \
         --set prometheus.prometheusSpec.web.tlsConfig.keySecret.key=tls.key \
-        --timeout=5m \
+        --set grafana.enabled=false \
+        --set alertmanager.enabled=false \
+        --timeout=10m \
         --wait
     
     log_success "kube-prometheus-stack deployed with TLS"


### PR DESCRIPTION
## Summary
- Increase kube-prometheus-stack helm install timeout from 5m to 10m — the current timeout is too short on busy clusters like CKS where GPU pod preemption delays scheduling
- Disable Grafana and Alertmanager in the prometheus stack — WVA only needs Prometheus for metrics collection, reducing the number of pods that need to come up

## Context
Every WVA-CKS nightly run fails at "Deploy guide via WVA install.sh" with:
```
Error: UPGRADE FAILED: context deadline exceeded
```
The install takes exactly 5 minutes (the current timeout) before failing. The full kube-prometheus-stack chart deploys Prometheus, Grafana, Alertmanager, and node-exporter — but WVA only needs Prometheus for its metrics pipeline.

## Files changed
- `deploy/kubernetes/install.sh` — timeout 5m→10m, disable grafana/alertmanager
- `deploy/kind-emulator/install.sh` — same changes for consistency

## Test plan
- [ ] Trigger WVA-CKS nightly after merge and verify prometheus installs successfully
- [ ] Verify WVA metrics pipeline works without Grafana/Alertmanager