### PR TITLE
🐛 Fix KEDA APIService race condition in nightly E2E

### DIFF
--- a/test/e2e-openshift/scale_to_zero_test.go
+++ b/test/e2e-openshift/scale_to_zero_test.go
@@ -155,8 +155,8 @@ retention_period: %s`, retentionPeriod),
 			// and gracefully skip if scale-to-zero cannot be validated.
 
 			scaledToZero := false
-			// Wait for retention period (3m) + buffer (2m) = 5m total
-			deadline := time.Now().Add(5 * time.Minute)
+			// Wait for retention period (3m) + buffer (7m) = 10m total
+			deadline := time.Now().Add(10 * time.Minute)
 
 			for time.Now().Before(deadline) {
 				va := &v1alpha1.VariantAutoscaling{}

--- a/test/e2e-openshift/sharegpt_scaleup_test.go
+++ b/test/e2e-openshift/sharegpt_scaleup_test.go
@@ -359,7 +359,7 @@ var _ = Describe("ShareGPT Scale-Up Test", Ordered, func() {
 						_, _ = fmt.Fprintf(GinkgoWriter, "External metrics API response (selector: %s): %s\n",
 							hpaMetricSelector, truncateString(resultStr, 500))
 					}
-				}, 5*time.Minute, 5*time.Second).Should(Succeed())
+				}, 10*time.Minute, 5*time.Second).Should(Succeed())
 			})
 
 			It("should create and run parallel load generation jobs", func() {


### PR DESCRIPTION
## Summary

- Add background APIService guard loop that re-patches `v1beta1.external.metrics.k8s.io` every 10s if KEDA reclaims it
- Guard starts when KEDA is detected during `deploy_prometheus_adapter()`, stops during cleanup
- Does **not** modify KEDA itself — just ensures the APIService always points to `prometheus-adapter`
- Increase external metrics API test timeout from 5min to 10min
- Increase scale-to-zero test timeout from 5min to 10min

## Problem

KEDA operator continuously reconciles the `v1beta1.external.metrics.k8s.io` APIService back to `keda-metrics-apiserver` within ~2 minutes. The existing one-shot patch in `install.sh` gets overwritten, causing the HPA to receive 404 errors when querying `wva_desired_replicas`. This makes the nightly E2E tests fail intermittently on OCP clusters with KEDA installed.

KEDA has no built-in option to disable external metrics registration ([issue #470](https://github.com/kedacore/keda/issues/470), open since 2019).

## Test plan

- [ ] Trigger WVA nightly on OCP — should no longer fail with KEDA APIService 404s
- [ ] Verify guard output shows re-patching in workflow logs when KEDA reclaims
- [ ] Verify guard stops cleanly during cleanup (no orphaned processes)
- [ ] Run multiple consecutive E2E runs to confirm stability