### PR TITLE
⚠️ Improve E2E workflow reliability and observability

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -943,6 +943,8 @@ jobs:
           DEPLOYMENT: ms-inference-scheduling-llm-d-modelservice-decode
           # Pass WVA_RELEASE_NAME so test can filter for current run's resources
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          # Controller instance label must match what the controller was deployed with
+          CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
           MODEL_ID: ${{ env.MODEL_ID }}
           REQUEST_RATE: ${{ env.REQUEST_RATE }}
           NUM_PROMPTS: ${{ env.NUM_PROMPTS }}

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -41,6 +41,9 @@ type E2EConfig struct {
 	InputTokens  int    // Average input tokens
 	OutputTokens int    // Average output tokens
 
+	// Controller isolation
+	ControllerInstance string // Controller instance label for multi-controller filtering
+
 	// Timeouts
 	PodReadyTimeout int // Seconds to wait for pods to be ready
 	ScaleUpTimeout  int // Seconds to wait for scale-up
@@ -81,6 +84,9 @@ func LoadConfigFromEnv() E2EConfig {
 		NumPrompts:   getEnvInt("NUM_PROMPTS", 1000),
 		InputTokens:  getEnvInt("INPUT_TOKENS", 100),
 		OutputTokens: getEnvInt("OUTPUT_TOKENS", 50),
+
+		// Controller isolation
+		ControllerInstance: getEnv("CONTROLLER_INSTANCE", ""),
 
 		// Timeout defaults
 		PodReadyTimeout: getEnvInt("POD_READY_TIMEOUT", 300), // 5 minutes

--- a/test/e2e/fixtures/va_builder.go
+++ b/test/e2e/fixtures/va_builder.go
@@ -21,6 +21,7 @@ func CreateVariantAutoscaling(
 	crClient client.Client,
 	namespace, name, deploymentName, modelID, accelerator string,
 	cost float64,
+	controllerInstance string,
 ) error {
 	// Check if VA already exists and delete it to ensure clean state
 	existingVA := &variantautoscalingv1alpha1.VariantAutoscaling{}
@@ -49,14 +50,19 @@ func CreateVariantAutoscaling(
 		return fmt.Errorf("failed to check for existing VA %s: %w", name, err)
 	}
 
+	labels := map[string]string{
+		"test-resource":                          "true",
+		"inference.optimization/acceleratorName": accelerator,
+	}
+	if controllerInstance != "" {
+		labels["wva.llmd.ai/controller-instance"] = controllerInstance
+	}
+
 	va := &variantautoscalingv1alpha1.VariantAutoscaling{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"test-resource":                          "true",
-				"inference.optimization/acceleratorName": accelerator,
-			},
+			Labels:    labels,
 		},
 		Spec: variantautoscalingv1alpha1.VariantAutoscalingSpec{
 			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
@@ -76,6 +82,7 @@ func CreateVariantAutoscalingWithDefaults(
 	ctx context.Context,
 	crClient client.Client,
 	namespace, name, deploymentName, modelID, accelerator string,
+	controllerInstance string,
 ) error {
-	return CreateVariantAutoscaling(ctx, crClient, namespace, name, deploymentName, modelID, accelerator, 30.0)
+	return CreateVariantAutoscaling(ctx, crClient, namespace, name, deploymentName, modelID, accelerator, 30.0, controllerInstance)
 }

--- a/test/e2e/limiter_test.go
+++ b/test/e2e/limiter_test.go
@@ -113,6 +113,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaA,
 			modelServiceA+"-decode", cfg.ModelID, "H100", 30.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VA A")
 
@@ -120,6 +121,7 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaB,
 			modelServiceB+"-decode", cfg.ModelID, "MI300X", 40.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VA B")
 

--- a/test/e2e/parallel_load_scaleup_test.go
+++ b/test/e2e/parallel_load_scaleup_test.go
@@ -152,6 +152,7 @@ var _ = Describe("Parallel Load Scale-Up Test", Label("full"), Ordered, func() {
 		err = fixtures.CreateVariantAutoscalingWithDefaults(
 			ctx, crClient, cfg.LLMDNamespace, vaName,
 			deploymentName, cfg.ModelID, cfg.AcceleratorType,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 

--- a/test/e2e/saturation_test.go
+++ b/test/e2e/saturation_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Saturation Mode - Single VariantAutoscaling", Label("full"), O
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaName,
 			deploymentName, cfg.ModelID, cfg.AcceleratorType, 30.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 
@@ -332,11 +333,11 @@ var _ = Describe("Saturation Mode - Multiple VariantAutoscalings", Label("full")
 
 		By("Creating two VAs with different costs")
 		// VA A: Lower cost (should be preferred)
-		err = fixtures.CreateVariantAutoscaling(ctx, crClient, cfg.LLMDNamespace, vaA, modelServiceA+"-decode", cfg.ModelID, "A100", 30.0)
+		err = fixtures.CreateVariantAutoscaling(ctx, crClient, cfg.LLMDNamespace, vaA, modelServiceA+"-decode", cfg.ModelID, "A100", 30.0, cfg.ControllerInstance)
 		Expect(err).NotTo(HaveOccurred())
 
 		// VA B: Higher cost
-		err = fixtures.CreateVariantAutoscaling(ctx, crClient, cfg.LLMDNamespace, vaB, modelServiceB+"-decode", cfg.ModelID, "H100", 50.0)
+		err = fixtures.CreateVariantAutoscaling(ctx, crClient, cfg.LLMDNamespace, vaB, modelServiceB+"-decode", cfg.ModelID, "H100", 50.0, cfg.ControllerInstance)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating HPAs for both deployments")

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -235,6 +235,7 @@ var _ = Describe("Scale-From-Zero Feature", Label("full"), Ordered, func() {
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaName,
 			modelServiceName+"-decode", cfg.ModelID, cfg.AcceleratorType, 30.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 

--- a/test/e2e/scale_to_zero_test.go
+++ b/test/e2e/scale_to_zero_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Scale-To-Zero Feature", Label("full", "flaky"), Ordered, func(
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaName,
 			deploymentName, cfg.ModelID, cfg.AcceleratorType, 30.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 
@@ -353,6 +354,7 @@ enable_scale_to_zero: false`, cfg.ModelID),
 		err = fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, vaName,
 			modelServiceName+"-decode", cfg.ModelID, cfg.AcceleratorType, 10.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -152,6 +152,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			err = fixtures.CreateVariantAutoscalingWithDefaults(
 				ctx, crClient, cfg.LLMDNamespace, vaName,
 				deploymentName, cfg.ModelID, cfg.AcceleratorType,
+				cfg.ControllerInstance,
 			)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 
@@ -861,6 +862,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			err = fixtures.CreateVariantAutoscalingWithDefaults(
 				ctx, crClient, cfg.LLMDNamespace, errorTestVAName,
 				deploymentName, cfg.ModelID, cfg.AcceleratorType,
+				cfg.ControllerInstance,
 			)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 

--- a/test/e2e/target_condition_test.go
+++ b/test/e2e/target_condition_test.go
@@ -130,6 +130,7 @@ var _ = Describe("VariantAutoscaling Target Condition", Label("smoke", "full"), 
 		err := fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, validVAName,
 			deployName, cfg.ModelID, cfg.AcceleratorType, 10.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 
@@ -158,6 +159,7 @@ var _ = Describe("VariantAutoscaling Target Condition", Label("smoke", "full"), 
 		err := fixtures.CreateVariantAutoscaling(
 			ctx, crClient, cfg.LLMDNamespace, invalidVAName,
 			nonExistentDeployName, cfg.ModelID, cfg.AcceleratorType, 10.0,
+			cfg.ControllerInstance,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create VariantAutoscaling")
 


### PR DESCRIPTION
Improves the OpenShift E2E workflow based on feedback from the FMA team (llm-d-incubation/llm-d-fast-model-actuation#269-#277). Same patterns apply here since the FMA workflow was cloned from this one.

**Changes:**
- **Go version**: Use hardcoded `1.24.x` build preference instead of extracting minimum from `go.mod`. The `go` directive in `go.mod` states the minimum required version, not the preferred build version.
- **State dump**: Dump cluster state unconditionally (`if: always()`) instead of only on failure. Provides baseline diagnostics for comparison when investigating failures. GPU scale-down on failure remains separate.
- **Workflow summary**: Add a summary annotation in the gate job so the Actions UI clearly shows whether E2E tests were skipped or actually ran.