### PR TITLE
Bug: allow unknown arguments to wva controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -131,6 +132,11 @@ func main() {
 	opts.BindFlags(gfs) // zap expects a standard Go FlagSet and pflag.FlagSet is not compatible.
 	flag.CommandLine.AddGoFlagSet(gfs)
 
+	// Allow unknown flags for backward/forward compatibility
+	flag.CommandLine.ParseErrorsAllowlist = flag.ParseErrorsAllowlist{
+		UnknownFlags: true,
+	}
+
 	flag.Parse()
 
 	logging.InitLogging(&opts, loggerVerbosity)
@@ -138,6 +144,17 @@ func main() {
 
 	setupLog := ctrl.Log.WithName("setup")
 	setupLog.Info("Logger initialized")
+
+	// Log unknown flags that were ignored
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "--") {
+			flagName := strings.TrimPrefix(arg, "--")
+			flagName = strings.Split(flagName, "=")[0] // Handle --flag=value
+			if flag.CommandLine.Lookup(flagName) == nil {
+				setupLog.Info("Unknown flag ignored", "flag", arg)
+			}
+		}
+	}
 
 	// Get REST config early (needed for config loading)
 	restConfig := ctrl.GetConfigOrDie()


### PR DESCRIPTION
Currently wva controller latest image won't start (using kind) due to the deployment has "--config-file" as argument to the controller. This is due to the new parameter was added but the image wasn't rebuilt. This PR allows support of unknown flags in which case the controller just logs instead of errors out. Here's the error:
```
2026-02-27T19:01:22.890683239Z       --webhook-cert-path string                  The directory that contains the webhook certificate.
2026-02-27T19:01:22.890684568Z       --zap-devel                                 Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
2026-02-27T19:01:22.890685957Z       --zap-encoder encoder                       Zap log encoding (one of 'json' or 'console')
2026-02-27T19:01:22.890687262Z       --zap-log-level level                       Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
2026-02-27T19:01:22.890689216Z       --zap-stacktrace-level level                Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
2026-02-27T19:01:22.890696323Z       --zap-time-encoding time-encoding           Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
2026-02-27T19:01:22.890712661Z unknown flag: --config-file
```