### PR TITLE
🐛 Fix nightly to use consolidated test suite

### DIFF
--- a/.github/workflows/nightly-e2e-cks.yaml
+++ b/.github/workflows/nightly-e2e-cks.yaml
@@ -74,5 +74,5 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      test_target: test-e2e-openshift
+      test_target: test-e2e-full
     secrets: inherit


### PR DESCRIPTION
## Summary
- Switch `test_target` from deprecated `test-e2e-openshift` to `test-e2e-full` in `nightly-e2e-cks.yaml`
- The old `test/e2e-openshift/` suite was removed in #787 — the nightly now references a deleted test directory
- `test-e2e-full` runs the consolidated `test/e2e/` suite which supports all platforms

## Context
Today's nightly (run 22476013211) failed because the deprecated Makefile target `test-e2e-openshift` now points to the deleted `test/e2e-openshift/` directory.

Companion PR: llm-d/llm-d#TBD (fixes the two WVA nightlies in the umbrella repo)

## Test plan
- [ ] Next nightly run passes with `test-e2e-full` target