### PR TITLE
Bug fix: fix zap-log-level flag

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,8 +1,6 @@
 package logging
 
 import (
-	"flag"
-
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -19,14 +17,10 @@ const (
 
 // InitLogging initializes the controller-runtime logger with zap backend.
 func InitLogging(opts *zap.Options, logVerbosity *int) {
-	// Unless -zap-log-level is explicitly set, use -v
-	useV := true
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "zap-log-level" {
-			useV = false
-		}
-	})
-	if useV {
+	// Unless --zap-log-level is explicitly set (via BindFlags), use -v
+	// When BindFlags parses --zap-log-level, it sets opts.Level to a non-nil value.
+	// If opts.Level is still nil, the user didn't set --zap-log-level, so we use -v.
+	if opts.Level == nil {
 		// See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.Level
 		lvl := -1 * (*logVerbosity)
 		opts.Level = uberzap.NewAtomicLevelAt(zapcore.Level(int8(lvl)))


### PR DESCRIPTION
Ref: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/763
The issue was the mismatching usage of flag libraries as such the following `if` was never true:
```
flag.Visit(func(f *flag.Flag) {
		if f.Name == "zap-log-level" {
			useV = false
		}
	})
```
New code was tested with the following settings and log was observed:
- no zap-log-level specified
- zap-log-level=debug, info, error
