### PR TITLE
🐛 fix: checkout PR head SHA for issue_comment triggered workflows

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -256,14 +256,26 @@ jobs:
     needs: [lint-and-test, check-code-changes, check-full-tests]
     if: >-
       always() && (
-        (github.event_name == 'issue_comment' && needs.check-full-tests.outputs.run_full == 'true') ||
-        (github.event_name == 'workflow_dispatch' && needs.check-full-tests.outputs.run_full == 'true') ||
+        (github.event_name == 'issue_comment' && needs.check-full-tests.outputs.run_full == 'true' && needs.check-code-changes.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && (
+          needs.check-full-tests.outputs.run_full == 'true' ||
+          (needs.check-code-changes.result == 'success' && needs.check-code-changes.outputs.has_code_changes == 'true')
+        )) ||
         (github.event_name == 'pull_request' && needs.check-code-changes.result == 'success' && needs.check-code-changes.outputs.has_code_changes == 'true')
       )
     timeout-minutes: 60
     permissions:
       contents: read
     steps:
+      - name: Validate PR head SHA for issue_comment events
+        if: github.event_name == 'issue_comment'
+        run: |
+          if [ -z "${{ needs.check-code-changes.outputs.pr_head_sha }}" ]; then
+            echo "::error::pr_head_sha is empty — refusing to fall back to main"
+            exit 1
+          fi
+          echo "Checkout will use PR head SHA: ${{ needs.check-code-changes.outputs.pr_head_sha }}"
+
       - name: Checkout source
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

Fixes https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/831

When `/trigger-e2e-full` is used on a PR, the workflow triggers via `issue_comment` event. For this event type, `github.sha` points to `main` (the default branch), **not** the PR head. This caused the `e2e-tests` job to build and test code from `main` instead of the PR changes.

## Root Cause

The `check-code-changes` job already correctly resolves the PR head SHA and checks it out, but `e2e-tests` did a bare `actions/checkout@v4` with no `ref:`, defaulting to `github.sha` (main for issue_comment events).

## Fix

- **check-code-changes**: Export `pr_head_sha` as a job output (already computed but not exposed)
- **e2e-tests**: Use `needs.check-code-changes.outputs.pr_head_sha` in checkout ref, with a validation step that fails fast if the SHA is empty (prevents silent fallback to main)
- **lint-and-test**: Skip entirely for `issue_comment` events — it already runs on `pull_request` triggers, so re-running on comments is unnecessary and would allow untrusted commenters to execute PR code
- **e2e-tests gate**: Tightened so `issue_comment` events only run when `check-full-tests` validates an approved trigger from a trusted collaborator AND `check-code-changes` succeeds
- **workflow_dispatch**: Preserved smoke-test path — runs when `run_full_tests=true` OR when code changes are detected (matching existing behavior)