### PR TITLE
update wva image after repo graduate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMAGE_TAG_BASE ?= ghcr.io/llm-d
 IMG_TAG ?= latest
-IMG ?= $(IMAGE_TAG_BASE)/workload-variant-autoscaler:$(IMG_TAG)
+IMG ?= $(IMAGE_TAG_BASE)/llm-d-workload-variant-autoscaler:$(IMG_TAG)
 KIND_ARGS ?= -t mix -n 3 -g 2   # Default: 3 nodes, 2 GPUs per node, mixed vendors
 CLUSTER_GPU_TYPE ?= nvidia-mix
 CLUSTER_NODES ?= 3

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -246,7 +246,7 @@ Examples:
   $(basename "$0")
 
   # Deploy with custom WVA image
-  IMG=<your_registry>/workload-variant-autoscaler:tag $(basename "$0")
+  IMG=<your_registry>/llm-d-workload-variant-autoscaler:tag $(basename "$0")
 
   # Deploy with custom model and accelerator
   $(basename "$0") -m unsloth/Meta-Llama-3.1-8B -a A100

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -293,7 +293,7 @@ KIND_IMAGE_PLATFORM=linux/arm64 make deploy-wva-emulated-on-kind CREATE_CLUSTER=
 Alternatively, build the image locally and deploy with `IfNotPresent` so the script skips the registry pull and loads your local single-platform image:
 
 ```bash
-make docker-build IMG=ghcr.io/llm-d/workload-variant-autoscaler:latest
+make docker-build IMG=ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest
 WVA_IMAGE_PULL_POLICY=IfNotPresent make deploy-wva-emulated-on-kind CREATE_CLUSTER=true DEPLOY_LLM_D=true
 ```
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -183,7 +183,7 @@ make deploy-wva-on-k8s
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
-export IMG="ghcr.io/yourorg/workload-variant-autoscaler:latest"
+export IMG="ghcr.io/yourorg/llm-d-workload-variant-autoscaler:latest"
 make deploy-wva-on-k8s
 ```
 
@@ -657,7 +657,7 @@ kubectl set env deployment/workload-variant-autoscaler-controller-manager \
 ### Update WVA Image
 
 ```bash
-export WVA_IMAGE="ghcr.io/yourorg/workload-variant-autoscaler:custom-tag"
+export WVA_IMAGE="ghcr.io/yourorg/llm-d-workload-variant-autoscaler:custom-tag"
 export DEPLOY_LLM_D=false  # Don't redeploy llm-d
 export DEPLOY_PROMETHEUS=false  # Don't redeploy Prometheus
 make deploy-wva-on-k8s

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -28,7 +28,7 @@ Using kustomize for more control:
 make install
 
 # Deploy the controller
-make deploy IMG=quay.io/llm-d/workload-variant-autoscaler:latest
+make deploy IMG=quay.io/llm-d/llm-d-workload-variant-autoscaler:latest
 ```
 
 ### Option 3: Local Development (Kind Emulator):
@@ -44,7 +44,7 @@ Key configuration options:
 ```yaml
 # custom-values.yaml
 image:
-  repository: quay.io/llm-d/workload-variant-autoscaler
+  repository: quay.io/llm-d/llm-d-workload-variant-autoscaler
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update WVA new image - has an extra `llm-d` prefix 
New image - `ghcr.io/llm-d/llm-d-workload-variant-autoscaler`