### PR TITLE
🐛 fix: report e2e commit status to fork PR head SHA

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -271,7 +271,23 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      statuses: write  # For reporting status on fork PR commits
     steps:
+      - name: Set pending status on PR head
+        if: github.event_name == 'issue_comment' && needs.check-code-changes.outputs.pr_head_sha != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.check-code-changes.outputs.pr_head_sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'E2E tests running...',
+              context: '${{ github.workflow }} / e2e (comment trigger)'
+            });
+
       - name: Validate PR head SHA for issue_comment events
         if: github.event_name == 'issue_comment'
         run: |
@@ -320,10 +336,12 @@ jobs:
 
       - name: Build WVA image locally
         id: build-image
+        env:
+          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
         run: |
           # Generate unique image tag for this PR run (local image, no registry needed)
           IMAGE_NAME="llm-d-workload-variant-autoscaler"
-          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${GITHUB_SHA:0:7}"
+          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${CHECKOUT_SHA:0:7}"
           # Use localhost prefix for local-only image (Kind will load it directly)
           FULL_IMAGE="localhost/${IMAGE_NAME}:${IMAGE_TAG}"
           
@@ -374,3 +392,53 @@ jobs:
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |
           make ${{ steps.test-type.outputs.test_target }}
+
+  # Report status back to PR for issue_comment triggered runs
+  # This ensures fork PRs show the correct status after /trigger-e2e-full runs complete
+  report-status:
+    runs-on: ubuntu-latest
+    needs: [check-code-changes, check-full-tests, e2e-tests]
+    if: always() && github.event_name == 'issue_comment' && needs.check-full-tests.outputs.run_full == 'true'
+    permissions:
+      statuses: write
+    steps:
+      - name: Report status to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prHeadSha = '${{ needs.check-code-changes.outputs.pr_head_sha }}';
+            const e2eResult = '${{ needs.e2e-tests.result }}';
+
+            if (!prHeadSha) {
+              console.log('No PR head SHA available, skipping status report');
+              return;
+            }
+
+            let state, description;
+            if (e2eResult === 'success') {
+              state = 'success';
+              description = 'E2E tests passed';
+            } else if (e2eResult === 'skipped') {
+              state = 'failure';
+              description = 'E2E tests did not run (prerequisite failed or skipped)';
+            } else if (e2eResult === 'cancelled') {
+              state = 'failure';
+              description = 'E2E tests cancelled';
+            } else {
+              state = 'failure';
+              description = 'E2E tests failed';
+            }
+
+            console.log(`Reporting status to PR commit ${prHeadSha}: ${state} - ${description}`);
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: prHeadSha,
+              state: state,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: description,
+              context: '${{ github.workflow }} / e2e (comment trigger)'
+            });
+
+            console.log('Status reported successfully');


### PR DESCRIPTION
## Problem

When `/trigger-e2e-full` is commented on a fork PR, the `issue_comment` event always associates the workflow run with `main` (GitHub limitation). The previous fixes (PR #832, PR #839) correctly fixed the **code checkout** to use the PR's head SHA, but no commit status was reported back to the PR. This means:

1. The PR shows **no e2e check status** after `/trigger-e2e-full`
2. The Actions UI shows `main`'s SHA, making it appear tests ran against main
3. Prow/Tide can't see the check result on the PR

## Fix

Mirrors the pattern already used in `ci-e2e-openshift.yaml`:

- **`report-status` job**: Runs after `e2e-tests` for `issue_comment` events, calls `repos.createCommitStatus()` on the PR head SHA with the test result (success/failure)
- **Pending status step**: Sets a `pending` commit status on the PR head SHA when e2e-tests starts, giving immediate feedback
- **Image tag fix**: Replaces `GITHUB_SHA` with `pr_head_sha` in the image tag so logs show the actual code being built
- **`statuses: write` permission**: Added to `e2e-tests` and `report-status` jobs

## Testing

- YAML syntax validated
- Pattern matches the proven `ci-e2e-openshift.yaml` implementation
- Skipped e2e-tests correctly report failure (not pending) when prerequisite fails

Closes #831