### PR TITLE
Fix Helm release workflow and align repo to chart v0.5.1

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -167,18 +167,20 @@ jobs:
             -f visibility='public' || echo "::warning::Could not set chart package to public — may need manual update"
 
       # -----------------------------------------
-      # 11. Commit updated chart files
+      # 11. Commit updated chart files back to default branch
       # -----------------------------------------
       - name: Commit updated Helm chart files
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          CHART_DIR="charts/workload-variant-autoscaler"
+          # Save release-patched chart files (they are lost when we checkout default branch)
+          cp "$CHART_DIR/Chart.yaml" Chart.yaml.release
+          cp "$CHART_DIR/values.yaml" values.yaml.release
+
           # Configure Git user to match the person who triggered the release
-          # This ensures each person is responsible for their own release commits
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-          # Configure remote to use github.token (belongs to the person who triggered workflow)
           git remote set-url origin https://${{ github.token }}@github.com/${{ github.repository }}.git
 
           # Checkout the default branch (we're in detached HEAD from tag checkout)
@@ -186,15 +188,13 @@ jobs:
           DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch" | cut -d' ' -f5 || echo "main")
           git checkout $DEFAULT_BRANCH
           git pull origin $DEFAULT_BRANCH
-          
-          # Stage changes
-          git add charts/workload-variant-autoscaler/Chart.yaml
-          git add charts/workload-variant-autoscaler/values.yaml
 
-          # Commit with message showing who created the release
+          # Restore the release version into the repo so the commit updates the chart
+          cp Chart.yaml.release "$CHART_DIR/Chart.yaml"
+          cp values.yaml.release "$CHART_DIR/values.yaml"
+
+          git add "$CHART_DIR/Chart.yaml" "$CHART_DIR/values.yaml"
           COMMIT_MSG="Release ${{ steps.version.outputs.tag }}: update Chart.yaml and values.yaml"
           git commit -m "$COMMIT_MSG" || echo "No changes to commit"
-          
           # Push directly to main (bypass enabled via role-based permissions)
-          # The person who triggered the workflow must have Write/Maintain role with bypass
           git push origin $DEFAULT_BRANCH || echo "Push failed - ensure your role has bypass permissions"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ helm upgrade workload-variant-autoscaler ./charts/workload-variant-autoscaler \
 
 ### Breaking Changes
 
-#### v0.5.0 (upcoming)
+#### v0.5.1
 - **VariantAutoscaling CRD**: Added `scaleTargetRef` field as **required**. v0.4.1 VariantAutoscaling resources without `scaleTargetRef` must be updated before upgrading:
   - **Impact on Scale-to-Zero**: VAs without `scaleTargetRef` will not scale to zero properly, even with HPAScaleToZero enabled and HPA `minReplicas: 0`, because the HPA cannot reference the target deployment.
   - **Migration**: Update existing VAs to include `scaleTargetRef`:

--- a/charts/workload-variant-autoscaler/Chart.yaml
+++ b/charts/workload-variant-autoscaler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: workload-variant-autoscaler
 description: Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
 type: application
-version: 0.5.0
-appVersion: "v0.5.0"
+version: 0.5.1
+appVersion: "v0.5.1"

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -1,8 +1,15 @@
 # workload-variant-autoscaler
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
 Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
+
+### Chart registry (OCI)
+
+The chart is published to GitHub Container Registry under the **llm-d** org (not llm-d-incubation). Use this OCI URL in Helm or Helmfile:
+
+- **OCI URL:** `oci://ghcr.io/llm-d/workload-variant-autoscaler`
+- **Example:** `helm pull oci://ghcr.io/llm-d/workload-variant-autoscaler --version 0.5.1`
 
 ## Installation (OpenShift)
 Helm is the recommended installation method. Before running, be sure to delete all previous helm installations for `workload-variant-autoscaler` and `prometheus-adapter`. To list all helm charts installed in the cluster run `helm ls -A`.
@@ -11,7 +18,7 @@ Helm is the recommended installation method. Before running, be sure to delete a
 ```
 export OWNER="llm-d"
 export WVA_PROJECT="llm-d-workload-variant-autoscaler"
-export WVA_RELEASE="v0.5.0"
+export WVA_RELEASE="v0.5.1"
 export WVA_NS="workload-variant-autoscaler-system"
 export MON_NS="openshift-user-workload-monitoring"
 

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -9,7 +9,7 @@ wva:
 
   image:
     repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
-    tag: v0.5.0
+    tag: v0.5.1
   imagePullPolicy: Always
 
   metrics:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
-  newTag: v0.4.1
+  newTag: v0.5.1

--- a/docs/saturation-analyzer.md
+++ b/docs/saturation-analyzer.md
@@ -1,4 +1,3 @@
-# NOTE: we are currently updating the documentation to be aligned with the 0.4.0 release
 # Saturation Analyzer
 
 ## Overview


### PR DESCRIPTION

- Helm release workflow: Step 11 was overwriting the release-patched `Chart.yaml` and `values.yaml` when checking out the default branch, so the repo was never updated after publishing to GHCR. The job now saves those files before checkout and restores them before committing, so the default branch gets the correct chart version on each release.
- Version alignment: Bumped chart and default image references to v0.5.1: 