### PR TITLE
feat: add support for podman + bump version for llm-d and all images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ vendor/
 
 # Submodules and sibling repos (not needed for building the manager binary)
 sample-data/
+llm-d/
 llm-d-infra/
 # If building from a parent repo that includes llmd or GAIE, add:
 # llmd/

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -1113,7 +1113,7 @@ jobs:
           for ns in "$LLMD_NAMESPACE" "$LLMD_NAMESPACE_B"; do
             if kubectl get namespace "$ns" &>/dev/null; then
               echo "=== Scaling down decode deployments in $ns ==="
-              kubectl scale deployment -n "$ns" -l llm-d.ai/inferenceServing=true --replicas=0 || true
+              kubectl scale deployment -n "$ns" -l llm-d.ai/inference-serving=true --replicas=0 || true
               # Also try by name pattern in case labels are missing
               kubectl get deployment -n "$ns" -o name 2>/dev/null | grep decode | while read -r deploy; do
                 echo "  Scaling down: $deploy"

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,6 @@ gpu.cluster
 # llm-d and llm-d-infra directories
 llm-d/
 llm-d-infra/
-llmd/
-llmd-infra/
 
 *.tgz
 actionlint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CLUSTER_GPU_TYPE ?= nvidia-mix
 CLUSTER_NODES ?= 3
 CLUSTER_GPUS ?= 4
 KUBECONFIG ?= $(HOME)/.kube/config
-K8S_VERSION ?= v1.32.0
+K8S_VERSION ?= v1.32.0 # match OCP 4.19
 
 CONTROLLER_NAMESPACE ?= workload-variant-autoscaler-system
 MONITORING_NAMESPACE ?= openshift-user-workload-monitoring
@@ -195,6 +195,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \
+		CONTAINER_TOOL=$(CONTAINER_TOOL) \
 		./deploy/install.sh; \
 	else \
 		echo "IMG not set - using default image from registry (latest)"; \
@@ -205,6 +206,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
+		CONTAINER_TOOL=$(CONTAINER_TOOL) \
 		./deploy/install.sh; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA) or keda (ScaledObject)
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
+LLM_D_INFERENCE_SIM_IMG_TAG ?= v0.7.1  # ghcr.io/llm-d/llm-d-inference-sim image tag for E2E tests which does not follow llm-d release version
 
 # Flags for deploy/install.sh installation script
 CREATE_CLUSTER ?= false
@@ -195,6 +196,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \
+		LLM_D_INFERENCE_SIM_IMG_TAG=$(LLM_D_INFERENCE_SIM_IMG_TAG) \
 		CONTAINER_TOOL=$(CONTAINER_TOOL) \
 		./deploy/install.sh; \
 	else \
@@ -206,6 +208,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
+		LLM_D_INFERENCE_SIM_IMG_TAG=$(LLM_D_INFERENCE_SIM_IMG_TAG) \
 		CONTAINER_TOOL=$(CONTAINER_TOOL) \
 		./deploy/install.sh; \
 	fi

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,7 @@ All deployment methods require:
 - **kubectl** (v1.24+) - Kubernetes CLI
 - **helm** (v3.8+) - Package manager for Kubernetes
 - **git** - Git CLI
+- **docker** or **podman** - Container tool for building and loading images
 
 Optional but recommended:
 
@@ -41,6 +42,8 @@ Platform-specific requirements:
 
 - **OpenShift**: `oc` CLI (v4.12+)
 - **Kind**: `kind` CLI for local testing
+
+**Container Tool Support**: The deployment scripts support both Docker and Podman. Set `CONTAINER_TOOL=podman` to use Podman, or leave unset to use the default (`docker`).
 
 ### Cluster Requirements
 
@@ -266,6 +269,22 @@ kubectl get hpa --all-namespaces | grep -v kube-system  # Should be empty (excep
 - ❌ VariantAutoscaling CRs (tests create these)
 - ❌ HPA resources (tests create these)
 - ❌ Model services (tests create these)
+```
+
+##### Example 8: Using specific llm-d release and Podman
+
+Deploy with a specific llm-d release version and use Podman instead of Docker:
+
+```bash
+export HF_TOKEN="hf_xxxxx"
+export LLM_D_RELEASE="v0.5.0"      # Pin to specific llm-d version
+export CONTAINER_TOOL=podman       # Use Podman instead of Docker
+make deploy-wva-emulated-on-kind
+
+# The LLM_D_RELEASE variable automatically sets:
+# - LLM_D_INFERENCE_SCHEDULER_IMG=ghcr.io/llm-d/llm-d-inference-scheduler:v0.5.0
+# - LLM_D_INFERENCE_SIM_IMG=ghcr.io/llm-d/llm-d-inference-sim:v0.5.0
+# - llm-d repository clone version
 ```
 
 ### Method 2: Helm Chart
@@ -620,6 +639,12 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | `WVA_IMAGE_REPO` | WVA image repository | `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` |
 | `WVA_IMAGE_TAG` | WVA image tag | `latest` |
 | `WVA_IMAGE_PULL_POLICY` | Image pull policy | `Always` |
+| `LLM_D_RELEASE` | llm-d release version (controls all llm-d images) | `v0.5.1` |
+| `LLM_D_INFERENCE_SCHEDULER_IMG` | Override llm-d inference scheduler image | `ghcr.io/llm-d/llm-d-inference-scheduler:$LLM_D_RELEASE` |
+| `LLM_D_INFERENCE_SIM_IMG` | Override llm-d inference simulator image | `ghcr.io/llm-d/llm-d-inference-sim:$LLM_D_RELEASE` |
+| `CONTAINER_TOOL` | Container tool to use (docker or podman) | `docker` |
+
+**Centralized llm-d Version Management**: Setting `LLM_D_RELEASE` automatically configures all llm-d component images to use the same release version. This ensures version consistency across the llm-d inference scheduler and simulator. Individual image variables can override this if needed.
 
 #### Namespace Configuration
 
@@ -680,7 +705,6 @@ HPA_STABILIZATION_SECONDS=30 ./deploy/install.sh
 | `WVA_LOG_LEVEL` | WVA logging level | `info` |
 | `VLLM_SVC_ENABLED` | Enable vLLM Service | `true` |
 | `VLLM_SVC_NODEPORT` | vLLM NodePort | `30000` |
-| `LLM_D_RELEASE` | llm-d version | `v0.3.0` |
 | `VLLM_MAX_NUM_SEQS` | vLLM max concurrent sequences per replica | (unset - uses vLLM default) |
 
 **vLLM Performance Tuning:**

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -785,11 +785,12 @@ EOF
 deploy_llm_d_infrastructure() {
     log_info "Deploying llm-d infrastructure..."
 
-    # Clone llm-d repo if not exists or if has older version locally
+    # Clone llm-d repo if not exists, or re-clone if version mismatch detected
     if [ -d "$LLM_D_PROJECT/.git" ]; then
-        CURRENT_TAG=$(cd "$LLM_D_PROJECT" && git describe --tags --exact-match 2>/dev/null || echo "unknown")
-        if [ "$CURRENT_TAG" != "$LLM_D_RELEASE" ]; then
-            log_warning "$LLM_D_PROJECT exists but has version '$CURRENT_TAG' (expected: $LLM_D_RELEASE)"
+        # Check current version (try tag first, then branch)
+        CURRENT_VERSION=$(cd "$LLM_D_PROJECT" && git describe --tags --exact-match 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        if [ "$CURRENT_VERSION" != "$LLM_D_RELEASE" ]; then
+            log_warning "$LLM_D_PROJECT exists but has version '$CURRENT_VERSION' (expected: $LLM_D_RELEASE)"
             rm -rf "$LLM_D_PROJECT"
         else
             log_info "$LLM_D_PROJECT directory already exists with correct version ($LLM_D_RELEASE)"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -47,7 +47,7 @@ CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
 # llm-d Configuration
 LLM_D_OWNER=${LLM_D_OWNER:-"llm-d"}
 LLM_D_PROJECT=${LLM_D_PROJECT:-"llm-d"}
-LLM_D_RELEASE=${LLM_D_RELEASE:-"v0.3.0"}
+LLM_D_RELEASE=${LLM_D_RELEASE:-"v0.5.1"}
 LLM_D_MODELSERVICE_NAME=${LLM_D_MODELSERVICE_NAME:-"ms-$WELL_LIT_PATH_NAME-llm-d-modelservice"}
 LLM_D_EPP_NAME=${LLM_D_EPP_NAME:-"gaie-$WELL_LIT_PATH_NAME-epp"}
 CLIENT_PREREQ_DIR=${CLIENT_PREREQ_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/prereq/client-setup"}
@@ -57,9 +57,8 @@ LLM_D_MODELSERVICE_VALUES=${LLM_D_MODELSERVICE_VALUES:-"$EXAMPLE_DIR/ms-$WELL_LI
 ITL_AVERAGE_LATENCY_MS=${ITL_AVERAGE_LATENCY_MS:-20}
 TTFT_AVERAGE_LATENCY_MS=${TTFT_AVERAGE_LATENCY_MS:-200}
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
-# llm-d-inference scheduler with image with flowcontrol support
-# TODO: update once the llm-d-inference-scheduler v0.5.0 is released
-LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/llm-d-inference-scheduler:v0.5.0-rc.1"}
+LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/llm-d-inference-scheduler:$LLM_D_RELEASE"}
+LLM_D_INFERENCE_SIM_IMG=${LLM_D_INFERENCE_SIM_IMG:-"ghcr.io/llm-d/llm-d-inference-sim:$LLM_D_RELEASE"}
 
 # Gateway Configuration
 GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"} # Options: kgateway, istio
@@ -615,7 +614,7 @@ spec:
       serviceAccountName: gaie-sim-sa
       containers:
       - name: epp
-        image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.3.2
+        image: $LLM_D_INFERENCE_SCHEDULER_IMG
         imagePullPolicy: Always
         args:
         - --poolName=$POOL_NAME_2
@@ -686,7 +685,7 @@ spec:
     spec:
       containers:
       - name: vllm
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.5.1
+        image: $LLM_D_INFERENCE_SIM_IMG
         imagePullPolicy: Always
         args:
         - --model=$MODEL_ID_2
@@ -786,12 +785,23 @@ EOF
 deploy_llm_d_infrastructure() {
     log_info "Deploying llm-d infrastructure..."
 
-     # Clone llm-d repo if not exists
+    # Clone llm-d repo if not exists or if has older version locally
+    if [ -d "$LLM_D_PROJECT/.git" ]; then
+        CURRENT_TAG=$(cd "$LLM_D_PROJECT" && git describe --tags --exact-match 2>/dev/null || echo "unknown")
+        if [ "$CURRENT_TAG" != "$LLM_D_RELEASE" ]; then
+            log_warning "$LLM_D_PROJECT exists but has version '$CURRENT_TAG' (expected: $LLM_D_RELEASE)"
+            rm -rf "$LLM_D_PROJECT"
+        else
+            log_info "$LLM_D_PROJECT directory already exists with correct version ($LLM_D_RELEASE)"
+        fi
+    elif [ -d "$LLM_D_PROJECT" ]; then
+        log_warning "$LLM_D_PROJECT exists but is not a git repository - removing it"
+        rm -rf "$LLM_D_PROJECT"
+    fi
+
     if [ ! -d "$LLM_D_PROJECT" ]; then
         log_info "Cloning $LLM_D_PROJECT repository (release: $LLM_D_RELEASE)"
         git clone -b $LLM_D_RELEASE -- https://github.com/$LLM_D_OWNER/$LLM_D_PROJECT.git $LLM_D_PROJECT &> /dev/null
-    else
-        log_warning "$LLM_D_PROJECT directory already exists, skipping clone"
     fi
 
     # Check for HF_TOKEN (use dummy for emulated deployments)
@@ -838,7 +848,7 @@ deploy_llm_d_infrastructure() {
     # Install Gateway control plane if enabled
     if [[ "$INSTALL_GATEWAY_CTRLPLANE" == "true" ]]; then
         log_info "Installing Gateway control plane ($GATEWAY_PROVIDER)"
-        helmfile apply -f "$GATEWAY_PREREQ_DIR/$GATEWAY_PROVIDER.helmfile.yaml"
+        helmfile apply -f "$GATEWAY_PREREQ_DIR/$GATEWAY_PROVIDER.helmfile.yaml" --suppress-diff
     else
         log_info "Skipping Gateway control plane installation (INSTALL_GATEWAY_CTRLPLANE=false)"
     fi
@@ -929,7 +939,7 @@ deploy_llm_d_infrastructure() {
       helmfile_selector="--selector kind!=autoscaling"
       log_info "Skipping WVA in helmfile (will be deployed separately from local chart)"
     fi
-    helmfile apply -e $GATEWAY_PROVIDER -n ${LLMD_NS} $helmfile_selector
+    helmfile apply -e $GATEWAY_PROVIDER -n ${LLMD_NS} $helmfile_selector --suppress-diff
 
     # Post-deploy: align the WVA vllm-service selector and ServiceMonitor to match
     # the actual pod labels. The llm-d-modelservice chart sets pod labels from

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -43,6 +43,18 @@ VALUES_FILE=${VALUES_FILE:-"$WVA_PROJECT/charts/workload-variant-autoscaler/valu
 # Controller instance identifier for multi-controller isolation (optional)
 # When set, adds controller_instance label to metrics and HPA selectors
 CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
+# InferencePool API group
+# inference.networking.k8s.io for v1, should be new default
+# inference.networking.x-k8s.io for v1alpha2
+POOL_GROUP=${POOL_GROUP:-"inference.networking.k8s.io"}
+if [ "$POOL_GROUP" = "inference.networking.k8s.io" ]; then
+    POOL_VERSION="v1"
+elif [ "$POOL_GROUP" = "inference.networking.x-k8s.io" ]; then
+    POOL_VERSION="v1alpha2"
+else
+    log_error "Unknown POOL_GROUP: $POOL_GROUP (expected inference.networking.k8s.io or inference.networking.x-k8s.io)"
+    exit 1
+fi
 
 # llm-d Configuration
 LLM_D_OWNER=${LLM_D_OWNER:-"llm-d"}
@@ -581,8 +593,27 @@ deploy_second_model_infrastructure() {
 
     # Create second InferencePool with different selector
     log_info "Creating second InferencePool: $POOL_NAME_2"
-    cat <<EOF | kubectl apply -n $LLMD_NS -f -
-apiVersion: inference.networking.x-k8s.io/v1alpha2
+    if [ "$POOL_VERSION" = "v1" ]; then
+        cat <<EOF | kubectl apply -n $LLMD_NS -f -
+apiVersion: ${POOL_GROUP}/${POOL_VERSION}
+kind: InferencePool
+metadata:
+  name: $POOL_NAME_2
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model-pool: "$MODEL_LABEL_2"
+      llm-d.ai/inference-serving: "true"
+  targetPorts:
+  - number: 8000
+  endpointPickerRef:
+    name: ${POOL_NAME_2}-epp
+    port:
+      number: 9002
+EOF
+    else
+        cat <<EOF | kubectl apply -n $LLMD_NS -f -
+apiVersion: ${POOL_GROUP}/${POOL_VERSION}
 kind: InferencePool
 metadata:
   name: $POOL_NAME_2
@@ -590,9 +621,11 @@ spec:
   targetPortNumber: 8000
   selector:
     llm-d.ai/model-pool: "$MODEL_LABEL_2"
+    llm-d.ai/inference-serving: "true"
   extensionRef:
     name: ${POOL_NAME_2}-epp
 EOF
+    fi
 
     # Create EPP deployment for second pool
     log_info "Creating EPP deployment for second pool"
@@ -676,12 +709,14 @@ spec:
     matchLabels:
       app: ${MS_NAME_2}-decode
       llm-d.ai/model-pool: "$MODEL_LABEL_2"
+      llm-d.ai/inference-serving: "true"
   template:
     metadata:
       labels:
         app: ${MS_NAME_2}-decode
         llm-d.ai/model-pool: "$MODEL_LABEL_2"
         llm-d.ai/model: "${MODEL_ID_2_SANITIZED}"
+        llm-d.ai/inference-serving: "true"
     spec:
       containers:
       - name: vllm
@@ -733,7 +768,7 @@ spec:
 EOF
 
     # Create InferenceModel for second model (maps model name to pool)
-    # Note: InferenceModel CRD may not be available in all environments
+    # TODO: InferenceModel only exists in inference.networking.x-k8s.io/v1alpha2, should use InfereceModelRewrite instead
     if kubectl get crd inferencemodels.inference.networking.x-k8s.io &>/dev/null; then
         log_info "Creating InferenceModel for second model"
         cat <<EOF | kubectl apply -n $LLMD_NS -f -
@@ -802,7 +837,11 @@ deploy_llm_d_infrastructure() {
 
     if [ ! -d "$LLM_D_PROJECT" ]; then
         log_info "Cloning $LLM_D_PROJECT repository (release: $LLM_D_RELEASE)"
-        git clone -b $LLM_D_RELEASE -- https://github.com/$LLM_D_OWNER/$LLM_D_PROJECT.git $LLM_D_PROJECT &> /dev/null
+        if ! git clone -b "$LLM_D_RELEASE" -- https://github.com/$LLM_D_OWNER/$LLM_D_PROJECT.git "$LLM_D_PROJECT" 2>&1 | grep -v "Cloning into"; then
+            log_error "Failed to clone $LLM_D_PROJECT repository (release: $LLM_D_RELEASE)"
+            return 1
+        fi
+        log_success "Successfully cloned $LLM_D_PROJECT repository (release: $LLM_D_RELEASE)"
     fi
 
     # Check for HF_TOKEN (use dummy for emulated deployments)
@@ -1036,6 +1075,7 @@ deploy_llm_d_infrastructure() {
 
     # Deploy InferenceObjective for GIE queuing when flow control is enabled (scale-from-zero / e2e).
     # Enables gateway-level queuing so inference_extension_flow_control_queue_size is populated.
+    # Note: InferenceObjective only exists in inference.networking.x-k8s.io v1alpha2
     if [ "$ENABLE_SCALE_TO_ZERO" == "true" ] || [ "$E2E_TESTS_ENABLED" == "true" ]; then
         if kubectl get crd inferenceobjectives.inference.networking.x-k8s.io &>/dev/null; then
             local infobj_file="${WVA_PROJECT}/deploy/inference-objective-e2e.yaml"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1068,6 +1068,14 @@ deploy_llm_d_infrastructure() {
                     }
                 }
             ]'
+            # Wait for EPP rollout to complete to ensure flowcontrol is enabled before tests run.
+            # Without this, tests may start while old EPP pod (without flowcontrol) is still serving
+            log_info "Waiting for EPP rollout to complete (flowcontrol enabled)..."
+            if kubectl rollout status deployment "$LLM_D_EPP_NAME" -n "$LLMD_NS" --timeout=120s; then
+                log_success "EPP rollout complete with flowcontrol enabled"
+            else
+                log_warning "EPP rollout did not complete in time - scale-from-zero test may fail"
+            fi
         else
             log_warning "Skipping inference-scheduler patch: Deployment $LLM_D_EPP_NAME not found in $LLMD_NS"
         fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -866,7 +866,11 @@ deploy_llm_d_infrastructure() {
     # Update model ID if different from the guide's actual default
     if [ "$MODEL_ID" != "$ACTUAL_DEFAULT_MODEL" ] ; then
         log_info "Updating deployment to use model: $MODEL_ID (replacing guide default: $ACTUAL_DEFAULT_MODEL)"
-        yq eval "(.. | select(. == \"$ACTUAL_DEFAULT_MODEL\")) = \"$MODEL_ID\" | (.. | select(. == \"hf://$ACTUAL_DEFAULT_MODEL\")) = \"hf://$MODEL_ID\"" -i "$LLM_D_MODELSERVICE_VALUES"
+        # Sanitize model name for k8s label (if MODEL_ID is unsloth/Meta-Llama-3.1-8B, label uses unsloth-Meta-Llama-3.1-8B)
+        MODEL_ID_SANITIZED=$(echo "$MODEL_ID" | tr '/' '-')
+        yq eval ".modelArtifacts.name = \"$MODEL_ID\" | \
+                 .modelArtifacts.uri = \"hf://$MODEL_ID\" | \
+                 .modelArtifacts.labels.\"llm-d.ai/model\" = \"$MODEL_ID_SANITIZED\"" -i "$LLM_D_MODELSERVICE_VALUES"
 
         # Increase model-storage volume size
         log_info "Increasing model-storage volume size for model: $MODEL_ID"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1105,7 +1105,7 @@ deploy_llm_d_infrastructure() {
     fi
 
     log_info "Waiting for llm-d components to initialize..."
-    kubectl wait --for=condition=Available deployment --all -n $LLMD_NS --timeout=60s || \
+    kubectl wait --for=condition=Available deployment --all -n $LLMD_NS --timeout=120s || \
         log_warning "llm-d components are not ready yet - check 'kubectl get pods -n $LLMD_NS'"
 
     # Align WVA with the InferencePool API group in use (scale-from-zero requires WVA to watch the same group).

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1109,6 +1109,11 @@ deploy_llm_d_infrastructure() {
             if helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
                 -n $WVA_NS --reuse-values --set wva.poolGroup=$DETECTED_POOL_GROUP --wait --timeout=60s; then
                 log_success "WVA upgraded with wva.poolGroup=$DETECTED_POOL_GROUP"
+                # Restart WVA controller to register InferencePool watcher after CRD v1 are installed.
+                log_info "Restarting WVA controller to register InferencePool watcher (CRDs now available)"
+                kubectl rollout restart deployment -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler
+                kubectl rollout status deployment -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler --timeout=60s
+                log_success "WVA controller restarted successfully"
             else
                 log_warning "WVA upgrade with poolGroup failed - scale-from-zero may not see the InferencePool"
             fi

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -39,6 +39,9 @@ WVA_LOG_LEVEL="debug" # WVA log level set to debug for emulated environments
 # Initial WVA pool group; install.sh auto-detects the actual InferencePool API group after llm-d deploy and upgrades WVA (scale-from-zero).
 POOL_GROUP=${POOL_GROUP:-"inference.networking.k8s.io"}
 
+# Container tool (docker or podman can pass from Makefile)
+CONTAINER_TOOL=${CONTAINER_TOOL:-docker}
+
 # llm-d Configuration
 LLM_D_INFERENCE_SIM_IMG_REPO=${LLM_D_INFERENCE_SIM_IMG_REPO:-"ghcr.io/llm-d/llm-d-inference-sim"}
 LLM_D_INFERENCE_SIM_IMG_TAG=${LLM_D_INFERENCE_SIM_IMG_TAG:-"latest"}
@@ -172,14 +175,14 @@ load_image() {
         log_info "Using local image only (WVA_IMAGE_PULL_POLICY=IfNotPresent)"
         
         # Check if the image exists locally
-        if ! docker image inspect "$WVA_IMAGE_REPO:$WVA_IMAGE_TAG" >/dev/null 2>&1; then
-            log_error "Image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG' not found locally - Please build the image first (e.g., 'make docker-build IMG=$WVA_IMAGE_REPO:$WVA_IMAGE_TAG')"
+        if ! $CONTAINER_TOOL image inspect "$WVA_IMAGE_REPO:$WVA_IMAGE_TAG" >/dev/null 2>&1; then
+            log_error "Image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG' not found locally - Please build the image first (e.g., 'make $CONTAINER_TOOL-build IMG=$WVA_IMAGE_REPO:$WVA_IMAGE_TAG')"
         else
             log_success "Found local image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG'"
         fi
     else
         # Pull a single-platform image so kind load does not hit "content digest not found"
-        # (multi-platform manifests can reference blobs that are not in the docker save stream).
+        # (multi-platform manifests can reference blobs that are not in the $CONTAINER_TOOL save stream).
         local platform="${KIND_IMAGE_PLATFORM:-}"
         if [ -z "$platform" ]; then
             case "$(uname -m)" in
@@ -201,9 +204,18 @@ load_image() {
     fi
     
     # Load the image into the KIND cluster
-    kind load docker-image "$WVA_IMAGE_REPO:$WVA_IMAGE_TAG" --name "$CLUSTER_NAME"
-    
-    log_success "Image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG' loaded into KIND cluster '$CLUSTER_NAME'"
+    if [ "$CONTAINER_TOOL" = "podman" ]; then
+        # Podman requires a different approach - save to tar and load archive
+        log_info "Using Podman - saving image to tar archive for Kind loading..."
+        local tmp_tar="/tmp/wva-image-$(date +%s).tar"
+        $CONTAINER_TOOL save -o "$tmp_tar" "$WVA_IMAGE_REPO:$WVA_IMAGE_TAG"
+        kind load image-archive "$tmp_tar" --name "$CLUSTER_NAME"
+        rm -f "$tmp_tar"
+        log_success "Image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG' loaded into KIND cluster '$CLUSTER_NAME' (via archive)"
+    else
+        kind load docker-image "$WVA_IMAGE_REPO:$WVA_IMAGE_TAG" --name "$CLUSTER_NAME"
+        log_success "Image '$WVA_IMAGE_REPO:$WVA_IMAGE_TAG' loaded into KIND cluster '$CLUSTER_NAME'"
+    fi
 }
 
 #### REQUIRED FUNCTION used by deploy/install.sh ####

--- a/deploy/kubernetes/create-kind-cluster-with-nvidia.sh
+++ b/deploy/kubernetes/create-kind-cluster-with-nvidia.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-
 set -e
 set -o pipefail
+
+# Container tool (docker or podman)
+CONTAINER_TOOL=${CONTAINER_TOOL:-docker}
 
 GPU_OPERATOR_NS=gpu-operator
 
@@ -22,10 +24,10 @@ echo "> Deploying cert manager"
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml
 
 echo "> Creating symlink in the control-plane container"
-docker exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real
+$CONTAINER_TOOL exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real
 
 echo "> Unmounting the nvidia devices in the control-plane container"
-docker exec -ti kind-control-plane umount -R /proc/driver/nvidia
+$CONTAINER_TOOL exec -ti kind-control-plane umount -R /proc/driver/nvidia
 
 # According to https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html
 echo "> Adding/updateding the NVIDIA Helm repository"

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -8,7 +8,7 @@ WVA has a multi-layered testing strategy:
 
 1. **Unit Tests** - Fast, isolated tests for individual packages and functions
 2. **Integration Tests** - Tests for component interactions within the controller
-3. **E2E Tests** - Environment-agnostic end-to-end tests (Kind emulated or OpenShift), with smoke and full tiers
+3. **E2E Tests** - End-to-end tests on Kind clusters with emulated GPUs, with smoke and full tiers
 
 ## Unit Tests
 
@@ -134,10 +134,12 @@ var _ = AfterSuite(func() {
 
 ## End-to-End Tests
 
-WVA provides a **single consolidated E2E suite** that runs on multiple environments (Kind with emulated GPUs, or OpenShift/kubernetes with real infrastructure). Tests are environment-agnostic and parameterized via environment variables; they create VA, HPA, and model services dynamically as part of the test workflow.
+WVA provides a **single consolidated E2E suite** that runs on Kind clusters with emulated GPUs. Tests create VA, HPA, and model services dynamically as part of the test workflow.
+
+> **Note**: E2E tests are only supported on Kind clusters (`ENVIRONMENT=kind-emulator`). The test fixtures and labels are configured specifically for the Kind emulator deployment which uses the `simulated-accelerators` guide from llm-d. Running E2E tests on other environments (OpenShift, generic Kubernetes) is not supported for now.
 
 - **Location**: `test/e2e/`
-- **Environments**: Kind (emulated), OpenShift, or generic Kubernetes
+- **Supported Environment**: Kind (emulated GPUs only)
 - **Tiers**: Smoke (~5–10 min) for PRs; full suite (~15–25 min) for comprehensive validation
 
 ### Infra-Only Setup (Required Before Running Tests)

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -253,10 +253,15 @@ func (e *Engine) processInactiveVariant(ctx context.Context, va wvav1alpha1.Vari
 	// Check for pending requests using EPP flowcontrol queue size metrics
 	result := results["all_metrics"]
 	pendingRequestExist := false
+	var queueMetricFound bool
+	var queueMetricModels []string
 	for _, value := range result.Values {
 		metricName := value.Labels["__name__"]
 		if metricName == targetEPPMetricName && value.Value > 0 {
-			if value.Labels[targetEPPMetricLabel] == va.Spec.ModelID {
+			queueMetricFound = true
+			modelLabel := value.Labels[targetEPPMetricLabel]
+			queueMetricModels = append(queueMetricModels, modelLabel)
+			if modelLabel == va.Spec.ModelID {
 				logger.Info(
 					"Target workload has pending requests, scaling up from zero", "metricName", metricName,
 					"metric", value.Labels, "value", value.Value)
@@ -267,6 +272,13 @@ func (e *Engine) processInactiveVariant(ctx context.Context, va wvav1alpha1.Vari
 	}
 
 	if !pendingRequestExist {
+		// Log INFO only when queue exists but model doesn't match
+		if queueMetricFound {
+			logger.Info("Scale-from-zero: queue has pending requests but model not matched",
+				"va", va.Name,
+				"vaModelID", va.Spec.ModelID,
+				"queueModels", queueMetricModels)
+		}
 		// Scale-from-zero loop runs every 100ms; log at DEBUG to avoid flooding (10/sec per inactive VA).
 		logger.V(logging.DEBUG).Info("Scale-from-zero: skipping VA, no pending requests in flow control queue",
 			"va", va.Name,

--- a/internal/utils/pool/pool.go
+++ b/internal/utils/pool/pool.go
@@ -154,9 +154,9 @@ func GetPoolGKNN(poolGroup string) (common.GKNN, error) {
 		poolNamespace = "default"
 	)
 
-	// Default to v1alpha2 group if empty
+	// Default to v1 (since llm-d already by default use v1 than v1alpha2) if empty
 	if poolGroup == "" {
-		poolGroup = PoolGroupV1Alpha2
+		poolGroup = PoolGroupV1
 	}
 
 	// Validate poolGroup against valid values

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -61,14 +61,14 @@ func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
+				"llm-d.ai/inference-serving": "true",
 				"test-resource":             "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
+				"llm-d.ai/inference-serving": "true",
 			},
 			Ports: []corev1.ServicePort{
 				{Name: "http", Port: int32(port), Protocol: corev1.ProtocolTCP},

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -60,14 +60,14 @@ func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 			Name:      serviceName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":                       appLabel,
+				"app":                        appLabel,
 				"llm-d.ai/inference-serving": "true",
-				"test-resource":             "true",
+				"test-resource":              "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app":                       appLabel,
+				"app":                        appLabel,
 				"llm-d.ai/inference-serving": "true",
 			},
 			Ports: []corev1.ServicePort{

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -87,11 +87,11 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
-		"app":                       appLabel,
-		"llm-d.ai/inferenceServing": "true",
-		"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
-		"llm-d.ai/model-pool":       poolName,
-		"test-resource":             "true",
+		"app":                         appLabel,
+		"llm-d.ai/inference-serving": "true",
+		"llm-d.ai/model":              "ms-sim-llm-d-modelservice",
+		"llm-d.ai/model-pool":         poolName,
+		"test-resource":               "true",
 	}
 
 	envVars := []corev1.EnvVar{
@@ -136,7 +136,7 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                       appLabel,
-					"llm-d.ai/inferenceServing": "true",
+					"llm-d.ai/inference-serving": "true",
 					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
 					"llm-d.ai/model-pool":       poolName,
 				},

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -86,12 +86,20 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 		image = "ghcr.io/llm-d/llm-d-cuda-dev:latest"
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
+	// Labels must include all labels from the infrastructure InferencePool's selector.
+	// For kind-emulator (gaie-sim), the selector uses:
+	// - llm-d.ai/inference-serving: "true"
+	// - llm-d.ai/guide: "simulated-accelerators"
+	// - llm-d.ai/accelerator-variant: "cpu"
+	// - llm-d.ai/model: "random"
 	labels := map[string]string{
-		"app":                         appLabel,
-		"llm-d.ai/inference-serving": "true",
-		"llm-d.ai/model":              "ms-sim-llm-d-modelservice",
-		"llm-d.ai/model-pool":         poolName,
-		"test-resource":               "true",
+		"app":                          appLabel,
+		"llm-d.ai/inference-serving":   "true",
+		"llm-d.ai/guide":               poolName,
+		"llm-d.ai/accelerator-variant": "cpu",
+		"llm-d.ai/model":               "random",
+		"llm-d.ai/model-pool":          poolName,
+		"test-resource":                "true",
 	}
 
 	envVars := []corev1.EnvVar{
@@ -135,10 +143,11 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":                       appLabel,
-					"llm-d.ai/inference-serving": "true",
-					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
-					"llm-d.ai/model-pool":       poolName,
+					"app":                          appLabel,
+					"llm-d.ai/inference-serving":   "true",
+					"llm-d.ai/guide":               poolName,
+					"llm-d.ai/accelerator-variant": "cpu",
+					"llm-d.ai/model":               "random", // to match simulator model
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -28,7 +28,9 @@ import (
 // Uses KEDA ScaledObject when standard HPA rejects minReplicas=0 (e.g. OpenShift).
 var _ = Describe("Scale-From-Zero Feature", Label("smoke", "full"), Ordered, func() {
 	var (
-		poolName         = "scale-from-zero-pool"
+		// poolName must match the infrastructure InferencePool's selector label (llm-d.ai/guide).
+		// E2E tests only run on kind-emulator which uses "simulated-accelerators" (WELL_LIT_PATH_NAME).
+		poolName         = "simulated-accelerators"
 		modelServiceName = "scale-from-zero-ms"
 		vaName           = "scale-from-zero-va"
 		hpaName          = "scale-from-zero-hpa"

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Scale-From-Zero Feature", Label("smoke", "full"), Ordered, fun
 			g.Expect(err).NotTo(HaveOccurred(), "EPP service should exist")
 		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "EPP service should exist")
 
-		// Wait for EPP pods to be ready
+		// Wait for EPP pods to be ready with flowcontrol enabled
 		Eventually(func(g Gomega) {
 			podList, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("inferencepool=%s", eppServiceName),
@@ -67,21 +67,38 @@ var _ = Describe("Scale-From-Zero Feature", Label("smoke", "full"), Ordered, fun
 			g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
 			g.Expect(len(podList.Items)).To(BeNumerically(">", 0), "EPP pods should exist")
 
-			// Check that at least one pod is ready
-			hasReadyPod := false
+			// Check that at least one pod is ready with flowcontrol enabled
+			hasReadyPodWithFlowControl := false
 			for _, pod := range podList.Items {
+				isReady := false
 				for _, condition := range pod.Status.Conditions {
 					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-						hasReadyPod = true
+						isReady = true
 						break
 					}
 				}
-				if hasReadyPod {
+				if !isReady {
+					continue
+				}
+				// double ehck flowcontrol is enabled as env var
+				for _, container := range pod.Spec.Containers {
+					for _, env := range container.Env {
+						if env.Name == "ENABLE_EXPERIMENTAL_FLOW_CONTROL_LAYER" && env.Value == "true" {
+							hasReadyPodWithFlowControl = true
+							break
+						}
+					}
+					if hasReadyPodWithFlowControl {
+						break
+					}
+				}
+				if hasReadyPodWithFlowControl {
 					break
 				}
 			}
-			g.Expect(hasReadyPod).To(BeTrue(), "At least one EPP pod should be ready")
-		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "EPP pods should be ready")
+			g.Expect(hasReadyPodWithFlowControl).To(BeTrue(),
+				"At least one ready EPP pod should have ENABLE_EXPERIMENTAL_FLOW_CONTROL_LAYER=true")
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(), "EPP pods should be ready with flowcontrol enabled")
 
 		// Additional delay to ensure the datastore is fully populated after EPP is ready
 		time.Sleep(5 * time.Second)

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -326,8 +326,9 @@ var _ = Describe("Scale-From-Zero Feature", Label("smoke", "full"), Ordered, fun
 			GinkgoWriter.Println("Job pod is running and sending requests")
 
 			// Give requests time to queue up in EPP before checking for scale-up
+			// Increased from 10s to 20s for CI environments where gateway may need more time
 			By("Waiting for requests to queue up in EPP flow control queue")
-			time.Sleep(10 * time.Second)
+			time.Sleep(20 * time.Second)
 
 			By("Monitoring VariantAutoscaling for scale-from-zero decision")
 			Eventually(func(g Gomega) {

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -345,11 +345,60 @@ var _ = Describe("Scale-From-Zero Feature", Label("smoke", "full"), Ordered, fun
 				optCond := variantautoscalingv1alpha1.GetCondition(va, variantautoscalingv1alpha1.TypeOptimizationReady)
 
 				GinkgoWriter.Printf("VA DesiredOptimizedAlloc.NumReplicas: %d (waiting for > 0)\n", optimized)
+				GinkgoWriter.Printf("  VA.Spec.ModelID: %s\n", va.Spec.ModelID)
+				GinkgoWriter.Printf("  VA.Spec.ScaleTargetRef: %s\n", va.Spec.ScaleTargetRef.Name)
+				GinkgoWriter.Printf("  VA.Labels: %v\n", va.Labels)
 				if metricsCond != nil {
 					GinkgoWriter.Printf("  MetricsAvailable: %s/%s (%s)\n", metricsCond.Status, metricsCond.Reason, metricsCond.Message)
+				} else {
+					GinkgoWriter.Printf("  MetricsAvailable: <nil>\n")
 				}
 				if optCond != nil {
 					GinkgoWriter.Printf("  OptimizationReady: %s/%s (%s)\n", optCond.Status, optCond.Reason, optCond.Message)
+				} else {
+					GinkgoWriter.Printf("  OptimizationReady: <nil>\n")
+				}
+
+				// Check deployment status
+				deploy, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, modelServiceName+"-decode", metav1.GetOptions{})
+				if err == nil {
+					GinkgoWriter.Printf("  Deployment: desired=%d, current=%d, ready=%d\n",
+						*deploy.Spec.Replicas, deploy.Status.Replicas, deploy.Status.ReadyReplicas)
+				} else {
+					GinkgoWriter.Printf("  Deployment: error getting deployment: %v\n", err)
+				}
+
+				// Check controller pods
+				controllerPods, err := k8sClient.CoreV1().Pods(cfg.WVANamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/name=workload-variant-autoscaler",
+				})
+				if err == nil {
+					readyCount := 0
+					for _, pod := range controllerPods.Items {
+						if isPodReady(&pod) {
+							readyCount++
+						}
+					}
+					GinkgoWriter.Printf("  Controller pods: %d total, %d ready\n", len(controllerPods.Items), readyCount)
+				}
+
+				// Check EPP pods with flow control
+				eppPods, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/component=inference-scheduler",
+				})
+				if err == nil {
+					flowControlCount := 0
+					for _, pod := range eppPods.Items {
+						for _, container := range pod.Spec.Containers {
+							for _, env := range container.Env {
+								if env.Name == "ENABLE_EXPERIMENTAL_FLOW_CONTROL_LAYER" && env.Value == "true" {
+									flowControlCount++
+									break
+								}
+							}
+						}
+					}
+					GinkgoWriter.Printf("  EPP pods: %d total, %d with flowControl enabled\n", len(eppPods.Items), flowControlCount)
 				}
 
 				// Scale-from-zero engine should detect pending requests and recommend scaling up
@@ -495,4 +544,14 @@ fi
 			},
 		},
 	}
+}
+
+// isPodReady checks if a pod is in Ready condition
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }

--- a/test/utils/debug_helpers.go
+++ b/test/utils/debug_helpers.go
@@ -35,7 +35,7 @@ func DumpControllerLogs(ctx context.Context, k8sClient *kubernetes.Clientset, co
 	for _, pod := range pods.Items {
 		_, _ = fmt.Fprintf(w, "\n--- Logs from pod %s ---\n", pod.Name)
 		logs, err := k8sClient.CoreV1().Pods(controllerNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-			TailLines: ptr.To(int64(200)),
+			TailLines: ptr.To(int64(2000)),
 		}).DoRaw(ctx)
 		if err != nil {
 			_, _ = fmt.Fprintf(w, "Failed to get logs: %v\n", err)

--- a/test/utils/resources/llmdsim.go
+++ b/test/utils/resources/llmdsim.go
@@ -23,17 +23,17 @@ func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port st
 			Replicas: ptr.To(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":                       appLabel,
+					"app":                        appLabel,
 					"llm-d.ai/inference-serving": "true",
-					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
+					"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                       appLabel,
+						"app":                        appLabel,
 						"llm-d.ai/inference-serving": "true",
-						"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
+						"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -161,17 +161,17 @@ func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, 
 			Replicas: ptr.To(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":                       appLabel,
+					"app":                        appLabel,
 					"llm-d.ai/inference-serving": "true",
-					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
+					"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                       appLabel,
+						"app":                        appLabel,
 						"llm-d.ai/inference-serving": "true",
-						"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
+						"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -251,13 +251,13 @@ func CreateLlmdSimService(namespace, serviceName, appLabel string, nodePort, por
 			Name:      serviceName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":                       appLabel,
+				"app":                        appLabel,
 				"llm-d.ai/inference-serving": "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app":                       appLabel,
+				"app":                        appLabel,
 				"llm-d.ai/inference-serving": "true",
 			},
 			Ports: []corev1.ServicePort{

--- a/test/utils/resources/llmdsim.go
+++ b/test/utils/resources/llmdsim.go
@@ -24,7 +24,7 @@ func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port st
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                       appLabel,
-					"llm-d.ai/inferenceServing": "true",
+					"llm-d.ai/inference-serving": "true",
 					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
 				},
 			},
@@ -32,7 +32,7 @@ func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port st
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app":                       appLabel,
-						"llm-d.ai/inferenceServing": "true",
+						"llm-d.ai/inference-serving": "true",
 						"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
 					},
 				},
@@ -162,7 +162,7 @@ func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                       appLabel,
-					"llm-d.ai/inferenceServing": "true",
+					"llm-d.ai/inference-serving": "true",
 					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
 				},
 			},
@@ -170,7 +170,7 @@ func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, 
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app":                       appLabel,
-						"llm-d.ai/inferenceServing": "true",
+						"llm-d.ai/inference-serving": "true",
 						"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
 					},
 				},
@@ -252,13 +252,13 @@ func CreateLlmdSimService(namespace, serviceName, appLabel string, nodePort, por
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
+				"llm-d.ai/inference-serving": "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
+				"llm-d.ai/inference-serving": "true",
 			},
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION
# Changes
- use env variable LLM_D_RELEASE to control all image in the deploy/install.sh
- clone llm-d to local based on local version if match required release version
- use env variable CONTAINER_TOOL to support podmano on fedora
- remove/update *ignore files
- update default infpool API versoin to v1
- fix e2e test on scale-from-zero: github action or make target only runs on "kind", model name is wrong need to be randon, guide name is wrong need to match what is set in the gaie-sim, add restart deployment after FC is enabled, add restart after API(infpool CRD is applied in the cluster)

# Notes
without the change ,it runs with 
```
NAME        NAMESPACE   CHART                                                                        VERSION   DURATION
infra-sim   llm-d-sim   llm-d-infra/llm-d-infra                                                      v1.3.3          0s
gaie-sim    llm-d-sim   oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool   v1.0.1          1s
ms-sim      llm-d-sim   llm-d-modelservice/llm-d-modelservice                                        v0.2.11         1s
```


# Test

```
go test -v -timeout 20m -ginkgo.focus="Scale-From-Zero Feature" -ginkgo.v .
=== RUN   TestE2E
Running Suite: E2E Test Suite - /home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e
============================================================================================
Random Seed: 1773071948

Will run 6 of 48 specs
------------------------------
[BeforeSuite] 
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/suite_test.go:49
  STEP: Loading configuration from environment @ 03/09/26 16:59:08.259
  === E2E Test Configuration ===
  Environment: kind-emulator
  WVA Namespace: workload-variant-autoscaler-system
  LLMD Namespace: llm-d-sim
  Use Simulator: true
  Scale-to-Zero Enabled: false
  Scaler Backend: prometheus-adapter
  Model ID: unsloth/Meta-Llama-3.1-8B
  Load Strategy: synthetic
  ==============================

  STEP: Initializing Kubernetes client @ 03/09/26 16:59:08.259
  STEP: Verifying WVA controller is running @ 03/09/26 16:59:08.263
  STEP: Verifying llm-d infrastructure @ 03/09/26 16:59:08.271
  STEP: Verifying Prometheus is available @ 03/09/26 16:59:08.272
  STEP: Restarting prometheus-adapter pods @ 03/09/26 16:59:08.274
  Deleted prometheus-adapter pod: prometheus-adapter-6748c5c5c6-b8q64
  Deleted prometheus-adapter pod: prometheus-adapter-6748c5c5c6-d8js6
  STEP: Waiting for prometheus-adapter pods to be ready @ 03/09/26 16:59:08.284
  prometheus-adapter pods restarted and ready
  BeforeSuite completed successfully - infrastructure ready
[BeforeSuite] PASSED [0.031 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Scale-From-Zero Feature Initial state verification should have VariantAutoscaling resource created [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:219
  STEP: Waiting for InferencePool to be reconciled (allows time for controller to register it in datastore) @ 03/09/26 16:59:08.29
  Looking for EPP service: gaie-sim-epp in namespace: llm-d-sim
  STEP: Creating model service deployment with 0 initial replicas @ 03/09/26 16:59:13.301
  STEP: Scaling deployment to 0 replicas @ 03/09/26 16:59:13.309
  STEP: Creating service to expose model server @ 03/09/26 16:59:13.319
  STEP: Creating ServiceMonitor for metrics scraping @ 03/09/26 16:59:13.326
  STEP: Verifying deployment is at 0 replicas @ 03/09/26 16:59:13.335
  STEP: Creating VariantAutoscaling resource @ 03/09/26 16:59:18.341
  STEP: Creating scaler with minReplicas=0 (HPA or ScaledObject per backend) @ 03/09/26 16:59:18.35
  STEP: Waiting for VA to be ready and InferencePool to be available in datastore @ 03/09/26 16:59:18.354
  Scale-from-zero test setup complete with deployment at 0 replicas
  STEP: Verifying VariantAutoscaling exists @ 03/09/26 17:00:18.383
  VariantAutoscaling resource verified: scale-from-zero-va
• [70.095 seconds]
------------------------------
Scale-From-Zero Feature Initial state verification should verify deployment starts at zero replicas [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:232
  STEP: Checking deployment has 0 replicas @ 03/09/26 17:00:18.385
  Deployment verified at 0 replicas
• [0.001 seconds]
------------------------------
Scale-From-Zero Feature Initial state verification should have scaler configured with minReplicas=0 [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:246
  STEP: Verifying HPA allows scale-to-zero @ 03/09/26 17:00:18.386
• [0.001 seconds]
------------------------------
Scale-From-Zero Feature Scale-from-zero with pending requests should detect pending requests and trigger scale-from-zero [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:284
  STEP: Discovering inference gateway service @ 03/09/26 17:00:18.387
  Found inference gateway service: infra-sim-inference-gateway-istio
  STEP: Creating a job to send requests while deployment is at zero @ 03/09/26 17:00:18.389
  Created scale-from-zero trigger job: scale-from-zero-trigger-1773072018
  STEP: Waiting for job pod to be running and sending requests @ 03/09/26 17:00:18.397
  Job pod is running and sending requests
  STEP: Waiting for requests to queue up in EPP flow control queue @ 03/09/26 17:00:23.405
  STEP: Monitoring VariantAutoscaling for scale-from-zero decision @ 03/09/26 17:00:33.414
  VA DesiredOptimizedAlloc.NumReplicas: 1 (waiting for > 0)
    MetricsAvailable: True/ScaleFromZero (Scaled from zero due to pending requests)
  Scale-from-zero engine detected pending requests and recommended scale-up
• [15.028 seconds]
------------------------------
Scale-From-Zero Feature Scale-from-zero with pending requests should scale deployment up from zero [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:363
  STEP: Monitoring deployment for actual scale-up from zero @ 03/09/26 17:00:33.415
  Current replicas: 1, ready: 1 (waiting for > 0)
  Deployment successfully scaled up from zero
• [0.001 seconds]
------------------------------
Scale-From-Zero Feature Scale-from-zero with pending requests should successfully process requests after scaling up [smoke, full]
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/scale_from_zero_test.go:388
  STEP: Verifying the trigger job completes successfully @ 03/09/26 17:00:33.417
  Requests processed successfully after scale-from-zero
  STEP: Cleaning up trigger job @ 03/09/26 17:01:33.448
  STEP: Cleaning up scale-from-zero test resources @ 03/09/26 17:01:33.452
  Successfully deleted ServiceMonitor scale-from-zero-ms-monitor
• [60.059 seconds]
------------------------------
SSSSSSS
------------------------------
[AfterSuite] 
/home/wenzhou/tmp/llm-d-workload-variant-autoscaler/test/e2e/suite_test.go:215
  STEP: Cleaning up any leftover test resources @ 03/09/26 17:01:33.476
  Cleaning up test resources...
  Keeping Kind cluster for debugging (set DELETE_CLUSTER=true to delete)
[AfterSuite] PASSED [0.017 seconds]
------------------------------

Ran 6 of 48 Specs in 145.235 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 42 Skipped
--- PASS: TestE2E (145.24s)
PASS
ok      github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e     145.256s
```