### PR TITLE
cleanup:  remove unused BENCHMARK_MODE var in install scripts

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -641,8 +641,6 @@ jobs:
           # HF_TOKEN is inherited from GITHUB_ENV (set in 'Get HF token from cluster secret' step)
           ENVIRONMENT: openshift
           INSTALL_GATEWAY_CTRLPLANE: "false"
-          # Disable benchmark mode - istioBench environment not available in llm-d helmfile
-          BENCHMARK_MODE: "false"
           E2E_TESTS_ENABLED: "true"
           NAMESPACE_SCOPED: "false"
           # Pass PR-specific namespaces to install script
@@ -748,8 +746,6 @@ jobs:
           # HF_TOKEN is inherited from GITHUB_ENV
           ENVIRONMENT: openshift
           INSTALL_GATEWAY_CTRLPLANE: "false"
-          # Disable benchmark mode - istioBench environment not available in llm-d helmfile
-          BENCHMARK_MODE: "false"
           E2E_TESTS_ENABLED: "true"
           NAMESPACE_SCOPED: "false"
           # Override namespaces for Model B stack

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -148,7 +148,6 @@ export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window (default:
 # Gateway Configuration
 export GATEWAY_PROVIDER="istio"             # Gateway provider: istio, kgateway
 export INSTALL_GATEWAY_CTRLPLANE="true"     # Install gateway control plane
-export BENCHMARK_MODE="true"                # Use benchmark configuration (for Istio only)
 
 # SLO Targets
 export SLO_TPOT=10                         # Time per output token (ms) SLO
@@ -636,7 +635,6 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 |----------|-------------|---------|
 | `GATEWAY_PROVIDER` | Gateway implementation | `istio` |
 | `INSTALL_GATEWAY_CTRLPLANE` | Install gateway control plane | `false` (prompts user) |
-| `BENCHMARK_MODE` | Use benchmark Istio config | `true` |
 
 #### Deployment Flags
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -63,7 +63,6 @@ LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/ll
 
 # Gateway Configuration
 GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"} # Options: kgateway, istio
-BENCHMARK_MODE=${BENCHMARK_MODE:-"false"} # if true, updates to Istio config for benchmark (istioBench env required in helmfile)
 # Save original value to detect if explicitly set via environment variable
 INSTALL_GATEWAY_CTRLPLANE_ORIGINAL="${INSTALL_GATEWAY_CTRLPLANE:-}"
 INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-false}"

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -54,7 +54,6 @@ SLO_TPOT=24     # Target time-per-output-token SLO (in ms)
 SLO_TTFT=500  # Target time-to-first-token SLO (in ms)
 
 # Gateway Configuration
-BENCHMARK_MODE="false"  # if true, deploys gateway in benchmark mode - unavailable for simulated deployments
 INSTALL_GATEWAY_CTRLPLANE="true" # if true, installs gateway control plane providers - defaults to true for emulated clusters
 
 # Prometheus Configuration

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -109,7 +109,6 @@ export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (bat
 For a complete list of all configuration options, see the [Configuration Reference](../README.md#configuration-reference) in the main deployment guide.
 export ACCELERATOR_TYPE="A100"              # GPU type (auto-detected)
 export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway
-export BENCHMARK_MODE="true"                # Use Istio benchmark config
 ```
 
 **Deployment flags** - Control which components to deploy:

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -97,7 +97,6 @@ export HF_TOKEN="hf_xxxxx"                  # Required: HuggingFace token
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B" # Model to deploy
 export ACCELERATOR_TYPE="H100"              # GPU type (auto-detected)
 export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway
-export BENCHMARK_MODE="true"                # Use Istio benchmark config
 
 # Performance tuning (optional)
 export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)


### PR DESCRIPTION
- Ref: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/682
- Tested by deploying kind cluster
- INSTALL_CLIENT_TOOLS may be another candidate.