### PR TITLE
Fix/contributing crd setup notes

### DIFF
--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -398,7 +398,6 @@ make create-kind-cluster
 ### InferencePool CRD not found during `make deploy-wva-emulated-on-kind`
 
 **Symptom:**
-
 ```
 Error: no matches for kind "InferencePool" in version "inference.networking.x-k8s.io/v1alpha2"
 ensure CRDs are installed first


### PR DESCRIPTION
In docs/developer-guide/development.md:
- Recommend 'CREATE_CLUSTER=true make deploy-wva-emulated-on-kind' as the preferred one-shot setup to avoid a CRD timing race
- Preserve the two-step alternative with a note pointing to Known Setup Issues
- Add 'Known Setup Issues' section with symptom, cause, and two remediation options for the InferencePool CRD-not-found error