### PR TITLE
build: sync Helm chart CRD from config/crd/bases on make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cp config/crd/bases/llmd.ai_variantautoscalings.yaml charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
## Why

The CRD lives in two places:
- `config/crd/bases/` — generated by controller-gen, used by kustomize
- `charts/workload-variant-autoscaler/crds/` — used by Helm

Previously, `make manifests` only updated `config/crd/bases/`. The Helm chart CRD had to be manually synced, which is easy to forget and leads to silent drift — the Helm-deployed cluster gets a stale schema while the kustomize path gets the correct one.

## What

Adds a `cp` step to the `manifests` target so both files are always updated together in a single `make manifests` run.

## Impact

No functional change to the CRD schema itself. Pure tooling fix.