### PR TITLE
e2e fix: limiter e2e "Saturation Mode - Multiple VariantAutoscalings" fix

### DIFF
--- a/test/e2e/saturation_test.go
+++ b/test/e2e/saturation_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Saturation Mode - Multiple VariantAutoscalings", Label("full")
 		err = fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceB, poolB, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceB, modelServiceB+"-decode", 8001)
+		err = fixtures.EnsureService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceB, modelServiceB+"-decode", 8000)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating ServiceMonitor for service B")
@@ -439,7 +439,7 @@ var _ = Describe("Saturation Mode - Multiple VariantAutoscalings", Label("full")
 		err := fixtures.CreateLoadJob(ctx, k8sClient, cfg.LLMDNamespace, "multi-load-a", targetA, loadCfg)
 		Expect(err).NotTo(HaveOccurred())
 
-		targetB := fmt.Sprintf("http://%s-service:8001", modelServiceB)
+		targetB := fmt.Sprintf("http://%s-service:8000", modelServiceB)
 		err = fixtures.CreateLoadJob(ctx, k8sClient, cfg.LLMDNamespace, "multi-load-b", targetB, loadCfg)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -468,8 +468,18 @@ var _ = Describe("Saturation Mode - Multiple VariantAutoscalings", Label("full")
 				})
 		})
 
-		By("Waiting for both VAs to detect saturation")
-		time.Sleep(2 * time.Minute)
+		By("Waiting for both load jobs to complete")
+		Eventually(func(g Gomega) {
+			jobA, err := k8sClient.BatchV1().Jobs(cfg.LLMDNamespace).Get(ctx, jobNameA, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(jobA.Status.Succeeded).To(BeNumerically(">", 0), "Job A should complete successfully")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			jobB, err := k8sClient.BatchV1().Jobs(cfg.LLMDNamespace).Get(ctx, jobNameB, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(jobB.Status.Succeeded).To(BeNumerically(">", 0), "Job B should complete successfully")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 		By("Verifying VA A (cheaper) scaled up more than VA B")
 		vaAObj := &variantautoscalingv1alpha1.VariantAutoscaling{}


### PR DESCRIPTION
The issue and fix are the same as describe here:
https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/862#issue-4047835586

The job pods take around 3 minutes so waiting for 5 minutes should be ok.