### PR TITLE
e2e fix: Fix smoke_test by removing variants before test

### DIFF
--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -18,6 +18,7 @@ import (
 	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
 )
 
 var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"), func() {
@@ -119,6 +120,16 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 		BeforeAll(func() {
 			// Note: InferencePool should already exist from infra-only deployment
 			// We no longer create InferencePools in individual tests
+
+			By("Deleting all existing VariantAutoscaling objects for clean test state")
+			deletedCount, vaCleanupErr := utils.DeleteAllVariantAutoscalings(ctx, crClient, cfg.LLMDNamespace)
+			if vaCleanupErr != nil {
+				GinkgoWriter.Printf("Warning: Failed to clean up existing VAs: %v\n", vaCleanupErr)
+			} else if deletedCount > 0 {
+				GinkgoWriter.Printf("Deleted %d existing VariantAutoscaling objects\n", deletedCount)
+			} else {
+				GinkgoWriter.Println("No existing VariantAutoscaling objects found")
+			}
 
 			By("Creating model service deployment")
 			err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs)

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -45,6 +45,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1246,4 +1247,48 @@ func SetupTestEnvironment(image string, numNodes, gpusPerNode int, gpuTypes stri
 	gom.Expect(os.Setenv("DEPLOY_VA", "false")).To(gom.Succeed())                  // tests create their own VariantAutoscaling resources
 	gom.Expect(os.Setenv("DEPLOY_HPA", "false")).To(gom.Succeed())                 // tests create their own HPAs if needed
 	gom.Expect(os.Setenv("VLLM_SVC_ENABLED", "false")).To(gom.Succeed())           // tests deploy their own Service
+}
+
+// DeleteAllVariantAutoscalings deletes all VariantAutoscaling objects in a namespace
+// and waits for them to be fully removed. This is useful for ensuring a clean test state.
+// Returns the number of VAs that were deleted.
+func DeleteAllVariantAutoscalings(ctx context.Context, crClient client.Client, namespace string) (int, error) {
+	vaList := &v1alpha1.VariantAutoscalingList{}
+	if err := crClient.List(ctx, vaList, client.InNamespace(namespace)); err != nil {
+		return 0, fmt.Errorf("failed to list VariantAutoscaling objects: %w", err)
+	}
+
+	if len(vaList.Items) == 0 {
+		return 0, nil
+	}
+
+	deletedCount := 0
+	for i := range vaList.Items {
+		va := &vaList.Items[i]
+		if err := crClient.Delete(ctx, va); err != nil {
+			if errors.IsNotFound(err) {
+				continue // Already deleted
+			}
+			return deletedCount, fmt.Errorf("failed to delete VA %s: %w", va.Name, err)
+		}
+		deletedCount++
+	}
+
+	// Wait for all VAs to be fully deleted (with timeout)
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(waitCtx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		remainingVAs := &v1alpha1.VariantAutoscalingList{}
+		if err := crClient.List(ctx, remainingVAs, client.InNamespace(namespace)); err != nil {
+			return false, err
+		}
+		return len(remainingVAs.Items) == 0, nil
+	})
+
+	if err != nil {
+		return deletedCount, fmt.Errorf("timeout waiting for VAs to be deleted: %w", err)
+	}
+
+	return deletedCount, nil
 }


### PR DESCRIPTION
The issue:
- This test keeps on failing at " Basic VA lifecycle should scale up under load" as it tries to scale from 1 to 2. The issue is that by default, the kind cluster is installed with a variant pointing to the same model id. Two variants pointing to the same model id and prevent scaling - will take a look at that next. However, for "Basic VA lifecycle", to keep it simple, we can just make sure we start with clean environment by deleting existing VAs in the llm-d-sim namespace.
- After the fix:
```
Smoke Tests - Infrastructure Readiness Basic VA lifecycle should scale up under load [smoke, full]
/home/shuynh/workload-variant-autoscaler-shuynh/workload-variant-autoscaler/test/e2e/smoke_test.go:479
  STEP: Waiting for VA to stabilize at minReplicas @ 03/10/26 12:12:04.803
  Waiting for VA to be ready: optimized=2, minReplicas=1
  STEP: Waiting for deployment to stabilize (no pods in transition) @ 03/10/26 12:12:04.805
  Waiting for deployment stability: spec=1, status=1, ready=1
  STEP: Waiting for VA to settle at minReplicas before recording initial state (best-effort) @ 03/10/26 12:12:04.806
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Waiting for VA to settle: optimized=2, minReplicas=1
  Initial optimized replicas (after stabilization): 1 (settled=true)
  STEP: Starting burst load generation to trigger scale-up @ 03/10/26 12:15:30.461
  STEP: Verifying load job was created @ 03/10/26 12:15:30.471
  Load job status: Active=0, Succeeded=0, Failed=0
  STEP: Waiting for load job pod to start @ 03/10/26 12:15:30.473
  Job exists but no pods yet. Job status: Active=0, Succeeded=0, Failed=0
  Load generation job is running
  STEP: Waiting for load generation to ramp up (30 seconds) @ 03/10/26 12:15:35.482
  STEP: Waiting for VA to detect saturation and recommend scale-up @ 03/10/26 12:16:06.506
  [⏳ Progress 1] 35s elapsed | 6m25s remaining
    VA: 1 replicas (initial: 1) | Metrics: True/MetricsFound | LastRun: 12:15:59
    HPA: Desired=2 | Current=2 | Deployment: Spec=2 | Ready=2
    Load: Phase=Running | Config: burst pattern, 3000 prompts | Active=1 | Succeeded=0 | Failed=0 (~11% of expected 5m10s)
  [⏳ Progress 2] 45s elapsed | 6m15s remaining
    VA: 1 replicas (initial: 1) | Metrics: True/MetricsFound | LastRun: 12:15:59
    HPA: Desired=2 | Current=2 | Deployment: Spec=2 | Ready=2
    Load: Phase=Running | Config: burst pattern, 3000 prompts | Active=1 | Succeeded=0 | Failed=0 (~14% of expected 5m10s)
  [⏳ Progress 3] 55s elapsed | 6m5s remaining
    VA: 1 replicas (initial: 1) | Metrics: True/MetricsFound | LastRun: 12:15:59
    HPA: Desired=1 | Current=2 | Deployment: Spec=1 | Ready=1
    Load: Phase=Running | Config: burst pattern, 3000 prompts | Active=1 | Succeeded=0 | Failed=0 (~17% of expected 5m10s)
    └─ Accelerator: H100 | Metrics: Saturation metrics data is available for scaling decisions | HPA: True/SucceededRescale
  [✓ Progress 4] 1m5s elapsed | 5m55s remaining
    VA: 2 replicas (initial: 1) | Metrics: True/MetricsFound | LastRun: 12:16:30
    HPA: Desired=1 | Current=2 | Deployment: Spec=1 | Ready=1
    Load: Phase=Running | Config: burst pattern, 3000 prompts | Active=1 | Succeeded=0 | Failed=0 (~20% of expected 5m10s)
    └─ Accelerator: H100 | Metrics: Saturation metrics data is available for scaling decisions | HPA: True/SucceededRescale
  ✓ VA detected saturation and recommended 2 replicas (took 1m5.083532136s)
    → VA scale-up detected! Now verifying HPA and deployment scaling...
  STEP: Verifying HPA reads the metric and updates desired replicas @ 03/10/26 12:16:37.701
    HPA check: Desired=1 | Current=2 (elapsed: 0s)
    HPA check: Desired=2 | Current=1 (elapsed: 5s)
  ✓ HPA updated desired replicas to > 1 (took 5.004875205s)
  STEP: Waiting for deployment to scale up and new pods to be ready @ 03/10/26 12:16:42.706
    Deployment check: Spec=2 | Replicas=2 | Ready=1 | VA recommended=2 (elapsed: 0s)
    Deployment check: Spec=2 | Replicas=2 | Ready=2 | VA recommended=2 (elapsed: 10s)
  ✓ Deployment successfully scaled up under load (took 10.015793538s)
    Final state: VA recommended 2 replicas, deployment has 2 ready pods
  STEP: Verifying at least one additional pod becomes ready @ 03/10/26 12:16:52.722
  Deployment successfully scaled up under load
  STEP: Cleaning up test resources @ 03/10/26 12:16:52.724
  Successfully deleted HPA smoke-test-hpa-hpa
  Successfully deleted VA smoke-test-va
  Successfully deleted Job smoke-scaleup-load-load
  Successfully deleted ServiceMonitor smoke-test-ms-monitor
  Successfully deleted Service smoke-test-ms-service
  Successfully deleted Deployment smoke-test-ms-decode
• [280.313 seconds]
```