### PR TITLE
refactor: replace autoscalingv1.CrossVersionObjectReference with autoscalingv2

### DIFF
--- a/api/v1alpha1/variantautoscaling_types.go
+++ b/api/v1alpha1/variantautoscaling_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,7 +21,7 @@ type VariantAutoscalingSpec struct {
 	// ScaleTargetRef references the scalable resource to manage.
 	// This follows the same pattern as HorizontalPodAutoscaler.
 	// +kubebuilder:validation:Required
-	ScaleTargetRef autoscalingv1.CrossVersionObjectReference `json:"scaleTargetRef"`
+	ScaleTargetRef autoscalingv2.CrossVersionObjectReference `json:"scaleTargetRef"`
 
 	// ModelID specifies the unique identifier of the model to be autoscaled.
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1alpha1/variantautoscaling_types_test.go
+++ b/api/v1alpha1/variantautoscaling_types_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -27,7 +27,7 @@ func makeValidVA() *VariantAutoscaling {
 			},
 		},
 		Spec: VariantAutoscalingSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				Kind: "Deployment",
 				Name: "va-sample-deployment",
 			},
@@ -140,7 +140,7 @@ func TestStatusOmitEmpty(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: VariantAutoscalingSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				Kind: "Deployment",
 				Name: "va-empty-status-deployment",
 			},

--- a/charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
+++ b/charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
@@ -83,7 +83,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-map-type: atomic
               variantCost:
                 default: "10.0"
                 description: VariantCost specifies the cost per replica for this variant

--- a/config/crd/bases/llmd.ai_variantautoscalings.yaml
+++ b/config/crd/bases/llmd.ai_variantautoscalings.yaml
@@ -83,7 +83,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-map-type: atomic
               variantCost:
                 default: "10.0"
                 description: VariantCost specifies the cost per replica for this variant

--- a/internal/actuator/actuator_test.go
+++ b/internal/actuator/actuator_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -118,7 +118,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: resourceName,
 					},
@@ -149,7 +149,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: "non-existent",
 					},
@@ -209,7 +209,7 @@ var _ = Describe("Actuator", func() {
 					},
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: contextResourceName,
 					},
@@ -327,7 +327,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: contextResourceName,
 					},
@@ -387,7 +387,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: "incomplete-va",
 					},
@@ -456,7 +456,7 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: contextResourceName,
 					},

--- a/internal/collector/source/pod_va_mapper_test.go
+++ b/internal/collector/source/pod_va_mapper_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,7 +92,7 @@ var _ = Describe("PodVAMapper", func() {
 				Namespace: namespace,
 			},
 			Spec: llmdv1alpha1.VariantAutoscalingSpec{
-				ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 					Kind:       "Deployment",
 					Name:       deploymentName,
 					APIVersion: "apps/v1",

--- a/internal/controller/indexers/indexers.go
+++ b/internal/controller/indexers/indexers.go
@@ -22,7 +22,7 @@ import (
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -38,7 +38,7 @@ const (
 
 // scaleTargetIndexKey returns the composite index key for a scale target reference.
 // Format: Namespace/APIVersion/Kind/Name (e.g., "default/apps/v1/Deployment/my-app")
-func scaleTargetIndexKey(namespace string, ref autoscalingv1.CrossVersionObjectReference) string {
+func scaleTargetIndexKey(namespace string, ref autoscalingv2.CrossVersionObjectReference) string {
 
 	if ref.APIVersion == "" {
 		switch ref.Kind {
@@ -77,7 +77,7 @@ func VAScaleTargetIndexFunc(o client.Object) []string {
 // FindVAForScaleTarget returns the VariantAutoscaling that targets the given scale resource.
 // Returns nil if no VariantAutoscaling targets this resource.
 // Note: A scale target should have at most one VariantAutoscaling targeting it, so the first match is returned.
-func FindVAForScaleTarget(ctx context.Context, c client.Client, ref autoscalingv1.CrossVersionObjectReference, namespace string) (*llmdVariantAutoscalingV1alpha1.VariantAutoscaling, error) {
+func FindVAForScaleTarget(ctx context.Context, c client.Client, ref autoscalingv2.CrossVersionObjectReference, namespace string) (*llmdVariantAutoscalingV1alpha1.VariantAutoscaling, error) {
 	var vaList llmdVariantAutoscalingV1alpha1.VariantAutoscalingList
 	if err := c.List(ctx, &vaList,
 		client.InNamespace(namespace),
@@ -103,7 +103,7 @@ func FindVAForScaleTarget(ctx context.Context, c client.Client, ref autoscalingv
 // Returns nil if no VariantAutoscaling targets a Deployment with the given name.
 // This is a wrapper around FindVAForScaleTarget for the Deployment scale target.
 func FindVAForDeployment(ctx context.Context, c client.Client, deploymentName, namespace string) (*llmdVariantAutoscalingV1alpha1.VariantAutoscaling, error) {
-	return FindVAForScaleTarget(ctx, c, autoscalingv1.CrossVersionObjectReference{
+	return FindVAForScaleTarget(ctx, c, autoscalingv2.CrossVersionObjectReference{
 		APIVersion: "apps/v1",
 		Kind:       "Deployment",
 		Name:       deploymentName,

--- a/internal/controller/indexers/indexers_test.go
+++ b/internal/controller/indexers/indexers_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -110,7 +110,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       deploymentName,
@@ -127,7 +127,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "other-deployment",
@@ -182,7 +182,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: otherNs.Name,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       deploymentName, // Same deployment name but different namespace
@@ -217,7 +217,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       sharedName,
@@ -237,7 +237,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 						Name:       sharedName,
@@ -261,7 +261,7 @@ var _ = Describe("Indexers", Ordered, func() {
 
 			// FindVAForScaleTarget with StatefulSet should return the StatefulSet-targeting VA
 			Eventually(func() string {
-				va, err := FindVAForScaleTarget(testCtx, mgrClient, autoscalingv1.CrossVersionObjectReference{
+				va, err := FindVAForScaleTarget(testCtx, mgrClient, autoscalingv2.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "StatefulSet",
 					Name:       sharedName,
@@ -282,7 +282,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       sharedName,
@@ -301,7 +301,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       sharedName,
@@ -315,7 +315,7 @@ var _ = Describe("Indexers", Ordered, func() {
 			}()
 
 			Eventually(func() error {
-				_, err := FindVAForScaleTarget(testCtx, mgrClient, autoscalingv1.CrossVersionObjectReference{
+				_, err := FindVAForScaleTarget(testCtx, mgrClient, autoscalingv2.CrossVersionObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       sharedName,
@@ -335,7 +335,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       deploymentName,
@@ -367,7 +367,7 @@ var _ = Describe("Indexers", Ordered, func() {
 					Namespace: namespace,
 				},
 				Spec: llmdv1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						// APIVersion is not set - should default to apps/v1
 						Kind: "Deployment",
 						Name: deploymentName,

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -85,7 +85,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					},
 					// TODO(user): Specify other spec details if needed.
 					Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-						ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 							Kind: "Deployment",
 							Name: resourceName,
 						},
@@ -192,7 +192,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					Namespace: "default",
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: "invalid-model-id",
 					},
@@ -310,7 +310,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					Namespace: "default",
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: resourceName,
 					},
@@ -402,7 +402,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 					Namespace: "default",
 				},
 				Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind: "Deployment",
 						Name: resourceName,
 					},

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -145,7 +145,7 @@ data:
 						},
 					},
 					Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-						ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 							Kind: "Deployment",
 							Name: name,
 						},
@@ -381,7 +381,7 @@ data:
 						},
 					},
 					Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
-						ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 							Kind: "Deployment",
 							Name: name,
 						},

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -155,7 +155,7 @@ type VariantDecision struct {
 	// Used by allocation algorithms to prioritize saturated variants.
 	SpareCapacity float64
 	// ScaleTargetRef references the Deployment/StatefulSet for scheduling constraints
-	ScaleTargetRef *autoscalingv1.CrossVersionObjectReference
+	ScaleTargetRef *autoscalingv2.CrossVersionObjectReference
 
 	// --- Pipeline tracking ---
 	// DecisionSteps records each pipeline stage's contribution to the final decision.

--- a/test/e2e/fixtures/va_builder.go
+++ b/test/e2e/fixtures/va_builder.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,7 +106,7 @@ func buildVariantAutoscaling(namespace, name, deploymentName, modelID, accelerat
 			Labels:    labels,
 		},
 		Spec: variantautoscalingv1alpha1.VariantAutoscalingSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       deploymentName,

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -41,7 +41,6 @@ import (
 	promAPI "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -876,7 +875,7 @@ func CreateVariantAutoscalingResource(namespace, resourceName, scaleTargetRefNam
 			},
 		},
 		Spec: v1alpha1.VariantAutoscalingSpec{
-			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       scaleTargetRefName,


### PR DESCRIPTION
### Summary

Closes #869 

- `VariantAutoscalingSpec.ScaleTargetRef` used `autoscalingv1.CrossVersionObjectReference`, the reason `k8s.io/api/autoscaling/v1` was imported across the codebase
- `autoscalingv2` defines an identical `CrossVersionObjectReference` type and will be imported for `HorizontalPodAutoscalerBehavior`, making the `autoscalingv1` dependency redundant
- Updated all production code, tests, and e2e fixtures (11 files) to use `autoscalingv2.CrossVersionObjectReference`

### Notes

- `internal/actuator/direct_actuator.go` retains its `autoscalingv1` import — it uses `autoscalingv1.Scale` for the scale subresource protocol, which has no equivalent in `autoscalingv2`
- The CRD schema loses `x-kubernetes-map-type: atomic` (a `v1`-specific marker on `CrossVersionObjectReference`); this has no practical impact — existing CRs require no migration and the wire format is unchanged.