### PR TITLE
🐛 Add unparseable to typos allowlist

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,8 @@ parms = "parms"
 # Short code fragments / false positives
 ot = "ot"
 vas = "vas"
+# Valid English variant (unparseable vs unparsable)
+unparseable = "unparseable"
 
 # Pre-existing typos in codebase (to be fixed separately)
 accelarator = "accelarator"


### PR DESCRIPTION
## Summary

- Add `unparseable` to `_typos.toml` allowlist — it's a valid English variant of `unparsable`, used intentionally in `configmap_helpers.go`
- Prevents false positive in nightly typo scan
- Updated #874 to remove this entry (4 real typos remain)