### PR TITLE
ci: run full e2e tests automatically on every PR

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -1,29 +1,8 @@
 name: CI - PR Checks
 
 # Cancel previous runs on the same PR when new commits are pushed
-# Only group by PR number for legitimate triggers (pull_request, workflow_dispatch, e2e trigger comments)
-# Regular comments get a unique group (run_id) so they don't cancel in-progress test runs
-#
-# Logic:
-# - Regular comments (not e2e trigger): unique group prevents cancellation of real tests
-# - Valid triggers: group 'ci-pr-checks-{pr_number}' (can cancel previous runs for same PR)
-# - Fallback chain for ID: pull_request.number -> issue.number -> run_id
-#
-# NOTE: Accepted commands (/trigger-e2e-full, /test-e2e-full, /test-full) must stay in sync
-#       with check-full-tests job validation
 concurrency:
-  group: >-
-    ${{
-      github.event_name == 'issue_comment' &&
-      !contains(github.event.comment.body, '/trigger-e2e-full') &&
-      !contains(github.event.comment.body, '/test-e2e-full') &&
-      !contains(github.event.comment.body, '/test-full')
-      && format('comment-isolated-{0}', github.run_id)
-      || format('ci-pr-checks-{0}',
-           github.event.pull_request.number
-           || github.event.issue.number
-           || github.run_id)
-    }}
+  group: ci-pr-checks-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 on:
@@ -31,17 +10,8 @@ on:
     branches:
       - main
       - dev
-  # Allow manual triggering of full e2e tests
+  # Allow manual triggering of the full CI pipeline
   workflow_dispatch:
-    inputs:
-      run_full_tests:
-        description: 'Run full e2e test suite on Kind (check to run full; unchecked runs no e2e)'
-        required: false
-        default: false
-        type: boolean
-  # Allow triggering via PR comments
-  issue_comment:
-    types: [created]
 
 jobs:
   # Check if PR contains code changes (not just docs/metadata)
@@ -49,47 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read  # For reading PR details when triggered via issue_comment
     outputs:
       has_code_changes: ${{ steps.set-output.outputs.has_code_changes }}
-      pr_head_sha: ${{ steps.pr-info.outputs.pr_head_sha }}
-      pr_head_repo: ${{ steps.pr-info.outputs.pr_head_repo }}
     steps:
-      - name: Get PR number for issue_comment events
-        id: pr-info
-        if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issue = context.payload.issue;
-            if (!issue.pull_request) {
-              core.setOutput('pr_number', '');
-              return;
-            }
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: issue.number
-            });
-            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            const headRepo = pr.head.repo ? pr.head.repo.full_name : baseRepo;
-            core.setOutput('pr_number', issue.number.toString());
-            core.setOutput('pr_head_sha', pr.head.sha);
-            core.setOutput('pr_head_repo', headRepo);
-
       - name: Checkout source
         uses: actions/checkout@v4
         with:
-          # For issue_comment on a fork PR: checkout from head repo so the commit exists
-          repository: ${{ steps.pr-info.outputs.pr_head_repo || github.repository }}
-          ref: ${{ github.event_name == 'issue_comment' && steps.pr-info.outputs.pr_head_sha || github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      
+
       - name: Check for code changes
         uses: dorny/paths-filter@v3
         id: filter
-        continue-on-error: true  # Don't fail if paths-filter can't determine changes (e.g., issue_comment without PR context)
+        continue-on-error: true
         with:
           filters: |
             code:
@@ -99,25 +42,18 @@ jobs:
               - '!LICENSE'
               - '!OWNERS'
               - '!PROJECT'
-      
+
       - name: Set output with default
         id: set-output
         run: |
-          # Use filter output if available, otherwise default to 'true' for issue_comment events
-          # This ensures /trigger-e2e-full works even if PR context is unclear
           FILTER_OUTPUT="${{ steps.filter.outputs.code }}"
-          if [ "${{ github.event_name }}" == "issue_comment" ] && [ -z "$FILTER_OUTPUT" ]; then
-            echo "has_code_changes=true" >> $GITHUB_OUTPUT
-          elif [ -n "$FILTER_OUTPUT" ]; then
+          if [ -n "$FILTER_OUTPUT" ]; then
             echo "has_code_changes=$FILTER_OUTPUT" >> $GITHUB_OUTPUT
           else
             echo "has_code_changes=true" >> $GITHUB_OUTPUT
           fi
 
-  # lint-and-test already runs on pull_request events; skip for issue_comment
-  # to avoid untrusted commenters triggering execution of PR code
   lint-and-test:
-    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -154,112 +90,12 @@ jobs:
         run: |
           make test
 
-  # Check if full e2e tests should run (via workflow_dispatch or comment trigger)
-  check-full-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write  # For posting comments and reactions on PRs
-    outputs:
-      run_full: ${{ steps.check.outputs.run_full }}
-    steps:
-      - name: Check if full tests requested
-        id: check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Helper to check if user has write access
-            async function hasWriteAccess(username) {
-              try {
-                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username: username
-                });
-                const privilegedRoles = ['admin', 'maintain', 'write'];
-                return privilegedRoles.includes(permission.permission);
-              } catch (e) {
-                console.log(`Could not get permissions for ${username}: ${e.message}`);
-                return false;
-              }
-            }
-
-            // Check workflow_dispatch input
-            const workflowInput = '${{ github.event.inputs.run_full_tests }}';
-            // Handle both boolean and string inputs
-            if (workflowInput === 'true' || workflowInput === true || workflowInput === 'True') {
-              core.setOutput('run_full', 'true');
-              return;
-            }
-            
-            // Check for /trigger-e2e-full comment trigger
-            if (context.eventName === 'issue_comment') {
-              const comment = context.payload.comment.body.trim();
-              const issue = context.payload.issue;
-
-              // Only process /trigger-e2e-full comments on PRs
-              if (!issue.pull_request) {
-                console.log('Comment is not on a PR, skipping');
-                core.setOutput('run_full', 'false');
-                return;
-              }
-
-              // Accept multiple command variants (case-sensitive, exact match)
-              const validCommands = ['/trigger-e2e-full', '/test-e2e-full', '/test-full'];
-              if (!validCommands.includes(comment)) {
-                console.log(`Comment "${comment}" is not a valid trigger command, skipping`);
-                core.setOutput('run_full', 'false');
-                return;
-              }
-
-              // Check if commenter has write access
-              const commenter = context.payload.comment.user.login;
-              const hasAccess = await hasWriteAccess(commenter);
-              if (!hasAccess) {
-                console.log(`User ${commenter} does not have write access, ignoring ${comment}`);
-                core.setOutput('run_full', 'false');
-                return;
-              }
-
-              // Get PR details
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: issue.number
-              });
-
-              console.log(`${comment} approved by ${commenter} for PR #${issue.number}`);
-              console.log(`PR head SHA: ${pr.head.sha}`);
-
-              // Add reaction to acknowledge
-              await github.rest.reactions.createForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'rocket'
-              });
-
-              // Post comment with link to the workflow run
-              const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `🚀 **Kind E2E (full)** triggered by \`${comment}\`\n\n[View the Kind E2E workflow run](${runUrl})`
-              });
-
-              core.setOutput('run_full', 'true');
-              return;
-            }
-            
-            core.setOutput('run_full', 'false');
-
   # E2E smoke tests - run automatically on every PR with code changes
   # Skip if PR only contains docs/metadata changes
   e2e-tests-smoke:
     runs-on: ubuntu-latest
-    needs: [lint-and-test, check-code-changes, check-full-tests]
-    if: github.event_name == 'pull_request' && needs.check-code-changes.result == 'success' && needs.check-code-changes.outputs.has_code_changes == 'true'
+    needs: [lint-and-test, check-code-changes]
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
     timeout-minutes: 60
     permissions:
       contents: read
@@ -297,21 +133,19 @@ jobs:
 
       - name: Build WVA image locally
         id: build-image
-        env:
-          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
         run: |
           # Generate unique image tag for this PR run (local image, no registry needed)
           IMAGE_NAME="llm-d-workload-variant-autoscaler"
-          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${CHECKOUT_SHA:0:7}"
+          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${GITHUB_SHA:0:7}"
           # Use localhost prefix for local-only image (Kind will load it directly)
           FULL_IMAGE="localhost/${IMAGE_NAME}:${IMAGE_TAG}"
-          
+
           echo "Building local image: $FULL_IMAGE"
           echo "Image will be loaded into Kind cluster (no push needed)"
-          
+
           # Build image locally (no push needed for Kind)
           make docker-build IMG="$FULL_IMAGE"
-          
+
           echo "image=$FULL_IMAGE" >> $GITHUB_OUTPUT
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "Image built locally: $FULL_IMAGE"
@@ -339,51 +173,17 @@ jobs:
         run: |
           make test-e2e-smoke-with-setup
 
-  # Full Kind E2E - runs only when triggered (/trigger-e2e-full or workflow_dispatch with run_full_tests).
-  # Add "e2e-tests-full" as a required status check in branch protection so it appears on every PR
-  # and must run and pass before merge (shows as "Expected" until triggered).
+  # Full Kind E2E - runs automatically on every PR with code changes alongside smoke tests
   e2e-tests-full:
     runs-on: ubuntu-latest
-    needs: [lint-and-test, check-code-changes, check-full-tests]
-    if: >-
-      always() && needs.check-full-tests.outputs.run_full == 'true' && needs.check-code-changes.result == 'success'
-      && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')
+    needs: [lint-and-test, check-code-changes]
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
     timeout-minutes: 60
     permissions:
       contents: read
-      statuses: write
     steps:
-      - name: Set pending status on PR head
-        if: github.event_name == 'issue_comment' && needs.check-code-changes.outputs.pr_head_sha != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.check-code-changes.outputs.pr_head_sha }}',
-              state: 'pending',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'Full E2E tests running...',
-              context: '${{ github.workflow }} / e2e (comment trigger)'
-            });
-
-      - name: Validate PR head SHA for issue_comment events
-        if: github.event_name == 'issue_comment'
-        run: |
-          if [ -z "${{ needs.check-code-changes.outputs.pr_head_sha }}" ]; then
-            echo "::error::pr_head_sha is empty — refusing to fall back to main"
-            exit 1
-          fi
-          echo "Checkout will use PR head SHA: ${{ needs.check-code-changes.outputs.pr_head_sha }}"
-          echo "PR head repo: ${{ needs.check-code-changes.outputs.pr_head_repo || github.repository }}"
-
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.check-code-changes.outputs.pr_head_repo || github.repository }}
-          ref: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Go version from go.mod
         run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
@@ -415,11 +215,9 @@ jobs:
 
       - name: Build WVA image locally
         id: build-image
-        env:
-          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
         run: |
           IMAGE_NAME="llm-d-workload-variant-autoscaler"
-          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${CHECKOUT_SHA:0:7}"
+          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${GITHUB_SHA:0:7}"
           FULL_IMAGE="localhost/${IMAGE_NAME}:${IMAGE_TAG}"
           echo "Building local image: $FULL_IMAGE"
           make docker-build IMG="$FULL_IMAGE"
@@ -443,53 +241,3 @@ jobs:
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |
           make test-e2e-full-with-setup
-
-  # Report status back to PR for issue_comment triggered runs
-  # This ensures fork PRs show the correct status after /trigger-e2e-full runs complete
-  report-status:
-    runs-on: ubuntu-latest
-    needs: [check-code-changes, check-full-tests, e2e-tests-full]
-    if: always() && github.event_name == 'issue_comment' && needs.check-full-tests.outputs.run_full == 'true'
-    permissions:
-      statuses: write
-    steps:
-      - name: Report status to PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prHeadSha = '${{ needs.check-code-changes.outputs.pr_head_sha }}';
-            const e2eResult = '${{ needs.e2e-tests-full.result }}';
-
-            if (!prHeadSha) {
-              console.log('No PR head SHA available, skipping status report');
-              return;
-            }
-
-            let state, description;
-            if (e2eResult === 'success') {
-              state = 'success';
-              description = 'E2E tests passed';
-            } else if (e2eResult === 'skipped') {
-              state = 'failure';
-              description = 'E2E tests did not run (prerequisite failed or skipped)';
-            } else if (e2eResult === 'cancelled') {
-              state = 'failure';
-              description = 'E2E tests cancelled';
-            } else {
-              state = 'failure';
-              description = 'E2E tests failed';
-            }
-
-            console.log(`Reporting status to PR commit ${prHeadSha}: ${state} - ${description}`);
-
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: prHeadSha,
-              state: state,
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: description,
-              context: '${{ github.workflow }} / e2e (comment trigger)'
-            });
-
-            console.log('Status reported successfully');


### PR DESCRIPTION
## Summary
- Remove the `/trigger-e2e-full` comment-gated mechanism for running full e2e tests
- Run `e2e-tests-full` automatically alongside `e2e-tests-smoke` on every PR with code changes
- Remove `check-full-tests` job, `report-status` job, `issue_comment` trigger, and all associated fork-PR workarounds
- Simplify concurrency group and `check-code-changes` job

## Test plan
- [ ] Verify `e2e-tests-smoke` and `e2e-tests-full` both trigger on a PR with code changes
- [ ] Verify neither e2e job triggers on a docs-only PR
- [ ] Verify `workflow_dispatch` still works for manual runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)