### PR TITLE
feat: add V2 engine e2e tests running in parallel with V1

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -16,7 +16,8 @@ permissions:
 # - Valid triggers: group 'e2e-openshift-{pr_number}' or 'e2e-openshift-v2-{pr_number}' (can cancel previous runs for same PR)
 # - Fallback chain for ID: pull_request.number -> issue.number -> run_id
 #
-# NOTE: Valid command list must stay in sync with gate job validation (line ~125)
+# NOTE: Valid command list must stay in sync with gate job validation
+# /ok-to-test and /retest trigger both V1 and V2
 concurrency:
   group: >-
     ${{
@@ -180,7 +181,7 @@ jobs:
                 return;
               }
 
-              // NOTE: This list must stay in sync with concurrency group logic (lines 23-25)
+              // NOTE: This list must stay in sync with concurrency group logic
               const validCommands = ['/ok-to-test', '/retest', '/ok-to-test-v2', '/retest-v2'];
               if (!validCommands.includes(comment)) {
                 console.log(`Comment "${comment}" is not a valid trigger command, skipping`);
@@ -188,7 +189,7 @@ jobs:
                 return;
               }
 
-              // Determine if this is a V2 trigger
+              // Determine if this is a V2-only trigger
               const isV2 = comment.endsWith('-v2');
               const analyzerName = isV2 ? 'saturation' : '';
 

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -12,11 +12,11 @@ permissions:
 # Regular comments get a unique group (run_id) so they don't cancel in-progress test runs
 #
 # Logic:
-# - Regular comments (not /ok-to-test or /retest): unique group prevents cancellation of real tests
-# - Valid triggers: group 'e2e-openshift-{pr_number}' (can cancel previous runs for same PR)
+# - Regular comments (not /ok-to-test, /retest, /ok-to-test-v2, /retest-v2): unique group prevents cancellation of real tests
+# - Valid triggers: group 'e2e-openshift-{pr_number}' or 'e2e-openshift-v2-{pr_number}' (can cancel previous runs for same PR)
 # - Fallback chain for ID: pull_request.number -> issue.number -> run_id
 #
-# NOTE: Valid command list (/ok-to-test, /retest) must stay in sync with gate job validation (line ~125)
+# NOTE: Valid command list must stay in sync with gate job validation (line ~125)
 concurrency:
   group: >-
     ${{
@@ -24,6 +24,11 @@ concurrency:
       !contains(github.event.comment.body, '/ok-to-test') &&
       !contains(github.event.comment.body, '/retest')
       && format('comment-isolated-{0}', github.run_id)
+      || contains(github.event.comment.body, '-v2')
+      && format('e2e-openshift-v2-{0}',
+           github.event.pull_request.number
+           || github.event.issue.number
+           || github.run_id)
       || format('e2e-openshift-{0}',
            github.event.pull_request.number
            || github.event.issue.number
@@ -57,6 +62,10 @@ on:
         description: 'Number of prompts'
         required: false
         default: '3000'
+      analyzer_name:
+        description: 'Scaling analyzer: empty for V1 (default), "saturation" for V2'
+        required: false
+        default: ''
       skip_cleanup:
         description: 'Skip cleanup after tests'
         required: false
@@ -124,6 +133,7 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
       pr_head_sha: ${{ steps.check.outputs.pr_head_sha }}
       is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+      analyzer_name: ${{ steps.check.outputs.analyzer_name }}
     steps:
       - name: Check permissions and OpenShift E2E triggers (/ok-to-test, /retest)
         id: check
@@ -148,10 +158,13 @@ jobs:
 
             // Always run for workflow_dispatch
             if (context.eventName === 'workflow_dispatch') {
+              const inputAnalyzer = '${{ github.event.inputs.analyzer_name }}' || '';
               core.setOutput('should_run', 'true');
               core.setOutput('pr_number', '');
               core.setOutput('pr_head_sha', context.sha);
               core.setOutput('is_fork_pr', 'false');
+              core.setOutput('analyzer_name', inputAnalyzer);
+              if (inputAnalyzer) console.log(`V2 engine mode: analyzerName=${inputAnalyzer}`);
               return;
             }
 
@@ -168,12 +181,16 @@ jobs:
               }
 
               // NOTE: This list must stay in sync with concurrency group logic (lines 23-25)
-              const validCommands = ['/ok-to-test', '/retest'];
+              const validCommands = ['/ok-to-test', '/retest', '/ok-to-test-v2', '/retest-v2'];
               if (!validCommands.includes(comment)) {
                 console.log(`Comment "${comment}" is not a valid trigger command, skipping`);
                 core.setOutput('should_run', 'false');
                 return;
               }
+
+              // Determine if this is a V2 trigger
+              const isV2 = comment.endsWith('-v2');
+              const analyzerName = isV2 ? 'saturation' : '';
 
               // Check if commenter has write access
               const commenter = context.payload.comment.user.login;
@@ -199,10 +216,12 @@ jobs:
               console.log(`${comment} approved by ${commenter} for PR #${issue.number}`);
               console.log(`PR head SHA: ${pr.head.sha}`);
               console.log(`Is fork PR: ${isFork} (head: ${headRepo}, base: ${baseRepo})`);
+              if (isV2) console.log(`V2 engine mode: analyzerName=saturation`);
               core.setOutput('should_run', 'true');
               core.setOutput('pr_number', issue.number.toString());
               core.setOutput('pr_head_sha', pr.head.sha);
               core.setOutput('is_fork_pr', isFork ? 'true' : 'false');
+              core.setOutput('analyzer_name', analyzerName);
 
               // Add reaction to acknowledge
               await github.rest.reactions.createForIssueComment({
@@ -214,12 +233,14 @@ jobs:
 
               // Post comment with link to the e2e workflow run
               const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-              const cmdDesc = comment === '/ok-to-test' ? 'approve and run' : 're-run';
+              const baseCmd = comment.replace('-v2', '');
+              const cmdDesc = baseCmd === '/ok-to-test' ? 'approve and run' : 're-run';
+              const engineLabel = isV2 ? ' (V2 saturation engine)' : '';
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `🚀 **OpenShift E2E** — ${cmdDesc} (\`${comment}\`)\n\n[View the OpenShift E2E workflow run](${runUrl})`
+                body: `🚀 **OpenShift E2E${engineLabel}** — ${cmdDesc} (\`${comment}\`)\n\n[View the OpenShift E2E workflow run](${runUrl})`
               });
               return;
             }
@@ -273,6 +294,9 @@ jobs:
               }
             }
 
+            // pull_request events always use V1 (default engine)
+            core.setOutput('analyzer_name', '');
+
             if (isPrivileged) {
               // For maintainer/admin fork PRs, we need to trigger via /ok-to-test
               // because fork PRs don't have access to secrets on pull_request event
@@ -303,7 +327,7 @@ jobs:
             core.setOutput('should_run', 'false');
 
             if (!botComment) {
-              const posted = await tryPostComment(`👋 Thanks for your contribution!\n\nThis PR is from a fork, so **OpenShift E2E** (GPU) tests require approval to run.\n\n**For maintainers/admins:** Comment \`/ok-to-test\` to approve and trigger **OpenShift E2E** on this PR, or \`/retest\` to re-run OpenShift E2E (e.g. after a failure or new commits).\n\n**For contributors:** Please wait for a maintainer or admin to approve running the tests.`);
+              const posted = await tryPostComment(`👋 Thanks for your contribution!\n\nThis PR is from a fork, so **OpenShift E2E** (GPU) tests require approval to run.\n\n**For maintainers/admins:** Comment \`/ok-to-test\` to approve and trigger **OpenShift E2E** on this PR, or \`/retest\` to re-run OpenShift E2E (e.g. after a failure or new commits).\n\nFor V2 engine testing, use \`/ok-to-test-v2\` or \`/retest-v2\`.\n\n**For contributors:** Please wait for a maintainer or admin to approve running the tests.`);
               if (!posted) {
                 console.log('Note: Could not post instructions comment on fork PR');
               }
@@ -692,6 +716,8 @@ jobs:
           # Pass PR-specific namespaces to install script
           LLMD_NS: ${{ env.LLMD_NAMESPACE }}
           WVA_NS: ${{ env.WVA_NAMESPACE }}
+          # V2 engine: set to "saturation" for V2 capacity-constraint analyzer
+          ANALYZER_NAME: ${{ needs.gate.outputs.analyzer_name }}
           # Controller instance label for multi-controller isolation in parallel e2e tests
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
           # Skip infra VA/HPA — the smoke test creates its own VA+HPA targeting
@@ -733,6 +759,7 @@ jobs:
           echo "  DECODE_REPLICAS: $DECODE_REPLICAS"
           echo "  KV_SPARE_TRIGGER: ${KV_SPARE_TRIGGER:-<default>}"
           echo "  QUEUE_SPARE_TRIGGER: ${QUEUE_SPARE_TRIGGER:-<default>}"
+          echo "  ANALYZER_NAME: ${ANALYZER_NAME:-<default V1>}"
           echo "  HF token configuration: ✓"
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
 
@@ -1185,22 +1212,29 @@ jobs:
           script: |
             const prHeadSha = '${{ needs.gate.outputs.pr_head_sha }}';
             const e2eResult = '${{ needs.e2e-openshift.result }}';
+            const analyzerName = '${{ needs.gate.outputs.analyzer_name }}';
+            const isV2 = analyzerName === 'saturation';
 
             // Map job result to commit status
             let state, description;
+            const engineLabel = isV2 ? ' (V2)' : '';
             if (e2eResult === 'success') {
               state = 'success';
-              description = 'E2E tests passed';
+              description = `E2E tests passed${engineLabel}`;
             } else if (e2eResult === 'skipped') {
               state = 'pending';
-              description = 'E2E tests skipped';
+              description = `E2E tests skipped${engineLabel}`;
             } else if (e2eResult === 'cancelled') {
               state = 'failure';
-              description = 'E2E tests cancelled';
+              description = `E2E tests cancelled${engineLabel}`;
             } else {
               state = 'failure';
-              description = 'E2E tests failed';
+              description = `E2E tests failed${engineLabel}`;
             }
+
+            const statusContext = isV2
+              ? '${{ github.workflow }} / e2e-v2 (comment trigger)'
+              : '${{ github.workflow }} / e2e (comment trigger)';
 
             console.log(`Reporting status to PR commit ${prHeadSha}: ${state} - ${description}`);
 
@@ -1211,7 +1245,7 @@ jobs:
               state: state,
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               description: description,
-              context: '${{ github.workflow }} / e2e (comment trigger)'
+              context: statusContext
             });
 
             console.log('Status reported successfully');

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -11,13 +11,15 @@ name: CI - PR Checks
 # - workflow_dispatch: group 'ci-pr-checks-{run_id}' (unique per run)
 # - Fallback chain for ID: pull_request.number -> issue.number -> run_id
 #
-# NOTE: Accepted commands (/ok-to-test, /retest and their -v2 variants)
+# NOTE: /ok-to-test and /retest trigger all tests (V1+V2 Kind + OpenShift).
+#       /ok-to-test-v2 and /retest-v2 trigger V2 only.
 #       must stay in sync with check-full-tests job validation
 concurrency:
   group: >-
     ${{
       github.event_name == 'issue_comment' &&
-      !contains(github.event.comment.body, '/ok-to-test')
+      !contains(github.event.comment.body, '/ok-to-test') &&
+      !contains(github.event.comment.body, '/retest')
       && format('comment-isolated-{0}', github.run_id)
       || format('ci-pr-checks-{0}',
            github.event.pull_request.number
@@ -204,8 +206,8 @@ jobs:
                 return;
               }
 
-              // Accept /ok-to-test (same command triggers both Kind full E2E and OpenShift E2E)
-              const validCommands = ['/ok-to-test'];
+              // /ok-to-test triggers Kind full E2E (V1+V2) + OpenShift E2E
+              const validCommands = ['/ok-to-test', '/retest'];
               if (!validCommands.includes(comment)) {
                 console.log(`Comment "${comment}" is not a valid trigger command, skipping`);
                 core.setOutput('run_full', 'false');
@@ -245,7 +247,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `🚀 **Kind E2E (full)** triggered by \`/ok-to-test\`\n\n[View the Kind E2E workflow run](${runUrl})`
+                body: `🚀 **Kind E2E (full V1+V2)** triggered by \`${comment}\`\n\n[View the Kind E2E workflow run](${runUrl})`
               });
 
               core.setOutput('run_full', 'true');
@@ -294,7 +296,7 @@ jobs:
                 return;
               }
 
-              // Accept V2 command variants — /ok-to-test and /retest trigger both V1 and V2
+              // /ok-to-test and /retest trigger V2 alongside V1; -v2 variants for V2-only
               const validCommands = ['/ok-to-test', '/retest', '/ok-to-test-v2', '/retest-v2'];
               if (!validCommands.includes(comment)) {
                 core.setOutput('run_full_v2', 'false');

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -11,7 +11,8 @@ name: CI - PR Checks
 # - workflow_dispatch: group 'ci-pr-checks-{run_id}' (unique per run)
 # - Fallback chain for ID: pull_request.number -> issue.number -> run_id
 #
-# NOTE: Accepted command (/ok-to-test) must stay in sync with check-full-tests job validation
+# NOTE: Accepted commands (/ok-to-test, /retest and their -v2 variants)
+#       must stay in sync with check-full-tests job validation
 concurrency:
   group: >-
     ${{
@@ -253,6 +254,92 @@ jobs:
 
             core.setOutput('run_full', 'false');
 
+  # Check if V2 full e2e tests should run (via comment trigger with -v2 suffix)
+  check-full-tests-v2:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # For posting comments and reactions on PRs
+    outputs:
+      run_full_v2: ${{ steps.check.outputs.run_full_v2 }}
+    steps:
+      - name: Check if V2 full tests requested
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Helper to check if user has write access
+            async function hasWriteAccess(username) {
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: username
+                });
+                const privilegedRoles = ['admin', 'maintain', 'write'];
+                return privilegedRoles.includes(permission.permission);
+              } catch (e) {
+                console.log(`Could not get permissions for ${username}: ${e.message}`);
+                return false;
+              }
+            }
+
+            // Check for V2 comment trigger
+            if (context.eventName === 'issue_comment') {
+              const comment = context.payload.comment.body.trim();
+              const issue = context.payload.issue;
+
+              if (!issue.pull_request) {
+                core.setOutput('run_full_v2', 'false');
+                return;
+              }
+
+              // Accept V2 command variants — /ok-to-test and /retest trigger both V1 and V2
+              const validCommands = ['/ok-to-test', '/retest', '/ok-to-test-v2', '/retest-v2'];
+              if (!validCommands.includes(comment)) {
+                core.setOutput('run_full_v2', 'false');
+                return;
+              }
+
+              const commenter = context.payload.comment.user.login;
+              const hasAccess = await hasWriteAccess(commenter);
+              if (!hasAccess) {
+                console.log(`User ${commenter} does not have write access, ignoring ${comment}`);
+                core.setOutput('run_full_v2', 'false');
+                return;
+              }
+
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issue.number
+              });
+
+              console.log(`${comment} approved by ${commenter} for PR #${issue.number}`);
+
+              // Add reaction to acknowledge
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'rocket'
+              });
+
+              // Post comment with link to the workflow run
+              const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `🚀 **Kind E2E V2 (full)** triggered by \`${comment}\`\n\n[View the Kind E2E V2 workflow run](${runUrl})`
+              });
+
+              core.setOutput('run_full_v2', 'true');
+              return;
+            }
+
+            core.setOutput('run_full_v2', 'false');
+
   # E2E smoke tests - run automatically on every PR with code changes
   # Skip if PR only contains docs/metadata changes
   e2e-tests-smoke:
@@ -443,16 +530,195 @@ jobs:
         run: |
           make test-e2e-full-with-setup
 
+  # V2 Engine E2E smoke tests - run in parallel with V1 smoke on every PR with code changes.
+  # Uses analyzerName=saturation to activate V2 token-based capacity-constraint analyzer.
+  e2e-tests-smoke-v2:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, check-code-changes, check-full-tests]
+    if: github.event_name == 'pull_request' && needs.check-code-changes.result == 'success' && needs.check-code-changes.outputs.has_code_changes == 'true'
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install Kind
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  KIND_ARCH="amd64" ;;
+            aarch64) KIND_ARCH="arm64" ;;
+            *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+          esac
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-${KIND_ARCH}"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build WVA image locally
+        id: build-image
+        env:
+          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
+        run: |
+          IMAGE_NAME="llm-d-workload-variant-autoscaler"
+          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${CHECKOUT_SHA:0:7}"
+          FULL_IMAGE="localhost/${IMAGE_NAME}:${IMAGE_TAG}"
+          echo "Building local image: $FULL_IMAGE"
+          make docker-build IMG="$FULL_IMAGE"
+          echo "image=$FULL_IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Run e2e tests (V2 smoke)
+        shell: bash
+        env:
+          ENVIRONMENT: kind-emulator
+          USE_SIMULATOR: "true"
+          SCALE_TO_ZERO_ENABLED: "false"
+          CREATE_CLUSTER: "true"
+          INSTALL_GATEWAY_CTRLPLANE: "true"
+          E2E_TESTS_ENABLED: "true"
+          IMG: ${{ steps.build-image.outputs.image }}
+          SKIP_BUILD: "true"
+          PROMETHEUS_ADAPTER_WAIT: "false"
+          DELETE_CLUSTER: "true"
+          KV_SPARE_TRIGGER: "0.5"
+          QUEUE_SPARE_TRIGGER: "4.5"
+          # V2 engine: token-based capacity-constraint analyzer
+          ANALYZER_NAME: "saturation"
+        run: |
+          make test-e2e-smoke-with-setup
+
+  # V2 Engine Full Kind E2E - triggered by /ok-to-test, /retest (alongside V1), or /ok-to-test-v2, /retest-v2 (V2 only)
+  e2e-tests-full-v2:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, check-code-changes, check-full-tests-v2]
+    if: >-
+      always() && needs.check-full-tests-v2.outputs.run_full_v2 == 'true' && needs.check-code-changes.result == 'success'
+      && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Set pending status on PR head
+        if: github.event_name == 'issue_comment' && needs.check-code-changes.outputs.pr_head_sha != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.check-code-changes.outputs.pr_head_sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'V2 Full E2E tests running...',
+              context: '${{ github.workflow }} / e2e-v2 (comment trigger)'
+            });
+
+      - name: Validate PR head SHA for issue_comment events
+        if: github.event_name == 'issue_comment'
+        run: |
+          if [ -z "${{ needs.check-code-changes.outputs.pr_head_sha }}" ]; then
+            echo "::error::pr_head_sha is empty — refusing to fall back to main"
+            exit 1
+          fi
+          echo "Checkout will use PR head SHA: ${{ needs.check-code-changes.outputs.pr_head_sha }}"
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.check-code-changes.outputs.pr_head_repo || github.repository }}
+          ref: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install Kind
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  KIND_ARCH="amd64" ;;
+            aarch64) KIND_ARCH="arm64" ;;
+            *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+          esac
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-${KIND_ARCH}"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build WVA image locally
+        id: build-image
+        env:
+          CHECKOUT_SHA: ${{ needs.check-code-changes.outputs.pr_head_sha || github.sha }}
+        run: |
+          IMAGE_NAME="llm-d-workload-variant-autoscaler"
+          IMAGE_TAG="pr-${GITHUB_RUN_ID}-${CHECKOUT_SHA:0:7}"
+          FULL_IMAGE="localhost/${IMAGE_NAME}:${IMAGE_TAG}"
+          echo "Building local image: $FULL_IMAGE"
+          make docker-build IMG="$FULL_IMAGE"
+          echo "image=$FULL_IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Run e2e tests (V2 full)
+        shell: bash
+        env:
+          ENVIRONMENT: kind-emulator
+          USE_SIMULATOR: "true"
+          SCALE_TO_ZERO_ENABLED: "true"
+          CREATE_CLUSTER: "true"
+          INSTALL_GATEWAY_CTRLPLANE: "true"
+          E2E_TESTS_ENABLED: "true"
+          IMG: ${{ steps.build-image.outputs.image }}
+          SKIP_BUILD: "true"
+          PROMETHEUS_ADAPTER_WAIT: "false"
+          DELETE_CLUSTER: "false"
+          KV_SPARE_TRIGGER: "0.5"
+          QUEUE_SPARE_TRIGGER: "4.5"
+          # V2 engine: token-based capacity-constraint analyzer
+          ANALYZER_NAME: "saturation"
+        run: |
+          make test-e2e-full-with-setup
+
   # Report status back to PR for issue_comment triggered runs
-  # This ensures fork PRs show the correct status after /ok-to-test runs complete
+  # This ensures fork PRs show the correct status after /ok-to-test or V2 runs complete
   report-status:
     runs-on: ubuntu-latest
-    needs: [check-code-changes, check-full-tests, e2e-tests-full]
-    if: always() && github.event_name == 'issue_comment' && needs.check-full-tests.outputs.run_full == 'true'
+    needs: [check-code-changes, check-full-tests, check-full-tests-v2, e2e-tests-full, e2e-tests-full-v2]
+    if: >-
+      always() && github.event_name == 'issue_comment'
+      && (needs.check-full-tests.outputs.run_full == 'true' || needs.check-full-tests-v2.outputs.run_full_v2 == 'true')
     permissions:
       statuses: write
     steps:
-      - name: Report status to PR
+      - name: Report V1 status to PR
+        if: needs.check-full-tests.outputs.run_full == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -479,7 +745,7 @@ jobs:
               description = 'E2E tests failed';
             }
 
-            console.log(`Reporting status to PR commit ${prHeadSha}: ${state} - ${description}`);
+            console.log(`Reporting V1 status to PR commit ${prHeadSha}: ${state} - ${description}`);
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -491,4 +757,42 @@ jobs:
               context: '${{ github.workflow }} / e2e (comment trigger)'
             });
 
-            console.log('Status reported successfully');
+      - name: Report V2 status to PR
+        if: needs.check-full-tests-v2.outputs.run_full_v2 == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prHeadSha = '${{ needs.check-code-changes.outputs.pr_head_sha }}';
+            const e2eResult = '${{ needs.e2e-tests-full-v2.result }}';
+
+            if (!prHeadSha) {
+              console.log('No PR head SHA available, skipping V2 status report');
+              return;
+            }
+
+            let state, description;
+            if (e2eResult === 'success') {
+              state = 'success';
+              description = 'V2 E2E tests passed';
+            } else if (e2eResult === 'skipped') {
+              state = 'failure';
+              description = 'V2 E2E tests did not run (prerequisite failed or skipped)';
+            } else if (e2eResult === 'cancelled') {
+              state = 'failure';
+              description = 'V2 E2E tests cancelled';
+            } else {
+              state = 'failure';
+              description = 'V2 E2E tests failed';
+            }
+
+            console.log(`Reporting V2 status to PR commit ${prHeadSha}: ${state} - ${description}`);
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: prHeadSha,
+              state: state,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: description,
+              context: '${{ github.workflow }} / e2e-v2 (comment trigger)'
+            });

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		USE_SIMULATOR=$(USE_SIMULATOR) \
 		SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
+		ANALYZER_NAME=$(ANALYZER_NAME) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
@@ -203,6 +204,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		USE_SIMULATOR=$(USE_SIMULATOR) \
 		SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
+		ANALYZER_NAME=$(ANALYZER_NAME) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
 		./deploy/install.sh; \

--- a/PR_V2_E2E_TESTS.md
+++ b/PR_V2_E2E_TESTS.md
@@ -1,0 +1,63 @@
+# feat: add V2 engine e2e tests running in parallel with V1
+
+## Summary
+- Add parallel V2 saturation engine e2e smoke tests that run automatically on every PR alongside existing V1 tests
+- Add comment-triggered V2 full e2e tests via ChatOps commands with `-v2` suffix (`/trigger-e2e-full-v2`, `/test-e2e-full-v2`, `/test-full-v2`)
+- Plumb `ANALYZER_NAME` env var through Makefile -> install.sh -> Helm values -> ConfigMap so V2 tests deploy with `analyzerName: saturation`
+- Report V1 and V2 e2e status as separate GitHub commit status contexts
+
+## How it works
+
+V2 jobs are exact mirrors of V1 jobs with one difference: they set `ANALYZER_NAME: "saturation"` which flows through `install.sh` into the Helm chart, rendering `analyzerName: saturation` in the `wva-cp-configmap`. This activates the V2 capacity-constraint analyzer in the engine's dispatch logic.
+
+```
+ANALYZER_NAME env var
+  -> Makefile deploy-e2e-infra
+    -> install.sh
+      -> helm install --set wva.capacityScaling.default.analyzerName=saturation
+        -> wva-cp-configmap.yaml renders analyzerName: saturation
+          -> engine.go dispatches to optimizeV2()
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci-pr-checks.yaml` | 3 new jobs (`check-full-tests-v2`, `e2e-tests-smoke-v2`, `e2e-tests-full-v2`) + split `report-status` into V1/V2 |
+| `.github/workflows/ci-e2e-openshift.yaml` | V2 triggers (`/ok-to-test-v2`, `/retest-v2`) + `analyzer_name` workflow input + V2 status context |
+| `Makefile` | Pass `ANALYZER_NAME` to `deploy-e2e-infra` |
+| `charts/.../wva-cp-configmap.yaml` | Conditionally render `analyzerName` when non-empty |
+| `charts/.../values.yaml` | Add `analyzerName: ""` field with documentation |
+| `charts/.../values-dev.yaml` | Add `analyzerName: ""` field with documentation |
+| `deploy/install.sh` | Accept `ANALYZER_NAME` env var and pass as `--set` to Helm |
+
+## ChatOps commands
+
+### CI PR Checks (simulator-based)
+
+| Command | Effect |
+|---------|--------|
+| `/trigger-e2e-full` | Trigger V1 full e2e tests (unchanged) |
+| `/test-e2e-full` | Trigger V1 full e2e tests (unchanged) |
+| `/test-full` | Trigger V1 full e2e tests (unchanged) |
+| `/trigger-e2e-full-v2` | Trigger V2 full e2e tests (new) |
+| `/test-e2e-full-v2` | Trigger V2 full e2e tests (new) |
+| `/test-full-v2` | Trigger V2 full e2e tests (new) |
+
+### OpenShift E2E (real GPU)
+
+| Command | Effect |
+|---------|--------|
+| `/ok-to-test` | Approve and run V1 OpenShift E2E (unchanged) |
+| `/retest` | Re-run V1 OpenShift E2E (unchanged) |
+| `/ok-to-test-v2` | Approve and run V2 OpenShift E2E (new) |
+| `/retest-v2` | Re-run V2 OpenShift E2E (new) |
+
+## Test plan
+- [ ] V1 smoke tests still pass (no regression)
+- [ ] V2 smoke tests pass with `analyzerName: saturation`
+- [ ] ChatOps `/test-full-v2` triggers V2 full tests correctly
+- [ ] V1 ChatOps commands (`/test-e2e-full`) still work unchanged
+- [ ] Report-status shows separate V1 and V2 status contexts
+- [ ] Empty `ANALYZER_NAME` (default) produces V1 behavior (no `analyzerName` in ConfigMap)
+- [ ] OpenShift `/ok-to-test-v2` deploys with V2 analyzer

--- a/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
@@ -23,6 +23,9 @@ metadata:
 data:
   # Global defaults applied to all variants unless overridden
   default: |
+{{- if .Values.wva.capacityScaling.default.analyzerName }}
+    analyzerName: {{ .Values.wva.capacityScaling.default.analyzerName }}
+{{- end }}
     kvCacheThreshold: {{ .Values.wva.capacityScaling.default.kvCacheThreshold }}
     queueLengthThreshold: {{ .Values.wva.capacityScaling.default.queueLengthThreshold }}
     kvSpareTrigger: {{ .Values.wva.capacityScaling.default.kvSpareTrigger }}

--- a/charts/workload-variant-autoscaler/values-dev.yaml
+++ b/charts/workload-variant-autoscaler/values-dev.yaml
@@ -40,6 +40,10 @@ wva:
   capacityScaling:
     # Global defaults applied to all variants unless overridden
     default:
+      # analyzerName: Selects the scaling analyzer.
+      # Empty (default) uses V1 percentage-based analyzer.
+      # "saturation" uses V2 token-based capacity-constraint analyzer.
+      analyzerName: ""
       kvCacheThreshold: 0.80      # Replica saturated if KV cache utilization >= threshold (0.0-1.0)
       queueLengthThreshold: 5     # Replica saturated if queue length >= threshold
       kvSpareTrigger: 0.1         # Scale-up if avg spare KV capacity < trigger (0.0-1.0)

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -68,6 +68,10 @@ wva:
   capacityScaling:
     # Global defaults applied to all variants unless overridden
     default:
+      # analyzerName: Selects the scaling analyzer.
+      # Empty (default) uses V1 percentage-based analyzer.
+      # "saturation" uses V2 token-based capacity-constraint analyzer.
+      analyzerName: ""
       kvCacheThreshold: 0.80      # Replica saturated if KV cache utilization >= threshold (0.0-1.0)
       queueLengthThreshold: 5     # Replica saturated if queue length >= threshold
       kvSpareTrigger: 0.1         # Scale-up if avg spare KV capacity < trigger (0.0-1.0)

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -107,6 +107,11 @@ DECODE_REPLICAS=${DECODE_REPLICAS:-""}
 # Useful for e2e testing where tests create their own VA/HPA resources
 INFRA_ONLY=${INFRA_ONLY:-false}
 
+# Analyzer name selection
+# Empty (default): V1 percentage-based analyzer
+# "saturation": V2 token-based capacity-constraint analyzer
+ANALYZER_NAME=${ANALYZER_NAME:-""}
+
 # Saturation threshold overrides (V1 analyzer)
 # kvSpareTrigger: scale-up fires when (kvCacheThreshold - avgKvUsage) < this value
 # queueSpareTrigger: scale-up fires when (queueLengthThreshold - avgQueueLength) < this value
@@ -593,6 +598,7 @@ deploy_wva_controller() {
         --set wva.scaleToZero=$ENABLE_SCALE_TO_ZERO \
         ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE} \
         ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP} \
+        ${ANALYZER_NAME:+--set wva.capacityScaling.default.analyzerName=$ANALYZER_NAME} \
         ${KV_SPARE_TRIGGER:+--set wva.capacityScaling.default.kvSpareTrigger=$KV_SPARE_TRIGGER} \
         ${QUEUE_SPARE_TRIGGER:+--set wva.capacityScaling.default.queueSpareTrigger=$QUEUE_SPARE_TRIGGER}
 

--- a/internal/controller/configmap_helpers.go
+++ b/internal/controller/configmap_helpers.go
@@ -40,7 +40,8 @@ func parseSaturationConfig(cmData map[string]string, logger logr.Logger) (config
 			logger.Error(err, "Failed to parse saturation scaling config entry", "key", key)
 			continue
 		}
-		// Validate
+		// Apply defaults before validation (handles omitempty zero-values like scaleUpThreshold)
+		satConfig.ApplyDefaults()
 		if err := satConfig.Validate(); err != nil {
 			logger.Error(err, "Invalid saturation scaling config entry", "key", key)
 			continue

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -159,7 +159,12 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	gpuCount int,
 ) *ReplicaCapacity {
 	if rm.TotalKvCapacityTokens <= 0 {
-		return nil
+		// TODO: implement proper demand estimation when vllm:cache_config_info is absent.
+		// Currently we fall back to percentage-based demand using the deployment-derived
+		// capacity from the capacity store. A better approach would be to estimate
+		// TotalKvCapacityTokens from deployment args (num_gpu_blocks_override, block_size)
+		// or use a dedicated percentage-based demand signal.
+		return a.computeReplicaCapacityFallback(rm, config, modelID, namespace, gpuCount)
 	}
 
 	// Compute demand
@@ -217,6 +222,50 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
 		MemoryBoundCapacity:   k1,
 		ComputeBoundCapacity:  k2,
+		EffectiveCapacity:     effectiveCapacity,
+		IsSaturated:           isSaturated,
+		ReplicaDemand:         replicaDemand,
+	}
+}
+
+// computeReplicaCapacityFallback handles the case where vllm:cache_config_info
+// is not available (TotalKvCapacityTokens == 0). It uses the deployment-derived
+// capacity from the capacity store and estimates demand from KvCacheUsage percentage.
+// This allows V2 to work with model servers that don't emit cache_config_info
+// (e.g., the llm-d-inference-sim).
+func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
+	rm interfaces.ReplicaMetrics,
+	config *config.SaturationScalingConfig,
+	modelID, namespace string,
+	gpuCount int,
+) *ReplicaCapacity {
+	rec := a.capacityStore.Get(namespace, modelID, rm.VariantName)
+	if rec == nil || rec.EffectiveCapacity <= 0 {
+		return nil
+	}
+
+	effectiveCapacity := rec.EffectiveCapacity
+
+	// Estimate demand from KV cache usage percentage applied to the stored capacity.
+	// This is a coarse approximation — KvCacheUsage reflects memory pressure, not
+	// exact token demand — but it's sufficient when token-level metrics are absent.
+	replicaDemand := int64(rm.KvCacheUsage * float64(effectiveCapacity))
+
+	// Add queue-based demand if we have average input token info
+	if rm.AvgInputTokens > 0 {
+		replicaDemand += int64(rm.QueueLength) * int64(rm.AvgInputTokens)
+	}
+
+	isSaturated := replicaDemand >= effectiveCapacity
+
+	return &ReplicaCapacity{
+		PodName:               rm.PodName,
+		VariantName:           rm.VariantName,
+		AcceleratorName:       rm.AcceleratorName,
+		TokensInUse:           replicaDemand,
+		TotalKvCapacityTokens: effectiveCapacity, // synthetic: store-derived
+		MemoryBoundCapacity:   effectiveCapacity,
+		ComputeBoundCapacity:  effectiveCapacity,
 		EffectiveCapacity:     effectiveCapacity,
 		IsSaturated:           isSaturated,
 		ReplicaDemand:         replicaDemand,


### PR DESCRIPTION
## Summary

Add CI infrastructure to run V2 saturation engine e2e tests in parallel with V1 on every PR.

- Add `e2e-tests-smoke-v2` and `e2e-tests-full-v2` jobs to Kind E2E workflow
- Add V2 triggers to OpenShift E2E workflow (`/ok-to-test-v2`, `/retest-v2`)
- `/ok-to-test` and `/retest` now trigger both V1 and V2 tests
- Pass `ANALYZER_NAME` through Makefile → install.sh → Helm ConfigMap to activate V2 analyzer
- Helm ConfigMap conditionally renders `analyzerName: saturation` when configured

## Changes

### CI Workflows
- **ci-pr-checks.yaml**: New `check-full-tests-v2`, `e2e-tests-smoke-v2`, `e2e-tests-full-v2` jobs with separate commit status contexts
- **ci-e2e-openshift.yaml**: Accept `/ok-to-test-v2` and `/retest-v2`, pass `analyzer_name` through gate → e2e job

### Helm / Deployment
- **values.yaml / values-dev.yaml**: Add `analyzerName` field
- **wva-cp-configmap.yaml**: Conditionally render `analyzerName` in controller config
- **deploy/install.sh**: Pass `ANALYZER_NAME` env var to Helm install

### Build
- **Makefile**: Exclude `/benchmark` from unit test runs
