### PR TITLE
ci: skip OpenShift E2E tests for doc-only PRs

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -71,12 +71,53 @@ on:
         default: '240'
 
 jobs:
+  # Check if PR contains code changes (not just docs/metadata)
+  check-code-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_code_changes: ${{ steps.set-output.outputs.has_code_changes }}
+    steps:
+      - name: Checkout source
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Check for code changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+              - '!README.md'
+              - '!CONTRIBUTING.md'
+              - '!LICENSE'
+              - '!OWNERS'
+              - '!PROJECT'
+
+      - name: Set output
+        id: set-output
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Always run for issue_comment (/ok-to-test, /retest) and workflow_dispatch
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ steps.filter.outputs.code }}" ]; then
+            echo "has_code_changes=${{ steps.filter.outputs.code }}" >> $GITHUB_OUTPUT
+          else
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+          fi
+
   # Gate: Check permissions and handle /ok-to-test for fork PRs.
   # - Maintainers (write access): Tests run automatically on pull_request.
   # - Fork PRs: Gate succeeds (no failure) so the PR does not show a false red check; E2E runs
   #   only after a maintainer comments /ok-to-test. Branch protection should require the
   #   "e2e-openshift" job so merge stays blocked until that run passes.
   gate:
+    needs: check-code-changes
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}


### PR DESCRIPTION
## Summary
- Adds a `check-code-changes` job to the OpenShift E2E workflow that detects documentation-only PRs using `dorny/paths-filter` (same config as `ci-pr-checks.yaml`)
- Skips the entire E2E pipeline (gate → build-image → e2e-openshift → report-status) when only docs/metadata files change, saving GPU runner time
- Comment triggers (`/ok-to-test`, `/retest`) and `workflow_dispatch` always run regardless of file changes

## Test plan
- [ ] Verify OpenShift E2E is skipped when PR only changes files in `docs/**`, `README.md`, `CONTRIBUTING.md`, `LICENSE`, `OWNERS`, or `PROJECT`
- [ ] Verify OpenShift E2E still runs normally for PRs with code changes
- [ ] Verify `/ok-to-test` and `/retest` comment triggers still work on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)