### PR TITLE
feat(helm): add keda.enabled flag and hpa/keda ownership disable support

### DIFF
--- a/charts/workload-variant-autoscaler/templates/hpa.yaml
+++ b/charts/workload-variant-autoscaler/templates/hpa.yaml
@@ -1,3 +1,13 @@
+{{- /*
+hpa.yaml — deploys a plain Kubernetes HorizontalPodAutoscaler that reads the
+wva_desired_replicas external metric exposed by the Prometheus Adapter.
+
+Set hpa.enabled=false when an external platform (e.g. KServe) already owns
+the HPA for the same target Deployment. Two controllers competing over the
+same HPA leads to undefined, conflicting scaling behavior.
+
+See docs/integrations/kserve-integration.md for the full migration guide.
+*/ -}}
 {{- if .Values.hpa.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/workload-variant-autoscaler/templates/keda.yaml
+++ b/charts/workload-variant-autoscaler/templates/keda.yaml
@@ -1,0 +1,80 @@
+{{- /*
+keda.yaml — deploys a KEDA ScaledObject that drives replica counts using
+the wva_desired_replicas Prometheus metric emitted by the WVA controller.
+
+Enable with: --set keda.enabled=true
+Disable with: --set keda.enabled=false (default)
+
+IMPORTANT: Do NOT enable both hpa.enabled and keda.enabled for the same
+target Deployment — two competing autoscalers will produce undefined behavior.
+Set hpa.enabled=false when keda.enabled=true.
+
+KServe integration: set both hpa.enabled=false and keda.enabled=false
+(the default) to allow KServe (or another external platform) to own all
+autoscaling sub-resources exclusively. WVA continues to emit
+wva_desired_replicas metrics that the external autoscaler can consume.
+*/ -}}
+{{- if .Values.keda.enabled }}
+{{- if and .Values.hpa.enabled .Values.keda.enabled }}
+{{- fail "hpa.enabled and keda.enabled cannot both be true for the same target Deployment. Set hpa.enabled=false when using KEDA." }}
+{{- end }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "workload-variant-autoscaler.fullname" . }}-scaledobject
+  namespace: {{ .Values.llmd.namespace }}
+  labels:
+    {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
+    scaler: wva-keda
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ printf "%s-decode" .Values.llmd.modelName }}
+
+  pollingInterval:  {{ .Values.keda.pollingInterval }}
+  cooldownPeriod:   {{ .Values.keda.cooldownPeriod }}
+  minReplicaCount:  {{ .Values.keda.minReplicaCount }}
+  maxReplicaCount:  {{ .Values.keda.maxReplicaCount }}
+
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "workload-variant-autoscaler.fullname" . }}-keda-hpa
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.keda.behavior.scaleUp.stabilizationWindowSeconds }}
+          selectPolicy: {{ .Values.keda.behavior.scaleUp.selectPolicy }}
+          policies:
+          {{- range .Values.keda.behavior.scaleUp.policies }}
+          - type: {{ .type }}
+            value: {{ .value }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.keda.behavior.scaleDown.stabilizationWindowSeconds }}
+          selectPolicy: {{ .Values.keda.behavior.scaleDown.selectPolicy }}
+          policies:
+          {{- range .Values.keda.behavior.scaleDown.policies }}
+          - type: {{ .type }}
+            value: {{ .value }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+
+  triggers:
+  - type: prometheus
+    name: wva-desired-replicas
+    metadata:
+      serverAddress: {{ required "keda.prometheusServerAddress is required when keda.enabled=true" .Values.keda.prometheusServerAddress | quote }}
+      query: |
+        wva_desired_replicas{
+          variant_name="{{ include "workload-variant-autoscaler.fullname" . }}-va",
+          exported_namespace="{{ .Values.llmd.namespace }}"
+          {{- if .Values.wva.controllerInstance }},
+          controller_instance="{{ .Values.wva.controllerInstance }}"
+          {{- end }}
+        }
+      threshold:           {{ .Values.keda.threshold | quote }}
+      activationThreshold: {{ .Values.keda.activationThreshold | quote }}
+      metricType:          "AverageValue"
+      unsafeSsl:           {{ .Values.keda.unsafeSsl | quote }}
+{{- end }}

--- a/charts/workload-variant-autoscaler/tests/hpa_keda_ownership_test.yaml
+++ b/charts/workload-variant-autoscaler/tests/hpa_keda_ownership_test.yaml
@@ -1,0 +1,110 @@
+# Helm unit tests for hpa.enabled and keda.enabled flags.
+# Run with: helm unittest charts/workload-variant-autoscaler (requires helm-unittest plugin)
+
+suite: HPA / KEDA ownership flags
+
+templates:
+  - templates/hpa.yaml
+  - templates/keda.yaml
+
+tests:
+  # ──────────────────────────────────────────────────────────────────
+  # HPA tests
+  # ──────────────────────────────────────────────────────────────────
+
+  - it: "hpa.enabled=true (default) should render an HPA"
+    set:
+      hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/hpa.yaml
+      - isKind:
+          of: HorizontalPodAutoscaler
+        template: templates/hpa.yaml
+
+  - it: "hpa.enabled=false should render NO HPA (external controller owns it)"
+    set:
+      hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/hpa.yaml
+
+  # ──────────────────────────────────────────────────────────────────
+  # KEDA tests
+  # ──────────────────────────────────────────────────────────────────
+
+  - it: "keda.enabled=false (default) should render NO ScaledObject"
+    set:
+      keda.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/keda.yaml
+
+  - it: "keda.enabled=true should render a ScaledObject"
+    set:
+      hpa.enabled: false
+      keda.enabled: true
+      keda.prometheusServerAddress: "https://prometheus.svc:9090"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/keda.yaml
+      - isKind:
+          of: ScaledObject
+        template: templates/keda.yaml
+      - equal:
+          path: apiVersion
+          value: "keda.sh/v1alpha1"
+        template: templates/keda.yaml
+      - matchRegex:
+          path: spec.triggers[0].metadata.serverAddress
+          pattern: "^https://"
+        template: templates/keda.yaml
+
+  - it: "keda.enabled=true should use correct metric query labels"
+    set:
+      hpa.enabled: false
+      keda.enabled: true
+      keda.prometheusServerAddress: "https://prometheus.svc:9090"
+      llmd.namespace: "test-namespace"
+    asserts:
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: "exported_namespace=\"test-namespace\""
+        template: templates/keda.yaml
+
+  - it: "keda.enabled=true should respect minReplicaCount and maxReplicaCount"
+    set:
+      hpa.enabled: false
+      keda.enabled: true
+      keda.prometheusServerAddress: "https://prometheus.svc:9090"
+      keda.minReplicaCount: 1
+      keda.maxReplicaCount: 5
+    asserts:
+      - equal:
+          path: spec.minReplicaCount
+          value: 1
+        template: templates/keda.yaml
+      - equal:
+          path: spec.maxReplicaCount
+          value: 5
+        template: templates/keda.yaml
+
+  # ──────────────────────────────────────────────────────────────────
+  # External-platform mode: both disabled
+  # ──────────────────────────────────────────────────────────────────
+
+  - it: "hpa.enabled=false + keda.enabled=false should render neither (KServe mode)"
+    set:
+      hpa.enabled: false
+      keda.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/hpa.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/keda.yaml

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -100,7 +100,24 @@ va:
   sloTpot: 10
   sloTtft: 1000
 
+# ───────────────────────────────────────────────────────────────────────────
+# Autoscaling sub-resource ownership
+#
+# WVA emits wva_desired_replicas metrics that external autoscalers consume.
+# By default WVA also creates an HPA that reads those metrics. If an external
+# platform (e.g. KServe) already owns the HPA or ScaledObject for the same
+# target Deployment, set hpa.enabled=false (and keda.enabled=false) to
+# prevent conflicting controllers competing over the same scaling objects.
+#
+# Migration path:
+#   Phase 1 (today/KServe): hpa.enabled=false, keda.enabled=false
+#     → external platform owns HPA/ScaledObject; WVA only emits metrics.
+#   Phase 2 (future): hpa.enabled=true OR keda.enabled=true
+#     → WVA owns autoscaling sub-resources end-to-end.
+# ───────────────────────────────────────────────────────────────────────────
 hpa:
+  # Set to false when an external controller (e.g. KServe) owns the HPA
+  # for the target Deployment. Only one controller should own the HPA at a time.
   enabled: true
   # minReplicas: 0 enables scale-to-zero (requires HPAScaleToZero feature gate in k8s)
   # minReplicas: 1 is the safe default that prevents scale-to-zero
@@ -124,6 +141,56 @@ hpa:
         - type: Pods
           value: 10
           periodSeconds: 150
+
+# KEDA ScaledObject — alternative to the built-in HPA above.
+# Enable this when you want WVA to manage a KEDA ScaledObject instead of
+# (or in addition to) a plain HPA. Requires KEDA to be installed in the cluster.
+# Do NOT enable both hpa.enabled and keda.enabled for the same target Deployment —
+# that would create two competing autoscalers.
+# Set both to false to let an external platform (e.g. KServe) own all
+# autoscaling sub-resources.
+keda:
+  # Set to true to let WVA deploy a KEDA ScaledObject for the target Deployment.
+  # Ensure hpa.enabled=false when this is enabled to avoid dual-controller conflicts.
+  enabled: false
+
+  # Minimum replica count (0 = scale-to-zero, KEDA's native support).
+  minReplicaCount: 0
+  maxReplicaCount: 10
+
+  # How often KEDA polls metrics (seconds).
+  pollingInterval: 15
+  # Idle time before scaling to zero (seconds).
+  cooldownPeriod: 30
+
+  # Prometheus trigger — must point to the same Prometheus instance
+  # that WVA emits wva_desired_replicas metrics to.
+  # Example: https://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+  prometheusServerAddress: ""
+
+  # Scaling threshold: replica count target per metric value.
+  threshold: "1"
+  # Scale out from zero only when metric exceeds this value.
+  activationThreshold: "0"
+  # Set to "true" to skip TLS verification (development only).
+  unsafeSsl: "false"
+
+  # Optional: advanced HPA behavior config injected into the KEDA-managed HPA.
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 10
+          periodSeconds: 30
+    scaleDown:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 10
+          periodSeconds: 30
 
 vllmService:
   enabled: true

--- a/docs/integrations/kserve-integration.md
+++ b/docs/integrations/kserve-integration.md
@@ -1,0 +1,115 @@
+# KServe Integration with the Workload-Variant-Autoscaler (WVA)
+
+## Overview
+
+WVA creates and manages autoscaling sub-resources (HPA and KEDA ScaledObjects) for inference
+workloads as part of its Helm chart deployment. KServe also creates and manages HPA objects as
+part of its `LLMInferenceService` reconciliation for the same target Deployment.
+
+**Two controllers owning autoscaling objects for the same Deployment leads to undefined and
+conflicting scaling behavior.** This document explains how to safely integrate WVA with KServe
+today, and the longer-term migration path.
+
+---
+
+## Integration Phases
+
+### Phase 1 — Current (KServe owns HPA/KEDA)
+
+In this phase, KServe is the authoritative owner of HPA and KEDA ScaledObjects. WVA is
+deployed in **metrics-only mode**: it computes the desired replica count and exposes it via the
+`wva_desired_replicas` Prometheus metric, but does **not** create any HPA or ScaledObject in the
+cluster. KServe's HPA can consume `wva_desired_replicas` via the Prometheus Adapter external
+metrics API.
+
+**Helm configuration:**
+
+```yaml
+hpa:
+  enabled: false   # WVA will NOT create an HPA — KServe owns it
+
+keda:
+  enabled: false   # WVA will NOT create a ScaledObject — KServe owns it (default)
+```
+
+Or via `helm install` / `helm upgrade`:
+
+```bash
+helm upgrade --install workload-variant-autoscaler ./charts/workload-variant-autoscaler \
+  --set hpa.enabled=false \
+  --set keda.enabled=false
+```
+
+**What WVA still does in this mode:**
+- Watches `VariantAutoscaling` CRs and target Deployments.
+- Runs the saturation/queueing-model optimization engine.
+- Emits `wva_desired_replicas`, `wva_current_replicas`, and `wva_desired_ratio` metrics.
+- Updates `VariantAutoscaling` status with the optimized allocation.
+
+**What KServe does:**
+- Creates and manages the HPA object (or ScaledObject) for the Deployment.
+- Configures the HPA to consume `wva_desired_replicas` from the external metrics API.
+
+---
+
+### Phase 2 — Future (WVA owns HPA/KEDA end-to-end)
+
+In the long term, KServe aims to offload autoscaling sub-resource management entirely to WVA.
+Once KServe stops managing HPA/ScaledObject objects on its side, operators simply re-enable
+WVA's HPA (or KEDA) creation — **no API changes required**.
+
+```yaml
+hpa:
+  enabled: true    # WVA now owns the HPA
+```
+
+Or with KEDA:
+
+```yaml
+hpa:
+  enabled: false   # Do NOT enable both simultaneously
+keda:
+  enabled: true    # WVA now owns the ScaledObject
+  prometheusServerAddress: "https://prometheus.svc:9090"
+```
+
+> [!IMPORTANT]
+> Never set both `hpa.enabled=true` and `keda.enabled=true` for the same target Deployment.
+> The Helm chart will reject this combination with a validation error at render time.
+
+---
+
+## Configuration Reference
+
+| Value | Default | Description |
+|---|---|---|
+| `hpa.enabled` | `true` | Set `false` to prevent WVA from creating an HPA. |
+| `keda.enabled` | `false` | Set `true` to have WVA create a KEDA ScaledObject. |
+| `keda.prometheusServerAddress` | `""` | Required when `keda.enabled=true`. |
+| `keda.minReplicaCount` | `0` | Minimum replicas (0 = scale-to-zero). |
+| `keda.maxReplicaCount` | `10` | Maximum replicas. |
+| `keda.pollingInterval` | `15` | Metric polling interval (seconds). |
+| `keda.cooldownPeriod` | `30` | Idle period before scaling to zero (seconds). |
+| `keda.threshold` | `"1"` | Target metric value per replica. |
+| `keda.activationThreshold` | `"0"` | Scale from zero when metric exceeds this. |
+| `keda.unsafeSsl` | `"false"` | Skip TLS verification (dev only). |
+
+---
+
+## Conflict Prevention
+
+The Helm chart enforces mutual exclusion at render time:
+
+```
+hpa.enabled=true  + keda.enabled=true  → helm fail (rejected)
+hpa.enabled=false + keda.enabled=false → OK (external platform owns both)
+hpa.enabled=true  + keda.enabled=false → OK (WVA owns HPA)
+hpa.enabled=false + keda.enabled=true  → OK (WVA owns ScaledObject via KEDA)
+```
+
+---
+
+## Further Reading
+
+- [HPA Integration Guide](./hpa-integration.md)
+- [KEDA Integration Guide](./keda-integration.md)


### PR DESCRIPTION
Adds an opt-out mechanism so external platforms (e.g. KServe) can exclusively own HPA and KEDA ScaledObject sub-resources for a target Deployment, while WVA continues to emit wva_desired_replicas metrics.

Changes:
- values.yaml: add keda stanza (enabled: false by default) with full ScaledObject configuration; add ownership comments to hpa block
- templates/hpa.yaml: add doc comment pointing to KServe guide
- templates/keda.yaml (new): renders a keda.sh/v1alpha1 ScaledObject when keda.enabled=true; includes a helm fail guard that rejects hpa.enabled=true+keda.enabled=true simultaneously
- tests/hpa_keda_ownership_test.yaml (new): helm-unittest tests for all four ownership combinations
- docs/integrations/kserve-integration.md (new): integration guide documenting Phase 1 (KServe owns) and Phase 2 (WVA owns) migration

Supported ownership modes:
  hpa.enabled=true,  keda.enabled=false -> HPA only (default) hpa.enabled=false, keda.enabled=false -> no sub-resources (KServe mode) hpa.enabled=false, keda.enabled=true  -> KEDA ScaledObject only hpa.enabled=true,  keda.enabled=true  -> helm error (rejected)