### PR TITLE
feat(helm): expose controller replica count as configurable value

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
       {{- include "workload-variant-autoscaler.selectorLabels" . | nindent 6 }}
-  replicas: 2
+  replicas: {{ .Values.wva.replicaCount }}
   template:
     metadata:
       annotations:

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -6,6 +6,7 @@ controller:
 
 wva:
   enabled: true
+  replicaCount: 2
 
   image:
     repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler


### PR DESCRIPTION
## Summary

- Adds `wva.replicas` to `values.yaml` (default: `2`, preserving current behavior) so users can configure the controller manager replica count via `--set wva.replicas=N` without editing templates directly.
- Replaces the hardcoded `replicas: 2` in the controller manager deployment template with `{{ .Values.wva.replicas }}`.

Closes #907