### PR TITLE
fix: skip CA cert loading when insecureSkipVerify is true and no cert is provided

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-configmap.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-configmap.yaml
@@ -21,8 +21,10 @@ data:
     # Prometheus Configuration (REQUIRED)
     # Base URL for Prometheus API (must use HTTPS).
     PROMETHEUS_BASE_URL: {{ .Values.wva.prometheus.baseURL | quote }}
+    {{- if .Values.wva.prometheus.caCert }}
     # Filesystem path to the CA certificate used to verify Prometheus TLS cert.
     PROMETHEUS_CA_CERT_PATH: {{ .Values.wva.prometheus.tls.caCertPath | default "/etc/ssl/certs/prometheus-ca.crt" | quote }}
+    {{- end }}
     # Whether to skip TLS certificate verification when connecting to Prometheus.
     PROMETHEUS_TLS_INSECURE_SKIP_VERIFY: {{ if and .Values.wva.prometheus.tls (hasKey .Values.wva.prometheus.tls "insecureSkipVerify") }}{{ .Values.wva.prometheus.tls.insecureSkipVerify | quote }}{{ else }}"true"{{ end }}
 

--- a/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-deployment-controller-manager.yaml
@@ -105,10 +105,12 @@ spec:
           mountPath: /etc/wva/config.yaml
           subPath: config.yaml
           readOnly: true
+        {{- if .Values.wva.prometheus.caCert }}
         - name: prometheus-ca-cert
           mountPath: /etc/ssl/certs/prometheus-ca.crt
           subPath: ca.crt
           readOnly: true
+        {{- end }}
         - name: epp-metrics-token
           mountPath: /var/run/secrets/epp-metrics
           readOnly: true
@@ -116,10 +118,11 @@ spec:
       - name: wva-config
         configMap:
           name: {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-config
+      {{- if .Values.wva.prometheus.caCert }}
       - name: prometheus-ca-cert
         configMap:
           name: {{ include "workload-variant-autoscaler.fullname" . }}-prometheus-ca
-          optional: true
+      {{- end }}
       - name: epp-metrics-token
         secret:
           secretName: {{ include "workload-variant-autoscaler.fullname" . }}-epp-metrics-token

--- a/charts/workload-variant-autoscaler/templates/prometheus-ca-configmap-prom.yaml
+++ b/charts/workload-variant-autoscaler/templates/prometheus-ca-configmap-prom.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if and .Values.controller.enabled .Values.wva.prometheus.caCert }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,9 +8,5 @@ metadata:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 data:
   ca.crt: |
-    {{- if .Values.wva.prometheus.caCert }}
 {{ .Values.wva.prometheus.caCert | indent 4 }}
-    {{- else }}
-    # CA certificate not provided - using system CA bundle
-    {{- end }}
 {{- end }}

--- a/charts/workload-variant-autoscaler/templates/prometheus-ca-configmap-wva.yaml
+++ b/charts/workload-variant-autoscaler/templates/prometheus-ca-configmap-wva.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enabled }}
+{{- if and .Values.controller.enabled .Values.wva.prometheus.caCert }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,9 +8,5 @@ metadata:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 data:
   ca.crt: |
-    {{- if .Values.wva.prometheus.caCert }}
 {{ .Values.wva.prometheus.caCert | indent 4 }}
-    {{- else }}
-    # CA certificate not provided - using system CA bundle
-    {{- end }}
 {{- end }}

--- a/charts/workload-variant-autoscaler/values-dev.yaml
+++ b/charts/workload-variant-autoscaler/values-dev.yaml
@@ -27,7 +27,7 @@ wva:
     # Development security configuration (relaxed for easier development)
     tls:
       insecureSkipVerify: true   # Development: true, Production: false
-      caCertPath: "/etc/ssl/certs/prometheus-ca.crt"
+      # caCertPath: "/etc/ssl/certs/prometheus-ca.crt"  # Only used when caCert is provided
     # caCert: |  # Uncomment and provide your CA certificate
     #   -----BEGIN CERTIFICATE-----
     #   YOUR_CA_CERTIFICATE_HERE

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -39,7 +39,7 @@ wva:
     # Development security configuration (relaxed for easier development)
     tls:
       insecureSkipVerify: true   # Development: true, Production: false
-      caCertPath: "/etc/ssl/certs/prometheus-ca.crt"
+      # caCertPath: "/etc/ssl/certs/prometheus-ca.crt"  # Only used when caCert is provided
     # caCert: |  # Uncomment and provide your CA certificate
     #   -----BEGIN CERTIFICATE-----
     #   YOUR_CA_CERTIFICATE_HERE

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -35,6 +35,11 @@ func CreateTLSConfig(cfg *config.Config) (*tls.Config, error) {
 		MinVersion:         tls.VersionTLS12, // Enforce minimum TLS version - https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/tls-security-profiles#:~:text=requires%20a%20minimum-,TLS%20version%20of%201.2,-.
 	}
 
+	if insecureSkipVerify {
+		ctrl.Log.V(logging.VERBOSE).Info("TLS certificate verification is disabled, skipping certificate loading")
+		return config, nil
+	}
+
 	// Load CA certificate if provided
 	if caCertPath != "" {
 		caCert, err := os.ReadFile(caCertPath)

--- a/internal/utils/tls_test.go
+++ b/internal/utils/tls_test.go
@@ -86,23 +86,52 @@ func TestCreateTLSConfig(t *testing.T) {
 			}),
 			expectError: false,
 		},
+		{
+			name: "insecure skip verify with invalid CA cert path should not error",
+			promConfig: testConfigFromEnv(t, map[string]string{
+				"PROMETHEUS_BASE_URL":                 "https://prometheus:9090",
+				"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY": "true",
+				"PROMETHEUS_CA_CERT_PATH":             "/nonexistent/path/ca.crt",
+			}),
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := CreateTLSConfig(tt.promConfig)
+			tlsCfg, err := CreateTLSConfig(tt.promConfig)
 			if tt.expectError {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
 			if tt.promConfig != nil {
-				assert.NotNil(t, config)
+				assert.NotNil(t, tlsCfg)
 			} else {
-				assert.Nil(t, config)
+				assert.Nil(t, tlsCfg)
 			}
 		})
 	}
+}
+
+func TestCreateTLSConfig_InsecureSkipVerifySkipsCertLoading(t *testing.T) {
+	invalidCertFile, err := os.CreateTemp(t.TempDir(), "invalid-cert-*.crt")
+	require.NoError(t, err)
+	_, err = invalidCertFile.WriteString("# CA certificate not provided - using system CA bundle")
+	require.NoError(t, err)
+	require.NoError(t, invalidCertFile.Close())
+
+	cfg := testConfigFromEnv(t, map[string]string{
+		"PROMETHEUS_BASE_URL":                 "https://prometheus:9090",
+		"PROMETHEUS_TLS_INSECURE_SKIP_VERIFY": "true",
+		"PROMETHEUS_CA_CERT_PATH":             invalidCertFile.Name(),
+	})
+
+	tlsCfg, err := CreateTLSConfig(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, tlsCfg)
+	assert.True(t, tlsCfg.InsecureSkipVerify)
+	assert.Nil(t, tlsCfg.RootCAs, "RootCAs should be nil when insecureSkipVerify is true")
 }
 
 func TestValidateTLSConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #908

With default Helm values (`insecureSkipVerify: true`, no `caCert`), the controller crashes at startup trying to parse a placeholder comment (`# CA certificate not provided`) as a PEM certificate.

### Root Cause

- The Helm chart unconditionally creates a ConfigMap with a placeholder comment as `ca.crt`, mounts it into the container, and sets `PROMETHEUS_CA_CERT_PATH` pointing to it.
- `ValidateTLSConfig` correctly skips cert checks when `insecureSkipVerify` is true, but `CreateTLSConfig` ignores the flag and unconditionally reads and parses the file — failing on the placeholder.

### Changes

**Go (`internal/utils/tls.go`):**
- Return early from `CreateTLSConfig` when `insecureSkipVerify` is true, skipping all certificate loading.

**Helm chart:**
- `prometheus-ca-configmap-wva.yaml`: only create ConfigMap when `wva.prometheus.caCert` is set.
- `prometheus-ca-configmap-prom.yaml`: same.
- `wva-configmap.yaml`: only emit `PROMETHEUS_CA_CERT_PATH` when `wva.prometheus.caCert` is set.
- `wva-deployment-controller-manager.yaml`: only mount CA cert volume when `wva.prometheus.caCert` is set.
- `values.yaml` / `values-dev.yaml`: comment out `caCertPath` default to avoid confusion.

**Tests (`internal/utils/tls_test.go`):**
- Added test for `insecureSkipVerify: true` with a nonexistent cert path.
- Added test for `insecureSkipVerify: true` with a file containing the exact placeholder comment
  (reproduces the crash scenario).

### Behavior by Scenario

| Scenario | Before | After |
|----------|--------|-------|
| `insecureSkipVerify: true`, no `caCert` (default) | Crash | Works |
| `insecureSkipVerify: true`, `caCert` provided | Loads cert unnecessarily | Skips loading (cert was ignored anyway) |
| `insecureSkipVerify: false`, `caCert` provided (production) | Works | No change |
| `insecureSkipVerify: false`, no `caCert` | Crash | Falls back to system CA bundle |

## Test Plan

- [x] `go test ./internal/utils/ -v` — all pass including new test cases
- [x] `go test ./test/chart/ -v` — all chart tests pass