### PR TITLE
Feat: Add saturation and capacity Prometheus metrics for WVA observability

### DIFF
--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -101,6 +101,7 @@ func (a *Actuator) EmitSaturationMetrics(ctx context.Context, decision interface
 		decision.VariantName,
 		decision.Namespace,
 		decision.AcceleratorName,
+		decision.AnalyzerVersion,
 		decision.Utilization,
 		decision.SpareCapacity,
 		decision.RequiredCapacity,

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -100,12 +100,21 @@ func (a *Actuator) EmitSaturationMetrics(ctx context.Context, decision interface
 		ctx,
 		decision.VariantName,
 		decision.Namespace,
+		decision.ModelID,
 		decision.AcceleratorName,
-		decision.AnalyzerVersion,
+		decision.RequiredCapacityUnit,
 		decision.Utilization,
 		decision.SpareCapacity,
 		decision.RequiredCapacity,
 		decision.KvCacheTokensUsed,
-		decision.KvCacheTokensTotal,
+		decision.KvCacheTokensCapacity,
 	)
+}
+
+// DeleteSaturationMetricsForVariant removes all saturation metric series for a
+// variant. Call this when the current optimization cycle produced no fresh
+// decision for the variant, or when the VA is being deleted — so dashboards
+// don't show stale values.
+func (a *Actuator) DeleteSaturationMetricsForVariant(variantName, namespace string) {
+	a.MetricsEmitter.DeleteSaturationMetricsForVariant(variantName, namespace)
 }

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -6,6 +6,7 @@ import (
 
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,4 +92,19 @@ func (a *Actuator) EmitMetrics(ctx context.Context, variantAutoscaling *llmdOptv
 		"desiredReplicas", desiredReplicas,
 		"accelerator", variantAutoscaling.Status.DesiredOptimizedAlloc.Accelerator)
 	return nil
+}
+
+// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics from a decision.
+func (a *Actuator) EmitSaturationMetrics(ctx context.Context, decision interfaces.VariantDecision) error {
+	return a.MetricsEmitter.EmitSaturationMetrics(
+		ctx,
+		decision.VariantName,
+		decision.Namespace,
+		decision.AcceleratorName,
+		decision.Utilization,
+		decision.SpareCapacity,
+		decision.RequiredCapacity,
+		decision.KvCacheTokensUsed,
+		decision.KvCacheTokensTotal,
+	)
 }

--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -94,9 +94,11 @@ func (a *Actuator) EmitMetrics(ctx context.Context, variantAutoscaling *llmdOptv
 	return nil
 }
 
-// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics from a decision.
-func (a *Actuator) EmitSaturationMetrics(ctx context.Context, decision interfaces.VariantDecision) error {
-	return a.MetricsEmitter.EmitSaturationMetrics(
+// RecordSaturationMetrics records saturation analysis and KV cache capacity
+// metrics from a decision. The controller does not actively push metrics —
+// Prometheus scrapes them — so the verb is "Record", not "Emit".
+func (a *Actuator) RecordSaturationMetrics(ctx context.Context, decision interfaces.VariantDecision) {
+	a.MetricsEmitter.RecordSaturationMetrics(
 		ctx,
 		decision.VariantName,
 		decision.Namespace,
@@ -109,12 +111,4 @@ func (a *Actuator) EmitSaturationMetrics(ctx context.Context, decision interface
 		decision.KvCacheTokensUsed,
 		decision.KvCacheTokensCapacity,
 	)
-}
-
-// DeleteSaturationMetricsForVariant removes all saturation metric series for a
-// variant. Call this when the current optimization cycle produced no fresh
-// decision for the variant, or when the VA is being deleted — so dashboards
-// don't show stale values.
-func (a *Actuator) DeleteSaturationMetricsForVariant(variantName, namespace string) {
-	a.MetricsEmitter.DeleteSaturationMetricsForVariant(variantName, namespace)
 }

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -131,6 +131,26 @@ const (
 	// WVAMetricsFreshnessStatus is a gauge that tracks the freshness status of metrics for each variant.
 	// Labels: variant_name, status
 	WVAMetricsFreshnessStatus = "wva_metrics_freshness_status"
+
+	// WVASaturationUtilization is a gauge that tracks per-variant utilization ratio (0.0-1.0).
+	// Labels: variant_name, namespace, accelerator_type
+	WVASaturationUtilization = "wva_saturation_utilization"
+
+	// WVASpareCapacity is a gauge that tracks per-variant spare capacity (0.0-1.0).
+	// Labels: variant_name, namespace, accelerator_type
+	WVASpareCapacity = "wva_spare_capacity"
+
+	// WVARequiredCapacity is a gauge that tracks model-level required capacity.
+	// >0 means scale-up needed. Labels: variant_name, namespace
+	WVARequiredCapacity = "wva_required_capacity"
+
+	// WVAKvCacheTokensUsed is a gauge that tracks total KV cache tokens currently in use per variant.
+	// Labels: variant_name, namespace
+	WVAKvCacheTokensUsed = "wva_kv_cache_tokens_used"
+
+	// WVAKvCacheTokensTotal is a gauge that tracks total KV cache token capacity per variant.
+	// Labels: variant_name, namespace
+	WVAKvCacheTokensTotal = "wva_kv_cache_tokens_total"
 )
 
 // Metric Label Names

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -141,7 +141,11 @@ const (
 	WVASpareCapacity = "wva_spare_capacity"
 
 	// WVARequiredCapacity is a gauge that tracks model-level required capacity.
-	// >0 means scale-up needed. Labels: variant_name, namespace
+	// >0 means scale-up needed.
+	// Units differ by analyzer (use the analyzer_version label to distinguish):
+	//   - V1: binary signal (0.0 = no scale-up, 1.0 = scale-up needed)
+	//   - V2: continuous token-based demand
+	// Labels: variant_name, namespace, analyzer_version
 	WVARequiredCapacity = "wva_required_capacity"
 
 	// WVAKvCacheTokensUsed is a gauge that tracks total KV cache tokens currently in use per variant.
@@ -165,6 +169,7 @@ const (
 	LabelControllerInstance = "controller_instance"
 	LabelStatus             = "status"
 	LabelQueryType          = "query_type"
+	LabelAnalyzerVersion    = "analyzer_version"
 )
 
 // Metric Label Values for query_type
@@ -174,4 +179,10 @@ const (
 	QueryTypeQueueLength  = "queue_length"
 	QueryTypeRequestCount = "request_count"
 	QueryTypeCacheConfig  = "cache_config"
+)
+
+// Analyzer version label values used in saturation metrics.
+const (
+	AnalyzerVersionV1 = "v1"
+	AnalyzerVersionV2 = "v2"
 )

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -133,28 +133,28 @@ const (
 	WVAMetricsFreshnessStatus = "wva_metrics_freshness_status"
 
 	// WVASaturationUtilization is a gauge that tracks per-variant utilization ratio (0.0-1.0).
-	// Labels: variant_name, namespace, accelerator_type
+	// Labels: variant_name, namespace, model_name, accelerator_type
 	WVASaturationUtilization = "wva_saturation_utilization"
 
 	// WVASpareCapacity is a gauge that tracks per-variant spare capacity (0.0-1.0).
-	// Labels: variant_name, namespace, accelerator_type
+	// Labels: variant_name, namespace, model_name, accelerator_type
 	WVASpareCapacity = "wva_spare_capacity"
 
 	// WVARequiredCapacity is a gauge that tracks model-level required capacity.
 	// >0 means scale-up needed.
-	// Units differ by analyzer (use the analyzer_version label to distinguish):
-	//   - V1: binary signal (0.0 = no scale-up, 1.0 = scale-up needed)
-	//   - V2: continuous token-based demand
-	// Labels: variant_name, namespace, analyzer_version
+	// Value semantics differ by analyzer (use the "unit" label to distinguish):
+	//   - unit="binary"     (V1): 0.0 = no scale-up, 1.0 = scale-up needed
+	//   - unit="continuous" (V2): continuous token-based demand
+	// Labels: variant_name, namespace, model_name, unit
 	WVARequiredCapacity = "wva_required_capacity"
 
 	// WVAKvCacheTokensUsed is a gauge that tracks total KV cache tokens currently in use per variant.
-	// Labels: variant_name, namespace
+	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensUsed = "wva_kv_cache_tokens_used"
 
-	// WVAKvCacheTokensTotal is a gauge that tracks total KV cache token capacity per variant.
-	// Labels: variant_name, namespace
-	WVAKvCacheTokensTotal = "wva_kv_cache_tokens_total"
+	// WVAKvCacheTokensCapacity is a gauge that tracks total KV cache token capacity per variant.
+	// Labels: variant_name, namespace, model_name
+	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
 )
 
 // Metric Label Names
@@ -169,7 +169,11 @@ const (
 	LabelControllerInstance = "controller_instance"
 	LabelStatus             = "status"
 	LabelQueryType          = "query_type"
-	LabelAnalyzerVersion    = "analyzer_version"
+	// LabelUnit distinguishes the unit of a metric value when a single metric name
+	// carries values with different semantic units. Currently applied to
+	// wva_required_capacity, whose value is either a binary scale-up signal (V1)
+	// or a continuous token-demand value (V2).
+	LabelUnit = "unit"
 )
 
 // Metric Label Values for query_type
@@ -181,8 +185,9 @@ const (
 	QueryTypeCacheConfig  = "cache_config"
 )
 
-// Analyzer version label values used in saturation metrics.
+// Values for the LabelUnit Prometheus label, describing how to interpret the
+// metric value ("binary" 0/1 vs. "continuous" absolute quantity).
 const (
-	AnalyzerVersionV1 = "v1"
-	AnalyzerVersionV2 = "v2"
+	UnitBinary     = "binary"
+	UnitContinuous = "continuous"
 )

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -292,18 +292,21 @@ func buildDecisionsWithOptimizer(
 		}
 
 		decisions = append(decisions, interfaces.VariantDecision{
-			VariantName:     name,
-			ModelID:         req.ModelID,
-			Namespace:       req.Namespace,
-			AcceleratorName: vc.AcceleratorName,
-			Cost:            vc.Cost,
-			Role:            state.Role,
-			CurrentReplicas: state.CurrentReplicas,
-			TargetReplicas:  target,
-			Action:          action,
-			Reason:          reason,
-			MinReplicas:     state.MinReplicas,
-			MaxReplicas:     state.MaxReplicas,
+			VariantName:      name,
+			ModelID:          req.ModelID,
+			Namespace:        req.Namespace,
+			AcceleratorName:  vc.AcceleratorName,
+			Cost:             vc.Cost,
+			Role:             state.Role,
+			CurrentReplicas:  state.CurrentReplicas,
+			TargetReplicas:   target,
+			Action:           action,
+			Reason:           reason,
+			MinReplicas:      state.MinReplicas,
+			MaxReplicas:      state.MaxReplicas,
+			Utilization:      vc.Utilization,
+			SpareCapacity:    1.0 - vc.Utilization,
+			RequiredCapacity: req.Result.RequiredCapacity,
 		})
 	}
 	return decisions

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -583,6 +583,8 @@ func (e *Engine) optimizeV2(
 
 	// Stage 1: Collect ModelScalingRequests for all models
 	var requests []pipeline.ModelScalingRequest
+	// modelReplicaMetrics collects per-model replica metrics for KV token enrichment
+	modelReplicaMetrics := make(map[string][]interfaces.ReplicaMetrics)
 
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
@@ -623,6 +625,7 @@ func (e *Engine) optimizeV2(
 		}
 
 		requests = append(requests, *req)
+		modelReplicaMetrics[modelID] = data.replicaMetrics
 	}
 
 	if len(requests) == 0 {
@@ -669,6 +672,11 @@ func (e *Engine) optimizeV2(
 				"modelID", req.ModelID)
 		}
 	}
+
+	// Stage 4: Enrich decisions with KV cache token data from replicaMetrics.
+	// Utilization, RequiredCapacity, and SpareCapacity are already set by
+	// buildDecisionsWithOptimizer from AnalyzerResult.
+	enrichDecisionsWithKvTokenData(allDecisions, modelReplicaMetrics)
 
 	return allDecisions
 }
@@ -868,6 +876,77 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 	}
 
 	return decisions
+}
+
+// enrichDecisionsFromReplicaMetrics populates saturation observability fields on decisions
+// by aggregating per-pod ReplicaMetrics per variant. Used by the V1 path where
+// Utilization and RequiredCapacity are not set by the optimizer.
+func enrichDecisionsFromReplicaMetrics(decisions []interfaces.VariantDecision, replicaMetrics []interfaces.ReplicaMetrics, shouldScaleUp bool) {
+	// Aggregate per variant
+	type variantAgg struct {
+		kvUsed     int64
+		kvTotal    int64
+		kvUsageSum float64
+		count      int
+	}
+	agg := make(map[string]*variantAgg)
+	for _, rm := range replicaMetrics {
+		a, ok := agg[rm.VariantName]
+		if !ok {
+			a = &variantAgg{}
+			agg[rm.VariantName] = a
+		}
+		a.kvUsed += rm.TokensInUse
+		a.kvTotal += rm.TotalKvCapacityTokens
+		a.kvUsageSum += rm.KvCacheUsage
+		a.count++
+	}
+
+	requiredCapacity := float64(0)
+	if shouldScaleUp {
+		requiredCapacity = 1.0
+	}
+
+	for i := range decisions {
+		d := &decisions[i]
+		d.RequiredCapacity = requiredCapacity
+		if a, ok := agg[d.VariantName]; ok && a.count > 0 {
+			d.KvCacheTokensUsed = a.kvUsed
+			d.KvCacheTokensTotal = a.kvTotal
+			d.Utilization = a.kvUsageSum / float64(a.count)
+		}
+	}
+}
+
+// enrichDecisionsWithKvTokenData sets KvCacheTokensUsed and KvCacheTokensTotal on decisions
+// from replica metrics aggregated per variant. Used by V2 path where Utilization and
+// RequiredCapacity are already set from AnalyzerResult.
+func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, modelReplicaMetrics map[string][]interfaces.ReplicaMetrics) {
+	// Build per-variant KV token aggregation across all models
+	type kvAgg struct {
+		kvUsed  int64
+		kvTotal int64
+	}
+	agg := make(map[string]*kvAgg)
+	for _, metrics := range modelReplicaMetrics {
+		for _, rm := range metrics {
+			a, ok := agg[rm.VariantName]
+			if !ok {
+				a = &kvAgg{}
+				agg[rm.VariantName] = a
+			}
+			a.kvUsed += rm.TokensInUse
+			a.kvTotal += rm.TotalKvCapacityTokens
+		}
+	}
+
+	for i := range decisions {
+		d := &decisions[i]
+		if a, ok := agg[d.VariantName]; ok {
+			d.KvCacheTokensUsed = a.kvUsed
+			d.KvCacheTokensTotal = a.kvTotal
+		}
+	}
 }
 
 // hasMinReplicasAboveZero returns true if any variant in the states has MinReplicas > 0.
@@ -1247,6 +1326,13 @@ func (e *Engine) applySaturationDecisions(
 					"accelerator", acceleratorName)
 			}
 			updateVa.Status.Actuation.Applied = true
+		}
+
+		// Emit saturation and capacity metrics for observability
+		if hasDecision {
+			if err := act.EmitSaturationMetrics(ctx, decision); err != nil {
+				logger.Error(err, "Failed to emit saturation metrics", "variant", updateVa.Name)
+			}
 		}
 
 		// Update Shared State and Trigger Reconcile via Channel

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1345,21 +1345,14 @@ func (e *Engine) applySaturationDecisions(
 			updateVa.Status.Actuation.Applied = true
 		}
 
-		// Emit saturation and capacity metrics for observability.
-		// When this cycle produced no fresh decision for the variant, actively
-		// clear the existing series so dashboards show a gap ("no fresh data")
-		// rather than stale values that would otherwise persist until Prometheus'
-		// 5-minute staleness marker fires. For fully-deleted VAs, additional
-		// cleanup via the reconciler's delete handler / finalizer is still
-		// required (see DeleteSaturationMetricsForVariant).
+		// Record saturation and capacity metrics when this cycle produced a
+		// fresh decision for the variant. When there is no fresh decision the
+		// existing series persist with their last-recorded values until
+		// Prometheus' staleness marker fires; surfacing freshness on the
+		// dashboard side is tracked as a follow-up (e.g. an explicit "up"
+		// gauge per VA, rather than deleting series here).
 		if hasDecision {
-			if err := act.EmitSaturationMetrics(ctx, decision); err != nil {
-				logger.Error(err, "Failed to emit saturation metrics", "variant", updateVa.Name)
-			}
-		} else {
-			act.DeleteSaturationMetricsForVariant(updateVa.Name, updateVa.Namespace)
-			logger.V(logging.DEBUG).Info("Cleared stale saturation metrics (no fresh decision this cycle)",
-				"variant", updateVa.Name, "namespace", updateVa.Namespace)
+			act.RecordSaturationMetrics(ctx, decision)
 		}
 
 		// Update Shared State and Trigger Reconcile via Channel

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -879,53 +879,6 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 	return decisions
 }
 
-// enrichDecisionsFromReplicaMetrics populates saturation observability fields on decisions
-// by aggregating per-pod ReplicaMetrics per variant. Used by the V1 path where
-// Utilization and RequiredCapacity are not set by the optimizer.
-func enrichDecisionsFromReplicaMetrics(decisions []interfaces.VariantDecision, replicaMetrics []interfaces.ReplicaMetrics, shouldScaleUp bool) {
-	// Aggregate per variant
-	type variantAgg struct {
-		kvUsed     int64
-		kvTotal    int64
-		kvUsageSum float64
-		count      int
-	}
-	agg := make(map[string]*variantAgg)
-	for _, rm := range replicaMetrics {
-		a, ok := agg[rm.VariantName]
-		if !ok {
-			a = &variantAgg{}
-			agg[rm.VariantName] = a
-		}
-		a.kvUsed += rm.TokensInUse
-		a.kvTotal += rm.TotalKvCapacityTokens
-		a.kvUsageSum += rm.KvCacheUsage
-		a.count++
-	}
-
-	requiredCapacity := float64(0)
-	if shouldScaleUp {
-		requiredCapacity = 1.0
-	}
-
-	for i := range decisions {
-		d := &decisions[i]
-		d.RequiredCapacity = requiredCapacity
-		d.RequiredCapacityUnit = constants.UnitBinary
-		if a, ok := agg[d.VariantName]; ok && a.count > 0 {
-			d.KvCacheTokensUsed = a.kvUsed
-			d.KvCacheTokensCapacity = a.kvTotal
-			// V1 reasons about saturation per-replica using KvCacheUsage fractions
-			// (rm.KvCacheUsage is 0.0-1.0), not tokens. Report the mean of those
-			// per-replica fractions as the variant-level utilization — this
-			// matches what the V1 analyzer actually evaluates against its
-			// thresholds. V2 uses a different (token-demand / capacity) formula;
-			// see the field doc on VariantDecision.Utilization.
-			d.Utilization = a.kvUsageSum / float64(a.count)
-		}
-	}
-}
-
 // enrichDecisionsWithKvTokenData sets KvCacheTokensUsed, KvCacheTokensCapacity, and
 // RequiredCapacityUnit on decisions from replica metrics aggregated per (model, variant).
 // Used by V2 path where Utilization and RequiredCapacity are already set from
@@ -1349,8 +1302,8 @@ func (e *Engine) applySaturationDecisions(
 		// fresh decision for the variant. When there is no fresh decision the
 		// existing series persist with their last-recorded values until
 		// Prometheus' staleness marker fires; surfacing freshness on the
-		// dashboard side is tracked as a follow-up (e.g. an explicit "up"
-		// gauge per VA, rather than deleting series here).
+		// dashboard side is tracked in #1082 (an explicit "up" gauge per VA,
+		// rather than deleting series here).
 		if hasDecision {
 			act.RecordSaturationMetrics(ctx, decision)
 		}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -911,17 +911,23 @@ func enrichDecisionsFromReplicaMetrics(decisions []interfaces.VariantDecision, r
 	for i := range decisions {
 		d := &decisions[i]
 		d.RequiredCapacity = requiredCapacity
-		d.AnalyzerVersion = constants.AnalyzerVersionV1
+		d.RequiredCapacityUnit = constants.UnitBinary
 		if a, ok := agg[d.VariantName]; ok && a.count > 0 {
 			d.KvCacheTokensUsed = a.kvUsed
-			d.KvCacheTokensTotal = a.kvTotal
+			d.KvCacheTokensCapacity = a.kvTotal
+			// V1 reasons about saturation per-replica using KvCacheUsage fractions
+			// (rm.KvCacheUsage is 0.0-1.0), not tokens. Report the mean of those
+			// per-replica fractions as the variant-level utilization — this
+			// matches what the V1 analyzer actually evaluates against its
+			// thresholds. V2 uses a different (token-demand / capacity) formula;
+			// see the field doc on VariantDecision.Utilization.
 			d.Utilization = a.kvUsageSum / float64(a.count)
 		}
 	}
 }
 
-// enrichDecisionsWithKvTokenData sets KvCacheTokensUsed, KvCacheTokensTotal, and
-// AnalyzerVersion on decisions from replica metrics aggregated per (model, variant).
+// enrichDecisionsWithKvTokenData sets KvCacheTokensUsed, KvCacheTokensCapacity, and
+// RequiredCapacityUnit on decisions from replica metrics aggregated per (model, variant).
 // Used by V2 path where Utilization and RequiredCapacity are already set from
 // AnalyzerResult.
 //
@@ -952,10 +958,10 @@ func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, mode
 
 	for i := range decisions {
 		d := &decisions[i]
-		d.AnalyzerVersion = constants.AnalyzerVersionV2
+		d.RequiredCapacityUnit = constants.UnitContinuous
 		if a, ok := agg[variantKey{modelID: d.ModelID, variant: d.VariantName}]; ok {
 			d.KvCacheTokensUsed = a.kvUsed
-			d.KvCacheTokensTotal = a.kvTotal
+			d.KvCacheTokensCapacity = a.kvTotal
 		}
 	}
 }
@@ -1340,14 +1346,20 @@ func (e *Engine) applySaturationDecisions(
 		}
 
 		// Emit saturation and capacity metrics for observability.
-		// Note: stale time series for deleted VAs are not cleaned up automatically here.
-		// The metrics package exposes DeleteSaturationMetrics for callers (e.g., the
-		// VariantAutoscaling reconciler's delete handler / finalizer) to remove series
-		// when a VA is removed.
+		// When this cycle produced no fresh decision for the variant, actively
+		// clear the existing series so dashboards show a gap ("no fresh data")
+		// rather than stale values that would otherwise persist until Prometheus'
+		// 5-minute staleness marker fires. For fully-deleted VAs, additional
+		// cleanup via the reconciler's delete handler / finalizer is still
+		// required (see DeleteSaturationMetricsForVariant).
 		if hasDecision {
 			if err := act.EmitSaturationMetrics(ctx, decision); err != nil {
 				logger.Error(err, "Failed to emit saturation metrics", "variant", updateVa.Name)
 			}
+		} else {
+			act.DeleteSaturationMetricsForVariant(updateVa.Name, updateVa.Namespace)
+			logger.V(logging.DEBUG).Info("Cleared stale saturation metrics (no fresh decision this cycle)",
+				"variant", updateVa.Name, "namespace", updateVa.Namespace)
 		}
 
 		// Update Shared State and Trigger Reconcile via Channel

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -36,6 +36,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
@@ -910,6 +911,7 @@ func enrichDecisionsFromReplicaMetrics(decisions []interfaces.VariantDecision, r
 	for i := range decisions {
 		d := &decisions[i]
 		d.RequiredCapacity = requiredCapacity
+		d.AnalyzerVersion = constants.AnalyzerVersionV1
 		if a, ok := agg[d.VariantName]; ok && a.count > 0 {
 			d.KvCacheTokensUsed = a.kvUsed
 			d.KvCacheTokensTotal = a.kvTotal
@@ -918,22 +920,30 @@ func enrichDecisionsFromReplicaMetrics(decisions []interfaces.VariantDecision, r
 	}
 }
 
-// enrichDecisionsWithKvTokenData sets KvCacheTokensUsed and KvCacheTokensTotal on decisions
-// from replica metrics aggregated per variant. Used by V2 path where Utilization and
-// RequiredCapacity are already set from AnalyzerResult.
+// enrichDecisionsWithKvTokenData sets KvCacheTokensUsed, KvCacheTokensTotal, and
+// AnalyzerVersion on decisions from replica metrics aggregated per (model, variant).
+// Used by V2 path where Utilization and RequiredCapacity are already set from
+// AnalyzerResult.
+//
+// Aggregation is keyed by (modelID, variantName) — not just variantName — because
+// variant names can collide across different models in the same reconcile cycle.
 func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, modelReplicaMetrics map[string][]interfaces.ReplicaMetrics) {
-	// Build per-variant KV token aggregation across all models
 	type kvAgg struct {
 		kvUsed  int64
 		kvTotal int64
 	}
-	agg := make(map[string]*kvAgg)
-	for _, metrics := range modelReplicaMetrics {
+	type variantKey struct {
+		modelID string
+		variant string
+	}
+	agg := make(map[variantKey]*kvAgg)
+	for modelID, metrics := range modelReplicaMetrics {
 		for _, rm := range metrics {
-			a, ok := agg[rm.VariantName]
+			k := variantKey{modelID: modelID, variant: rm.VariantName}
+			a, ok := agg[k]
 			if !ok {
 				a = &kvAgg{}
-				agg[rm.VariantName] = a
+				agg[k] = a
 			}
 			a.kvUsed += rm.TokensInUse
 			a.kvTotal += rm.TotalKvCapacityTokens
@@ -942,7 +952,8 @@ func enrichDecisionsWithKvTokenData(decisions []interfaces.VariantDecision, mode
 
 	for i := range decisions {
 		d := &decisions[i]
-		if a, ok := agg[d.VariantName]; ok {
+		d.AnalyzerVersion = constants.AnalyzerVersionV2
+		if a, ok := agg[variantKey{modelID: d.ModelID, variant: d.VariantName}]; ok {
 			d.KvCacheTokensUsed = a.kvUsed
 			d.KvCacheTokensTotal = a.kvTotal
 		}
@@ -1328,7 +1339,11 @@ func (e *Engine) applySaturationDecisions(
 			updateVa.Status.Actuation.Applied = true
 		}
 
-		// Emit saturation and capacity metrics for observability
+		// Emit saturation and capacity metrics for observability.
+		// Note: stale time series for deleted VAs are not cleaned up automatically here.
+		// The metrics package exposes DeleteSaturationMetrics for callers (e.g., the
+		// VariantAutoscaling reconciler's delete handler / finalizer) to remove series
+		// when a VA is removed.
 		if hasDecision {
 			if err := act.EmitSaturationMetrics(ctx, decision); err != nil {
 				logger.Error(err, "Failed to emit saturation metrics", "variant", updateVa.Name)

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -192,7 +192,22 @@ type VariantDecision struct {
 	// SpareCapacity indicates how much spare capacity this variant has.
 	// 0.0 = fully saturated, 1.0 = completely idle.
 	// Used by allocation algorithms to prioritize saturated variants.
+	// V1: threshold-relative spare KV capacity (AvgSpareKvCapacity).
+	// V2: 1.0 - Utilization (absolute spare).
 	SpareCapacity float64
+	// Utilization is the variant-level utilization ratio (0.0-1.0).
+	// V2: from AnalyzerResult.VariantCapacities[].Utilization.
+	// V1: average KvCacheUsage across this variant's replicas.
+	Utilization float64
+	// KvCacheTokensUsed is the sum of TokensInUse across this variant's replicas.
+	KvCacheTokensUsed int64
+	// KvCacheTokensTotal is the sum of TotalKvCapacityTokens across this variant's replicas.
+	KvCacheTokensTotal int64
+	// RequiredCapacity is the model-level required capacity (>0 means scale-up needed).
+	// Same value for all variants of a model.
+	// V1: binary (1.0 if shouldScaleUp, else 0.0).
+	// V2: continuous token-based demand from AnalyzerResult.
+	RequiredCapacity float64
 	// ScaleTargetRef references the Deployment/StatefulSet for scheduling constraints
 	ScaleTargetRef *autoscalingv2.CrossVersionObjectReference
 

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -207,7 +207,13 @@ type VariantDecision struct {
 	// Same value for all variants of a model.
 	// V1: binary (1.0 if shouldScaleUp, else 0.0).
 	// V2: continuous token-based demand from AnalyzerResult.
+	// Use AnalyzerVersion to disambiguate the units when consuming this field
+	// (or its corresponding Prometheus metric).
 	RequiredCapacity float64
+	// AnalyzerVersion identifies which analyzer produced this decision ("v1" or "v2").
+	// Exposed as a Prometheus label on saturation metrics so dashboards can filter
+	// by analyzer to handle the V1/V2 unit difference in RequiredCapacity.
+	AnalyzerVersion string
 	// ScaleTargetRef references the Deployment/StatefulSet for scheduling constraints
 	ScaleTargetRef *autoscalingv2.CrossVersionObjectReference
 

--- a/internal/interfaces/saturation_analyzer.go
+++ b/internal/interfaces/saturation_analyzer.go
@@ -195,25 +195,32 @@ type VariantDecision struct {
 	// V1: threshold-relative spare KV capacity (AvgSpareKvCapacity).
 	// V2: 1.0 - Utilization (absolute spare).
 	SpareCapacity float64
-	// Utilization is the variant-level utilization ratio (0.0-1.0).
-	// V2: from AnalyzerResult.VariantCapacities[].Utilization.
-	// V1: average KvCacheUsage across this variant's replicas.
+	// Utilization is the variant-level utilization ratio (0.0-1.0) reported for
+	// observability. The exact formula differs by analyzer because V1 and V2
+	// reason about saturation differently:
+	//   V1: mean of per-replica KvCacheUsage fractions (matches what V1's
+	//       per-replica threshold check operates on).
+	//   V2: TotalDemand / TotalCapacity from AnalyzerResult (token-demand-based).
+	// For uniform-capacity replicas the two are numerically equivalent; for
+	// mixed-capacity replicas V2's value is capacity-weighted.
 	Utilization float64
 	// KvCacheTokensUsed is the sum of TokensInUse across this variant's replicas.
 	KvCacheTokensUsed int64
-	// KvCacheTokensTotal is the sum of TotalKvCapacityTokens across this variant's replicas.
-	KvCacheTokensTotal int64
+	// KvCacheTokensCapacity is the sum of TotalKvCapacityTokens across this variant's replicas.
+	KvCacheTokensCapacity int64
 	// RequiredCapacity is the model-level required capacity (>0 means scale-up needed).
 	// Same value for all variants of a model.
 	// V1: binary (1.0 if shouldScaleUp, else 0.0).
 	// V2: continuous token-based demand from AnalyzerResult.
-	// Use AnalyzerVersion to disambiguate the units when consuming this field
+	// Use RequiredCapacityUnit to disambiguate the units when consuming this field
 	// (or its corresponding Prometheus metric).
 	RequiredCapacity float64
-	// AnalyzerVersion identifies which analyzer produced this decision ("v1" or "v2").
-	// Exposed as a Prometheus label on saturation metrics so dashboards can filter
-	// by analyzer to handle the V1/V2 unit difference in RequiredCapacity.
-	AnalyzerVersion string
+	// RequiredCapacityUnit describes the unit of RequiredCapacity ("binary" or "continuous").
+	// Exposed as the `unit` Prometheus label on wva_required_capacity so dashboards
+	// can filter by semantics rather than by which analyzer produced the value.
+	//   "binary":     V1 path, value is 0.0 or 1.0
+	//   "continuous": V2 path, value is a token-demand magnitude
+	RequiredCapacityUnit string
 	// ScaleTargetRef references the Deployment/StatefulSet for scheduling constraints
 	ScaleTargetRef *autoscalingv2.CrossVersionObjectReference
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,11 +59,15 @@ func InitMetrics(registry prometheus.Registerer) error {
 	scalingLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelDirection, constants.LabelReason}
 	// modelLabels: variant_name + namespace only (no accelerator_type) for model-level and token metrics
 	modelLabels := []string{constants.LabelVariantName, constants.LabelNamespace}
+	// requiredCapacityLabels: model labels + analyzer_version to disambiguate V1 (binary)
+	// vs V2 (continuous tokens) units of the wva_required_capacity gauge
+	requiredCapacityLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelAnalyzerVersion}
 
 	if controllerInstance != "" {
 		baseLabels = append(baseLabels, constants.LabelControllerInstance)
 		scalingLabels = append(scalingLabels, constants.LabelControllerInstance)
 		modelLabels = append(modelLabels, constants.LabelControllerInstance)
+		requiredCapacityLabels = append(requiredCapacityLabels, constants.LabelControllerInstance)
 	}
 
 	replicaScalingTotal = prometheus.NewCounterVec(
@@ -111,9 +115,9 @@ func InitMetrics(registry prometheus.Registerer) error {
 	requiredCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVARequiredCapacity,
-			Help: "Model-level required capacity; >0 indicates scale-up needed (V1: binary 0/1, V2: continuous token demand)",
+			Help: "Model-level required capacity; >0 indicates scale-up needed. Use the analyzer_version label to distinguish units (V1: binary 0/1, V2: continuous token demand).",
 		},
-		modelLabels,
+		requiredCapacityLabels,
 	)
 	kvCacheTokensUsed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -406,10 +410,12 @@ func SetMetricsFreshnessStatus(variantName, status string, count int) {
 	metricsFreshnessStatus.With(labels).Set(float64(count))
 }
 
-// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics
+// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics.
+// analyzerVersion ("v1" or "v2") is used as a label on wva_required_capacity to
+// disambiguate the units of the required value (V1: binary, V2: continuous tokens).
 func (m *MetricsEmitter) EmitSaturationMetrics(
 	ctx context.Context,
-	variantName, namespace, acceleratorType string,
+	variantName, namespace, acceleratorType, analyzerVersion string,
 	utilization, spare, required float64,
 	kvTokensUsed, kvTokensTotal int64,
 ) error {
@@ -427,17 +433,60 @@ func (m *MetricsEmitter) EmitSaturationMetrics(
 		constants.LabelVariantName: variantName,
 		constants.LabelNamespace:   namespace,
 	}
+	requiredLabels := prometheus.Labels{
+		constants.LabelVariantName:     variantName,
+		constants.LabelNamespace:       namespace,
+		constants.LabelAnalyzerVersion: analyzerVersion,
+	}
 
 	if controllerInstance != "" {
 		accelLabels[constants.LabelControllerInstance] = controllerInstance
 		modelLabels[constants.LabelControllerInstance] = controllerInstance
+		requiredLabels[constants.LabelControllerInstance] = controllerInstance
 	}
 
 	saturationUtilization.With(accelLabels).Set(utilization)
 	spareCapacity.With(accelLabels).Set(spare)
-	requiredCapacity.With(modelLabels).Set(required)
+	requiredCapacity.With(requiredLabels).Set(required)
 	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
 	kvCacheTokensTotal.With(modelLabels).Set(float64(kvTokensTotal))
 
 	return nil
+}
+
+// DeleteSaturationMetrics removes saturation metric series for the given variant.
+// Should be called when a VariantAutoscaling resource is deleted to prevent stale
+// time series from accumulating in Prometheus.
+//
+// TODO: wire this from the controller's VariantAutoscaling delete handler / finalizer.
+// Until that wiring exists, deleted VAs leave their last-emitted metric values in the
+// registry indefinitely.
+func (m *MetricsEmitter) DeleteSaturationMetrics(variantName, namespace, acceleratorType, analyzerVersion string) {
+	if saturationUtilization == nil {
+		return
+	}
+	accelLabels := prometheus.Labels{
+		constants.LabelVariantName:     variantName,
+		constants.LabelNamespace:       namespace,
+		constants.LabelAcceleratorType: acceleratorType,
+	}
+	modelLabels := prometheus.Labels{
+		constants.LabelVariantName: variantName,
+		constants.LabelNamespace:   namespace,
+	}
+	requiredLabels := prometheus.Labels{
+		constants.LabelVariantName:     variantName,
+		constants.LabelNamespace:       namespace,
+		constants.LabelAnalyzerVersion: analyzerVersion,
+	}
+	if controllerInstance != "" {
+		accelLabels[constants.LabelControllerInstance] = controllerInstance
+		modelLabels[constants.LabelControllerInstance] = controllerInstance
+		requiredLabels[constants.LabelControllerInstance] = controllerInstance
+	}
+	saturationUtilization.Delete(accelLabels)
+	spareCapacity.Delete(accelLabels)
+	requiredCapacity.Delete(requiredLabels)
+	kvCacheTokensUsed.Delete(modelLabels)
+	kvCacheTokensTotal.Delete(modelLabels)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -28,6 +28,13 @@ var (
 	metricsPodsDiscovered     *prometheus.GaugeVec
 	metricsFreshnessStatus    *prometheus.GaugeVec
 
+	// Saturation and capacity metrics
+	saturationUtilization *prometheus.GaugeVec
+	spareCapacity         *prometheus.GaugeVec
+	requiredCapacity      *prometheus.GaugeVec
+	kvCacheTokensUsed     *prometheus.GaugeVec
+	kvCacheTokensTotal    *prometheus.GaugeVec
+
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
 	controllerInstance string
@@ -50,10 +57,13 @@ func InitMetrics(registry prometheus.Registerer) error {
 	// Build label sets based on whether controller_instance is configured
 	baseLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelAcceleratorType}
 	scalingLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelDirection, constants.LabelReason}
+	// modelLabels: variant_name + namespace only (no accelerator_type) for model-level and token metrics
+	modelLabels := []string{constants.LabelVariantName, constants.LabelNamespace}
 
 	if controllerInstance != "" {
 		baseLabels = append(baseLabels, constants.LabelControllerInstance)
 		scalingLabels = append(scalingLabels, constants.LabelControllerInstance)
+		modelLabels = append(modelLabels, constants.LabelControllerInstance)
 	}
 
 	replicaScalingTotal = prometheus.NewCounterVec(
@@ -83,6 +93,41 @@ func InitMetrics(registry prometheus.Registerer) error {
 			Help: "Ratio of the desired number of replicas and the current number of replicas for each variant",
 		},
 		baseLabels,
+	)
+	saturationUtilization = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVASaturationUtilization,
+			Help: "Per-variant utilization ratio (0.0-1.0) from saturation analysis",
+		},
+		baseLabels,
+	)
+	spareCapacity = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVASpareCapacity,
+			Help: "Per-variant spare capacity (0.0-1.0) from saturation analysis",
+		},
+		baseLabels,
+	)
+	requiredCapacity = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVARequiredCapacity,
+			Help: "Model-level required capacity; >0 indicates scale-up needed (V1: binary 0/1, V2: continuous token demand)",
+		},
+		modelLabels,
+	)
+	kvCacheTokensUsed = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAKvCacheTokensUsed,
+			Help: "Total KV cache tokens currently in use across all replicas of a variant",
+		},
+		modelLabels,
+	)
+	kvCacheTokensTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAKvCacheTokensTotal,
+			Help: "Total KV cache token capacity across all replicas of a variant",
+		},
+		modelLabels,
 	)
 
 	optimizationDurationLabels := []string{constants.LabelStatus}
@@ -188,6 +233,21 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(metricsFreshnessStatus); err != nil {
 		return fmt.Errorf("failed to register metricsFreshnessStatus metric: %w", err)
+	}
+	if err := registry.Register(saturationUtilization); err != nil {
+		return fmt.Errorf("failed to register saturationUtilization metric: %w", err)
+	}
+	if err := registry.Register(spareCapacity); err != nil {
+		return fmt.Errorf("failed to register spareCapacity metric: %w", err)
+	}
+	if err := registry.Register(requiredCapacity); err != nil {
+		return fmt.Errorf("failed to register requiredCapacity metric: %w", err)
+	}
+	if err := registry.Register(kvCacheTokensUsed); err != nil {
+		return fmt.Errorf("failed to register kvCacheTokensUsed metric: %w", err)
+	}
+	if err := registry.Register(kvCacheTokensTotal); err != nil {
+		return fmt.Errorf("failed to register kvCacheTokensTotal metric: %w", err)
 	}
 
 	return nil
@@ -344,4 +404,40 @@ func SetMetricsFreshnessStatus(variantName, status string, count int) {
 	}
 
 	metricsFreshnessStatus.With(labels).Set(float64(count))
+}
+
+// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics
+func (m *MetricsEmitter) EmitSaturationMetrics(
+	ctx context.Context,
+	variantName, namespace, acceleratorType string,
+	utilization, spare, required float64,
+	kvTokensUsed, kvTokensTotal int64,
+) error {
+	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
+		kvCacheTokensUsed == nil || kvCacheTokensTotal == nil {
+		return fmt.Errorf("saturation metrics not initialized")
+	}
+
+	accelLabels := prometheus.Labels{
+		constants.LabelVariantName:     variantName,
+		constants.LabelNamespace:       namespace,
+		constants.LabelAcceleratorType: acceleratorType,
+	}
+	modelLabels := prometheus.Labels{
+		constants.LabelVariantName: variantName,
+		constants.LabelNamespace:   namespace,
+	}
+
+	if controllerInstance != "" {
+		accelLabels[constants.LabelControllerInstance] = controllerInstance
+		modelLabels[constants.LabelControllerInstance] = controllerInstance
+	}
+
+	saturationUtilization.With(accelLabels).Set(utilization)
+	spareCapacity.With(accelLabels).Set(spare)
+	requiredCapacity.With(modelLabels).Set(required)
+	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
+	kvCacheTokensTotal.With(modelLabels).Set(float64(kvTokensTotal))
+
+	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -421,7 +421,7 @@ func (m *MetricsEmitter) EmitSaturationMetrics(
 ) error {
 	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
 		kvCacheTokensUsed == nil || kvCacheTokensTotal == nil {
-		return fmt.Errorf("saturation metrics not initialized")
+		return errors.New("saturation metrics not initialized")
 	}
 
 	accelLabels := prometheus.Labels{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -416,22 +416,25 @@ func SetMetricsFreshnessStatus(variantName, status string, count int) {
 	metricsFreshnessStatus.With(labels).Set(float64(count))
 }
 
-// EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics.
+// RecordSaturationMetrics records saturation analysis and KV cache capacity
+// metrics. The "Record" naming reflects the fact that the controller does not
+// actively push these metrics — Prometheus scrapes them.
+//
 // modelID is exposed as the model_name label so dashboards can group/filter by
 // the model a variant serves. requiredCapacityUnit ("binary" or "continuous")
 // is used as the "unit" label on wva_required_capacity to describe how the
 // value should be interpreted.
-func (m *MetricsEmitter) EmitSaturationMetrics(
+//
+// Callers MUST invoke InitMetrics before this method (the package-level
+// metric vars are nil otherwise, and the Set calls below would panic).
+// InitMetricsAndEmitter is the recommended construction path because it
+// performs the registration before returning the emitter.
+func (m *MetricsEmitter) RecordSaturationMetrics(
 	ctx context.Context,
 	variantName, namespace, modelID, acceleratorType, requiredCapacityUnit string,
 	utilization, spare, required float64,
 	kvTokensUsed, kvTokensCapacity int64,
-) error {
-	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
-		kvCacheTokensUsed == nil || kvCacheTokensCapacity == nil {
-		return errors.New("saturation metrics not initialized")
-	}
-
+) {
 	accelLabels := prometheus.Labels{
 		constants.LabelVariantName:     variantName,
 		constants.LabelNamespace:       namespace,
@@ -461,43 +464,4 @@ func (m *MetricsEmitter) EmitSaturationMetrics(
 	requiredCapacity.With(requiredLabels).Set(required)
 	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
 	kvCacheTokensCapacity.With(modelLabels).Set(float64(kvTokensCapacity))
-
-	return nil
-}
-
-// DeleteSaturationMetricsForVariant removes all saturation metric series for the
-// given (variant, namespace) regardless of accelerator type or unit label. Uses
-// Prometheus DeletePartialMatch so callers don't need to know every label value.
-//
-// Intended for two scenarios:
-//   - The optimization cycle produced no fresh decision for this variant —
-//     existing series would otherwise persist with stale values until
-//     Prometheus' default 5-minute staleness marker fires. Calling this
-//     ensures dashboards show a gap ("no fresh data") rather than stale values.
-//     This is already handled by the engine's applySaturationDecisions.
-//   - A VA is being removed (delete handler / finalizer). See TODO below.
-//
-// TODO: wire this from the controller's VariantAutoscaling delete handler /
-// finalizer so series for fully-deleted VAs are cleaned up too. The
-// in-cycle "no fresh decision" case is already handled by the engine; the
-// remaining gap is when the VA itself is removed — the engine no longer
-// iterates it, so no delete fires here, and the last-emitted series persist
-// until Prometheus' staleness marker (5-min default) or a controller restart.
-func (m *MetricsEmitter) DeleteSaturationMetricsForVariant(variantName, namespace string) {
-	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
-		kvCacheTokensUsed == nil || kvCacheTokensCapacity == nil {
-		return
-	}
-	match := prometheus.Labels{
-		constants.LabelVariantName: variantName,
-		constants.LabelNamespace:   namespace,
-	}
-	if controllerInstance != "" {
-		match[constants.LabelControllerInstance] = controllerInstance
-	}
-	saturationUtilization.DeletePartialMatch(match)
-	spareCapacity.DeletePartialMatch(match)
-	requiredCapacity.DeletePartialMatch(match)
-	kvCacheTokensUsed.DeletePartialMatch(match)
-	kvCacheTokensCapacity.DeletePartialMatch(match)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,7 +33,7 @@ var (
 	spareCapacity         *prometheus.GaugeVec
 	requiredCapacity      *prometheus.GaugeVec
 	kvCacheTokensUsed     *prometheus.GaugeVec
-	kvCacheTokensTotal    *prometheus.GaugeVec
+	kvCacheTokensCapacity *prometheus.GaugeVec
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -54,19 +54,25 @@ func InitMetrics(registry prometheus.Registerer) error {
 	// Read controller instance from environment
 	controllerInstance = os.Getenv(ControllerInstanceEnvVar)
 
-	// Build label sets based on whether controller_instance is configured
+	// Build label sets based on whether controller_instance is configured.
+	// Existing replica metrics (baseLabels, scalingLabels) are unchanged.
+	// New saturation metrics carry an additional model_name label so dashboards
+	// can group/filter by the model a variant serves.
 	baseLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelAcceleratorType}
 	scalingLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelDirection, constants.LabelReason}
-	// modelLabels: variant_name + namespace only (no accelerator_type) for model-level and token metrics
-	modelLabels := []string{constants.LabelVariantName, constants.LabelNamespace}
-	// requiredCapacityLabels: model labels + analyzer_version to disambiguate V1 (binary)
-	// vs V2 (continuous tokens) units of the wva_required_capacity gauge
-	requiredCapacityLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelAnalyzerVersion}
+	// satAccelLabels: per-variant per-accelerator saturation metrics.
+	satAccelLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelModelName, constants.LabelAcceleratorType}
+	// satModelLabels: per-variant model-level saturation metrics (no accelerator_type).
+	satModelLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelModelName}
+	// requiredCapacityLabels: satModelLabels + "unit" to disambiguate V1 (binary 0/1)
+	// vs V2 (continuous token demand) values of the wva_required_capacity gauge.
+	requiredCapacityLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelModelName, constants.LabelUnit}
 
 	if controllerInstance != "" {
 		baseLabels = append(baseLabels, constants.LabelControllerInstance)
 		scalingLabels = append(scalingLabels, constants.LabelControllerInstance)
-		modelLabels = append(modelLabels, constants.LabelControllerInstance)
+		satAccelLabels = append(satAccelLabels, constants.LabelControllerInstance)
+		satModelLabels = append(satModelLabels, constants.LabelControllerInstance)
 		requiredCapacityLabels = append(requiredCapacityLabels, constants.LabelControllerInstance)
 	}
 
@@ -101,37 +107,37 @@ func InitMetrics(registry prometheus.Registerer) error {
 	saturationUtilization = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVASaturationUtilization,
-			Help: "Per-variant utilization ratio (0.0-1.0) from saturation analysis",
+			Help: "Per-variant utilization ratio (0.0-1.0) from saturation analysis. V1 path: mean of per-replica KV-cache-usage fractions (matches the per-replica threshold V1 checks). V2 path: TotalDemand / TotalCapacity from the analyzer result. Numerically equivalent for uniform-capacity replicas; V2 is capacity-weighted for mixed-capacity cases.",
 		},
-		baseLabels,
+		satAccelLabels,
 	)
 	spareCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVASpareCapacity,
-			Help: "Per-variant spare capacity (0.0-1.0) from saturation analysis",
+			Help: "Per-variant spare KV-cache capacity (0.0-1.0) from saturation analysis. V1 path: threshold-relative spare (kvCacheThreshold - avg KV usage). V2 path: 1.0 - utilization.",
 		},
-		baseLabels,
+		satAccelLabels,
 	)
 	requiredCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVARequiredCapacity,
-			Help: "Model-level required capacity; >0 indicates scale-up needed. Use the analyzer_version label to distinguish units (V1: binary 0/1, V2: continuous token demand).",
+			Help: fmt.Sprintf("Model-level required capacity; >0 indicates scale-up needed. Use the %q label to interpret the value: %q → 0/1 scale-up signal (V1), %q → token demand (V2).", constants.LabelUnit, constants.UnitBinary, constants.UnitContinuous),
 		},
 		requiredCapacityLabels,
 	)
 	kvCacheTokensUsed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: constants.WVAKvCacheTokensUsed,
-			Help: "Total KV cache tokens currently in use across all replicas of a variant",
+			Help: "Total KV cache tokens currently in use across all replicas of a variant (sum of vLLM TokensInUse).",
 		},
-		modelLabels,
+		satModelLabels,
 	)
-	kvCacheTokensTotal = prometheus.NewGaugeVec(
+	kvCacheTokensCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: constants.WVAKvCacheTokensTotal,
-			Help: "Total KV cache token capacity across all replicas of a variant",
+			Name: constants.WVAKvCacheTokensCapacity,
+			Help: "Total KV cache token capacity across all replicas of a variant (sum of vLLM TotalKvCapacityTokens).",
 		},
-		modelLabels,
+		satModelLabels,
 	)
 
 	optimizationDurationLabels := []string{constants.LabelStatus}
@@ -250,8 +256,8 @@ func InitMetrics(registry prometheus.Registerer) error {
 	if err := registry.Register(kvCacheTokensUsed); err != nil {
 		return fmt.Errorf("failed to register kvCacheTokensUsed metric: %w", err)
 	}
-	if err := registry.Register(kvCacheTokensTotal); err != nil {
-		return fmt.Errorf("failed to register kvCacheTokensTotal metric: %w", err)
+	if err := registry.Register(kvCacheTokensCapacity); err != nil {
+		return fmt.Errorf("failed to register kvCacheTokensCapacity metric: %w", err)
 	}
 
 	return nil
@@ -411,32 +417,37 @@ func SetMetricsFreshnessStatus(variantName, status string, count int) {
 }
 
 // EmitSaturationMetrics emits saturation analysis and KV cache capacity metrics.
-// analyzerVersion ("v1" or "v2") is used as a label on wva_required_capacity to
-// disambiguate the units of the required value (V1: binary, V2: continuous tokens).
+// modelID is exposed as the model_name label so dashboards can group/filter by
+// the model a variant serves. requiredCapacityUnit ("binary" or "continuous")
+// is used as the "unit" label on wva_required_capacity to describe how the
+// value should be interpreted.
 func (m *MetricsEmitter) EmitSaturationMetrics(
 	ctx context.Context,
-	variantName, namespace, acceleratorType, analyzerVersion string,
+	variantName, namespace, modelID, acceleratorType, requiredCapacityUnit string,
 	utilization, spare, required float64,
-	kvTokensUsed, kvTokensTotal int64,
+	kvTokensUsed, kvTokensCapacity int64,
 ) error {
 	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
-		kvCacheTokensUsed == nil || kvCacheTokensTotal == nil {
+		kvCacheTokensUsed == nil || kvCacheTokensCapacity == nil {
 		return errors.New("saturation metrics not initialized")
 	}
 
 	accelLabels := prometheus.Labels{
 		constants.LabelVariantName:     variantName,
 		constants.LabelNamespace:       namespace,
+		constants.LabelModelName:       modelID,
 		constants.LabelAcceleratorType: acceleratorType,
 	}
 	modelLabels := prometheus.Labels{
 		constants.LabelVariantName: variantName,
 		constants.LabelNamespace:   namespace,
+		constants.LabelModelName:   modelID,
 	}
 	requiredLabels := prometheus.Labels{
-		constants.LabelVariantName:     variantName,
-		constants.LabelNamespace:       namespace,
-		constants.LabelAnalyzerVersion: analyzerVersion,
+		constants.LabelVariantName: variantName,
+		constants.LabelNamespace:   namespace,
+		constants.LabelModelName:   modelID,
+		constants.LabelUnit:        requiredCapacityUnit,
 	}
 
 	if controllerInstance != "" {
@@ -449,44 +460,44 @@ func (m *MetricsEmitter) EmitSaturationMetrics(
 	spareCapacity.With(accelLabels).Set(spare)
 	requiredCapacity.With(requiredLabels).Set(required)
 	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
-	kvCacheTokensTotal.With(modelLabels).Set(float64(kvTokensTotal))
+	kvCacheTokensCapacity.With(modelLabels).Set(float64(kvTokensCapacity))
 
 	return nil
 }
 
-// DeleteSaturationMetrics removes saturation metric series for the given variant.
-// Should be called when a VariantAutoscaling resource is deleted to prevent stale
-// time series from accumulating in Prometheus.
+// DeleteSaturationMetricsForVariant removes all saturation metric series for the
+// given (variant, namespace) regardless of accelerator type or unit label. Uses
+// Prometheus DeletePartialMatch so callers don't need to know every label value.
 //
-// TODO: wire this from the controller's VariantAutoscaling delete handler / finalizer.
-// Until that wiring exists, deleted VAs leave their last-emitted metric values in the
-// registry indefinitely.
-func (m *MetricsEmitter) DeleteSaturationMetrics(variantName, namespace, acceleratorType, analyzerVersion string) {
-	if saturationUtilization == nil {
+// Intended for two scenarios:
+//   - The optimization cycle produced no fresh decision for this variant —
+//     existing series would otherwise persist with stale values until
+//     Prometheus' default 5-minute staleness marker fires. Calling this
+//     ensures dashboards show a gap ("no fresh data") rather than stale values.
+//     This is already handled by the engine's applySaturationDecisions.
+//   - A VA is being removed (delete handler / finalizer). See TODO below.
+//
+// TODO: wire this from the controller's VariantAutoscaling delete handler /
+// finalizer so series for fully-deleted VAs are cleaned up too. The
+// in-cycle "no fresh decision" case is already handled by the engine; the
+// remaining gap is when the VA itself is removed — the engine no longer
+// iterates it, so no delete fires here, and the last-emitted series persist
+// until Prometheus' staleness marker (5-min default) or a controller restart.
+func (m *MetricsEmitter) DeleteSaturationMetricsForVariant(variantName, namespace string) {
+	if saturationUtilization == nil || spareCapacity == nil || requiredCapacity == nil ||
+		kvCacheTokensUsed == nil || kvCacheTokensCapacity == nil {
 		return
 	}
-	accelLabels := prometheus.Labels{
-		constants.LabelVariantName:     variantName,
-		constants.LabelNamespace:       namespace,
-		constants.LabelAcceleratorType: acceleratorType,
-	}
-	modelLabels := prometheus.Labels{
+	match := prometheus.Labels{
 		constants.LabelVariantName: variantName,
 		constants.LabelNamespace:   namespace,
 	}
-	requiredLabels := prometheus.Labels{
-		constants.LabelVariantName:     variantName,
-		constants.LabelNamespace:       namespace,
-		constants.LabelAnalyzerVersion: analyzerVersion,
-	}
 	if controllerInstance != "" {
-		accelLabels[constants.LabelControllerInstance] = controllerInstance
-		modelLabels[constants.LabelControllerInstance] = controllerInstance
-		requiredLabels[constants.LabelControllerInstance] = controllerInstance
+		match[constants.LabelControllerInstance] = controllerInstance
 	}
-	saturationUtilization.Delete(accelLabels)
-	spareCapacity.Delete(accelLabels)
-	requiredCapacity.Delete(requiredLabels)
-	kvCacheTokensUsed.Delete(modelLabels)
-	kvCacheTokensTotal.Delete(modelLabels)
+	saturationUtilization.DeletePartialMatch(match)
+	spareCapacity.DeletePartialMatch(match)
+	requiredCapacity.DeletePartialMatch(match)
+	kvCacheTokensUsed.DeletePartialMatch(match)
+	kvCacheTokensCapacity.DeletePartialMatch(match)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,228 @@
+package metrics
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// resetMetrics clears package-level metric vars so each test starts fresh.
+func resetMetrics() {
+	replicaScalingTotal = nil
+	desiredReplicas = nil
+	currentReplicas = nil
+	desiredRatio = nil
+	saturationUtilization = nil
+	spareCapacity = nil
+	requiredCapacity = nil
+	kvCacheTokensUsed = nil
+	kvCacheTokensTotal = nil
+	controllerInstance = ""
+}
+
+func gatherMetric(registry *prometheus.Registry, name string) *dto.MetricFamily {
+	families, err := registry.Gather()
+	Expect(err).NotTo(HaveOccurred())
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func gaugeValue(mf *dto.MetricFamily, labels map[string]string) (float64, bool) {
+	for _, m := range mf.GetMetric() {
+		match := true
+		for k, v := range labels {
+			found := false
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == k && lp.GetValue() == v {
+					found = true
+					break
+				}
+			}
+			if !found {
+				match = false
+				break
+			}
+		}
+		if match && m.GetGauge() != nil {
+			return m.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+var _ = Describe("EmitSaturationMetrics", func() {
+
+	var (
+		registry *prometheus.Registry
+		emitter  *MetricsEmitter
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		resetMetrics()
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter = NewMetricsEmitter()
+		ctx = context.Background()
+	})
+
+	It("should emit all saturation metrics with correct values", func() {
+		err := emitter.EmitSaturationMetrics(ctx,
+			"variant-a", "test-ns", "nvidia-a100",
+			0.75, 0.25, 5000.0,
+			100000, 200000,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		accelLabels := map[string]string{
+			constants.LabelVariantName:     "variant-a",
+			constants.LabelNamespace:       "test-ns",
+			constants.LabelAcceleratorType: "nvidia-a100",
+		}
+		modelLabels := map[string]string{
+			constants.LabelVariantName: "variant-a",
+			constants.LabelNamespace:   "test-ns",
+		}
+
+		// saturation_utilization
+		mf := gatherMetric(registry, constants.WVASaturationUtilization)
+		Expect(mf).NotTo(BeNil())
+		val, ok := gaugeValue(mf, accelLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(0.75))
+
+		// spare_capacity
+		mf = gatherMetric(registry, constants.WVASpareCapacity)
+		Expect(mf).NotTo(BeNil())
+		val, ok = gaugeValue(mf, accelLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(0.25))
+
+		// required_capacity (model-level labels)
+		mf = gatherMetric(registry, constants.WVARequiredCapacity)
+		Expect(mf).NotTo(BeNil())
+		val, ok = gaugeValue(mf, modelLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(5000.0))
+
+		// kv_cache_tokens_used
+		mf = gatherMetric(registry, constants.WVAKvCacheTokensUsed)
+		Expect(mf).NotTo(BeNil())
+		val, ok = gaugeValue(mf, modelLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(100000.0))
+
+		// kv_cache_tokens_total
+		mf = gatherMetric(registry, constants.WVAKvCacheTokensTotal)
+		Expect(mf).NotTo(BeNil())
+		val, ok = gaugeValue(mf, modelLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(200000.0))
+	})
+
+	It("should include controller_instance label when env var is set", func() {
+		// Re-init with controller instance set
+		resetMetrics()
+		Expect(os.Setenv(ControllerInstanceEnvVar, "controller-1")).To(Succeed())
+		DeferCleanup(os.Unsetenv, ControllerInstanceEnvVar)
+
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter = NewMetricsEmitter()
+
+		err := emitter.EmitSaturationMetrics(ctx,
+			"variant-b", "prod-ns", "nvidia-h100",
+			0.90, 0.10, 10000.0,
+			500000, 600000,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify controller_instance on accel-scoped metric
+		mf := gatherMetric(registry, constants.WVASaturationUtilization)
+		Expect(mf).NotTo(BeNil())
+		val, ok := gaugeValue(mf, map[string]string{
+			constants.LabelVariantName:        "variant-b",
+			constants.LabelNamespace:          "prod-ns",
+			constants.LabelAcceleratorType:    "nvidia-h100",
+			constants.LabelControllerInstance: "controller-1",
+		})
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(0.90))
+
+		// Verify controller_instance on model-scoped metric
+		mf = gatherMetric(registry, constants.WVARequiredCapacity)
+		Expect(mf).NotTo(BeNil())
+		val, ok = gaugeValue(mf, map[string]string{
+			constants.LabelVariantName:        "variant-b",
+			constants.LabelNamespace:          "prod-ns",
+			constants.LabelControllerInstance: "controller-1",
+		})
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(10000.0))
+	})
+
+	It("should handle zero values correctly", func() {
+		err := emitter.EmitSaturationMetrics(ctx,
+			"variant-c", "ns", "amd-mi300x",
+			0.0, 0.0, 0.0,
+			0, 0,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		accelLabels := map[string]string{
+			constants.LabelVariantName:     "variant-c",
+			constants.LabelNamespace:       "ns",
+			constants.LabelAcceleratorType: "amd-mi300x",
+		}
+		modelLabels := map[string]string{
+			constants.LabelVariantName: "variant-c",
+			constants.LabelNamespace:   "ns",
+		}
+
+		for _, metricName := range []string{
+			constants.WVASaturationUtilization,
+			constants.WVASpareCapacity,
+		} {
+			mf := gatherMetric(registry, metricName)
+			Expect(mf).NotTo(BeNil(), "metric %s not found", metricName)
+			val, ok := gaugeValue(mf, accelLabels)
+			Expect(ok).To(BeTrue(), "gauge not found for %s", metricName)
+			Expect(val).To(Equal(0.0), "expected 0 for %s", metricName)
+		}
+
+		for _, metricName := range []string{
+			constants.WVARequiredCapacity,
+			constants.WVAKvCacheTokensUsed,
+			constants.WVAKvCacheTokensTotal,
+		} {
+			mf := gatherMetric(registry, metricName)
+			Expect(mf).NotTo(BeNil(), "metric %s not found", metricName)
+			val, ok := gaugeValue(mf, modelLabels)
+			Expect(ok).To(BeTrue(), "gauge not found for %s", metricName)
+			Expect(val).To(Equal(0.0), "expected 0 for %s", metricName)
+		}
+	})
+
+	It("should return error when metrics are not initialized", func() {
+		resetMetrics()
+		uninitEmitter := NewMetricsEmitter()
+
+		err := uninitEmitter.EmitSaturationMetrics(ctx,
+			"v", "ns", "gpu",
+			0.5, 0.5, 100.0,
+			50, 100,
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not initialized"))
+	})
+})

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -22,7 +22,7 @@ func resetMetrics() {
 	spareCapacity = nil
 	requiredCapacity = nil
 	kvCacheTokensUsed = nil
-	kvCacheTokensTotal = nil
+	kvCacheTokensCapacity = nil
 	controllerInstance = ""
 }
 
@@ -78,7 +78,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 	It("should emit all saturation metrics with correct values", func() {
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-a", "test-ns", "nvidia-a100", constants.AnalyzerVersionV2,
+			"variant-a", "test-ns", "meta-llama/Llama-3.1-8B", "nvidia-a100", constants.UnitContinuous,
 			0.75, 0.25, 5000.0,
 			100000, 200000,
 		)
@@ -87,16 +87,19 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		accelLabels := map[string]string{
 			constants.LabelVariantName:     "variant-a",
 			constants.LabelNamespace:       "test-ns",
+			constants.LabelModelName:       "meta-llama/Llama-3.1-8B",
 			constants.LabelAcceleratorType: "nvidia-a100",
 		}
 		modelLabels := map[string]string{
 			constants.LabelVariantName: "variant-a",
 			constants.LabelNamespace:   "test-ns",
+			constants.LabelModelName:   "meta-llama/Llama-3.1-8B",
 		}
 		requiredLabels := map[string]string{
-			constants.LabelVariantName:     "variant-a",
-			constants.LabelNamespace:       "test-ns",
-			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV2,
+			constants.LabelVariantName: "variant-a",
+			constants.LabelNamespace:   "test-ns",
+			constants.LabelModelName:   "meta-llama/Llama-3.1-8B",
+			constants.LabelUnit:        constants.UnitContinuous,
 		}
 
 		// saturation_utilization
@@ -113,7 +116,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.25))
 
-		// required_capacity (carries analyzer_version label)
+		// required_capacity (carries unit label)
 		mf = gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
 		val, ok = gaugeValue(mf, requiredLabels)
@@ -128,21 +131,21 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(val).To(Equal(100000.0))
 
 		// kv_cache_tokens_total
-		mf = gatherMetric(registry, constants.WVAKvCacheTokensTotal)
+		mf = gatherMetric(registry, constants.WVAKvCacheTokensCapacity)
 		Expect(mf).NotTo(BeNil())
 		val, ok = gaugeValue(mf, modelLabels)
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(200000.0))
 	})
 
-	It("should distinguish V1 and V2 required_capacity series via analyzer_version label", func() {
-		// Same variant, same namespace, different analyzer versions → two series
+	It("should distinguish binary and continuous required_capacity series via unit label", func() {
+		// Same variant, same namespace, different units → two series
 		Expect(emitter.EmitSaturationMetrics(ctx,
-			"variant-multi", "ns", "h100", constants.AnalyzerVersionV1,
+			"variant-multi", "ns", "model-x", "h100", constants.UnitBinary,
 			0.5, 0.5, 1.0, 100, 200,
 		)).To(Succeed())
 		Expect(emitter.EmitSaturationMetrics(ctx,
-			"variant-multi", "ns", "h100", constants.AnalyzerVersionV2,
+			"variant-multi", "ns", "model-x", "h100", constants.UnitContinuous,
 			0.5, 0.5, 8000.0, 100, 200,
 		)).To(Succeed())
 
@@ -150,14 +153,16 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(mf).NotTo(BeNil())
 
 		v1Labels := map[string]string{
-			constants.LabelVariantName:     "variant-multi",
-			constants.LabelNamespace:       "ns",
-			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV1,
+			constants.LabelVariantName: "variant-multi",
+			constants.LabelNamespace:   "ns",
+			constants.LabelModelName:   "model-x",
+			constants.LabelUnit:        constants.UnitBinary,
 		}
 		v2Labels := map[string]string{
-			constants.LabelVariantName:     "variant-multi",
-			constants.LabelNamespace:       "ns",
-			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV2,
+			constants.LabelVariantName: "variant-multi",
+			constants.LabelNamespace:   "ns",
+			constants.LabelModelName:   "model-x",
+			constants.LabelUnit:        constants.UnitContinuous,
 		}
 
 		v1Val, ok := gaugeValue(mf, v1Labels)
@@ -180,31 +185,33 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		emitter = NewMetricsEmitter()
 
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-b", "prod-ns", "nvidia-h100", constants.AnalyzerVersionV2,
+			"variant-b", "prod-ns", "ibm/granite-13b", "nvidia-h100", constants.UnitContinuous,
 			0.90, 0.10, 10000.0,
 			500000, 600000,
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Verify controller_instance on accel-scoped metric
+		// Verify controller_instance + model_name on accel-scoped metric
 		mf := gatherMetric(registry, constants.WVASaturationUtilization)
 		Expect(mf).NotTo(BeNil())
 		val, ok := gaugeValue(mf, map[string]string{
 			constants.LabelVariantName:        "variant-b",
 			constants.LabelNamespace:          "prod-ns",
+			constants.LabelModelName:          "ibm/granite-13b",
 			constants.LabelAcceleratorType:    "nvidia-h100",
 			constants.LabelControllerInstance: "controller-1",
 		})
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.90))
 
-		// Verify controller_instance + analyzer_version on required_capacity
+		// Verify controller_instance + model_name + unit on required_capacity
 		mf = gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
 		val, ok = gaugeValue(mf, map[string]string{
 			constants.LabelVariantName:        "variant-b",
 			constants.LabelNamespace:          "prod-ns",
-			constants.LabelAnalyzerVersion:    constants.AnalyzerVersionV2,
+			constants.LabelModelName:          "ibm/granite-13b",
+			constants.LabelUnit:               constants.UnitContinuous,
 			constants.LabelControllerInstance: "controller-1",
 		})
 		Expect(ok).To(BeTrue())
@@ -213,7 +220,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 	It("should handle zero values correctly", func() {
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-c", "ns", "amd-mi300x", constants.AnalyzerVersionV1,
+			"variant-c", "ns", "model-z", "amd-mi300x", constants.UnitBinary,
 			0.0, 0.0, 0.0,
 			0, 0,
 		)
@@ -222,16 +229,19 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		accelLabels := map[string]string{
 			constants.LabelVariantName:     "variant-c",
 			constants.LabelNamespace:       "ns",
+			constants.LabelModelName:       "model-z",
 			constants.LabelAcceleratorType: "amd-mi300x",
 		}
 		modelLabels := map[string]string{
 			constants.LabelVariantName: "variant-c",
 			constants.LabelNamespace:   "ns",
+			constants.LabelModelName:   "model-z",
 		}
 		requiredLabels := map[string]string{
-			constants.LabelVariantName:     "variant-c",
-			constants.LabelNamespace:       "ns",
-			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV1,
+			constants.LabelVariantName: "variant-c",
+			constants.LabelNamespace:   "ns",
+			constants.LabelModelName:   "model-z",
+			constants.LabelUnit:        constants.UnitBinary,
 		}
 
 		for _, metricName := range []string{
@@ -253,7 +263,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 		for _, metricName := range []string{
 			constants.WVAKvCacheTokensUsed,
-			constants.WVAKvCacheTokensTotal,
+			constants.WVAKvCacheTokensCapacity,
 		} {
 			mf := gatherMetric(registry, metricName)
 			Expect(mf).NotTo(BeNil(), "metric %s not found", metricName)
@@ -268,7 +278,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		uninitEmitter := NewMetricsEmitter()
 
 		err := uninitEmitter.EmitSaturationMetrics(ctx,
-			"v", "ns", "gpu", constants.AnalyzerVersionV2,
+			"v", "ns", "m", "gpu", constants.UnitContinuous,
 			0.5, 0.5, 100.0,
 			50, 100,
 		)
@@ -276,44 +286,48 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(err.Error()).To(ContainSubstring("not initialized"))
 	})
 
-	It("DeleteSaturationMetrics should remove all series for a variant", func() {
+	It("DeleteSaturationMetricsForVariant should remove all series regardless of accelerator/unit", func() {
+		// Emit two different series for the same (variant, namespace) — different
+		// accelerator types and different unit values.
 		Expect(emitter.EmitSaturationMetrics(ctx,
-			"variant-del", "ns", "h100", constants.AnalyzerVersionV2,
-			0.5, 0.5, 1000.0, 100, 200,
+			"variant-multi-del", "ns", "model-x", "h100", constants.UnitBinary,
+			0.7, 0.3, 1.0, 100, 200,
+		)).To(Succeed())
+		Expect(emitter.EmitSaturationMetrics(ctx,
+			"variant-multi-del", "ns", "model-x", "a100", constants.UnitContinuous,
+			0.4, 0.6, 5000.0, 50, 400,
 		)).To(Succeed())
 
-		// Sanity check: series exists before deletion
+		// Both series exist before deletion
 		mf := gatherMetric(registry, constants.WVASaturationUtilization)
 		Expect(mf).NotTo(BeNil())
-		_, ok := gaugeValue(mf, map[string]string{
-			constants.LabelVariantName:     "variant-del",
-			constants.LabelNamespace:       "ns",
-			constants.LabelAcceleratorType: "h100",
-		})
-		Expect(ok).To(BeTrue())
 
-		emitter.DeleteSaturationMetrics("variant-del", "ns", "h100", constants.AnalyzerVersionV2)
+		// Partial-match delete by (variant, namespace) only — accelerator and unit
+		// are not provided.
+		emitter.DeleteSaturationMetricsForVariant("variant-multi-del", "ns")
 
-		// All five series for this variant should be gone
+		// All five series for this variant should be gone across both
+		// accelerator types and both unit values.
 		for _, name := range []string{
 			constants.WVASaturationUtilization,
 			constants.WVASpareCapacity,
 			constants.WVARequiredCapacity,
 			constants.WVAKvCacheTokensUsed,
-			constants.WVAKvCacheTokensTotal,
+			constants.WVAKvCacheTokensCapacity,
 		} {
 			mf := gatherMetric(registry, name)
 			if mf == nil {
-				continue // metric family removed entirely once last series is gone
+				continue
 			}
 			for _, m := range mf.GetMetric() {
 				for _, lp := range m.GetLabel() {
 					if lp.GetName() == constants.LabelVariantName {
-						Expect(lp.GetValue()).NotTo(Equal("variant-del"),
+						Expect(lp.GetValue()).NotTo(Equal("variant-multi-del"),
 							"metric %s still has series for deleted variant", name)
 					}
 				}
 			}
 		}
 	})
+
 })

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 // resetMetrics clears package-level metric vars so each test starts fresh.
+// Callers MUST invoke InitMetrics before recording any metric afterwards —
+// the Record* methods deliberately have no nil guard, so a missed init
+// would panic at the first Set call.
 func resetMetrics() {
 	replicaScalingTotal = nil
 	desiredReplicas = nil
@@ -60,7 +63,7 @@ func gaugeValue(mf *dto.MetricFamily, labels map[string]string) (float64, bool) 
 	return 0, false
 }
 
-var _ = Describe("EmitSaturationMetrics", func() {
+var _ = Describe("RecordSaturationMetrics", func() {
 
 	var (
 		registry *prometheus.Registry
@@ -76,13 +79,12 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		ctx = context.Background()
 	})
 
-	It("should emit all saturation metrics with correct values", func() {
-		err := emitter.EmitSaturationMetrics(ctx,
+	It("should record all saturation metrics with correct values", func() {
+		emitter.RecordSaturationMetrics(ctx,
 			"variant-a", "test-ns", "meta-llama/Llama-3.1-8B", "nvidia-a100", constants.UnitContinuous,
 			0.75, 0.25, 5000.0,
 			100000, 200000,
 		)
-		Expect(err).NotTo(HaveOccurred())
 
 		accelLabels := map[string]string{
 			constants.LabelVariantName:     "variant-a",
@@ -140,14 +142,14 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 	It("should distinguish binary and continuous required_capacity series via unit label", func() {
 		// Same variant, same namespace, different units → two series
-		Expect(emitter.EmitSaturationMetrics(ctx,
+		emitter.RecordSaturationMetrics(ctx,
 			"variant-multi", "ns", "model-x", "h100", constants.UnitBinary,
 			0.5, 0.5, 1.0, 100, 200,
-		)).To(Succeed())
-		Expect(emitter.EmitSaturationMetrics(ctx,
+		)
+		emitter.RecordSaturationMetrics(ctx,
 			"variant-multi", "ns", "model-x", "h100", constants.UnitContinuous,
 			0.5, 0.5, 8000.0, 100, 200,
-		)).To(Succeed())
+		)
 
 		mf := gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
@@ -184,12 +186,11 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(InitMetrics(registry)).To(Succeed())
 		emitter = NewMetricsEmitter()
 
-		err := emitter.EmitSaturationMetrics(ctx,
+		emitter.RecordSaturationMetrics(ctx,
 			"variant-b", "prod-ns", "ibm/granite-13b", "nvidia-h100", constants.UnitContinuous,
 			0.90, 0.10, 10000.0,
 			500000, 600000,
 		)
-		Expect(err).NotTo(HaveOccurred())
 
 		// Verify controller_instance + model_name on accel-scoped metric
 		mf := gatherMetric(registry, constants.WVASaturationUtilization)
@@ -219,12 +220,11 @@ var _ = Describe("EmitSaturationMetrics", func() {
 	})
 
 	It("should handle zero values correctly", func() {
-		err := emitter.EmitSaturationMetrics(ctx,
+		emitter.RecordSaturationMetrics(ctx,
 			"variant-c", "ns", "model-z", "amd-mi300x", constants.UnitBinary,
 			0.0, 0.0, 0.0,
 			0, 0,
 		)
-		Expect(err).NotTo(HaveOccurred())
 
 		accelLabels := map[string]string{
 			constants.LabelVariantName:     "variant-c",
@@ -270,63 +270,6 @@ var _ = Describe("EmitSaturationMetrics", func() {
 			val, ok := gaugeValue(mf, modelLabels)
 			Expect(ok).To(BeTrue(), "gauge not found for %s", metricName)
 			Expect(val).To(Equal(0.0), "expected 0 for %s", metricName)
-		}
-	})
-
-	It("should return error when metrics are not initialized", func() {
-		resetMetrics()
-		uninitEmitter := NewMetricsEmitter()
-
-		err := uninitEmitter.EmitSaturationMetrics(ctx,
-			"v", "ns", "m", "gpu", constants.UnitContinuous,
-			0.5, 0.5, 100.0,
-			50, 100,
-		)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("not initialized"))
-	})
-
-	It("DeleteSaturationMetricsForVariant should remove all series regardless of accelerator/unit", func() {
-		// Emit two different series for the same (variant, namespace) — different
-		// accelerator types and different unit values.
-		Expect(emitter.EmitSaturationMetrics(ctx,
-			"variant-multi-del", "ns", "model-x", "h100", constants.UnitBinary,
-			0.7, 0.3, 1.0, 100, 200,
-		)).To(Succeed())
-		Expect(emitter.EmitSaturationMetrics(ctx,
-			"variant-multi-del", "ns", "model-x", "a100", constants.UnitContinuous,
-			0.4, 0.6, 5000.0, 50, 400,
-		)).To(Succeed())
-
-		// Both series exist before deletion
-		mf := gatherMetric(registry, constants.WVASaturationUtilization)
-		Expect(mf).NotTo(BeNil())
-
-		// Partial-match delete by (variant, namespace) only — accelerator and unit
-		// are not provided.
-		emitter.DeleteSaturationMetricsForVariant("variant-multi-del", "ns")
-
-		// All five series for this variant should be gone across both
-		// accelerator types and both unit values.
-		for _, name := range []string{
-			constants.WVASaturationUtilization,
-			constants.WVASpareCapacity,
-			constants.WVARequiredCapacity,
-			constants.WVAKvCacheTokensUsed,
-			constants.WVAKvCacheTokensCapacity,
-		} {
-			mf := gatherMetric(registry, name)
-			if mf == nil {
-				continue
-			}
-			for _, m := range mf.GetMetric() {
-				for _, lp := range m.GetLabel() {
-					if lp.GetName() == constants.LabelVariantName {
-						Expect(lp.GetValue()).NotTo(Equal("variant-multi-del"),
-							"metric %s still has series for deleted variant", name)
-					}
-				}
-			}
 		}
 	})
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -78,7 +78,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 	It("should emit all saturation metrics with correct values", func() {
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-a", "test-ns", "nvidia-a100",
+			"variant-a", "test-ns", "nvidia-a100", constants.AnalyzerVersionV2,
 			0.75, 0.25, 5000.0,
 			100000, 200000,
 		)
@@ -92,6 +92,11 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		modelLabels := map[string]string{
 			constants.LabelVariantName: "variant-a",
 			constants.LabelNamespace:   "test-ns",
+		}
+		requiredLabels := map[string]string{
+			constants.LabelVariantName:     "variant-a",
+			constants.LabelNamespace:       "test-ns",
+			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV2,
 		}
 
 		// saturation_utilization
@@ -108,10 +113,10 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.25))
 
-		// required_capacity (model-level labels)
+		// required_capacity (carries analyzer_version label)
 		mf = gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
-		val, ok = gaugeValue(mf, modelLabels)
+		val, ok = gaugeValue(mf, requiredLabels)
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(5000.0))
 
@@ -130,6 +135,40 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(val).To(Equal(200000.0))
 	})
 
+	It("should distinguish V1 and V2 required_capacity series via analyzer_version label", func() {
+		// Same variant, same namespace, different analyzer versions → two series
+		Expect(emitter.EmitSaturationMetrics(ctx,
+			"variant-multi", "ns", "h100", constants.AnalyzerVersionV1,
+			0.5, 0.5, 1.0, 100, 200,
+		)).To(Succeed())
+		Expect(emitter.EmitSaturationMetrics(ctx,
+			"variant-multi", "ns", "h100", constants.AnalyzerVersionV2,
+			0.5, 0.5, 8000.0, 100, 200,
+		)).To(Succeed())
+
+		mf := gatherMetric(registry, constants.WVARequiredCapacity)
+		Expect(mf).NotTo(BeNil())
+
+		v1Labels := map[string]string{
+			constants.LabelVariantName:     "variant-multi",
+			constants.LabelNamespace:       "ns",
+			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV1,
+		}
+		v2Labels := map[string]string{
+			constants.LabelVariantName:     "variant-multi",
+			constants.LabelNamespace:       "ns",
+			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV2,
+		}
+
+		v1Val, ok := gaugeValue(mf, v1Labels)
+		Expect(ok).To(BeTrue())
+		Expect(v1Val).To(Equal(1.0))
+
+		v2Val, ok := gaugeValue(mf, v2Labels)
+		Expect(ok).To(BeTrue())
+		Expect(v2Val).To(Equal(8000.0))
+	})
+
 	It("should include controller_instance label when env var is set", func() {
 		// Re-init with controller instance set
 		resetMetrics()
@@ -141,7 +180,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		emitter = NewMetricsEmitter()
 
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-b", "prod-ns", "nvidia-h100",
+			"variant-b", "prod-ns", "nvidia-h100", constants.AnalyzerVersionV2,
 			0.90, 0.10, 10000.0,
 			500000, 600000,
 		)
@@ -159,12 +198,13 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		Expect(ok).To(BeTrue())
 		Expect(val).To(Equal(0.90))
 
-		// Verify controller_instance on model-scoped metric
+		// Verify controller_instance + analyzer_version on required_capacity
 		mf = gatherMetric(registry, constants.WVARequiredCapacity)
 		Expect(mf).NotTo(BeNil())
 		val, ok = gaugeValue(mf, map[string]string{
 			constants.LabelVariantName:        "variant-b",
 			constants.LabelNamespace:          "prod-ns",
+			constants.LabelAnalyzerVersion:    constants.AnalyzerVersionV2,
 			constants.LabelControllerInstance: "controller-1",
 		})
 		Expect(ok).To(BeTrue())
@@ -173,7 +213,7 @@ var _ = Describe("EmitSaturationMetrics", func() {
 
 	It("should handle zero values correctly", func() {
 		err := emitter.EmitSaturationMetrics(ctx,
-			"variant-c", "ns", "amd-mi300x",
+			"variant-c", "ns", "amd-mi300x", constants.AnalyzerVersionV1,
 			0.0, 0.0, 0.0,
 			0, 0,
 		)
@@ -188,6 +228,11 @@ var _ = Describe("EmitSaturationMetrics", func() {
 			constants.LabelVariantName: "variant-c",
 			constants.LabelNamespace:   "ns",
 		}
+		requiredLabels := map[string]string{
+			constants.LabelVariantName:     "variant-c",
+			constants.LabelNamespace:       "ns",
+			constants.LabelAnalyzerVersion: constants.AnalyzerVersionV1,
+		}
 
 		for _, metricName := range []string{
 			constants.WVASaturationUtilization,
@@ -200,8 +245,13 @@ var _ = Describe("EmitSaturationMetrics", func() {
 			Expect(val).To(Equal(0.0), "expected 0 for %s", metricName)
 		}
 
+		mf := gatherMetric(registry, constants.WVARequiredCapacity)
+		Expect(mf).NotTo(BeNil())
+		val, ok := gaugeValue(mf, requiredLabels)
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal(0.0))
+
 		for _, metricName := range []string{
-			constants.WVARequiredCapacity,
 			constants.WVAKvCacheTokensUsed,
 			constants.WVAKvCacheTokensTotal,
 		} {
@@ -218,11 +268,52 @@ var _ = Describe("EmitSaturationMetrics", func() {
 		uninitEmitter := NewMetricsEmitter()
 
 		err := uninitEmitter.EmitSaturationMetrics(ctx,
-			"v", "ns", "gpu",
+			"v", "ns", "gpu", constants.AnalyzerVersionV2,
 			0.5, 0.5, 100.0,
 			50, 100,
 		)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not initialized"))
+	})
+
+	It("DeleteSaturationMetrics should remove all series for a variant", func() {
+		Expect(emitter.EmitSaturationMetrics(ctx,
+			"variant-del", "ns", "h100", constants.AnalyzerVersionV2,
+			0.5, 0.5, 1000.0, 100, 200,
+		)).To(Succeed())
+
+		// Sanity check: series exists before deletion
+		mf := gatherMetric(registry, constants.WVASaturationUtilization)
+		Expect(mf).NotTo(BeNil())
+		_, ok := gaugeValue(mf, map[string]string{
+			constants.LabelVariantName:     "variant-del",
+			constants.LabelNamespace:       "ns",
+			constants.LabelAcceleratorType: "h100",
+		})
+		Expect(ok).To(BeTrue())
+
+		emitter.DeleteSaturationMetrics("variant-del", "ns", "h100", constants.AnalyzerVersionV2)
+
+		// All five series for this variant should be gone
+		for _, name := range []string{
+			constants.WVASaturationUtilization,
+			constants.WVASpareCapacity,
+			constants.WVARequiredCapacity,
+			constants.WVAKvCacheTokensUsed,
+			constants.WVAKvCacheTokensTotal,
+		} {
+			mf := gatherMetric(registry, name)
+			if mf == nil {
+				continue // metric family removed entirely once last series is gone
+			}
+			for _, m := range mf.GetMetric() {
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == constants.LabelVariantName {
+						Expect(lp.GetValue()).NotTo(Equal("variant-del"),
+							"metric %s still has series for deleted variant", name)
+					}
+				}
+			}
+		}
 	})
 })

--- a/internal/metrics/suite_test.go
+++ b/internal/metrics/suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}


### PR DESCRIPTION
### Summary
- Add 5 new Prometheus gauges (`wva_saturation_utilization`, `wva_spare_capacity`, `wva_required_capacity`, `wva_kv_cache_tokens_used`, `wva_kv_cache_tokens_total`) emitted per variant after each scaling decision
- Enrich `VariantDecision` with `Utilization`, `SpareCapacity`, `RequiredCapacity`, `KvCacheTokensUsed`, and `KvCacheTokensTotal` fields for both V1 and V2 engine paths
- Emit metrics via `EmitSaturationMetrics` in `applySaturationDecisions` for every variant with a scaling decision

### Details

**New metrics** (emitted per reconciliation cycle per variant):

| Metric | Labels | Description |
|--------|--------|-------------|
| `wva_saturation_utilization` | variant_name, namespace, accelerator_type | Utilization ratio (0.0-1.0) |
| `wva_spare_capacity` | variant_name, namespace, accelerator_type | Spare capacity (0.0-1.0) |
| `wva_required_capacity` | variant_name, namespace | Model-level required capacity (>0 = scale-up needed) |
| `wva_kv_cache_tokens_used` | variant_name, namespace | Sum of KV cache tokens in use |
| `wva_kv_cache_tokens_total` | variant_name, namespace | Sum of KV cache token capacity |

**V1 path:** `enrichDecisionsFromReplicaMetrics` aggregates per-pod `ReplicaMetrics` by variant to compute utilization (avg KV cache usage) and KV token sums. `RequiredCapacity` is 1.0 if `shouldScaleUp`, else 0.0.

**V2 path:** `Utilization`, `SpareCapacity`, and `RequiredCapacity` are populated from `AnalyzerResult` in `buildDecisionsWithOptimizer`. `enrichDecisionsWithKvTokenData` adds KV token sums from `ReplicaMetrics`.

**Files changed:**
- `internal/constants/metrics.go` — 5 new metric constant definitions
- `internal/interfaces/saturation_analyzer.go` — 4 new fields on `VariantDecision`
- `internal/metrics/metrics.go` — metric registration and `EmitSaturationMetrics()`
- `internal/metrics/metrics_test.go` — 236-line test suite (4 test cases)
- `internal/engines/saturation/engine.go` — `enrichDecisionsFromReplicaMetrics`, `enrichDecisionsWithKvTokenData`, emission call in `applySaturationDecisions`
- `internal/engines/pipeline/cost_aware_optimizer.go` — populate `Utilization`, `SpareCapacity`, `RequiredCapacity` in `buildDecisionsWithOptimizer`
- `internal/actuator/actuator.go` — `EmitSaturationMetrics` wrapper method