### PR TITLE
replace servicemonitor for WVA ns with field from metadata

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -41,6 +41,24 @@ patches:
   target:
     kind: Deployment
 
+# [NAMESPACE-SELECTOR] Ensure the ServiceMonitor namespaceSelector matches the
+# deployment namespace. Without this, the hardcoded value in monitor.yaml won't
+# update when an overlay changes the namespace (e.g. deploying into 'opendatahub'
+# or `redhat-ods-operator`).
+replacements:
+- source:
+    kind: Deployment
+    name: controller-manager
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ServiceMonitor
+      group: monitoring.coreos.com
+      version: v1
+      name: controller-manager-metrics-monitor
+    fieldPaths:
+    - spec.namespaceSelector.matchNames.0
+
 # Uncomment the patches line if you enable Metrics and CertManager
 # [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
 # This patch will protect the metrics with certManager self-signed certs.


### PR DESCRIPTION
# Fix ServiceMonitor namespaceSelector not updating when namespace is overridden

## Problem:
The ServiceMonitor in config/prometheus/monitor.yaml hardcodes namespaceSelector.matchNames: [workload-variant-autoscaler-system]. When a kustomize overlay changes the deployment namespace (e.g. the openshift overlay, or a downstream consumer like ODH deploying into opendatahub), the namespace: directive in the kustomization only updates metadata.namespace — it does not transform data fields like spec.namespaceSelector.matchNames. This causes Prometheus to look for scrape targets in workload-variant-autoscaler-system while the WVA controller pods are actually running in a different namespace, resulting in no metrics being scraped.

## Fix:
Add a kustomize replacement in config/default/kustomization.yaml that sources the namespace from the Deployment's metadata.namespace (which kustomize does transform) and writes it into the ServiceMonitor's spec.namespaceSelector.matchNames[0]. This ensures the two stay in sync regardless of what namespace any overlay sets.

Note: The Helm chart already handles this correctly via {{ .Release.Namespace }} — this bug only affects the kustomize deployment path.


cc @lionelvillard @shuynh2017 @pierDipi