### PR TITLE
update: add more lable from controller into servicemonitor

### DIFF
--- a/config/prometheus/servicemonitor.yaml
+++ b/config/prometheus/servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
+      app.kubernetes.io/name: workload-variant-autoscaler
       control-plane: controller-manager
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
# Descripton

the current selector  on label is too board
all controller has the same label we should have one to more speicific for wva

cc @Gregory-Pereira @vivekk16 