### PR TITLE
Fixes for WVA nightly E2E failing on CKS and OCP

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -43,6 +43,10 @@ VALUES_FILE=${VALUES_FILE:-"$WVA_PROJECT/charts/workload-variant-autoscaler/valu
 # Controller instance identifier for multi-controller isolation (optional)
 # When set, adds controller_instance label to metrics and HPA selectors
 CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
+# InferencePool API group to watch (v1 is the default, auto-detected after llm-d deploy)
+# Track if user explicitly set POOL_GROUP to avoid overriding their choice
+POOL_GROUP_USER_SET=${POOL_GROUP:+true}
+POOL_GROUP=${POOL_GROUP:-"inference.networking.k8s.io"}
 
 # llm-d Configuration
 LLM_D_OWNER=${LLM_D_OWNER:-"llm-d"}
@@ -1120,17 +1124,28 @@ deploy_llm_d_infrastructure() {
     # Align WVA with the InferencePool API group in use (scale-from-zero requires WVA to watch the same group).
     # llm-d version determines whether pools are inference.networking.k8s.io (v1) or inference.networking.x-k8s.io (v1alpha2).
     if [ "$DEPLOY_WVA" == "true" ]; then
-        detect_inference_pool_api_group
-        if [ -n "$DETECTED_POOL_GROUP" ]; then
-            log_info "Detected InferencePool API group: $DETECTED_POOL_GROUP; upgrading WVA to watch it (scale-from-zero)"
-            if helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-                -n $WVA_NS --reuse-values --set wva.poolGroup=$DETECTED_POOL_GROUP --wait --timeout=60s; then
-                log_success "WVA upgraded with wva.poolGroup=$DETECTED_POOL_GROUP"
-            else
-                log_warning "WVA upgrade with poolGroup failed - scale-from-zero may not see the InferencePool"
-            fi
+        # Only auto-detect and upgrade if user didn't explicitly set POOL_GROUP
+        if [ "$POOL_GROUP_USER_SET" == "true" ]; then
+            log_info "POOL_GROUP explicitly set by user to $POOL_GROUP - skipping auto-detection to respect user's choice"
         else
-            log_warning "Could not detect InferencePool API group - WVA may have empty datastore for scale-from-zero"
+            detect_inference_pool_api_group
+            if [ -n "$DETECTED_POOL_GROUP" ]; then
+                # Only upgrade if detected group differs from current POOL_GROUP
+                if [ "$DETECTED_POOL_GROUP" != "$POOL_GROUP" ]; then
+                    log_info "Detected InferencePool API group: $DETECTED_POOL_GROUP (differs from default $POOL_GROUP); upgrading WVA to watch it (scale-from-zero)"
+                    if helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
+                        -n $WVA_NS --reuse-values --set wva.poolGroup=$DETECTED_POOL_GROUP --wait --timeout=60s; then
+                        log_success "WVA upgraded with wva.poolGroup=$DETECTED_POOL_GROUP"
+                        POOL_GROUP=$DETECTED_POOL_GROUP
+                    else
+                        log_warning "WVA upgrade with poolGroup failed - scale-from-zero may not see the InferencePool"
+                    fi
+                else
+                    log_info "Detected InferencePool API group matches default ($POOL_GROUP) - no upgrade needed"
+                fi
+            else
+                log_warning "Could not detect InferencePool API group - using default POOL_GROUP=$POOL_GROUP (scale-from-zero may be misconfigured if cluster uses a different group)"
+            fi
         fi
     fi
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -34,7 +34,8 @@ import (
 )
 
 var (
-	errPoolNotSynced = errors.New("EndpointPool not found in datastore")
+	// ErrPoolNotSynced is returned when an EndpointPool is not found in the datastore
+	ErrPoolNotSynced = errors.New("EndpointPool not found in datastore")
 	errPoolIsNull    = errors.New("EndpointPool object is nil, does not exist")
 )
 
@@ -149,7 +150,7 @@ func (ds *datastore) PoolGet(namespacedName string) (*poolutil.EndpointPool, err
 
 	pool, exist := ds.pools.Load(namespacedName)
 	if !exist {
-		return nil, errPoolNotSynced
+		return nil, ErrPoolNotSynced
 	}
 
 	epp := pool.(*poolutil.EndpointPool)
@@ -182,7 +183,7 @@ func (ds *datastore) PoolGetFromLabels(namespace string, labels map[string]strin
 	})
 
 	if !exist {
-		return nil, errPoolNotSynced
+		return nil, ErrPoolNotSynced
 	}
 	return ep, nil
 }

--- a/internal/engines/scalefromzero/engine.go
+++ b/internal/engines/scalefromzero/engine.go
@@ -232,18 +232,33 @@ func (e *Engine) processInactiveVariant(ctx context.Context, deployments map[str
 	// Find target EPP for metrics collection in the same namespace as the VA
 	pool, err := e.Datastore.PoolGetFromLabels(va.Namespace, labels)
 	if err != nil {
-		logger.Error(err, "Error finding target EPP", "variant", va.Name, "namespace", va.Namespace, "target VA model", va.Spec.ModelID)
+		// Only skip on "not found" errors - return other errors to surface real datastore failures
+		if errors.Is(err, datastore.ErrPoolNotSynced) {
+			logger.V(logging.DEBUG).Info("Skipping variant, target EPP not found in datastore",
+				"variant", va.Name,
+				"namespace", va.Namespace,
+				"modelID", va.Spec.ModelID)
+			return nil
+		}
+		// Unexpected error - log and return to surface the issue
+		logger.Error(err, "Unexpected error finding target EPP",
+			"variant", va.Name,
+			"namespace", va.Namespace,
+			"modelID", va.Spec.ModelID)
 		return err
 	}
 
 	// Use EPP source from registry
-	eppSource := e.Datastore.PoolGetMetricsSource(pool.Namespace + "/" + pool.Name)
+	namespacedPoolName := pool.Namespace + "/" + pool.Name
+	eppSource := e.Datastore.PoolGetMetricsSource(namespacedPoolName)
 	if eppSource == nil {
-		logger.Info("Scale-from-zero: skipping VA, EPP metrics source not found in datastore",
-			"va", va.Name,
+		// This is unexpected - pool exists but metrics source is missing
+		err := fmt.Errorf("EPP metrics source not found in registry for pool %s", namespacedPoolName)
+		logger.Error(err, "Datastore inconsistency detected",
+			"variant", va.Name,
 			"namespace", va.Namespace,
-			"pool", pool.Namespace+"/"+pool.Name)
-		return errors.New("endpointpicker metrics source not found in datastore")
+			"pool", namespacedPoolName)
+		return err
 	}
 
 	results, err := eppSource.Refresh(ctx, source.RefreshSpec{})

--- a/internal/engines/scalefromzero/engine_test.go
+++ b/internal/engines/scalefromzero/engine_test.go
@@ -18,6 +18,7 @@ package scalefromzero
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,12 +92,12 @@ func TestSingleInactiveVariant(t *testing.T) {
 			resourceReplicas: 1,
 		},
 		{
-			name:             "Error from labels of inferencePool and deployment not matched",
+			name:             "Skip variant when labels of inferencePool and deployment don't match",
 			pool:             pool1,
 			labels:           map[string]string{"vllm": "test"},
 			datastoreSize:    1,
 			resourceReplicas: 0,
-			wantErr:          true,
+			wantErr:          false, // Changed: now returns nil to avoid blocking retry loop
 		},
 	}
 
@@ -343,4 +344,261 @@ func TestEmptyInactiveVariants(t *testing.T) {
 	// Should complete without error when no inactive VAs exist
 	err := engine.optimize(ctx)
 	assert.NoError(t, err, "Should not error when no inactive VAs exist")
+}
+
+func TestNamespacedMetricsSourceLookup(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   v1.GroupVersion.Group,
+		Version: v1.GroupVersion.Version,
+		Kind:    "InferencePool",
+	}
+
+	tests := []struct {
+		name          string
+		poolNamespace string
+		poolName      string
+		vaNamespace   string
+		expectSkip    bool
+		skipReason    string
+	}{
+		{
+			name:          "pool found in same namespace - processes variant",
+			poolNamespace: "test-ns",
+			poolName:      "pool1",
+			vaNamespace:   "test-ns",
+			expectSkip:    false,
+		},
+		{
+			name:          "pool not found in different namespace - skips gracefully",
+			poolNamespace: "pool-ns",
+			poolName:      "pool1",
+			vaNamespace:   "different-ns",
+			expectSkip:    true,
+			skipReason:    "pool not found in VA's namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create pool in its namespace
+			pool := utiltest.MakeInferencePool(tt.poolName).
+				Namespace(tt.poolNamespace).
+				Selector(selector_v1).
+				TargetPorts(8080).
+				EndpointPickerRef("epp-svc").ObjRef()
+			pool.SetGroupVersionKind(gvk)
+
+			// Create VA in its namespace (might be different)
+			va := unittestutil.CreateVariantAutoscalingResource(
+				tt.vaNamespace,
+				resourceName,
+				deploymentName,
+				modelId,
+				acceleratorName,
+				variantCost,
+			)
+
+			// Create deployment with matching labels in VA's namespace
+			dp := unittestutil.MakeDeployment(deploymentName, tt.vaNamespace, 0, selector_v1)
+
+			// Create service in pool's namespace
+			svc := unittestutil.MakeService("epp-svc", tt.poolNamespace)
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = v1alpha2.Install(scheme)
+			_ = v1.Install(scheme)
+			_ = vav1alpha1.AddToScheme(scheme)
+			_ = appsV1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			fakeClientInitialObjs := []client.Object{pool, dp, va, svc}
+			fakeDynamicClientInitialObject := []runtime.Object{dp}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(fakeClientInitialObjs...).
+				Build()
+
+			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, fakeDynamicClientInitialObject...)
+
+			ctx := context.Background()
+			ds := datastore.NewDatastore(nil)
+
+			// Reconcile the pool to add it to datastore
+			namespacedName := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			gknn := common.GKNN{
+				NamespacedName: namespacedName,
+				GroupKind: schema.GroupKind{
+					Group: pool.GroupVersionKind().Group,
+					Kind:  pool.GroupVersionKind().Kind,
+				},
+			}
+			req := ctrl.Request{NamespacedName: namespacedName}
+			inferencePoolReconciler := &poolreconciler.InferencePoolReconciler{
+				Client:    fakeClient,
+				Datastore: ds,
+				PoolGKNN:  gknn,
+			}
+
+			if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
+				t.Fatalf("Unexpected InferencePool reconcile error: %v", err)
+			}
+
+			// Verify pool is in datastore
+			poolList := ds.PoolList()
+			require.Equal(t, 1, len(poolList), "Pool should be in datastore")
+
+			// Verify metrics source is registered under the namespaced key (namespace/name)
+			// This is critical for processInactiveVariant which calls PoolGetMetricsSource(namespace/name)
+			namespacedPoolName := tt.poolNamespace + "/" + tt.poolName
+			metricsSource := ds.PoolGetMetricsSource(namespacedPoolName)
+			if tt.expectSkip {
+				// For cross-namespace test, metrics source won't be found (different namespace)
+				// This is expected and will be handled gracefully
+			} else {
+				// For same-namespace test, metrics source must be registered
+				require.NotNil(t, metricsSource, "Metrics source should be registered under namespaced key %s", namespacedPoolName)
+			}
+
+			mapper := testrestmapper.TestOnlyStaticRESTMapper(scheme, schema.GroupVersion{Group: "apps", Version: "v1"})
+
+			engine := &Engine{
+				client:         fakeClient,
+				executor:       nil,
+				Datastore:      ds,
+				DynamicClient:  fakeDynamicClient,
+				Mapper:         mapper,
+				maxConcurrency: 30,
+			}
+
+			// Get deployments map
+			deployments := map[string]*appsV1.Deployment{
+				tt.vaNamespace + "/" + deploymentName: dp,
+			}
+
+			// Process the inactive variant
+			err := engine.processInactiveVariant(ctx, deployments, *va, 0)
+
+			if tt.expectSkip {
+				// When pool is not found (different namespace), we expect nil error (skip)
+				assert.NoError(t, err, "Expected no error (skip) for: %s, but got: %v", tt.skipReason, err)
+			} else {
+				// When pool is found, we expect it to proceed
+				// It may error on EPP metrics refresh (which is expected in test environment)
+				// but it should NOT error on "pool not found"
+				if err != nil && errors.Is(err, datastore.ErrPoolNotSynced) {
+					t.Errorf("Should have found pool in same namespace, but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestPoolGetFromLabelsWithNamespace(t *testing.T) {
+	tests := []struct {
+		name          string
+		poolNamespace string
+		poolName      string
+		poolSelector  map[string]string
+		queryNs       string
+		queryLabels   map[string]string
+		expectFound   bool
+	}{
+		{
+			name:          "finds pool in same namespace with matching labels",
+			poolNamespace: "ns1",
+			poolName:      "pool1",
+			poolSelector:  map[string]string{"app": "test"},
+			queryNs:       "ns1",
+			queryLabels:   map[string]string{"app": "test", "version": "v1"},
+			expectFound:   true,
+		},
+		{
+			name:          "does not find pool in different namespace even with matching labels",
+			poolNamespace: "ns1",
+			poolName:      "pool1",
+			poolSelector:  map[string]string{"app": "test"},
+			queryNs:       "ns2",
+			queryLabels:   map[string]string{"app": "test", "version": "v1"},
+			expectFound:   false,
+		},
+		{
+			name:          "does not find pool with non-matching labels in same namespace",
+			poolNamespace: "ns1",
+			poolName:      "pool1",
+			poolSelector:  map[string]string{"app": "test"},
+			queryNs:       "ns1",
+			queryLabels:   map[string]string{"app": "different"},
+			expectFound:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{
+				Group:   v1.GroupVersion.Group,
+				Version: v1.GroupVersion.Version,
+				Kind:    "InferencePool",
+			}
+
+			pool := utiltest.MakeInferencePool(tt.poolName).
+				Namespace(tt.poolNamespace).
+				Selector(tt.poolSelector).
+				TargetPorts(8080).
+				EndpointPickerRef("epp-svc").ObjRef()
+			pool.SetGroupVersionKind(gvk)
+
+			svc := unittestutil.MakeService("epp-svc", tt.poolNamespace)
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = v1alpha2.Install(scheme)
+			_ = v1.Install(scheme)
+			_ = vav1alpha1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pool, svc).
+				Build()
+
+			ctx := context.Background()
+			ds := datastore.NewDatastore(nil)
+
+			// Reconcile pool to add to datastore
+			namespacedName := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			gknn := common.GKNN{
+				NamespacedName: namespacedName,
+				GroupKind: schema.GroupKind{
+					Group: pool.GroupVersionKind().Group,
+					Kind:  pool.GroupVersionKind().Kind,
+				},
+			}
+			req := ctrl.Request{NamespacedName: namespacedName}
+			inferencePoolReconciler := &poolreconciler.InferencePoolReconciler{
+				Client:    fakeClient,
+				Datastore: ds,
+				PoolGKNN:  gknn,
+			}
+
+			if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
+				t.Fatalf("Unexpected InferencePool reconcile error: %v", err)
+			}
+
+			// Query with namespace
+			foundPool, err := ds.PoolGetFromLabels(tt.queryNs, tt.queryLabels)
+
+			if tt.expectFound {
+				require.NoError(t, err, "Expected to find pool but got error")
+				require.NotNil(t, foundPool, "Expected to find pool but got nil")
+				assert.Equal(t, tt.poolNamespace, foundPool.Namespace, "Pool namespace should match")
+				assert.Equal(t, tt.poolName, foundPool.Name, "Pool name should match")
+			} else {
+				require.Error(t, err, "Expected error (not found) but got none")
+				assert.ErrorIs(t, err, datastore.ErrPoolNotSynced, "Error should be ErrPoolNotSynced")
+				assert.Nil(t, foundPool, "Pool should be nil when not found")
+			}
+		})
+	}
 }

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -83,11 +83,13 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
-		"app":                       appLabel,
-		"llm-d.ai/inferenceServing": "true",
-		"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
-		"llm-d.ai/model-pool":       poolName,
-		"test-resource":             "true",
+		"app":                        appLabel,
+		"llm-d.ai/inferenceServing":  "true",
+		"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
+		"llm-d.ai/model-pool":        poolName,
+		"test-resource":              "true",
+		"llm-d.ai/guide":             "workload-autoscaling",
+		"llm-d.ai/inference-serving": "true",
 	}
 
 	envVars := []corev1.EnvVar{
@@ -131,10 +133,12 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":                       appLabel,
-					"llm-d.ai/inferenceServing": "true",
-					"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
-					"llm-d.ai/model-pool":       poolName,
+					"app":                        appLabel,
+					"llm-d.ai/inferenceServing":  "true",
+					"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
+					"llm-d.ai/model-pool":        poolName,
+					"llm-d.ai/guide":             "workload-autoscaling",
+					"llm-d.ai/inference-serving": "true",
 				},
 			},
 			Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
This PR fixes the issues on the WVA nightly E2E tests on CKS and OCP clusters reported in this issue: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/884


## Changes Made:

### 1. **Added default POOL_GROUP initialization** :
```bash
# InferencePool API group to watch (v1 is the default, auto-detected after llm-d deploy)
POOL_GROUP=${POOL_GROUP:-"inference.networking.k8s.io"}
```
- Added check to compare `DETECTED_POOL_GROUP` with current `POOL_GROUP`
- Only performs helm upgrade if they differ

### 2. Updated test deployment labels:

- Set test deployment labels to match the infrastructure InferencePool's selector (`llm-d.ai/guide`: `workload-autoscaling`, `llm-d.ai/inference-serving`: `true`)

### 3. Isolate scale-from-zero engine errors:

- Fixed the scale-from-zero engine to prevent blocking when EndpointPool is not found

### Benefits:
  - This ensures WVA always has a valid `poolGroup` configuration while avoiding unnecessary helm upgrades when the default is correct. Hence, it saves 60s of retry time on every CKS/OCP nightly run.
 
**Related Issue**: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/884


**WARNING**: This PR has dependency on PR https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/957 being merged first.