### PR TITLE
fix: lint on test case

### DIFF
--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -67,7 +67,7 @@ type AnalyzerScoreConfig struct {
 	Name              string   `yaml:"name"`
 	Enabled           *bool    `yaml:"enabled,omitempty"`           // default true
 	Score             float64  `yaml:"score,omitempty"`             // default 1.0
-	ScaleUpThreshold  *float64 `yaml:"scaleUpThreshold,omitempty"` // overrides global
+	ScaleUpThreshold  *float64 `yaml:"scaleUpThreshold,omitempty"`  // overrides global
 	ScaleDownBoundary *float64 `yaml:"scaleDownBoundary,omitempty"` // overrides global
 }
 

--- a/internal/engines/pipeline/enforcer.go
+++ b/internal/engines/pipeline/enforcer.go
@@ -185,4 +185,3 @@ func updateDecisionAction(d *interfaces.VariantDecision, optimizerName string) {
 	}
 	d.Reason = fmt.Sprintf("V2 %s (optimizer: %s, enforced)", d.Action, optimizerName)
 }
-

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -967,10 +967,10 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						AnalyzedAt:       time.Now(),
-						SpareCapacity:    50000,
+						ModelID:       "model-1",
+						Namespace:     "default",
+						AnalyzedAt:    time.Now(),
+						SpareCapacity: 50000,
 						VariantCapacities: []interfaces.VariantCapacity{
 							{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
 							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
@@ -998,10 +998,10 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						AnalyzedAt:       time.Now(),
-						SpareCapacity:    80000, // enough to remove all
+						ModelID:       "model-1",
+						Namespace:     "default",
+						AnalyzedAt:    time.Now(),
+						SpareCapacity: 80000, // enough to remove all
 						VariantCapacities: []interfaces.VariantCapacity{
 							{VariantName: "keep-alive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 							{VariantName: "expendable", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},

--- a/internal/engines/scalefromzero/engine_test.go
+++ b/internal/engines/scalefromzero/engine_test.go
@@ -35,6 +35,7 @@ import (
 	poolreconciler "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 	unittestutil "github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -472,13 +473,13 @@ func TestNamespacedMetricsSourceLookup(t *testing.T) {
 				maxConcurrency: 30,
 			}
 
-			// Get deployments map
-			deployments := map[string]*appsV1.Deployment{
-				tt.vaNamespace + "/" + deploymentName: dp,
+			// Get scale targets map
+			scaleTargets := map[string]scaletarget.ScaleTargetAccessor{
+				tt.vaNamespace + "/" + deploymentName: scaletarget.NewDeploymentAccessor(dp),
 			}
 
 			// Process the inactive variant
-			err := engine.processInactiveVariant(ctx, deployments, *va, 0)
+			err := engine.processInactiveVariant(ctx, scaleTargets, *va, 0)
 
 			if tt.expectSkip {
 				// When pool is not found (different namespace), we expect nil error (skip)

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -1426,4 +1426,3 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet (single-node)", S
 		})
 	})
 })
-


### PR DESCRIPTION
# Notes
- to fix  ` Error: internal/engines/scalefromzero/engine_test.go:481:46: cannot use deployments (variable of type map[string]*"k8s.io/api/apps/v1".Deployment) as map[string]scaletarget.ScaleTargetAccessor value in argument to engine.processInactiveVariant (typecheck)` ref https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/910
- fmt


cc @shuynh2017 