### PR TITLE
fix(queueingmodel): propagate explicit SLO targets from default conf

### DIFF
--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -162,6 +162,15 @@ func buildQMConfig(
 		if defaultCfg.SLOMultiplier > 1.0 {
 			cfg.SLOMultiplier = defaultCfg.SLOMultiplier
 		}
+		if defaultCfg.TargetTTFT > 0 && defaultCfg.TargetITL > 0 {
+			modelKey := queueingmodel.MakeModelKey(namespace, modelID)
+			cfg.SLOTargets = map[string]*queueingmodel.SLOTarget{
+				modelKey: {
+					TargetTTFT: defaultCfg.TargetTTFT,
+					TargetITL:  defaultCfg.TargetITL,
+				},
+			}
+		}
 	}
 
 	// Scan for a per-model override matching this model


### PR DESCRIPTION
After this fix:

```
INFO    saturation/engine_queueing_model.go:132
Queueing model analysis completed {"modelID": "Qwen/Qwen3-0.6B", "totalSupply": 0, "totalDemand": 0, "utilization": 0, "requiredCapacity": 0, "spareCapacity": 0}
```