### PR TITLE
fix: pass SCALER_BACKEND=keda to OpenShift E2E test step

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -1046,6 +1046,8 @@ jobs:
           LLMD_NAMESPACE_B: ${{ env.LLMD_NAMESPACE_B }}
           GATEWAY_NAME: infra-inference-scheduling-inference-gateway-istio
           DEPLOYMENT: ms-inference-scheduling-llm-d-modelservice-decode
+          # Must match the scaler backend used during infrastructure deployment
+          SCALER_BACKEND: keda
           # Pass WVA_RELEASE_NAME so test can filter for current run's resources
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
           # Controller instance label must match what the controller was deployed with
@@ -1057,6 +1059,7 @@ jobs:
           echo "Running consolidated E2E tests on OpenShift with configuration:"
           echo "  ENVIRONMENT: $ENVIRONMENT"
           echo "  USE_SIMULATOR: $USE_SIMULATOR"
+          echo "  SCALER_BACKEND: $SCALER_BACKEND"
           echo "  SCALE_TO_ZERO_ENABLED: $SCALE_TO_ZERO_ENABLED"
           echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
           echo "  MONITORING_NAMESPACE: $MONITORING_NAMESPACE"


### PR DESCRIPTION
## Summary
- The CI deploys infrastructure with `SCALER_BACKEND: keda` (line 697), but the "Run OpenShift E2E tests" step did not pass this env var to the tests
- Without it, the test defaults to `prometheus-adapter` and queries the external metrics API directly — KEDA serves that API and returns 500 for unknown metrics instead of 404
- The test only tolerates `NotFound` (404), so it fails with `InternalError` (500)
- With `SCALER_BACKEND=keda` set, the test takes the KEDA-aware branch and checks for `ScaledObject` resources instead

Fixes #978

## Test plan
- [ ] OpenShift E2E CI passes (the three LWS specs should no longer 500)
- [ ] Verify `SCALER_BACKEND: keda` appears in the CI log output