### PR TITLE
Add optimization loop performance metrics

### DIFF
--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -113,8 +113,8 @@ const (
 	// Labels: status (success, error)
 	WVAOptimizationDurationSeconds = "wva_optimization_duration_seconds"
 
-	// WVAModelsProcessedTotal is a gauge that tracks the number of models processed in the last optimization cycle.
-	WVAModelsProcessedTotal = "wva_models_processed_total"
+	// WVAModelsProcessed is a gauge that tracks the number of models processed in the last optimization cycle.
+	WVAModelsProcessed = "wva_models_processed"
 )
 
 // Metric Label Names

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -108,6 +108,13 @@ const (
 	// WVADesiredRatio is a gauge that tracks the ratio of desired to current replicas.
 	// Labels: variant_name, namespace, accelerator_type
 	WVADesiredRatio = "wva_desired_ratio"
+
+	// WVAOptimizationDurationSeconds is a histogram that tracks the duration of each optimization cycle.
+	// Labels: status (success, error, partial)
+	WVAOptimizationDurationSeconds = "wva_optimization_duration_seconds"
+
+	// WVAModelsProcessedTotal is a counter that tracks the total number of models processed across optimization cycles.
+	WVAModelsProcessedTotal = "wva_models_processed_total"
 )
 
 // Metric Label Names
@@ -120,4 +127,5 @@ const (
 	LabelReason             = "reason"
 	LabelAcceleratorType    = "accelerator_type"
 	LabelControllerInstance = "controller_instance"
+	LabelStatus             = "status"
 )

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -110,10 +110,10 @@ const (
 	WVADesiredRatio = "wva_desired_ratio"
 
 	// WVAOptimizationDurationSeconds is a histogram that tracks the duration of each optimization cycle.
-	// Labels: status (success, error, partial)
+	// Labels: status (success, error)
 	WVAOptimizationDurationSeconds = "wva_optimization_duration_seconds"
 
-	// WVAModelsProcessedTotal is a counter that tracks the total number of models processed across optimization cycles.
+	// WVAModelsProcessedTotal is a gauge that tracks the number of models processed in the last optimization cycle.
 	WVAModelsProcessedTotal = "wva_models_processed_total"
 )
 

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -190,9 +190,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 			status = "error"
 		}
 		metrics.ObserveOptimizationDuration(time.Since(start).Seconds(), status)
-		if modelsProcessed > 0 {
-			metrics.SetModelsProcessed(modelsProcessed)
-		}
+		metrics.SetModelsProcessed(modelsProcessed)
 	}()
 
 	logger := ctrl.LoggerFrom(ctx)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -315,10 +315,7 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	} else {
 		logger.Info("No scaling decisions to apply, updating VA status with metrics")
 	}
-	if err := e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations); err != nil {
-		logger.Error(err, "Failed to apply saturation decisions")
-		return err
-	}
+	e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations)
 
 	logger.Info("Optimization completed successfully",
 		"mode", "saturation-only",
@@ -889,7 +886,7 @@ func (e *Engine) applySaturationDecisions(
 	decisions []interfaces.VariantDecision,
 	vaMap map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	currentAllocations map[string]*interfaces.Allocation,
-) error {
+) {
 	logger := ctrl.LoggerFrom(ctx)
 	// Create a map of decisions for O(1) lookup
 	// Use namespace/variantName as key to match vaMap and avoid collisions
@@ -1120,8 +1117,6 @@ func (e *Engine) applySaturationDecisions(
 				"reason", reason)
 		}
 	}
-
-	return nil
 }
 
 // emitSafetyNetMetrics emits fallback metrics when saturation analysis fails.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -103,9 +103,6 @@ type Engine struct {
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
 	// CostAwareOptimizer (unlimited) or GreedyByScoreOptimizer (limited).
 	optimizer pipeline.ScalingOptimizer
-
-	// metricsEmitter emits optimization loop performance metrics (duration, models processed).
-	metricsEmitter *metrics.MetricsEmitter
 }
 
 // NewEngine creates a new instance of the saturation engine.
@@ -148,7 +145,6 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
-		metricsEmitter:          metrics.NewMetricsEmitter(),
 	}
 
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
@@ -185,19 +181,17 @@ func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 }
 
 // optimize performs the optimization logic.
-func (e *Engine) optimize(ctx context.Context) error {
+func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	start := time.Now()
-	var optimizeErr error
 	var modelsProcessed int
 	defer func() {
-		duration := time.Since(start).Seconds()
 		status := "success"
-		if optimizeErr != nil {
+		if retErr != nil {
 			status = "error"
 		}
-		e.metricsEmitter.ObserveOptimizationDuration(duration, status)
+		metrics.ObserveOptimizationDuration(time.Since(start).Seconds(), status)
 		if modelsProcessed > 0 {
-			e.metricsEmitter.IncrModelsProcessed(modelsProcessed)
+			metrics.SetModelsProcessed(modelsProcessed)
 		}
 	}()
 
@@ -223,7 +217,6 @@ func (e *Engine) optimize(ctx context.Context) error {
 	activeVAs, _, err := utils.ActiveVariantAutoscaling(ctx, e.client)
 	if err != nil {
 		logger.Error(err, "Unable to get active variant autoscalings")
-		optimizeErr = err
 		return err
 	}
 
@@ -238,7 +231,6 @@ func (e *Engine) optimize(ctx context.Context) error {
 		if err != nil {
 			logger.Error(err, "Failed to collect cluster inventory")
 			// do not proceed to optimization if inventory collection fails in limited mode
-			optimizeErr = err
 			return err
 		}
 		// always print inventory until optimizer consumes it
@@ -247,6 +239,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 
 	// Group VAs by model for per-model capacity analysis
 	modelGroups := utils.GroupVariantAutoscalingByModel(activeVAs)
+	modelsProcessed = len(modelGroups)
 	logger.Info("Grouped VAs by model",
 		"modelCount", len(modelGroups),
 		"totalVAs", len(activeVAs))
@@ -326,11 +319,8 @@ func (e *Engine) optimize(ctx context.Context) error {
 	}
 	if err := e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations); err != nil {
 		logger.Error(err, "Failed to apply saturation decisions")
-		optimizeErr = err
 		return err
 	}
-
-	modelsProcessed = len(modelGroups)
 
 	logger.Info("Optimization completed successfully",
 		"mode", "saturation-only",

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -43,6 +43,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
@@ -102,6 +103,9 @@ type Engine struct {
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
 	// CostAwareOptimizer (unlimited) or GreedyByScoreOptimizer (limited).
 	optimizer pipeline.ScalingOptimizer
+
+	// metricsEmitter emits optimization loop performance metrics (duration, models processed).
+	metricsEmitter *metrics.MetricsEmitter
 }
 
 // NewEngine creates a new instance of the saturation engine.
@@ -144,6 +148,7 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
+		metricsEmitter:          metrics.NewMetricsEmitter(),
 	}
 
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
@@ -181,6 +186,21 @@ func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 
 // optimize performs the optimization logic.
 func (e *Engine) optimize(ctx context.Context) error {
+	start := time.Now()
+	var optimizeErr error
+	var modelsProcessed int
+	defer func() {
+		duration := time.Since(start).Seconds()
+		status := "success"
+		if optimizeErr != nil {
+			status = "error"
+		}
+		e.metricsEmitter.ObserveOptimizationDuration(duration, status)
+		if modelsProcessed > 0 {
+			e.metricsEmitter.IncrModelsProcessed(modelsProcessed)
+		}
+	}()
+
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Get optimization interval from Config (already a time.Duration)
@@ -203,6 +223,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 	activeVAs, _, err := utils.ActiveVariantAutoscaling(ctx, e.client)
 	if err != nil {
 		logger.Error(err, "Unable to get active variant autoscalings")
+		optimizeErr = err
 		return err
 	}
 
@@ -217,6 +238,7 @@ func (e *Engine) optimize(ctx context.Context) error {
 		if err != nil {
 			logger.Error(err, "Failed to collect cluster inventory")
 			// do not proceed to optimization if inventory collection fails in limited mode
+			optimizeErr = err
 			return err
 		}
 		// always print inventory until optimizer consumes it
@@ -304,8 +326,11 @@ func (e *Engine) optimize(ctx context.Context) error {
 	}
 	if err := e.applySaturationDecisions(ctx, allDecisions, vaMap, currentAllocations); err != nil {
 		logger.Error(err, "Failed to apply saturation decisions")
+		optimizeErr = err
 		return err
 	}
+
+	modelsProcessed = len(modelGroups)
 
 	logger.Info("Optimization completed successfully",
 		"mode", "saturation-only",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,7 +21,7 @@ var (
 	desiredRatio        *prometheus.GaugeVec
 
 	optimizationDuration *prometheus.HistogramVec
-	modelsProcessedTotal prometheus.Counter
+	modelsProcessedGauge prometheus.Gauge
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -80,18 +80,22 @@ func InitMetrics(registry prometheus.Registerer) error {
 		baseLabels,
 	)
 
+	optimizationDurationLabels := []string{constants.LabelStatus}
+	if controllerInstance != "" {
+		optimizationDurationLabels = append(optimizationDurationLabels, constants.LabelControllerInstance)
+	}
 	optimizationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    constants.WVAOptimizationDurationSeconds,
 			Help:    "Duration of optimization loop cycles in seconds",
 			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
-		[]string{constants.LabelStatus},
+		optimizationDurationLabels,
 	)
-	modelsProcessedTotal = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	modelsProcessedGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: constants.WVAModelsProcessedTotal,
-			Help: "Total number of models processed across optimization cycles",
+			Help: "Number of models processed in the last optimization cycle",
 		},
 	)
 
@@ -111,8 +115,8 @@ func InitMetrics(registry prometheus.Registerer) error {
 	if err := registry.Register(optimizationDuration); err != nil {
 		return fmt.Errorf("failed to register optimizationDuration metric: %w", err)
 	}
-	if err := registry.Register(modelsProcessedTotal); err != nil {
-		return fmt.Errorf("failed to register modelsProcessedTotal metric: %w", err)
+	if err := registry.Register(modelsProcessedGauge); err != nil {
+		return fmt.Errorf("failed to register modelsProcessedGauge metric: %w", err)
 	}
 
 	return nil
@@ -159,20 +163,24 @@ func (m *MetricsEmitter) EmitReplicaScalingMetrics(ctx context.Context, va *llmd
 }
 
 // ObserveOptimizationDuration records the duration of an optimization cycle with the given status.
-// Status should be one of: "success", "error", "partial".
-func (m *MetricsEmitter) ObserveOptimizationDuration(durationSeconds float64, status string) {
+// Status should be one of: "success", "error".
+func ObserveOptimizationDuration(durationSeconds float64, status string) {
 	if optimizationDuration == nil {
 		return
 	}
-	optimizationDuration.With(prometheus.Labels{constants.LabelStatus: status}).Observe(durationSeconds)
+	labels := prometheus.Labels{constants.LabelStatus: status}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	optimizationDuration.With(labels).Observe(durationSeconds)
 }
 
-// IncrModelsProcessed increments the models-processed counter by the given count.
-func (m *MetricsEmitter) IncrModelsProcessed(count int) {
-	if modelsProcessedTotal == nil {
+// SetModelsProcessed sets the gauge to the number of models processed in the last optimization cycle.
+func SetModelsProcessed(count int) {
+	if modelsProcessedGauge == nil {
 		return
 	}
-	modelsProcessedTotal.Add(float64(count))
+	modelsProcessedGauge.Set(float64(count))
 }
 
 // EmitReplicaMetrics emits current and desired replica metrics

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -20,6 +20,9 @@ var (
 	currentReplicas     *prometheus.GaugeVec
 	desiredRatio        *prometheus.GaugeVec
 
+	optimizationDuration *prometheus.HistogramVec
+	modelsProcessedTotal prometheus.Counter
+
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
 	controllerInstance string
@@ -77,6 +80,21 @@ func InitMetrics(registry prometheus.Registerer) error {
 		baseLabels,
 	)
 
+	optimizationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    constants.WVAOptimizationDurationSeconds,
+			Help:    "Duration of optimization loop cycles in seconds",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{constants.LabelStatus},
+	)
+	modelsProcessedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: constants.WVAModelsProcessedTotal,
+			Help: "Total number of models processed across optimization cycles",
+		},
+	)
+
 	// Register metrics with the registry
 	if err := registry.Register(replicaScalingTotal); err != nil {
 		return fmt.Errorf("failed to register replicaScalingTotal metric: %w", err)
@@ -89,6 +107,12 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(desiredRatio); err != nil {
 		return fmt.Errorf("failed to register desiredRatio metric: %w", err)
+	}
+	if err := registry.Register(optimizationDuration); err != nil {
+		return fmt.Errorf("failed to register optimizationDuration metric: %w", err)
+	}
+	if err := registry.Register(modelsProcessedTotal); err != nil {
+		return fmt.Errorf("failed to register modelsProcessedTotal metric: %w", err)
 	}
 
 	return nil
@@ -132,6 +156,23 @@ func (m *MetricsEmitter) EmitReplicaScalingMetrics(ctx context.Context, va *llmd
 
 	replicaScalingTotal.With(labels).Inc()
 	return nil
+}
+
+// ObserveOptimizationDuration records the duration of an optimization cycle with the given status.
+// Status should be one of: "success", "error", "partial".
+func (m *MetricsEmitter) ObserveOptimizationDuration(durationSeconds float64, status string) {
+	if optimizationDuration == nil {
+		return
+	}
+	optimizationDuration.With(prometheus.Labels{constants.LabelStatus: status}).Observe(durationSeconds)
+}
+
+// IncrModelsProcessed increments the models-processed counter by the given count.
+func (m *MetricsEmitter) IncrModelsProcessed(count int) {
+	if modelsProcessedTotal == nil {
+		return
+	}
+	modelsProcessedTotal.Add(float64(count))
 }
 
 // EmitReplicaMetrics emits current and desired replica metrics

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,7 +21,7 @@ var (
 	desiredRatio        *prometheus.GaugeVec
 
 	optimizationDuration *prometheus.HistogramVec
-	modelsProcessedGauge prometheus.Gauge
+	modelsProcessedGauge *prometheus.GaugeVec
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -92,11 +92,16 @@ func InitMetrics(registry prometheus.Registerer) error {
 		},
 		optimizationDurationLabels,
 	)
-	modelsProcessedGauge = prometheus.NewGauge(
+	modelsProcessedLabels := []string{}
+	if controllerInstance != "" {
+		modelsProcessedLabels = append(modelsProcessedLabels, constants.LabelControllerInstance)
+	}
+	modelsProcessedGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: constants.WVAModelsProcessedTotal,
+			Name: constants.WVAModelsProcessed,
 			Help: "Number of models processed in the last optimization cycle",
 		},
+		modelsProcessedLabels,
 	)
 
 	// Register metrics with the registry
@@ -180,7 +185,11 @@ func SetModelsProcessed(count int) {
 	if modelsProcessedGauge == nil {
 		return
 	}
-	modelsProcessedGauge.Set(float64(count))
+	labels := prometheus.Labels{}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	modelsProcessedGauge.With(labels).Set(float64(count))
 }
 
 // EmitReplicaMetrics emits current and desired replica metrics

--- a/internal/metrics/optimization_metrics_test.go
+++ b/internal/metrics/optimization_metrics_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestObserveOptimizationDuration(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+	emitter := NewMetricsEmitter()
+
+	// Observe a successful optimization
+	emitter.ObserveOptimizationDuration(0.15, "success")
+
+	// Observe a failed optimization
+	emitter.ObserveOptimizationDuration(2.5, "error")
+
+	// Verify the histogram was recorded
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAOptimizationDurationSeconds {
+			found = true
+			// Should have 2 metrics (one per status label)
+			if len(mf.GetMetric()) != 2 {
+				t.Errorf("Expected 2 metric series, got %d", len(mf.GetMetric()))
+			}
+			for _, m := range mf.GetMetric() {
+				h := m.GetHistogram()
+				if h == nil {
+					t.Error("Expected histogram metric")
+					continue
+				}
+				if h.GetSampleCount() != 1 {
+					t.Errorf("Expected 1 sample per status, got %d", h.GetSampleCount())
+				}
+				// Check status label
+				status := getLabelValue(m, constants.LabelStatus)
+				switch status {
+				case "success":
+					if h.GetSampleSum() < 0.1 || h.GetSampleSum() > 0.2 {
+						t.Errorf("Expected success duration ~0.15, got %f", h.GetSampleSum())
+					}
+				case "error":
+					if h.GetSampleSum() < 2.0 || h.GetSampleSum() > 3.0 {
+						t.Errorf("Expected error duration ~2.5, got %f", h.GetSampleSum())
+					}
+				default:
+					t.Errorf("Unexpected status label: %s", status)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAOptimizationDurationSeconds)
+	}
+}
+
+func TestIncrModelsProcessed(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+	emitter := NewMetricsEmitter()
+
+	// Increment models processed
+	emitter.IncrModelsProcessed(3)
+	emitter.IncrModelsProcessed(5)
+
+	// Verify the counter
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAModelsProcessedTotal {
+			found = true
+			if len(mf.GetMetric()) != 1 {
+				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
+			}
+			c := mf.GetMetric()[0].GetCounter()
+			if c == nil {
+				t.Error("Expected counter metric")
+			} else if c.GetValue() != 8 {
+				t.Errorf("Expected counter value 8 (3+5), got %f", c.GetValue())
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAModelsProcessedTotal)
+	}
+}
+
+func TestObserveOptimizationDuration_NilSafety(t *testing.T) {
+	// Reset the package-level vars to nil to simulate uninitialized state
+	savedDuration := optimizationDuration
+	savedCounter := modelsProcessedTotal
+	optimizationDuration = nil
+	modelsProcessedTotal = nil
+	defer func() {
+		optimizationDuration = savedDuration
+		modelsProcessedTotal = savedCounter
+	}()
+
+	emitter := NewMetricsEmitter()
+
+	// Should not panic when metrics are not initialized
+	emitter.ObserveOptimizationDuration(1.0, "success")
+	emitter.IncrModelsProcessed(5)
+}
+
+// getLabelValue returns the value of a label by name from a metric.
+func getLabelValue(m *dto.Metric, name string) string {
+	for _, l := range m.GetLabel() {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}

--- a/internal/metrics/optimization_metrics_test.go
+++ b/internal/metrics/optimization_metrics_test.go
@@ -29,13 +29,12 @@ func TestObserveOptimizationDuration(t *testing.T) {
 	if err := InitMetrics(registry); err != nil {
 		t.Fatalf("InitMetrics failed: %v", err)
 	}
-	emitter := NewMetricsEmitter()
 
 	// Observe a successful optimization
-	emitter.ObserveOptimizationDuration(0.15, "success")
+	ObserveOptimizationDuration(0.15, "success")
 
 	// Observe a failed optimization
-	emitter.ObserveOptimizationDuration(2.5, "error")
+	ObserveOptimizationDuration(2.5, "error")
 
 	// Verify the histogram was recorded
 	metrics, err := registry.Gather()
@@ -82,18 +81,17 @@ func TestObserveOptimizationDuration(t *testing.T) {
 	}
 }
 
-func TestIncrModelsProcessed(t *testing.T) {
+func TestSetModelsProcessed(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	if err := InitMetrics(registry); err != nil {
 		t.Fatalf("InitMetrics failed: %v", err)
 	}
-	emitter := NewMetricsEmitter()
 
-	// Increment models processed
-	emitter.IncrModelsProcessed(3)
-	emitter.IncrModelsProcessed(5)
+	// Set models processed (gauge should reflect the last value, not a sum)
+	SetModelsProcessed(3)
+	SetModelsProcessed(5)
 
-	// Verify the counter
+	// Verify the gauge
 	metrics, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("Failed to gather metrics: %v", err)
@@ -106,11 +104,11 @@ func TestIncrModelsProcessed(t *testing.T) {
 			if len(mf.GetMetric()) != 1 {
 				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
 			}
-			c := mf.GetMetric()[0].GetCounter()
-			if c == nil {
-				t.Error("Expected counter metric")
-			} else if c.GetValue() != 8 {
-				t.Errorf("Expected counter value 8 (3+5), got %f", c.GetValue())
+			g := mf.GetMetric()[0].GetGauge()
+			if g == nil {
+				t.Error("Expected gauge metric")
+			} else if g.GetValue() != 5 {
+				t.Errorf("Expected gauge value 5 (last set), got %f", g.GetValue())
 			}
 		}
 	}
@@ -119,22 +117,20 @@ func TestIncrModelsProcessed(t *testing.T) {
 	}
 }
 
-func TestObserveOptimizationDuration_NilSafety(t *testing.T) {
+func TestOptimizationMetrics_NilSafety(t *testing.T) {
 	// Reset the package-level vars to nil to simulate uninitialized state
 	savedDuration := optimizationDuration
-	savedCounter := modelsProcessedTotal
+	savedGauge := modelsProcessedGauge
 	optimizationDuration = nil
-	modelsProcessedTotal = nil
+	modelsProcessedGauge = nil
 	defer func() {
 		optimizationDuration = savedDuration
-		modelsProcessedTotal = savedCounter
+		modelsProcessedGauge = savedGauge
 	}()
 
-	emitter := NewMetricsEmitter()
-
 	// Should not panic when metrics are not initialized
-	emitter.ObserveOptimizationDuration(1.0, "success")
-	emitter.IncrModelsProcessed(5)
+	ObserveOptimizationDuration(1.0, "success")
+	SetModelsProcessed(5)
 }
 
 // getLabelValue returns the value of a label by name from a metric.

--- a/internal/metrics/optimization_metrics_test.go
+++ b/internal/metrics/optimization_metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The llm-d Authors
+Copyright 2026 The llm-d Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ func TestSetModelsProcessed(t *testing.T) {
 
 	var found bool
 	for _, mf := range metrics {
-		if mf.GetName() == constants.WVAModelsProcessedTotal {
+		if mf.GetName() == constants.WVAModelsProcessed {
 			found = true
 			if len(mf.GetMetric()) != 1 {
 				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
@@ -113,7 +113,7 @@ func TestSetModelsProcessed(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Metric %s not found in gathered metrics", constants.WVAModelsProcessedTotal)
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAModelsProcessed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add timing and throughput metrics for the optimization loop. Closes #914.

### New Metrics

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `wva_optimization_duration_seconds` | Histogram | `status` | Duration of each optimization cycle |
| `wva_models_processed_total` | Counter | — | Total models processed across cycles |

Histogram buckets: `{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}` seconds

Status labels: `success`, `error`

### Implementation

- `internal/constants/metrics.go` — New metric name and label constants
- `internal/metrics/metrics.go` — Register histogram + counter in `InitMetrics()`, add `ObserveOptimizationDuration()` and `IncrModelsProcessed()` methods on `MetricsEmitter`
- `internal/engines/saturation/engine.go` — Instrument `optimize()` with a deferred timing observation that captures duration and status (success/error), and tracks models processed per cycle
- `internal/metrics/optimization_metrics_test.go` — Unit tests

### Tests

```
=== RUN   TestObserveOptimizationDuration
--- PASS: TestObserveOptimizationDuration (0.00s)
=== RUN   TestIncrModelsProcessed
--- PASS: TestIncrModelsProcessed (0.00s)
=== RUN   TestObserveOptimizationDuration_NilSafety
--- PASS: TestObserveOptimizationDuration_NilSafety (0.00s)
PASS
```

### Acceptance Criteria (from issue)

- [x] Duration histogram emitted per optimization cycle
- [x] Models-processed counter incremented correctly
- [x] Unit tests verify histogram observation and counter increment