### PR TITLE
Saturation v2 fails to scale inference servers as it silently fails to get total demand

### DIFF
--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -39,7 +39,9 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 		Name: QuerySchedulerDispatchRate,
 		Type: source.QueryTypePromQL,
 		Template: `sum by (pod_name, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",target_model_name="{{.modelID}}"}[1m]))` +
-			` or sum by (pod_name, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",model_name="{{.modelID}}",target_model_name=""}[1m]))`,
+			` or sum by (pod_name, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",model_name="{{.modelID}}",target_model_name=""}[1m]))` +
+			` or sum by (pod_name) (rate(inference_extension_scheduler_attempts_total{status="success",target_model_name="{{.modelID}}"}[1m]))` +
+			` or sum by (pod_name) (rate(inference_extension_scheduler_attempts_total{status="success",model_name="{{.modelID}}",target_model_name=""}[1m]))`,
 		Params: []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Request dispatch rate per endpoint (requests/sec) from scheduler, " +
 			"representing the arrival rate to each replica for a specific model",


### PR DESCRIPTION
The EPP [issue](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2309) mentions adding a key namespace to metrics made available from inference servers in a different namespace. 

The code change we applied previously acts as a graceful degradation safety net by leveraging PromQL's or logic to intentionally bypass the namespace requirement when necessary. In this fallback layer, we completely stripe out the namespace= filter and remove namespace from the sum by() aggregation grouping.

**Note:** Because this fallback logic explicitly bypasses strict physical namespace tenant isolation on Prometheus, it requires the upstream model_name or target_model_name (e.g., InferencePool name or HuggingFace identifier string) to be absolutely unique across the entire Kubernetes cluster. If two identical model strings are deployed in separate namespaces and the fallback path triggers, the autoscaler will erroneously ingest blended traffic counts resulting in inaccurate scaling math.