### PR TITLE
Add Kubernetes events for scaling decisions

### DIFF
--- a/internal/constants/events.go
+++ b/internal/constants/events.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+// Kubernetes Event Reasons emitted by the WVA on VariantAutoscaling resources.
+// These follow CamelCase convention per Kubernetes API conventions.
+// View via: kubectl describe variantautoscaling <name>
+const (
+	// EventReasonScaledUp is a Normal event emitted when target replicas increased.
+	EventReasonScaledUp = "ScaledUp"
+
+	// EventReasonScaledDown is a Normal event emitted when target replicas decreased.
+	EventReasonScaledDown = "ScaledDown"
+
+	// EventReasonScaledToZero is a Normal event emitted when the scale-to-zero
+	// enforcer set the replica count to 0 due to no active requests.
+	EventReasonScaledToZero = "ScaledToZero"
+
+	// EventReasonResourceConstrained is a Warning event emitted when a scaling
+	// decision was constrained by GPU resource availability (limiter applied).
+	EventReasonResourceConstrained = "ResourceConstrained"
+
+	// EventReasonMetricsUnavailable is a Warning event emitted when Prometheus
+	// metrics could not be collected for a variant.
+	EventReasonMetricsUnavailable = "MetricsUnavailable"
+
+	// EventReasonOptimizationFailed is a Warning event emitted when the
+	// optimization analysis or optimizer returned an error for a variant.
+	EventReasonOptimizationFailed = "OptimizationFailed"
+)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -35,12 +36,14 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/discovery"
 	queueingmodel "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/queueingmodel"
 	saturation_v2 "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/analyzers/saturation_v2"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/common"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/executor"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	eventsHelper "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/events"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/saturation"
@@ -102,6 +105,11 @@ type Engine struct {
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
 	// CostAwareOptimizer (unlimited) or GreedyByScoreOptimizer (limited).
 	optimizer pipeline.ScalingOptimizer
+
+	// eventRecorder wraps Recorder with per-cycle rate limiting to emit
+	// Kubernetes events on VariantAutoscaling resources without flooding the
+	// API server.
+	eventRecorder *eventsHelper.RateLimitedRecorder
 }
 
 // NewEngine creates a new instance of the saturation engine.
@@ -144,6 +152,7 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
+		eventRecorder:           eventsHelper.New(recorder),
 	}
 
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
@@ -182,6 +191,10 @@ func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 // optimize performs the optimization logic.
 func (e *Engine) optimize(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
+
+	// Reset per-cycle rate limit state so events emitted in this cycle
+	// are not suppressed by state from the previous cycle.
+	e.eventRecorder.ResetCycle()
 
 	// Get optimization interval from Config (already a time.Duration)
 	interval := e.Config.OptimizationInterval()
@@ -1081,6 +1094,9 @@ func (e *Engine) applySaturationDecisions(
 			metricsMessage = llmdVariantAutoscalingV1alpha1.MessageMetricsAvailable
 		}
 
+		// Emit Kubernetes events for observability (rate-limited per cycle).
+		e.emitScalingEvents(&updateVa, decision, hasDecision, metricsAvailable, targetReplicas)
+
 		common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
 			VariantName:       vaName,
 			Namespace:         va.Namespace,
@@ -1109,6 +1125,65 @@ func (e *Engine) applySaturationDecisions(
 	}
 
 	return nil
+}
+
+// emitScalingEvents emits Kubernetes events on the VariantAutoscaling for
+// observability of scaling decisions and error conditions. Events are
+// rate-limited to at most one per (VA, reason) per optimization cycle.
+func (e *Engine) emitScalingEvents(
+	va *llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	decision interfaces.VariantDecision,
+	hasDecision, metricsAvailable bool,
+	targetReplicas int,
+) {
+	if va == nil || e.eventRecorder == nil {
+		return
+	}
+
+	// MetricsUnavailable: emit regardless of whether we have a decision.
+	if !metricsAvailable {
+		e.eventRecorder.Eventf(va, va.Namespace, va.Name,
+			corev1.EventTypeWarning, constants.EventReasonMetricsUnavailable,
+			"Failed to collect metrics for variant %q in namespace %q", va.Name, va.Namespace)
+	}
+
+	if !hasDecision {
+		return
+	}
+
+	currentReplicas := decision.CurrentReplicas
+
+	// ScaledToZero takes precedence over ScaledDown so operators see the
+	// distinct "scaled to zero by enforcer" signal rather than a generic
+	// scale-down.
+	if targetReplicas == 0 && currentReplicas > 0 {
+		e.eventRecorder.Eventf(va, va.Namespace, va.Name,
+			corev1.EventTypeNormal, constants.EventReasonScaledToZero,
+			"Scaled variant %q to 0 replicas (from %d): %s",
+			va.Name, currentReplicas, decision.Reason)
+	} else if targetReplicas > currentReplicas {
+		e.eventRecorder.Eventf(va, va.Namespace, va.Name,
+			corev1.EventTypeNormal, constants.EventReasonScaledUp,
+			"Scaled up variant %q from %d to %d replicas: %s",
+			va.Name, currentReplicas, targetReplicas, decision.Reason)
+	} else if targetReplicas < currentReplicas {
+		e.eventRecorder.Eventf(va, va.Namespace, va.Name,
+			corev1.EventTypeNormal, constants.EventReasonScaledDown,
+			"Scaled down variant %q from %d to %d replicas: %s",
+			va.Name, currentReplicas, targetReplicas, decision.Reason)
+	}
+
+	// ResourceConstrained: decision was limited by GPU availability.
+	if decision.WasLimited {
+		limitedBy := decision.LimitedBy
+		if limitedBy == "" {
+			limitedBy = "resource limiter"
+		}
+		e.eventRecorder.Eventf(va, va.Namespace, va.Name,
+			corev1.EventTypeWarning, constants.EventReasonResourceConstrained,
+			"Scaling decision for variant %q constrained by %s (original target: %d, final target: %d)",
+			va.Name, limitedBy, decision.OriginalTargetReplicas, targetReplicas)
+	}
 }
 
 // emitSafetyNetMetrics emits fallback metrics when saturation analysis fails.

--- a/internal/engines/saturation/events_test.go
+++ b/internal/engines/saturation/events_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	eventsHelper "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/events"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func newTestVA(name, namespace string) *llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
+	return &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// newTestEngine returns an Engine with just the eventRecorder initialized
+// for testing emitScalingEvents in isolation.
+func newTestEngine(recorder record.EventRecorder) *Engine {
+	return &Engine{
+		eventRecorder: eventsHelper.New(recorder),
+	}
+}
+
+func drainEvents(ch <-chan string) []string {
+	var events []string
+	for {
+		select {
+		case e := <-ch:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func TestEmitScalingEvents_ScaledUp(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas: 2,
+		Reason:          "saturation=0.85",
+	}
+	e.emitScalingEvents(va, decision, true, true, 4)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %v", len(events), events)
+	}
+	if !strings.Contains(events[0], constants.EventReasonScaledUp) {
+		t.Errorf("expected ScaledUp event, got %q", events[0])
+	}
+	if !strings.Contains(events[0], "2 to 4") {
+		t.Errorf("expected replica transition in message, got %q", events[0])
+	}
+}
+
+func TestEmitScalingEvents_ScaledDown(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas: 5,
+		Reason:          "low load",
+	}
+	e.emitScalingEvents(va, decision, true, true, 2)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if !strings.Contains(events[0], constants.EventReasonScaledDown) {
+		t.Errorf("expected ScaledDown event, got %q", events[0])
+	}
+	if !strings.Contains(events[0], "5 to 2") {
+		t.Errorf("expected replica transition in message, got %q", events[0])
+	}
+}
+
+func TestEmitScalingEvents_ScaledToZero(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas: 3,
+		Reason:          "no active requests",
+	}
+	e.emitScalingEvents(va, decision, true, true, 0)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if !strings.Contains(events[0], constants.EventReasonScaledToZero) {
+		t.Errorf("expected ScaledToZero event, got %q", events[0])
+	}
+	// Should NOT emit ScaledDown
+	if strings.Contains(events[0], constants.EventReasonScaledDown) {
+		t.Errorf("expected ScaledToZero (not ScaledDown), got %q", events[0])
+	}
+}
+
+func TestEmitScalingEvents_NoChange(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas: 3,
+	}
+	e.emitScalingEvents(va, decision, true, true, 3)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for no-change, got %d: %v", len(events), events)
+	}
+}
+
+func TestEmitScalingEvents_ResourceConstrained(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas:        2,
+		OriginalTargetReplicas: 10,
+		WasLimited:             true,
+		LimitedBy:              "gpu-limiter",
+		Reason:                 "scale up",
+	}
+	e.emitScalingEvents(va, decision, true, true, 4)
+
+	events := drainEvents(fake.Events)
+	// Expect ScaledUp + ResourceConstrained
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %v", len(events), events)
+	}
+	joined := strings.Join(events, "|")
+	if !strings.Contains(joined, constants.EventReasonScaledUp) {
+		t.Errorf("missing ScaledUp event: %v", events)
+	}
+	if !strings.Contains(joined, constants.EventReasonResourceConstrained) {
+		t.Errorf("missing ResourceConstrained event: %v", events)
+	}
+	if !strings.Contains(joined, "gpu-limiter") {
+		t.Errorf("expected limiter name in message, got %v", events)
+	}
+}
+
+func TestEmitScalingEvents_MetricsUnavailable(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{}
+	e.emitScalingEvents(va, decision, false, false, 0)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if !strings.Contains(events[0], constants.EventReasonMetricsUnavailable) {
+		t.Errorf("expected MetricsUnavailable event, got %q", events[0])
+	}
+}
+
+func TestEmitScalingEvents_NoDecisionNoMetricsAvailable(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	// No decision, metrics available — should emit nothing (no-op cycle)
+	e.emitScalingEvents(va, interfaces.VariantDecision{}, false, true, 3)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for no-decision steady state, got %d: %v", len(events), events)
+	}
+}
+
+func TestEmitScalingEvents_RateLimitedPerCycle(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+	va := newTestVA("va1", "ns1")
+
+	decision := interfaces.VariantDecision{
+		CurrentReplicas: 2,
+		Reason:          "high load",
+	}
+
+	// Emit the same scale-up decision 3 times within one cycle
+	e.emitScalingEvents(va, decision, true, true, 4)
+	e.emitScalingEvents(va, decision, true, true, 4)
+	e.emitScalingEvents(va, decision, true, true, 4)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Errorf("expected 1 event (rate limited), got %d", len(events))
+	}
+
+	// New cycle — should allow emission again
+	e.eventRecorder.ResetCycle()
+	e.emitScalingEvents(va, decision, true, true, 4)
+
+	events2 := drainEvents(fake.Events)
+	if len(events2) != 1 {
+		t.Errorf("expected 1 event after ResetCycle, got %d", len(events2))
+	}
+}
+
+func TestEmitScalingEvents_NilVA(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	e := newTestEngine(fake)
+
+	// Should not panic
+	e.emitScalingEvents(nil, interfaces.VariantDecision{CurrentReplicas: 2}, true, true, 4)
+
+	events := drainEvents(fake.Events)
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for nil VA, got %d", len(events))
+	}
+}
+
+func TestEmitScalingEvents_NilRecorder(t *testing.T) {
+	e := &Engine{eventRecorder: nil}
+	va := newTestVA("va1", "ns1")
+
+	// Should not panic
+	e.emitScalingEvents(va, interfaces.VariantDecision{CurrentReplicas: 2}, true, true, 4)
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events provides a rate-limited wrapper around the Kubernetes
+// EventRecorder for emitting events on VariantAutoscaling resources.
+package events
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+)
+
+// RateLimitedRecorder wraps an EventRecorder and ensures at most one event
+// per (namespace/name, reason) pair is emitted per cycle.
+//
+// ResetCycle must be called at the start of each optimization cycle to clear
+// the rate limit state.
+type RateLimitedRecorder struct {
+	recorder record.EventRecorder
+
+	mu    sync.Mutex
+	seen  map[string]struct{}
+}
+
+// New returns a new RateLimitedRecorder wrapping the given EventRecorder.
+// If recorder is nil, the returned RateLimitedRecorder is a no-op and is
+// safe to call.
+func New(recorder record.EventRecorder) *RateLimitedRecorder {
+	return &RateLimitedRecorder{
+		recorder: recorder,
+		seen:     make(map[string]struct{}),
+	}
+}
+
+// ResetCycle clears the rate limit state and should be called at the start
+// of each optimization cycle.
+func (r *RateLimitedRecorder) ResetCycle() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen = make(map[string]struct{})
+}
+
+// Eventf emits an event on the given object if no prior event with the same
+// reason has been emitted for the same (namespace/name) in the current cycle.
+// It is a no-op if the recorder is nil or object is nil.
+func (r *RateLimitedRecorder) Eventf(
+	object runtime.Object,
+	namespace, name, eventtype, reason, messageFmt string,
+	args ...interface{},
+) {
+	if r == nil || r.recorder == nil || object == nil {
+		return
+	}
+
+	key := utils.GetNamespacedKey(namespace, name) + "#" + reason
+
+	r.mu.Lock()
+	if _, ok := r.seen[key]; ok {
+		r.mu.Unlock()
+		return
+	}
+	r.seen[key] = struct{}{}
+	r.mu.Unlock()
+
+	r.recorder.Eventf(object, eventtype, reason, messageFmt, args...)
+}

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func newTestObject() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-va",
+			Namespace: "test-ns",
+		},
+	}
+}
+
+func drainEvents(ch <-chan string) []string {
+	var events []string
+	for {
+		select {
+		case e := <-ch:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func TestRateLimitedRecorder_EmitsEvent(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+	obj := newTestObject()
+
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "replicas 2->4")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if !strings.Contains(events[0], "ScaledUp") {
+		t.Errorf("expected event to contain ScaledUp, got %q", events[0])
+	}
+	if !strings.Contains(events[0], "replicas 2->4") {
+		t.Errorf("expected event to contain message, got %q", events[0])
+	}
+}
+
+func TestRateLimitedRecorder_RateLimitsSameReason(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+	obj := newTestObject()
+
+	// Same (ns/name, reason) emitted 3 times — should only produce 1 event
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "first")
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "second")
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "third")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 1 {
+		t.Errorf("expected 1 event (rate limited), got %d", len(events))
+	}
+}
+
+func TestRateLimitedRecorder_DifferentReasonsNotLimited(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+	obj := newTestObject()
+
+	// Same VA, different reasons — both should be emitted
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "first")
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeWarning, "ResourceConstrained", "second")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(events))
+	}
+}
+
+func TestRateLimitedRecorder_DifferentVAsNotLimited(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+	obj := newTestObject()
+
+	// Different VAs, same reason — both should be emitted
+	rec.Eventf(obj, "ns1", "va1", corev1.EventTypeNormal, "ScaledUp", "first")
+	rec.Eventf(obj, "ns2", "va2", corev1.EventTypeNormal, "ScaledUp", "second")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(events))
+	}
+}
+
+func TestRateLimitedRecorder_ResetCycle(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+	obj := newTestObject()
+
+	// Cycle 1
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "cycle1")
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "cycle1-dup")
+
+	// Reset before cycle 2
+	rec.ResetCycle()
+
+	// Cycle 2 — same (VA, reason) should be emitted again
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "cycle2")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 2 {
+		t.Errorf("expected 2 events (one per cycle), got %d", len(events))
+	}
+}
+
+func TestRateLimitedRecorder_NilRecorderNoPanic(t *testing.T) {
+	rec := New(nil)
+	obj := newTestObject()
+
+	// Should not panic
+	rec.Eventf(obj, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "msg")
+	rec.ResetCycle()
+}
+
+func TestRateLimitedRecorder_NilReceiverNoPanic(t *testing.T) {
+	var rec *RateLimitedRecorder
+
+	// Should not panic
+	rec.ResetCycle()
+}
+
+func TestRateLimitedRecorder_NilObjectNoEvent(t *testing.T) {
+	fake := record.NewFakeRecorder(10)
+	rec := New(fake)
+
+	rec.Eventf(nil, "test-ns", "test-va", corev1.EventTypeNormal, "ScaledUp", "msg")
+
+	events := drainEvents(fake.Events)
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for nil object, got %d", len(events))
+	}
+}


### PR DESCRIPTION
## Summary

Emit Kubernetes events on VariantAutoscaling resources for key scaling decisions and error conditions. Operators can inspect scaling history via `kubectl describe variantautoscaling <name>`. Closes #918.

### Event types

| Event | Type | Reason | When |
|-------|------|--------|------|
| Scale-up | Normal | `ScaledUp` | Target replicas increased |
| Scale-down | Normal | `ScaledDown` | Target replicas decreased |
| Scale-to-zero | Normal | `ScaledToZero` | Enforcer scaled variant to 0 (no active requests) |
| Resource constrained | Warning | `ResourceConstrained` | Decision was limited by GPU availability |
| Metrics unavailable | Warning | `MetricsUnavailable` | Prometheus query failed or returned no data |
| Optimization failed | Warning | `OptimizationFailed` | Reserved — constant added for future use by optimizer error path |

### Rate limiting

Events are rate-limited to at most **1 event per (VA, reason) per optimization cycle** to prevent API server flooding on rapid reconciliation cycles. Implemented via `internal/events.RateLimitedRecorder` which maintains a per-cycle seen-set and is reset at the start of each `optimize()` loop.

### Implementation

- **`internal/constants/events.go`** — Event reason constants (`EventReasonScaledUp`, `EventReasonScaledDown`, etc.)
- **`internal/events/`** — New package with `RateLimitedRecorder` wrapping `record.EventRecorder`. Nil-safe (no-op when recorder is nil). Thread-safe via `sync.Mutex`.
- **`internal/engines/saturation/engine.go`**:
  - `ResetCycle()` called at top of `optimize()` to clear per-cycle state
  - `emitScalingEvents()` helper on the Engine, called from `applySaturationDecisions()` after `metricsAvailable` is determined
  - Uses `decision.WasLimited` and `decision.LimitedBy` for `ResourceConstrained` events
  - `ScaledToZero` takes precedence over generic `ScaledDown` when target is 0 and current was > 0

### Tests

18 unit tests, all passing:

**`internal/events/events_test.go`** (8 tests):
- EmitsEvent, RateLimitsSameReason, DifferentReasonsNotLimited
- DifferentVAsNotLimited, ResetCycle, NilRecorder, NilReceiver, NilObject

**`internal/engines/saturation/events_test.go`** (10 tests):
- ScaledUp, ScaledDown, ScaledToZero, NoChange
- ResourceConstrained (with concurrent ScaledUp), MetricsUnavailable
- NoDecisionNoMetricsAvailable, RateLimitedPerCycle, NilVA, NilRecorder

```
=== RUN   TestEmitScalingEvents_ScaledUp
--- PASS: TestEmitScalingEvents_ScaledUp (0.00s)
...
PASS
ok  	github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/saturation	0.440s
ok  	github.com/llm-d/llm-d-workload-variant-autoscaler/internal/events	0.364s
```

### Acceptance criteria (from issue)

- [x] 6 event types emitted on appropriate conditions (5 active + 1 reserved for optimizer error path)
- [x] Events visible via `kubectl describe va <name>`
- [x] Events are rate-limited (no flooding on rapid cycles)
- [x] Unit tests verify event emission