### PR TITLE
docs: Document acceleratorName resolution on VariantAutoscaling

### DIFF
--- a/config/samples/variantautoscaling-integration.yaml
+++ b/config/samples/variantautoscaling-integration.yaml
@@ -6,6 +6,10 @@ metadata:
   name: sample-deployment
   namespace: llm-d-sim
   labels:
+    # Accelerator type fallback. WVA first auto-discovers the accelerator
+    # from the target Deployment's nodeSelector/nodeAffinity (nvidia.com/gpu.product,
+    # amd.com/gpu.product-name, cloud.google.com/gke-accelerator). This label
+    # is only used if auto-discovery fails (e.g., a simulator with no GPU node pins).
     inference.optimization/acceleratorName: A100
 spec:
   scaleTargetRef:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -532,6 +532,8 @@ helm install workload-variant-autoscaler ./charts/workload-variant-autoscaler \
 
 If you don't create VariantAutoscaling via Helm, create it manually:
 
+> **ℹ️ Accelerator name resolution:** WVA needs an accelerator name (e.g., `A100`) for each VA. It first auto-discovers this from the target Deployment's `nodeSelector` / `nodeAffinity` (`nvidia.com/gpu.product`, `amd.com/gpu.product-name`, or `cloud.google.com/gke-accelerator`), then falls back to the `inference.optimization/acceleratorName` label shown below. If both are missing, WVA silently skips metric emission for this VA. See [Accelerator Name Resolution](../docs/user-guide/configuration.md#accelerator-name-resolution).
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: llmd.ai/v1alpha1
@@ -540,6 +542,7 @@ metadata:
   name: my-vllm-deployment-decode
   namespace: llm-d-inference-scheduler
   labels:
+    # Fallback if the target Deployment has no GPU nodeSelector/nodeAffinity
     inference.optimization/acceleratorName: A100
 spec:
   # Model identifier

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -58,7 +58,7 @@ Every `VariantAutoscaling` must resolve to an **accelerator name** (e.g., `A100`
 
 2. **`inference.optimization/acceleratorName` label on the VariantAutoscaling** (fallback). Used if auto-discovery fails or the scale target has no GPU node selector.
 
-If **both** fail, WVA cannot build an allocation and will skip status updates and metric emission for the variant — HPA/KEDA will never receive a scaling signal. The failure is silent at the API level (the VA is accepted), but WVA controller logs contain:
+If **both** fail, WVA cannot build a full allocation. It will still set the `MetricsAvailable=False` condition on the VA (visible via `kubectl get va <name> -o yaml`), but it skips the full target-replicas calculation and does not emit scaling metrics — HPA/KEDA will never receive a scaling signal. The WVA controller logs contain:
 
 ```
 accelerator name not found in scale target nodeSelector/nodeAffinity or VA label

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -45,6 +45,47 @@ Choose between the following approaches:
 - [With HPA](hpa-integration.md) - Use Kubernetes HPA for autoscaling based on WVA's custom metrics
 - [With KEDA](keda-integration.md) - Use KEDA for autoscaling based on WVA's custom metrics
 
+### Accelerator Name Resolution
+
+Every `VariantAutoscaling` must resolve to an **accelerator name** (e.g., `A100`, `H100`, `L40S`) so WVA can build allocations, match against cluster inventory, and label emitted Prometheus metrics. WVA resolves the accelerator name in the following order:
+
+1. **Auto-discovery from the scale target** (preferred). WVA inspects the target `Deployment`/`LeaderWorkerSet` pod template for these `nodeSelector` / `nodeAffinity` keys:
+   - `nvidia.com/gpu.product`
+   - `amd.com/gpu.product-name`
+   - `cloud.google.com/gke-accelerator`
+
+   The first matching value is used.
+
+2. **`inference.optimization/acceleratorName` label on the VariantAutoscaling** (fallback). Used if auto-discovery fails or the scale target has no GPU node selector.
+
+If **both** fail, WVA cannot build an allocation and will skip status updates and metric emission for the variant — HPA/KEDA will never receive a scaling signal. The failure is silent at the API level (the VA is accepted), but WVA controller logs contain:
+
+```
+accelerator name not found in scale target nodeSelector/nodeAffinity or VA label
+```
+
+> **Helm users:** The chart injects the label automatically from `.Values.va.accelerator` (used as a fallback) but the comment in `values.yaml` notes it is optional — auto-discovery takes priority.
+
+**Recommendation:** For deployments that pin GPU type via `nodeSelector` or `nodeAffinity`, auto-discovery works out of the box. For deployments without GPU node selectors (e.g., simulators, tests, or shared clusters), set the label explicitly:
+
+```yaml
+apiVersion: llmd.ai/v1alpha1
+kind: VariantAutoscaling
+metadata:
+  name: my-variant
+  namespace: llm-d
+  labels:
+    # Fallback used if the target Deployment has no nvidia.com/gpu.product
+    # (or equivalent AMD/GKE) nodeSelector/nodeAffinity entry.
+    inference.optimization/acceleratorName: A100
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-vllm-deployment
+  modelID: "meta-llama/Llama-3.1-8B"
+```
+
 ## Operating Mode
 
 WVA operates in **saturation mode**.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -154,7 +154,67 @@ Fix the validation errors and reapply the resource.
 
 ---
 
-### 6. Controller Not Running
+### 6. Accelerator Name Cannot Be Resolved
+
+WVA needs to determine the accelerator (GPU) type for each `VariantAutoscaling`. It resolves this in two steps:
+
+1. **Auto-discovery** from the target `Deployment`/`LeaderWorkerSet` pod template by reading `nodeSelector` / `nodeAffinity` keys: `nvidia.com/gpu.product`, `amd.com/gpu.product-name`, or `cloud.google.com/gke-accelerator`.
+2. **Fallback** to the `inference.optimization/acceleratorName` label on the VA.
+
+If **both** fail, WVA silently skips status updates and metric emission for this variant — HPA/KEDA never receives a scaling signal. The VA appears healthy (no error events), but the resource effectively does nothing.
+
+**Check the scale target's node selector:**
+
+```bash
+# Get the scale target name from the VA
+TARGET=$(kubectl get va <va-name> -n <namespace> -o jsonpath='{.spec.scaleTargetRef.name}')
+
+# Inspect the deployment's nodeSelector for any GPU product keys
+kubectl get deployment "$TARGET" -n <namespace> \
+  -o jsonpath='{.spec.template.spec.nodeSelector}'
+```
+
+**Check the VA fallback label:**
+
+```bash
+kubectl get va <va-name> -n <namespace> \
+  -o jsonpath='{.metadata.labels.inference\.optimization/acceleratorName}'
+```
+
+**Controller log signature:**
+
+```
+accelerator name not found in scale target nodeSelector/nodeAffinity or VA label
+```
+
+or
+
+```
+Safety net: skipping metric emission - no accelerator name available
+```
+
+**Resolution:**
+
+Either pin GPU type via the target deployment's `nodeSelector`:
+
+```yaml
+# Deployment spec.template.spec.nodeSelector
+nodeSelector:
+  nvidia.com/gpu.product: A100
+```
+
+or set the label on the VA as an explicit override:
+
+```bash
+kubectl label va <va-name> -n <namespace> \
+  inference.optimization/acceleratorName=A100
+```
+
+See [Accelerator Name Resolution](configuration.md#accelerator-name-resolution) for details.
+
+---
+
+### 7. Controller Not Running
 
 The controller itself may not be running or may be experiencing errors.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -161,9 +161,16 @@ WVA needs to determine the accelerator (GPU) type for each `VariantAutoscaling`.
 1. **Auto-discovery** from the target `Deployment`/`LeaderWorkerSet` pod template by reading `nodeSelector` / `nodeAffinity` keys: `nvidia.com/gpu.product`, `amd.com/gpu.product-name`, or `cloud.google.com/gke-accelerator`.
 2. **Fallback** to the `inference.optimization/acceleratorName` label on the VA.
 
-If **both** fail, WVA silently skips status updates and metric emission for this variant — HPA/KEDA never receives a scaling signal. The VA appears healthy (no error events), but the resource effectively does nothing.
+If **both** fail, WVA cannot build a full allocation. It will still set the `MetricsAvailable=False` condition on the VA (which is a useful diagnostic signal — see below), but it skips the target-replicas calculation and does not emit scaling metrics — HPA/KEDA never receives a scaling signal.
 
-**Check the scale target's node selector:**
+**Check the VA condition first:**
+
+```bash
+kubectl get va <va-name> -n <namespace> -o jsonpath='{.status.conditions}' | jq .
+# Look for: type=MetricsAvailable, status=False, reason=MetricsMissing
+```
+
+**Check the scale target's node selector and node affinity:**
 
 ```bash
 # Get the scale target name from the VA
@@ -172,6 +179,10 @@ TARGET=$(kubectl get va <va-name> -n <namespace> -o jsonpath='{.spec.scaleTarget
 # Inspect the deployment's nodeSelector for any GPU product keys
 kubectl get deployment "$TARGET" -n <namespace> \
   -o jsonpath='{.spec.template.spec.nodeSelector}'
+
+# Also check nodeAffinity (the code checks both requiredDuringScheduling and preferredDuringScheduling)
+kubectl get deployment "$TARGET" -n <namespace> \
+  -o jsonpath='{.spec.template.spec.affinity.nodeAffinity}'
 ```
 
 **Check the VA fallback label:**
@@ -203,7 +214,7 @@ nodeSelector:
   nvidia.com/gpu.product: A100
 ```
 
-or set the label on the VA as an explicit override:
+or set the label on the VA as a fallback:
 
 ```bash
 kubectl label va <va-name> -n <namespace> \


### PR DESCRIPTION
## Summary

Document how WVA resolves the accelerator name for a `VariantAutoscaling`. Closes #855.

## Background

After #882 merged, WVA resolves the accelerator name in two steps:

1. **Auto-discovery** from the target Deployment/LWS pod template by reading `nodeSelector` / `nodeAffinity` for GPU product keys:
   - `nvidia.com/gpu.product`
   - `amd.com/gpu.product-name`
   - `cloud.google.com/gke-accelerator`
2. **Fallback** to the `inference.optimization/acceleratorName` label on the VA

If **both** fail, WVA silently skips status updates and metric emission for the variant — HPA/KEDA never receives a scaling signal. The failure is silent at the API level (the VA is accepted), but the controller log contains `accelerator name not found in scale target nodeSelector/nodeAffinity or VA label`.

This resolution logic was added in #882 but was never explicitly documented in user-facing docs, so users who hit the failure mode had no way to diagnose or fix it without reading source. Thanks to @ev-shindin for the #882 context on the issue thread.

## Changes

- **`docs/user-guide/configuration.md`** — New "Accelerator Name Resolution" subsection under "Enabling Autoscaling for a Model Deployment". Explains the two-step lookup, the failure log signature, the Helm note, and includes a complete manual YAML example.

- **`docs/user-guide/troubleshooting.md`** — New section "Accelerator Name Cannot Be Resolved" under "Why is my VariantAutoscaling not being reconciled?" with:
  - `kubectl` commands to inspect the scale target `nodeSelector`
  - `kubectl` command to inspect the VA fallback label
  - Two log signatures users will see
  - Resolution via either pinning GPU type on the Deployment **or** setting the label

- **`deploy/README.md`** — Info callout on the existing manual VA creation example explaining the resolution order. Links to the new configuration.md section.

- **`config/samples/variantautoscaling-integration.yaml`** — Inline comment annotating the label as a fallback, not a hard requirement, with the auto-discovery keys spelled out.

## Out of scope

- `docs/user-guide/crd-reference.md` is generated from CRD types (`CRD_OUTPUT` in the Makefile) and cannot be edited directly.
- The existing `TODO: remove this checks when we will move to a new version of the CRD with required accelerator field` at `internal/engines/saturation/engine.go` still applies as a future direction but is out of scope for this doc-only fix.

## Note on earlier framing

An earlier revision of this PR framed the label as **required**. That was accurate pre-#882 and matched the original issue description, but after #882 the label is a fallback — auto-discovery takes priority. All text has been rewritten to reflect the current behavior.