### PR TITLE
Fix saturation analyzer V1 docs to match implementation (#987)

### DIFF
--- a/docs/saturation-scaling-config.md
+++ b/docs/saturation-scaling-config.md
@@ -9,39 +9,40 @@ The Workload Variant Autoscaler supports saturation-based scaling using KV cache
 - ✅ **Efficient caching** with single read on startup (zero API calls during reconciliation)
 - ✅ **Automatic reload** via ConfigMap watch (immediate response to changes)
 - ✅ **Thread-safe** concurrent access with RWMutex
-- ✅ Graceful degradation to defaults if ConfigMap missing
+- ✅ Graceful degradation if ConfigMap missing (V2 has hardcoded defaults; V1 requires ConfigMap — see [Default Configuration](#default-configuration))
 
 ## Configuration
 
 ### ConfigMap Structure
 
-The saturation scaling configuration is stored in a ConfigMap named `capacity-scaling-config` in the Workload Variant Autoscaler controller's namespace.
+The saturation scaling configuration is stored in a ConfigMap named `wva-saturation-scaling-config` in the Workload Variant Autoscaler controller's namespace.
 
-**Location:** `deploy/configmap-capacity-scaling.yaml`
+**Location:** `deploy/configmap-saturation-scaling.yaml`
 
 ### Parameters
 
-| Parameter | Type | Description | Default |
-|-----------|------|-------------|---------|
+| Parameter | Type | Description | Recommended |
+|-----------|------|-------------|-------------|
 | `kvCacheThreshold` | float64 | Replica is considered saturated if KV cache utilization ≥ threshold (0.0-1.0) | 0.80 |
-| `queueLengthThreshold` | int | Replica is considered saturated if queue length ≥ threshold | 5 |
+| `queueLengthThreshold` | float64 | Replica is considered saturated if queue length ≥ threshold | 5 |
 | `kvSpareTrigger` | float64 | Scale-up signal if average spare KV capacity < trigger (0.0-1.0) | 0.10 |
-| `queueSpareTrigger` | int | Scale-up signal if average spare queue capacity < trigger | 3 |
+| `queueSpareTrigger` | float64 | Scale-up signal if average spare queue capacity < trigger | 3 |
 
 ### Default Configuration
 
-The default configuration is automatically used if:
-- The ConfigMap is not deployed
-- The ConfigMap exists but has no `default` entry
-- An entry fails validation
+The recommended values for the V1 (percentage-based) saturation analyzer are:
 
-**Default values:**
 ```yaml
 kvCacheThreshold: 0.80
 queueLengthThreshold: 5
 kvSpareTrigger: 0.1
 queueSpareTrigger: 3
 ```
+
+> **Important:** These V1 threshold values are **not hardcoded** in the analyzer code.
+> If the ConfigMap is missing or has no `default` entry, all V1 thresholds default to zero,
+> which will cause every replica to appear saturated and trigger continuous scale-up.
+> Always deploy the ConfigMap with a `default` entry containing valid thresholds.
 
 ### How Scale-Up Triggers Work
 
@@ -70,12 +71,12 @@ The saturation analyzer uses a **spare capacity model** to determine when to sca
 - Replica A: 65% KV cache usage → Spare capacity: 0.15
 - Replica B: 72% KV cache usage → Spare capacity: 0.08
 - Average spare KV: (0.15 + 0.08) / 2 = **0.115**
-- Since 0.115 > 0.10, no scale-up yet
-- If Replica B increases to 75%: Average spare = 0.10 → **Scale-up triggered**
+- Since 0.115 ≥ 0.10, no scale-up yet (trigger uses strict `<`)
+- If Replica B increases to 76%: Average spare = (0.15 + 0.04) / 2 = **0.095** → 0.095 < 0.10 → **Scale-up triggered**
 
 This proactive approach ensures adequate headroom and prevents request drops by scaling before saturation occurs.
 
-**For detailed implementation, see:** [Saturation Analyzer Documentation](saturation-analyzer.md)
+**For detailed implementation, see:** [Saturation Analyzer Documentation](user-guide/saturation-analyzer.md)
 
 ## Best Practices: Coordinating with InferenceScheduler (End Point Picker)
 
@@ -115,11 +116,11 @@ Using aligned thresholds ensures consistent capacity management across the clust
 #### WVA Saturation Scaling Configuration
 
 ```yaml
-# WVA Configuration (capacity-scaling-config ConfigMap)
+# WVA Configuration (wva-saturation-scaling-config ConfigMap)
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: capacity-scaling-config
+  name: wva-saturation-scaling-config
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
@@ -173,10 +174,10 @@ Choose thresholds based on your workload characteristics and SLO requirements:
 
 #### Step 2: Apply to WVA
 
-Update `capacity-scaling-config` ConfigMap:
+Update `wva-saturation-scaling-config` ConfigMap:
 
 ```bash
-kubectl edit cm capacity-scaling-config -n <workload-variant-autoscaler-namespace>
+kubectl edit cm wva-saturation-scaling-config -n <workload-variant-autoscaler-namespace>
 ```
 
 Changes take effect **immediately** (WVA watches ConfigMap and auto-reloads).
@@ -214,7 +215,7 @@ kubectl rollout restart deployment/gaie-llama-70b-epp -n lab
 
 **WVA verification:**
 ```bash
-kubectl get cm capacity-scaling-config -n <workload-variant-autoscaler-namespace> -o yaml
+kubectl get cm wva-saturation-scaling-config -n <workload-variant-autoscaler-namespace> -o yaml
 ```
 
 **EPP verification (per-model instance):**
@@ -255,21 +256,24 @@ kubectl logs -n production deployment/gaie-granite-13b-epp | grep -i "saturation
 
 ### 1. Using Default Configuration
 
-Simply deploy the controller without the ConfigMap. The system will log a warning and use hardcoded defaults:
+> **Warning:** For the V1 (percentage-based) analyzer, deploying without a ConfigMap will
+> result in zero-valued thresholds, causing all replicas to be marked as saturated.
+> Always deploy the ConfigMap with a `default` entry for V1.
 
+If the ConfigMap is missing, the system will log a warning:
 ```
-WARN Saturation scaling ConfigMap not found, using hardcoded defaults
+WARN Saturation scaling ConfigMap not found
 ```
 
 ### 2. Customizing Global Defaults
 
-Edit `deploy/configmap-capacity-scaling.yaml`:
+Edit `deploy/configmap-saturation-scaling.yaml`:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: capacity-scaling-config
+  name: wva-saturation-scaling-config
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
@@ -281,7 +285,7 @@ data:
 
 Apply the ConfigMap:
 ```bash
-kubectl apply -f deploy/configmap-capacity-scaling.yaml
+kubectl apply -f deploy/configmap-saturation-scaling.yaml
 ```
 
 **Note:** Changes take effect immediately! The controller watches the ConfigMap and automatically:
@@ -291,13 +295,18 @@ kubectl apply -f deploy/configmap-capacity-scaling.yaml
 
 ### 3. Per-Model Overrides
 
-Add model-specific configuration entries to override defaults for specific model/namespace pairs:
+Add model-specific configuration entries to override defaults for specific model/namespace pairs.
+
+The saturation engine resolves per-model config using a lookup key in the format
+`{modelID}#{namespace}` (see `internal/engines/saturation/engine.go` — `resolveSaturationConfig()`).
+The ConfigMap data key **must** match this format for overrides to take effect.
+Lookup order: `modelID#namespace` → `default` → zero-value with defaults applied.
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: capacity-scaling-config
+  name: wva-saturation-scaling-config
   namespace: <workload-variant-autoscaler-namespace>
 data:
   default: |
@@ -307,36 +316,39 @@ data:
     queueSpareTrigger: 3
 
   # Override for granite model in production namespace
-  granite-13b-production: |
-    model_id: ibm/granite-13b
-    namespace: production
+  # All fields must be specified — no inheritance from default
+  "ibm/granite-13b#production": |
     kvCacheThreshold: 0.85
+    queueLengthThreshold: 5
     kvSpareTrigger: 0.15
+    queueSpareTrigger: 3
 
   # Override for llama model in lab namespace
-  llama-70b-lab: |
-    model_id: meta/llama-70b
-    namespace: lab
+  "meta/llama-70b#lab": |
+    kvCacheThreshold: 0.80
     queueLengthThreshold: 20
+    kvSpareTrigger: 0.1
     queueSpareTrigger: 10
 ```
 
 **Key points:**
-- Entry keys (e.g., `granite-13b-production`) can be any descriptive name
-- Each override must include `model_id` and `namespace` fields
-- Only specified fields are overridden; others inherit from `default`
+- Override keys **must** use the format `{modelID}#{namespace}` to match the engine's lookup
+- The `model_id` and `namespace` YAML fields inside the entry are parsed but **not used for lookup**
+- Overrides **replace** the `default` config entirely — there is no field-level inheritance. If an override omits a field (e.g., `queueLengthThreshold`), that field will be zero, not inherited from `default`. Always specify all required fields in each override entry.
 - Multiple overrides can exist for different model/namespace combinations
 
-### 4. Partial Overrides
+### 4. Per-Model Overrides — No Field Inheritance
 
-You can override only specific parameters while inheriting the rest from defaults:
+Overrides **fully replace** the `default` config. There is no field-level merging — omitted
+fields will be zero, not inherited from `default`. Always specify all required threshold
+fields in each override entry:
 
 ```yaml
-  my-model-override: |
-    model_id: my-org/my-model
-    namespace: my-namespace
+  "my-org/my-model#my-namespace": |
     kvCacheThreshold: 0.90
-    # Other fields inherit from default
+    queueLengthThreshold: 5
+    kvSpareTrigger: 0.1
+    queueSpareTrigger: 3
 ```
 
 ## Validation
@@ -373,49 +385,33 @@ WARN Invalid saturation scaling config entry, skipping key=invalid-config error=
 The controller uses an **efficient caching mechanism** with ConfigMap watch for optimal performance:
 
 **Initialization (on controller startup):**
-```go
-// cmd/main.go
-reconciler := &controller.VariantAutoscalingReconciler{...}
-reconciler.SetupWithManager(mgr)  // Sets up ConfigMap watch
 
-// Initialize cache on startup
-if err := reconciler.InitializeCapacityConfigCache(context.Background()); err != nil {
-    setupLog.Warn("Failed to load initial saturation scaling config, will use defaults")
-}
-```
+The ConfigMap reconciler watches the `wva-saturation-scaling-config` ConfigMap and loads
+configuration into the shared `Config` object. On startup, the controller bootstraps the
+config cache (see `internal/controller/configmap_bootstrap.go`).
 
 **Reconciliation (zero API calls):**
+
+During the optimization loop, the engine reads config from the in-memory cache:
 ```go
-// In Reconcile loop - uses cached config (fast, no API call)
-capacityConfigs := r.getCapacityConfigFromCache()
+// In optimize() - reads cached config (no API call)
+saturationConfigMap := e.Config.SaturationConfigForNamespace(namespace)
 
-// For a specific VariantAutoscaling resource
-capacityConfig := r.getCapacityScalingConfigForVariant(
-    capacityConfigs,
-    va.Spec.ModelID,
-    va.Namespace,
-)
+// Resolve per-model config using "{modelID}#{namespace}" lookup
+saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
 
-// Use capacityConfig for saturation-based scaling decisions
-if currentKvUtil >= capacityConfig.KvCacheThreshold {
-    // Apply saturation scaling logic
-}
+// Use saturationConfig for saturation-based scaling decisions
+// (thresholds drive the analyzer's saturation detection)
 ```
 
 ### Automatic Cache Updates
 
-The controller watches the `capacity-scaling-config` ConfigMap for changes:
+The `ConfigMapReconciler` watches the `wva-saturation-scaling-config` ConfigMap for changes
+(see `internal/controller/configmap_reconciler.go`):
 
 1. **ConfigMap change detected** → Watch event triggered
-2. **Cache automatically reloaded** → New configuration loaded
-3. **All VariantAutoscaling resources reconciled** → New config applied immediately
-
-**Log output on ConfigMap change:**
-```
-INFO  Saturation scaling ConfigMap changed, reloading cache
-INFO  Saturation scaling config cache updated entries=3 has_default=true
-INFO  Triggering reconciliation for all VariantAutoscaling resources due to ConfigMap change count=5
-```
+2. **Cache automatically reloaded** → New configuration parsed and stored in `Config`
+3. **Next optimization cycle** picks up the new config automatically
 
 ### Performance Characteristics
 
@@ -440,12 +436,12 @@ INFO  Triggering reconciliation for all VariantAutoscaling resources due to Conf
 
 **Symptom:** Warning log message
 ```
-WARN Saturation scaling ConfigMap not found, using hardcoded defaults configmap=capacity-scaling-config namespace=<workload-variant-autoscaler-namespace>
+WARN Saturation scaling ConfigMap not found, using hardcoded defaults configmap=wva-saturation-scaling-config namespace=<workload-variant-autoscaler-namespace>
 ```
 
 **Solution:** Deploy the ConfigMap:
 ```bash
-kubectl apply -f deploy/configmap-capacity-scaling.yaml
+kubectl apply -f deploy/configmap-saturation-scaling.yaml
 ```
 
 ### Invalid Configuration Entry
@@ -479,15 +475,11 @@ data:
 **Symptom:** Model-specific override is not being used
 
 **Checklist:**
-1. Verify `model_id` exactly matches `va.Spec.ModelID`
-2. Verify `namespace` exactly matches the VariantAutoscaling resource namespace
-3. Check controller logs for validation errors
-4. Ensure entry passed validation (check for WARN logs)
-
-**Debug log (when override is applied):**
-```
-DEBUG Applied saturation scaling override key=my-override modelID=ibm/granite-13b namespace=production config={...}
-```
+1. Verify the ConfigMap data key uses the format `{modelID}#{namespace}` (e.g., `"ibm/granite-13b#production"`)
+2. Verify `modelID` exactly matches `va.Spec.ModelID`
+3. Verify `namespace` exactly matches the VariantAutoscaling resource namespace
+4. Check controller logs for validation errors
+5. Ensure entry passed validation (check for WARN logs)
 
 ### Config Changes Not Taking Effect
 
@@ -497,7 +489,7 @@ DEBUG Applied saturation scaling override key=my-override modelID=ibm/granite-13
 
 1. **Verify ConfigMap was updated:**
    ```bash
-   kubectl get cm capacity-scaling-config -n <workload-variant-autoscaler-namespace> -o yaml
+   kubectl get cm wva-saturation-scaling-config -n <workload-variant-autoscaler-namespace> -o yaml
    ```
 
 2. **Check controller logs for reload confirmation:**
@@ -528,11 +520,11 @@ DEBUG Applied saturation scaling override key=my-override modelID=ibm/granite-13
 WARN Failed to load initial saturation scaling config, will use defaults
 ```
 
-**Solution:** This is non-fatal. The controller continues with hardcoded defaults. To fix:
+**Solution:** This is non-fatal. The controller continues with zero-valued V1 thresholds (V2 has hardcoded defaults). To fix:
 
 1. Deploy the ConfigMap:
    ```bash
-   kubectl apply -f deploy/configmap-capacity-scaling.yaml
+   kubectl apply -f deploy/configmap-saturation-scaling.yaml
    ```
 
 2. The watch mechanism will automatically reload the cache once ConfigMap is available
@@ -544,12 +536,12 @@ WARN Failed to load initial saturation scaling config, will use defaults
 
 ## Example: Production Setup
 
-**deploy/configmap-capacity-scaling.yaml:**
+**deploy/configmap-saturation-scaling.yaml:**
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: capacity-scaling-config
+  name: wva-saturation-scaling-config
   namespace: <workload-variant-autoscaler-namespace>
 data:
   # Conservative defaults for most workloads
@@ -560,18 +552,14 @@ data:
     queueSpareTrigger: 3
 
   # High-priority production workload - scale aggressively
-  granite-prod: |
-    model_id: ibm/granite-13b
-    namespace: production
+  "ibm/granite-13b#production": |
     kvCacheThreshold: 0.70
     queueLengthThreshold: 3
     kvSpareTrigger: 0.20
     queueSpareTrigger: 5
 
   # Development workload - allow higher saturation
-  llama-dev: |
-    model_id: meta/llama-70b
-    namespace: development
+  "meta/llama-70b#development": |
     kvCacheThreshold: 0.90
     queueLengthThreshold: 15
     kvSpareTrigger: 0.05
@@ -580,35 +568,35 @@ data:
 
 Apply the configuration:
 ```bash
-kubectl apply -f deploy/configmap-capacity-scaling.yaml
+kubectl apply -f deploy/configmap-saturation-scaling.yaml
 ```
 
 Verify deployment:
 ```bash
-kubectl get cm capacity-scaling-config -n <workload-variant-autoscaler-namespace>
-kubectl describe cm capacity-scaling-config -n <workload-variant-autoscaler-namespace>
+kubectl get cm wva-saturation-scaling-config -n <workload-variant-autoscaler-namespace>
+kubectl describe cm wva-saturation-scaling-config -n <workload-variant-autoscaler-namespace>
 ```
 
 ## API Reference
 
 ### Go Structs
 
-**CapacityScalingConfig:**
+**SaturationScalingConfig** (defined in `internal/config/saturation_scaling.go`):
 ```go
-type CapacityScalingConfig struct {
+type SaturationScalingConfig struct {
     ModelID              string  `yaml:"model_id,omitempty"`
     Namespace            string  `yaml:"namespace,omitempty"`
     KvCacheThreshold     float64 `yaml:"kvCacheThreshold"`
-    QueueLengthThreshold int     `yaml:"queueLengthThreshold"`
+    QueueLengthThreshold float64 `yaml:"queueLengthThreshold"`
     KvSpareTrigger       float64 `yaml:"kvSpareTrigger"`
-    QueueSpareTrigger    int     `yaml:"queueSpareTrigger"`
+    QueueSpareTrigger    float64 `yaml:"queueSpareTrigger"`
+    // ... additional V2-specific fields omitted
 }
 ```
 
 **Methods:**
-- `DefaultCapacityScalingConfig() CapacityScalingConfig` - Returns hardcoded defaults
-- `Validate() error` - Validates configuration values
-- `Merge(override CapacityScalingConfig)` - Applies partial override
+- `ApplyDefaults()` - Fills in zero-valued V2 fields with their defaults (V1 fields have no hardcoded defaults)
+- `Validate() error` - Validates configuration values (thresholds in range, consistency checks)
 
 ## Architecture Notes
 
@@ -622,17 +610,18 @@ The caching mechanism uses the following components:
 - Write operations (cache reload) are exclusive
 
 **Defensive Copy:**
-- `getCapacityConfigFromCache()` returns a deep copy
+- `SaturationConfigForNamespace()` returns a deep copy
 - Prevents external code from modifying cached configuration
 - Each caller gets an independent copy
 
 **Watch Mechanism:**
-- Kubernetes watch on `capacity-scaling-config` ConfigMap
+- Kubernetes watch on `wva-saturation-scaling-config` ConfigMap
 - Predicate filters to only relevant ConfigMap events
 - Event handler reloads cache and triggers reconciliation
 
 **Graceful Degradation:**
 - Controller starts successfully even if ConfigMap missing
-- Uses hardcoded defaults as fallback
+- V2 analyzer uses hardcoded defaults (`scaleUpThreshold: 0.85`, `scaleDownBoundary: 0.70`)
+- V1 analyzer has **no hardcoded defaults** — all thresholds will be zero without ConfigMap
 - Automatically loads config once ConfigMap becomes available
 

--- a/docs/user-guide/saturation-analyzer.md
+++ b/docs/user-guide/saturation-analyzer.md
@@ -23,8 +23,9 @@ The Saturation Analyzer is a **fast, reactive, and safe saturation guardrail** t
   - [Scale-Up Decision](#scale-up-decision)
   - [Scale-Down Safety Simulation](#scale-down-safety-simulation)
 - [Decision Logic](#decision-logic)
-  - [Calculate Capacity Targets](#calculate-capacity-targets)
-- [Multi-Variant Analysis](#multi-variant-analysis)
+  - [Calculate Saturation Targets](#calculate-saturation-targets)
+  - [Model-Level Transition Blocking](#model-level-transition-blocking)
+  - [Scaling Decision Table](#scaling-decision-table-when-model-is-stable)
 - [Configuration](#configuration)
   - [Cascade Scaling Prevention](#cascade-scaling-prevention)
 - [Architecture](#architecture)
@@ -41,7 +42,7 @@ A replica is **non-saturated** if:
 kv_cache_usage < kvCacheThreshold AND queue_length < queueLengthThreshold
 ```
 
-**Default thresholds:**
+**Recommended thresholds** (set via ConfigMap — see [Configuration](#configuration)):
 - `kvCacheThreshold`: 0.80 (80%)
 - `queueLengthThreshold`: 5
 
@@ -68,26 +69,40 @@ Trigger scale-up if:
 avg_spare_kv < kvSpareTrigger OR avg_spare_queue < queueSpareTrigger
 ```
 
-**Default triggers:**
+**Recommended triggers** (set via ConfigMap — see [Configuration](#configuration)):
 - `kvSpareTrigger`: 0.1 (10%)
 - `queueSpareTrigger`: 3
 
+> **Note:** These V1 thresholds are **not hardcoded** in the analyzer. They must be provided
+> via the `wva-saturation-scaling-config` ConfigMap. If the ConfigMap is missing or has no
+> `default` entry, all thresholds default to zero, which will cause every replica to appear
+> saturated. Always deploy the ConfigMap with a `default` entry.
+
 ### Scale-Down Safety Simulation
 
-Before allowing scale-down, simulate total load redistribution across remaining replicas:
+Before allowing scale-down, the analyzer simulates load redistribution using a scale-factor
+approach. Instead of summing raw per-replica loads, it derives the current average load from
+the already-computed average spare capacity and then applies a `N/(N-1)` scale factor to
+predict load after removing one replica.
+
+See: `internal/saturation/analyzer.go` — `isScaleDownSafe()`
 
 ```
-remaining_replicas = N_non_sat - 1
+// Pre-condition: require at least 2 non-saturated replicas
+if N_non_sat < 2:
+    return unsafe
 
-// Calculate total load across all non-saturated replicas
-total_kv_load = Σ kv_cache_usage_i (for all non-saturated replicas)
-total_queue_load = Σ queue_length_i (for all non-saturated replicas)
+// Derive current average load from average spare capacity
+// (Load = Threshold - Spare)
+avg_kv_load = kvCacheThreshold - avg_spare_kv
+avg_queue_load = queueLengthThreshold - avg_spare_queue
 
-// Simulate removing one replica: redistribute total load
-avg_kv_after_removal = total_kv_load / remaining_replicas
-avg_queue_after_removal = total_queue_load / remaining_replicas
+// Simulate removing one replica: load increases by factor N/(N-1)
+scale_factor = N_non_sat / (N_non_sat - 1)
+avg_kv_after_removal = avg_kv_load * scale_factor
+avg_queue_after_removal = avg_queue_load * scale_factor
 
-// Calculate remaining spare capacity
+// Calculate remaining spare capacity after redistribution
 remaining_spare_kv = kvCacheThreshold - avg_kv_after_removal
 remaining_spare_queue = queueLengthThreshold - avg_queue_after_removal
 ```
@@ -95,43 +110,82 @@ remaining_spare_queue = queueLengthThreshold - avg_queue_after_removal
 **Scale-down is safe if:**
 ```
 remaining_spare_kv >= kvSpareTrigger AND
-remaining_spare_queue >= queueSpareTrigger AND
-N_non_sat >= 2
+remaining_spare_queue >= queueSpareTrigger
 ```
+
+> **Note:** The minimum-replicas check (`N_non_sat >= 2`) is enforced as a pre-condition
+> before the simulation runs, defined by `MinNonSaturatedReplicasForScaleDown` in
+> `internal/saturation/constants.go`.
 
 ## Decision Logic
 
-### Calculate Capacity Targets
+### Calculate Saturation Targets
 
-`CalculateCapacityTargets(capacityAnalysis, variantStates) → map[variantName]targetReplicas`
+`CalculateSaturationTargets(saturationAnalysis, variantStates) → map[variantName]targetReplicas`
 
-For each variant, determines target replicas based on **capacity needs only**:
+For each variant, determines target replicas based on **saturation analysis**:
+
+#### Model-Level Transition Blocking
+
+Before any scaling decisions are made, the analyzer checks whether the **entire model** is
+in a transitional state. If **any** variant of the model is transitioning, **all** scaling
+decisions for the model are blocked. This prevents decisions based on incomplete capacity data.
+
+See: `internal/saturation/analyzer.go` — `CalculateSaturationTargets()`, Step 1
+
+A variant is considered transitioning if **either** condition is true:
+
+| Check | Condition | Meaning |
+|-------|-----------|---------|
+| **Desired vs Current** | `DesiredReplicas ≠ 0 AND DesiredReplicas ≠ CurrentReplicas` | A previous scaling decision is still being applied |
+| **Metrics vs Current** | `MetricsCount ≠ CurrentReplicas` | Not all pods are ready and reporting metrics |
+
+When transition is detected:
+- Variants with a desired/current mismatch preserve their `DesiredReplicas` as the target
+- All other variants preserve their `CurrentReplicas` as the target
+- No new scale-up or scale-down decisions are made for any variant of the model
+
+#### Scaling Decision Table (when model is stable)
 
 | Condition | Target Replicas | Rationale |
 |-----------|----------------|-----------|
-| **desired ≠ 0 AND desired ≠ current** | target = **desired** | Preserve previous decision (from CRD status) |
-| Capacity needs scale-up | **Cheapest** non-preserved variant: readyReplicas + 1 | Cost-optimized capacity expansion (deterministic: alphabetically first variant on tie) |
-| Capacity allows scale-down | **Most expensive** non-preserved variant: readyReplicas - 1 | Cost-optimized capacity reduction (deterministic: alphabetically last variant on tie) |
+| Capacity needs scale-up | **Cheapest** eligible variant: readyReplicas + 1 | Cost-optimized capacity expansion (deterministic: alphabetically first variant on tie) |
+| Capacity allows scale-down | **Most expensive** eligible variant (with target > 1): readyReplicas - 1 | Cost-optimized capacity reduction (deterministic: alphabetically last variant on tie) |
 | Otherwise | target = readyReplicas | No capacity action needed |
 
-**Note:** `readyReplicas` = number of replicas reporting capacity metrics (from `VariantCapacityAnalysis.ReplicaCount`). This prevents excessive scale-up when replicas are still starting up.
+After scaling decisions, targets are clamped to `[minReplicas, maxReplicas]` bounds from the
+VariantAutoscaling spec (if specified).
+
+**Note:** `readyReplicas` = number of replicas reporting capacity metrics (from `VariantSaturationAnalysis.ReplicaCount`). This prevents excessive scale-up when replicas are still starting up.
 
 **Cascade Scaling Prevention:** Variants with pending replicas (pods that exist but are not yet ready) are skipped during scale-up selection. This prevents the controller from repeatedly scaling up the same variant while previous scale-up operations are still in progress. Pod startup can take 2-7 minutes depending on model size and hardware (container initialization, model loading, health checks).
 
-**Example Output:**
+> **Important:** Cascade prevention (pending replica checks) only applies when the model is
+> **not** in transition. If any variant triggers model-level transition blocking (above),
+> all decisions are blocked before the per-variant cascade prevention logic runs.
+
+**Example Output (model stable — all variants have metrics == current and desired == current or 0):**
 ```
 Model: llama-70b
 Variants:
   - v1-l4 (cost=$5): current=2, ready=2, desired=0 → target=3 (cheapest, scaled up for capacity)
-  - v2-a100 (cost=$20): current=4, ready=3, desired=4 → target=4 (preserved desired)
+  - v2-a100 (cost=$20): current=2, ready=2, desired=0 → target=2 (no change)
+```
 
-Note: v2-a100 has 4 current replicas but only 3 are ready (reporting metrics).
-      Target is set to desired=4 because desired ≠ current.
+**Example Output (model in transition — scaling blocked):**
+```
+Model: llama-70b
+Variants:
+  - v1-l4 (cost=$5): current=2, ready=2, desired=0 → target=2 (blocked: model transitioning)
+  - v2-a100 (cost=$20): current=4, ready=3, desired=0 → target=4 (preserved current)
+
+Note: v2-a100 has metrics(3) ≠ current(4) — only 3 of 4 pods are reporting.
+      This triggers model-level transition, blocking all variants from new decisions.
 ```
 
 **Key Principles:**
-1. **Ready replicas only**: Use replicas reporting metrics to avoid scaling up for not-yet-ready pods
-2. **Preserve desired replicas**: When desired ≠ current, always use desired as capacity target
+1. **Model-level transition blocking**: If any variant is transitioning, block all scaling for the model
+2. **Ready replicas only**: Use replicas reporting metrics to avoid scaling up for not-yet-ready pods
 3. **Cost-aware selection**: Cheapest variant for scale-up, most expensive for scale-down
 4. **Deterministic tie-breaking**: When variants have equal costs, alphabetically first for scale-up, last for scale-down
 5. **Pending replica awareness**: Skip variants with pending replicas during scale-up to prevent cascade scaling
@@ -151,7 +205,9 @@ T+60s: Both new pods still starting, saturation persists → Scale up to 5 repli
 T+90s: All 5 pods now ready, but we have 3 extra replicas (over-provisioned)
 ```
 
-**Solution:** WVA tracks **pending replicas** (`CurrentReplicas - ReadyReplicas`) per variant and skips variants with pending replicas during scale-up selection.
+**Solution:** WVA uses two layers of protection:
+1. **Model-level transition blocking** (primary): If any variant has `desired ≠ current` or `metrics ≠ current`, all scaling is blocked for the entire model (see [Transition Blocking](#model-level-transition-blocking) above).
+2. **Pending replica checks** (secondary): When the model is stable, variants with pending replicas are skipped during scale-up selection.
 
 **How It Works:**
 1. **Replica State Tracking**: Controller maintains `VariantReplicaState` with:
@@ -159,12 +215,23 @@ T+90s: All 5 pods now ready, but we have 3 extra replicas (over-provisioned)
    - `DesiredReplicas`: Target from previous run (from CRD status)
    - `PendingReplicas`: Pods that exist but aren't ready (`CurrentReplicas - ReadyReplicas`)
 
-2. **Scale-Up Selection**: When saturation triggers scale-up:
+2. **Model-Level Transition Check** (Step 1 in `CalculateSaturationTargets`):
+   ```
+   // If ANY variant is transitioning, block ALL scaling for the model
+   for each variant:
+       if variant.DesiredReplicas ≠ 0 AND DesiredReplicas ≠ CurrentReplicas:
+           model_in_transition = true
+       if variant.MetricsCount ≠ CurrentReplicas:
+           model_in_transition = true
+
+   if model_in_transition:
+       return preserved targets (no new decisions)
+   ```
+
+3. **Scale-Up Selection** (Step 4, only when model is stable):
    ```go
    // Pseudo-code from internal/saturation/analyzer.go
    for each variant:
-       if variant has preserved desired replicas:
-           skip  // Already has decision from previous run
        if variant.PendingReplicas > 0:
            skip  // Wait for pending pods to become ready
        if variant.Cost < cheapest.Cost:
@@ -173,14 +240,17 @@ T+90s: All 5 pods now ready, but we have 3 extra replicas (over-provisioned)
    scale_up(cheapest)  // Only if no pending replicas
    ```
 
-3. **Per-Variant Tracking**: Each variant is tracked independently. If variant-1 has pending replicas, variant-2 can still scale up if it's the cheapest eligible variant.
+4. **Per-Variant Tracking**: Each variant is tracked independently. If variant-1 has pending replicas, variant-2 can still scale up if it's the cheapest eligible variant.
 
 **Timeline Example (With Protection):**
 ```
-T+0s:  Saturation detected → Scale up variant-1 from 2 to 3 (PendingReplicas=1)
-T+30s: Saturation still detected, but variant-1 skipped (has 1 pending replica)
-       If variant-2 is cheaper and has no pending replicas → Scale up variant-2
-T+90s: variant-1 pod becomes ready (PendingReplicas=0), now eligible for scale-up again
+T+0s:   Saturation detected → Scale up variant-1 from 2 to 3
+T+30s:  variant-1: current=3, but only 2 pods reporting metrics
+        Check 2 triggers: metrics(2) ≠ current(3)
+        → Model in transition, ALL scaling blocked
+T+90s:  variant-1: all 3 pods ready and reporting metrics
+        metrics(3) == current(3), desired reset to 0
+        → Model stable, new scaling decisions allowed
 ```
 
 **Benefits:**
@@ -196,7 +266,7 @@ Saturation scaling thresholds are configured via ConfigMap (see [../saturation-s
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: capacity-scaling-config
+  name: wva-saturation-scaling-config
   namespace: workload-variant-autoscaler-system
 data:
   default: |
@@ -207,31 +277,43 @@ data:
 ```
 
 **Per-model overrides:**
+
+The saturation engine resolves per-model config using a lookup key in the format
+`{modelID}#{namespace}` (see `internal/engines/saturation/engine.go` — `resolveSaturationConfig()`).
+The ConfigMap data key **must** match this format for overrides to take effect.
+Lookup order: `modelID#namespace` → `default` → zero-value with defaults applied.
+
 ```yaml
-  llama-70b-prod: |
-    model_id: meta/llama-70b
-    namespace: production
+  "meta/llama-70b#production": |
     kvCacheThreshold: 0.85
+    queueLengthThreshold: 5
     kvSpareTrigger: 0.15
+    queueSpareTrigger: 3
 ```
+
+> **Note:** Overrides **fully replace** the `default` config — there is no field-level
+> inheritance. Always specify all required threshold fields. The `model_id` and `namespace`
+> YAML fields inside the entry are parsed into the config struct but are **not used for
+> lookup**. The ConfigMap data key itself determines which model/namespace the override
+> applies to.
 
 ## Architecture
 
 ### Components
 
-**1. Saturation Analyzer (`internal/capacity/analyzer.go`)**
+**1. Saturation Analyzer (`internal/saturation/analyzer.go`)**
 - Core analysis logic for saturation-based scaling decisions
 - Implements spare capacity calculations
 - Performs worst-case scale-down safety simulation
 - Makes **per-variant** scaling decisions with cost-awareness
 
-**2. Metrics Collector (`internal/collector/capacity_metrics.go`)**
+**2. Metrics Collector (`internal/collector/replica_metrics.go`)**
 - Collects vLLM metrics from Prometheus using `max_over_time[1m]` queries
 - Queries `constants.VLLMKvCacheUsagePerc` and `constants.VLLMNumRequestsWaiting`
 - Uses peak values over 1 minute for safety-first capacity analysis
 - Enriches metrics with pod metadata (variant name, accelerator type)
 
-**3. Interfaces (`internal/interfaces/capacity_analyzer.go`)**
+**3. Interfaces (`internal/interfaces/analyzer.go`, `internal/interfaces/saturation_analyzer.go`)**
 - Defines data structures for replica metrics (including variant cost)
 - Defines analysis results and per-variant decision types
 - Provides interface for capacity analysis
@@ -252,16 +334,16 @@ data:
          │ ReplicaMetrics[] (with cost)
          ↓
 ┌──────────────────────────┐
-│ AnalyzeModelCapacity     │  ← CapacityScalingConfig
+│ AnalyzeModelSaturation   │  ← SaturationScalingConfig
 └────────┬─────────────────┘
-         │ ModelCapacityAnalysis (with per-variant breakdown)
+         │ ModelSaturationAnalysis (with per-variant breakdown)
          ↓
-┌─────────────────────────────┐
-│ CalculateCapacityTargets    │  ← VariantReplicaState[] (current/desired from CRD)
-│ - Preserves desired replicas      │
-│ - Cost-aware variant selection    │
-└────────┬──────────────────────────┘
-         │ Capacity Targets: map[variantName]targetReplicas
+┌─────────────────────────────────┐
+│ CalculateSaturationTargets      │  ← VariantReplicaState[] (current/desired from CRD)
+│ - Model-level transition blocking     │
+│ - Cost-aware variant selection        │
+└────────┬────────────────────────────┘
+         │ Saturation Targets: map[variantName]targetReplicas
          ↓
 ┌──────────────────┐
 │    Controller    │


### PR DESCRIPTION
## Summary

Fixes #987 — aligns saturation analyzer V1 documentation with the actual codebase implementation.

Both `docs/user-guide/saturation-analyzer.md` and `docs/saturation-scaling-config.md` contained multiple discrepancies where documented behavior did not match code. Every algorithm description, code reference, and configuration example was cross-checked against the source.

## Changes

### `docs/user-guide/saturation-analyzer.md`

- **Scale-down simulation** — rewrote pseudocode to match the scale-factor approach in `isScaleDownSafe()` (`avg_load * N/(N-1)`) instead of the previously documented summation method (`total_load / remaining`)
- **Transition blocking** — added dedicated "Model-Level Transition Blocking" section documenting both checks (`desired != current` AND `metrics != current`) and that the **entire model** is blocked when any variant is transitioning (not per-variant preservation)
- **Cascade prevention** — clarified two-layer protection: model-level blocking (primary) + pending-replica checks (secondary, only when model is stable)
- **ConfigMap key format** — documented the actual `{modelID}#{namespace}` lookup format used by `resolveSaturationConfig()`, replacing arbitrary key names with `model_id`/`namespace` fields
- **Default thresholds** — changed "Default" to "Recommended" with note that V1 thresholds are not hardcoded and require ConfigMap
- **Override inheritance** — added note that overrides fully replace the default config (no field-level inheritance)
- **File paths** — fixed 3 wrong paths: `internal/capacity/analyzer.go` → `internal/saturation/analyzer.go`, `internal/collector/capacity_metrics.go` → `internal/collector/replica_metrics.go`, `internal/interfaces/capacity_analyzer.go` → `internal/interfaces/analyzer.go` + `saturation_analyzer.go`
- **Function/type names** — `CalculateCapacityTargets` → `CalculateSaturationTargets`, `AnalyzeModelCapacity` → `AnalyzeModelSaturation`, `VariantCapacityAnalysis` → `VariantSaturationAnalysis`, `CapacityScalingConfig` → `SaturationScalingConfig`
- **Min/max clamping** — documented that targets are clamped to `[minReplicas, maxReplicas]` from VA spec
- **Scale-down guard** — documented that variants with target <= 1 are skipped for scale-down
- **ConfigMap name** — `capacity-scaling-config` → `wva-saturation-scaling-config`

### `docs/saturation-scaling-config.md`

- **ConfigMap name** — `capacity-scaling-config` → `wva-saturation-scaling-config` throughout
- **Deploy file path** — `deploy/configmap-capacity-scaling.yaml` → `deploy/configmap-saturation-scaling.yaml`
- **Override key format** — replaced arbitrary key names with `{modelID}#{namespace}` format
- **No field inheritance** — corrected false claim that "omitted fields inherit from default"; overrides fully replace the default config, all fields must be specified
- **Default thresholds** — clarified V1 has no hardcoded defaults (V2 does: `scaleUpThreshold: 0.85`, `scaleDownBoundary: 0.70`)
- **Parameter types** — `queueLengthThreshold` and `queueSpareTrigger` corrected from `int` to `float64`
- **Scale-up example** — fixed boundary math: `0.10 < 0.10` is false with strict `<`, corrected to use `0.095 < 0.10`
- **API Reference** — `CapacityScalingConfig` → `SaturationScalingConfig`; removed non-existent methods; added actual methods
- **Code snippets** — replaced non-existent functions with actual code path (`SaturationConfigForNamespace`, `resolveSaturationConfig`)
- **Cross-doc link** — fixed broken relative link `saturation-analyzer.md` → `user-guide/saturation-analyzer.md`
- **Graceful degradation** — clarified that V2 has hardcoded defaults but V1 requires ConfigMap

## Verification

Every change was cross-checked against the source code:
- `internal/saturation/analyzer.go` — algorithm, transition checks, tie-breaking, min/max clamping
- `internal/saturation/constants.go` — `MinNonSaturatedReplicasForScaleDown`
- `internal/config/saturation_scaling.go` — struct fields, types, `ApplyDefaults()`, `Validate()`
- `internal/engines/saturation/engine.go` — `resolveSaturationConfig()` lookup logic
- `internal/controller/configmap_helpers.go` — `parseSaturationConfig()` key handling
- `internal/config/helpers.go` — `DefaultSaturationConfigMapName`
- `internal/collector/replica_metrics.go`, `internal/interfaces/analyzer.go`, `internal/interfaces/saturation_analyzer.go` — file existence

## Test plan

- [x] Documentation-only change — no code modified
- [x] Verify all internal links render correctly on GitHub
- [x] Verify ConfigMap examples are valid YAML