### PR TITLE
feat: add V1 default thresholds and partial override support for satu…

### DIFF
--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -106,17 +106,40 @@ func (c *SaturationScalingConfig) IsV2() bool {
 	return len(c.Analyzers) > 0 || c.AnalyzerName == "saturation"
 }
 
+// V1 analyzer default thresholds, applied when fields are omitted from YAML config.
+const (
+	DefaultKvCacheThreshold     = 0.80
+	DefaultQueueLengthThreshold = 5.0
+	DefaultKvSpareTrigger       = 0.10
+	DefaultQueueSpareTrigger    = 3.0
+)
+
 // V2 analyzer default thresholds, applied when fields are omitted from YAML config.
 const (
 	DefaultScaleUpThreshold  = 0.85
 	DefaultScaleDownBoundary = 0.70
 )
 
-// ApplyDefaults fills in zero-valued V2 fields with their defaults.
+// ApplyDefaults fills in zero-valued fields with their defaults.
+// V1 thresholds (KvCacheThreshold, QueueLengthThreshold, KvSpareTrigger, QueueSpareTrigger)
+// are always defaulted when zero. V2 thresholds are only defaulted when the config is V2.
 // Must be called before Validate() to handle omitempty zero-values correctly.
 func (c *SaturationScalingConfig) ApplyDefaults() {
 	if c.Priority == 0 {
 		c.Priority = DefaultPriority
+	}
+	// V1 defaults — apply unconditionally (V2 also inherits these for saturation checks)
+	if c.KvCacheThreshold == 0 {
+		c.KvCacheThreshold = DefaultKvCacheThreshold
+	}
+	if c.QueueLengthThreshold == 0 {
+		c.QueueLengthThreshold = DefaultQueueLengthThreshold
+	}
+	if c.KvSpareTrigger == 0 {
+		c.KvSpareTrigger = DefaultKvSpareTrigger
+	}
+	if c.QueueSpareTrigger == 0 {
+		c.QueueSpareTrigger = DefaultQueueSpareTrigger
 	}
 	if c.IsV2() {
 		if c.ScaleUpThreshold == 0 {
@@ -142,6 +165,48 @@ func (c *SaturationScalingConfig) ApplyDefaults() {
 				c.Analyzers[i].Enabled = &enabled
 			}
 		}
+	}
+}
+
+// Merge overlays non-zero fields from override onto c.
+// This allows per-model overrides to specify only the fields they want to change,
+// inheriting all other values from the base (typically the "default" config).
+func (c *SaturationScalingConfig) Merge(override SaturationScalingConfig) {
+	if override.KvCacheThreshold != 0 {
+		c.KvCacheThreshold = override.KvCacheThreshold
+	}
+	if override.QueueLengthThreshold != 0 {
+		c.QueueLengthThreshold = override.QueueLengthThreshold
+	}
+	if override.KvSpareTrigger != 0 {
+		c.KvSpareTrigger = override.KvSpareTrigger
+	}
+	if override.QueueSpareTrigger != 0 {
+		c.QueueSpareTrigger = override.QueueSpareTrigger
+	}
+	if override.AnalyzerName != "" {
+		c.AnalyzerName = override.AnalyzerName
+	}
+	if override.ScaleUpThreshold != 0 {
+		c.ScaleUpThreshold = override.ScaleUpThreshold
+	}
+	if override.ScaleDownBoundary != 0 {
+		c.ScaleDownBoundary = override.ScaleDownBoundary
+	}
+	if override.EnableLimiter {
+		c.EnableLimiter = override.EnableLimiter
+	}
+	if override.Priority != 0 {
+		c.Priority = override.Priority
+	}
+	if len(override.Analyzers) > 0 {
+		c.Analyzers = override.Analyzers
+	}
+	if override.ModelID != "" {
+		c.ModelID = override.ModelID
+	}
+	if override.Namespace != "" {
+		c.Namespace = override.Namespace
 	}
 }
 

--- a/internal/config/saturation_scaling_test.go
+++ b/internal/config/saturation_scaling_test.go
@@ -215,14 +215,32 @@ var _ = Describe("SaturationScalingConfig", func() {
 			Expect(config.ScaleDownBoundary).To(Equal(0.60))
 		})
 
-		It("should be no-op when not V2", func() {
+		It("should apply V1 defaults when not V2", func() {
 			config := SaturationScalingConfig{
 				AnalyzerName: "",
 			}
 			config.ApplyDefaults()
+			Expect(config.KvCacheThreshold).To(Equal(DefaultKvCacheThreshold))
+			Expect(config.QueueLengthThreshold).To(Equal(DefaultQueueLengthThreshold))
+			Expect(config.KvSpareTrigger).To(Equal(DefaultKvSpareTrigger))
+			Expect(config.QueueSpareTrigger).To(Equal(DefaultQueueSpareTrigger))
 			Expect(config.ScaleUpThreshold).To(Equal(0.0))
 			Expect(config.ScaleDownBoundary).To(Equal(0.0))
 			Expect(config.Analyzers).To(BeEmpty())
+		})
+
+		It("should not overwrite explicit V1 values", func() {
+			config := SaturationScalingConfig{
+				KvCacheThreshold:     0.75,
+				QueueLengthThreshold: 10,
+				KvSpareTrigger:       0.15,
+				QueueSpareTrigger:    5,
+			}
+			config.ApplyDefaults()
+			Expect(config.KvCacheThreshold).To(Equal(0.75))
+			Expect(config.QueueLengthThreshold).To(Equal(10.0))
+			Expect(config.KvSpareTrigger).To(Equal(0.15))
+			Expect(config.QueueSpareTrigger).To(Equal(5.0))
 		})
 
 		It("should apply default priority when zero", func() {
@@ -275,6 +293,109 @@ var _ = Describe("SaturationScalingConfig", func() {
 			}
 			config.ApplyDefaults()
 			Expect(config.Validate()).To(Succeed())
+		})
+	})
+
+	Context("Merge", func() {
+
+		It("should overlay non-zero fields from override", func() {
+			base := SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+			}
+			override := SaturationScalingConfig{
+				KvCacheThreshold: 0.85,
+				KvSpareTrigger:   0.15,
+			}
+			base.Merge(override)
+			Expect(base.KvCacheThreshold).To(Equal(0.85))
+			Expect(base.KvSpareTrigger).To(Equal(0.15))
+			// Unset fields in override should not change base
+			Expect(base.QueueLengthThreshold).To(Equal(5.0))
+			Expect(base.QueueSpareTrigger).To(Equal(3.0))
+		})
+
+		It("should overlay all fields when all are set", func() {
+			base := SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+				Priority:             1.0,
+			}
+			override := SaturationScalingConfig{
+				KvCacheThreshold:     0.90,
+				QueueLengthThreshold: 15,
+				KvSpareTrigger:       0.05,
+				QueueSpareTrigger:    2,
+				Priority:             5.0,
+			}
+			base.Merge(override)
+			Expect(base.KvCacheThreshold).To(Equal(0.90))
+			Expect(base.QueueLengthThreshold).To(Equal(15.0))
+			Expect(base.KvSpareTrigger).To(Equal(0.05))
+			Expect(base.QueueSpareTrigger).To(Equal(2.0))
+			Expect(base.Priority).To(Equal(5.0))
+		})
+
+		It("should not change base when override is empty", func() {
+			base := SaturationScalingConfig{
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+			}
+			override := SaturationScalingConfig{}
+			base.Merge(override)
+			Expect(base.KvCacheThreshold).To(Equal(0.80))
+			Expect(base.QueueLengthThreshold).To(Equal(5.0))
+			Expect(base.KvSpareTrigger).To(Equal(0.10))
+			Expect(base.QueueSpareTrigger).To(Equal(3.0))
+		})
+
+		It("should overlay V2 fields", func() {
+			base := SaturationScalingConfig{
+				AnalyzerName:      "saturation",
+				ScaleUpThreshold:  0.85,
+				ScaleDownBoundary: 0.70,
+			}
+			override := SaturationScalingConfig{
+				ScaleUpThreshold: 0.90,
+			}
+			base.Merge(override)
+			Expect(base.ScaleUpThreshold).To(Equal(0.90))
+			Expect(base.ScaleDownBoundary).To(Equal(0.70))
+			Expect(base.AnalyzerName).To(Equal("saturation"))
+		})
+
+		It("should overlay analyzers list", func() {
+			enabled := true
+			base := SaturationScalingConfig{
+				Analyzers: []AnalyzerScoreConfig{
+					{Name: "saturation", Score: 1.0, Enabled: &enabled},
+				},
+			}
+			override := SaturationScalingConfig{
+				Analyzers: []AnalyzerScoreConfig{
+					{Name: "custom", Score: 0.5},
+				},
+			}
+			base.Merge(override)
+			Expect(base.Analyzers).To(HaveLen(1))
+			Expect(base.Analyzers[0].Name).To(Equal("custom"))
+		})
+
+		It("should overlay ModelID and Namespace", func() {
+			base := SaturationScalingConfig{}
+			override := SaturationScalingConfig{
+				ModelID:   "llama-70b",
+				Namespace: "production",
+			}
+			base.Merge(override)
+			Expect(base.ModelID).To(Equal("llama-70b"))
+			Expect(base.Namespace).To(Equal("production"))
 		})
 	})
 

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -49,22 +49,25 @@ import (
 )
 
 // resolveSaturationConfig resolves config for a model.
-// Lookup: "{modelID}#{namespace}" → "default" → zero-value with defaults.
+// Starts from the "default" entry (or zero-value), then merges the model-specific
+// override "{modelID}#{namespace}" on top (if present). This allows per-model
+// overrides to specify only the fields they want to change.
+// ApplyDefaults is called last to fill any remaining zero-valued fields.
 func resolveSaturationConfig(
 	configMap map[string]config.SaturationScalingConfig,
 	modelID, namespace string,
 ) config.SaturationScalingConfig {
-	if cfg, ok := configMap[modelID+"#"+namespace]; ok {
-		cfg.ApplyDefaults()
-		return cfg
+	// Start with default config as base
+	base := config.SaturationScalingConfig{}
+	if defaultCfg, ok := configMap["default"]; ok {
+		base = defaultCfg
 	}
-	if cfg, ok := configMap["default"]; ok {
-		cfg.ApplyDefaults()
-		return cfg
+	// Overlay model-specific override if present (non-zero fields win)
+	if override, ok := configMap[modelID+"#"+namespace]; ok {
+		base.Merge(override)
 	}
-	cfg := config.SaturationScalingConfig{}
-	cfg.ApplyDefaults()
-	return cfg
+	base.ApplyDefaults()
+	return base
 }
 
 type Engine struct {

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -185,21 +185,29 @@ var _ = Describe("getRoleFromScaleTarget", func() {
 
 var _ = Describe("resolveSaturationConfig", func() {
 
-	It("should return model-specific config when present", func() {
+	It("should merge model-specific override onto default", func() {
 		configMap := map[string]config.SaturationScalingConfig{
 			"default": {
-				KvCacheThreshold: 0.80,
-				AnalyzerName:     "saturation",
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+				AnalyzerName:         "saturation",
 			},
 			"llama-70b#production": {
 				KvCacheThreshold: 0.85,
 				Priority:         5.0,
-				AnalyzerName:     "saturation",
 			},
 		}
 		cfg := resolveSaturationConfig(configMap, "llama-70b", "production")
+		// Overridden fields
 		Expect(cfg.KvCacheThreshold).To(Equal(0.85))
 		Expect(cfg.Priority).To(Equal(5.0))
+		// Inherited from default
+		Expect(cfg.QueueLengthThreshold).To(Equal(5.0))
+		Expect(cfg.KvSpareTrigger).To(Equal(0.10))
+		Expect(cfg.QueueSpareTrigger).To(Equal(3.0))
+		Expect(cfg.AnalyzerName).To(Equal("saturation"))
 	})
 
 	It("should fall back to default config when model-specific not found", func() {
@@ -214,11 +222,14 @@ var _ = Describe("resolveSaturationConfig", func() {
 		Expect(cfg.Priority).To(Equal(config.DefaultPriority))
 	})
 
-	It("should return zero-value with defaults when map is empty", func() {
+	It("should return V1 defaults when map is empty", func() {
 		configMap := map[string]config.SaturationScalingConfig{}
 		cfg := resolveSaturationConfig(configMap, "model-1", "ns-1")
 		Expect(cfg.Priority).To(Equal(config.DefaultPriority))
-		Expect(cfg.KvCacheThreshold).To(Equal(0.0))
+		Expect(cfg.KvCacheThreshold).To(Equal(config.DefaultKvCacheThreshold))
+		Expect(cfg.QueueLengthThreshold).To(Equal(config.DefaultQueueLengthThreshold))
+		Expect(cfg.KvSpareTrigger).To(Equal(config.DefaultKvSpareTrigger))
+		Expect(cfg.QueueSpareTrigger).To(Equal(config.DefaultQueueSpareTrigger))
 	})
 
 	It("should apply defaults on model-specific config", func() {
@@ -231,6 +242,27 @@ var _ = Describe("resolveSaturationConfig", func() {
 		Expect(cfg.ScaleUpThreshold).To(Equal(config.DefaultScaleUpThreshold))
 		Expect(cfg.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary))
 		Expect(cfg.Priority).To(Equal(config.DefaultPriority))
+		// V1 defaults also applied
+		Expect(cfg.KvCacheThreshold).To(Equal(config.DefaultKvCacheThreshold))
+	})
+
+	It("should allow partial override with only one field changed", func() {
+		configMap := map[string]config.SaturationScalingConfig{
+			"default": {
+				KvCacheThreshold:     0.80,
+				QueueLengthThreshold: 5,
+				KvSpareTrigger:       0.10,
+				QueueSpareTrigger:    3,
+			},
+			"model-1#ns-1": {
+				KvCacheThreshold: 0.90,
+			},
+		}
+		cfg := resolveSaturationConfig(configMap, "model-1", "ns-1")
+		Expect(cfg.KvCacheThreshold).To(Equal(0.90))
+		Expect(cfg.QueueLengthThreshold).To(Equal(5.0))
+		Expect(cfg.KvSpareTrigger).To(Equal(0.10))
+		Expect(cfg.QueueSpareTrigger).To(Equal(3.0))
 	})
 })
 


### PR DESCRIPTION
## Summary

Add hardcoded V1 default thresholds and partial override support for saturation scaling config, addressing the code changes requested in #987.

Previously, V1 saturation thresholds (`kvCacheThreshold`, `queueLengthThreshold`, `kvSpareTrigger`, `queueSpareTrigger`) defaulted to zero when the ConfigMap was missing or had no `default` entry. This caused all replicas to appear saturated and triggered continuous scale-up. Per-model overrides also required specifying all fields — omitted fields were zero, not inherited from the `default` config entry.

## Changes

### V1 Default Thresholds (`internal/config/saturation_scaling.go`)

- Add exported constants: `DefaultKvCacheThreshold=0.80`, `DefaultQueueLengthThreshold=5`, `DefaultKvSpareTrigger=0.10`, `DefaultQueueSpareTrigger=3`
- Update `ApplyDefaults()` to fill zero-valued V1 fields unconditionally (V2 defaults remain gated by `IsV2()`)

### Partial Override via Merge (`internal/config/saturation_scaling.go`)

- Add `SaturationScalingConfig.Merge(override)` method that overlays non-zero fields from an override onto the receiver
- Covers all fields: V1 thresholds, V2 thresholds, `AnalyzerName`, `Priority`, `EnableLimiter`, `Analyzers`, `ModelID`, `Namespace`

### Config Resolution (`internal/engines/saturation/engine.go`)

- Rewrite `resolveSaturationConfig()` to:
  1. Start from the `default` ConfigMap entry (or zero-value if absent)
  2. Merge the model-specific `{modelID}#{namespace}` override on top
  3. Call `ApplyDefaults()` last to fill any remaining zero fields
- Per-model entries now only need to specify the fields they want to change

### Tests

- `internal/config/saturation_scaling_test.go`: 9 new test cases
  - `ApplyDefaults`: V1 defaults applied when not V2; explicit V1 values preserved
  - `Merge`: partial overlay, full overlay, empty overlay, V2 fields, analyzers list, ModelID/Namespace
- `internal/engines/saturation/engine_v2_test.go`: updated + 1 new test case
  - Verify merge-onto-default behavior, V1 defaults when map is empty, partial single-field override

## Known limitation

`Merge` uses zero-value detection (`!= 0` / `!= ""`) to distinguish "set" from "unset" fields. This means boolean fields like `EnableLimiter` cannot be overridden from `true` to `false` via a per-model override. However this is expected. Limiter either enabled or disabled for all models.

## Test plan

- [x] `go test ./internal/config/...` — 50 passed
- [x] `go test ./internal/engines/saturation/...` (envtest via WSL) — 18 passed
- [x] `go build ./...` — clean
- [x] Verify existing e2e tests still pass in CI