### PR TITLE
Fixes for infra install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
+		DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		./deploy/install.sh; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=false \
+		DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -202,6 +202,16 @@ deploy_llm_d_infrastructure() {
       helmfile apply -e "$GATEWAY_PROVIDER" -n "${LLMD_NS}"
     fi
 
+    # Post-deploy workaround: Upstream EPP chart (v1.0.1) is missing RBAC for inferencemodelrewrites
+    log_info "Patching Role $LLM_D_EPP_NAME to include inferencemodelrewrites"
+    if kubectl get role "$LLM_D_EPP_NAME" -n "$LLMD_NS" &> /dev/null; then
+        kubectl patch role "$LLM_D_EPP_NAME" -n "$LLMD_NS" --type='json' -p='[{"op": "add", "path": "/rules/0/resources/-", "value": "inferencemodelrewrites"}]' && \
+            log_success "Patched Role $LLM_D_EPP_NAME successfully" || \
+            log_warning "Failed to patch Role $LLM_D_EPP_NAME"
+    else
+        log_warning "Role $LLM_D_EPP_NAME not found, skipping RBAC patch"
+    fi
+
     if [ "$E2E_TESTS_ENABLED" = "true" ] && [ "$INFRA_ONLY" = "true" ]; then
       if helm list -n "$LLMD_NS" --short 2>/dev/null | grep -q '^ms-'; then
         log_warning "Modelservice release still present in $LLMD_NS despite e2e selector; tests may need extra cleanup"


### PR DESCRIPTION
- Patches epp to look for inferencemodelrewrite
- Allows setup to start with a decode replica of 1

command to test:

```
make deploy-e2e-infra \
  ENVIRONMENT=openshift \
  WVA_NS=asmalvan-test-1 \
  LLMD_NS=asmalvan-test-1 \
  NAMESPACE_SCOPED=true \
  SKIP_BUILD=true \
  DECODE_REPLICAS=1 \
  IMG_TAG=v0.6.0 \
  LLM_D_RELEASE=v0.6.0
```

Manually tested output:

```
abhishekmalvankar@wecm-9-67-28-152 llm-d-workload-variant-autoscaler % oc get pods
NAME                                                              READY   STATUS      RESTARTS   AGE
access-to-harness-data-workload-pvc                               1/1     Running     0          7d18h
download-model-pwxl9                                              0/1     Completed   0          7d18h
gaie-inference-scheduling-epp-5cc5795bdc-wphss                    1/1     Running     0          7m51s
infra-inference-scheduling-inference-gateway-istio-85d976dvdrxw   1/1     Running     0          7m58s
ms-inference-scheduling-llm-d-modelservice-decode-767754fb2d2ch   1/1     Running     0          8m6s
workload-variant-autoscaler-controller-manager-5dfb89d8c5-qhhnx   1/1     Running     0          4m58s
workload-variant-autoscaler-controller-manager-5dfb89d8c5-wwjm4   1/1     Running     0          4m46s
```