### PR TITLE
Fix infra local metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,7 @@ test-benchmark: manifests generate fmt vet ## Run benchmark tests (scale-up-late
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
+	PROMETHEUS_TOKEN=$$(oc whoami -t 2>/dev/null || echo "") \
 	go test ./test/benchmark/ -timeout 75m -v -ginkgo.v \
 		-ginkgo.label-filter="phase3a"; \
 	TEST_EXIT_CODE=$$?; \

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -981,19 +981,36 @@ func (p *PrometheusClient) API() promv1.API {
 	return p.client
 }
 
+type authRoundTripper struct {
+	token string
+	rt    http.RoundTripper
+}
+
+func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+a.token)
+	return a.rt.RoundTrip(req)
+}
+
 // creates a new Prometheus client for e2e tests
 func NewPrometheusClient(baseURL string, insecureSkipVerify bool) (*PrometheusClient, error) {
 	config := promAPI.Config{
 		Address: baseURL,
 	}
 
-	if insecureSkipVerify {
-		roundTripper := promAPI.DefaultRoundTripper
-		if rt, ok := roundTripper.(*http.Transport); ok {
+	roundTripper := promAPI.DefaultRoundTripper
+	if rt, ok := roundTripper.(*http.Transport); ok {
+		if insecureSkipVerify {
 			rt.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
-		config.RoundTripper = roundTripper
 	}
+
+	if token := os.Getenv("PROMETHEUS_TOKEN"); token != "" {
+		roundTripper = &authRoundTripper{
+			token: token,
+			rt:    roundTripper,
+		}
+	}
+	config.RoundTripper = roundTripper
 
 	client, err := promAPI.NewClient(config)
 	if err != nil {


### PR DESCRIPTION
Benchmark, when run on a local laptop against a remote OpenShift cluster, did not provide crucial metrics such as avg replica usage, kv cache util, and queued requests. This PR fixes it.

Output from recent local run:

```
STEP: Extracting GuideLLM results from pod logs @ 04/13/26 22:05:37.333
    Request Totals: 5146
  STEP: Querying Prometheus for Replicas, Queue Depth, and KV Cache @ 04/13/26 22:06:15.362
  STEP: Collecting pod placement details for report @ 04/13/26 22:06:15.487
    Found 3 pods with selector llm-d.ai/role=decode
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-767754fbfk87z  Node: pokprod-b93r39s0  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-767754fbqfxsk  Node: pokprod-b93r44s0  GPU: NVIDIA-H100-80GB-HBM3  Startup: 0s
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-767754fbqx96n  Node: pokprod-b93r38s3  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s

  ========================================
    WVA PREFILL BENCHMARK RESULTS
  ========================================
    Duration:        670s
    Max Replicas:    3
    Avg Replicas:    2.57
    Avg Queue Depth: 37.41
    Avg EPP Queue:   104.70
    Avg KV Cache:    0.459
    TTFT:            {"count":5146,"max":70662.20188140869,"mean":19391.632931036936,"median":9202.468156814575,"min":100.24428367614746,"mode":100.24428367614746,"pdf":null,"percentiles":{"p001":126.42931938171387,"p01":205.86657524108887,"p05":538.5746955871582,"p10":995.9914684295654,"p25":3292.17791557312,"p50":9202.468156814575,"p75":37556.5288066864,"p90":49802.98185348511,"p95":51373.44455718994,"p99":54692.60287284851,"p999":70442.86227226257},"std_dev":19298.71263770372,"total_sum":99789343.06311607,"variance":372440309.4726653}
    ITL:             {"count":5140854,"max":70.89412009513175,"mean":32.88059536684256,"median":32.31628759725913,"min":10.9224123759074,"mode":30.447369461899644,"pdf":null,"percentiles":{"p001":11.196121677860722,"p01":12.694488177905688,"p05":17.259471051327818,"p10":22.910710211630697,"p25":27.00837739595064,"p50":32.31628759725913,"p75":41.04990835065718,"p90":42.85910036470797,"p95":43.39269164565567,"p99":48.8861232429176,"p999":68.45047070576742},"std_dev":8.506658704579625,"total_sum":169034340.21401405,"variance":72.3632423162003}
    Throughput:      {"count":5146000,"max":103885.64138248574,"mean":8577.266206692273,"median":6109.692643845594,"min":33.35437413333634,"mode":5772.964079050338,"pdf":null,"percentiles":{"p001":114.67795922147583,"p01":465.4764588944502,"p05":1287.799835060135,"p10":1964.8049787511202,"p25":3395.51778750936,"p50":6109.692643845594,"p75":11557.53210583362,"p90":18464.266912774725,"p95":24032.374634136842,"p99":35601.99220074152,"p999":51045.2245382085},"std_dev":7537.156634188366,"total_sum":44138611899.638435,"variance":56808730.12828971}
```