### PR TITLE
chore: add missing kubebuilder LWS scale annotation 

### DIFF
--- a/charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
+++ b/charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
@@ -203,6 +203,7 @@ spec:
                   accelerator:
                     description: |-
                       Accelerator is the type of accelerator for the optimized allocation.
+
                       Deprecated: This field is deprecated and will be removed in a future version. Use node selector or node affinity from scale target instead.
                     type: string
                   lastRunTime:

--- a/config/crd/bases/llmd.ai_variantautoscalings.yaml
+++ b/config/crd/bases/llmd.ai_variantautoscalings.yaml
@@ -203,6 +203,7 @@ spec:
                   accelerator:
                     description: |-
                       Accelerator is the type of accelerator for the optimized allocation.
+
                       Deprecated: This field is deprecated and will be removed in a future version. Use node selector or node affinity from scale target instead.
                     type: string
                   lastRunTime:

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -83,6 +83,7 @@ func NewVariantAutoscalingReconciler(
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/scale,verbs=get;update
 // +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch


### PR DESCRIPTION
- Ref: https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/985#discussion_r3075404296
- [x] make manifests
- [x] make lint 