### PR TITLE
refactor(discovery): add NodeDiscovery interface and consolidate node listing

### DIFF
--- a/internal/discovery/interface.go
+++ b/internal/discovery/interface.go
@@ -20,8 +20,19 @@ type UsageDiscovery interface {
 	DiscoverUsage(ctx context.Context) (map[string]int, error)
 }
 
-// FullDiscovery combines capacity and usage discovery for complete inventory tracking.
+// NodeDiscovery defines the interface for discovering per-node information including
+// labels and accelerator capacity. Enables label-aware features that need to match
+// node selectors against cluster nodes (e.g., namespace-scoped inventory).
+type NodeDiscovery interface {
+	// DiscoverNodes returns per-node info keyed by node name. Only nodes with at
+	// least one discovered accelerator are included. The returned map and all
+	// nested maps are freshly allocated and safe to mutate.
+	DiscoverNodes(ctx context.Context) (map[string]NodeInfo, error)
+}
+
+// FullDiscovery combines capacity, usage, and node discovery for complete inventory tracking.
 type FullDiscovery interface {
 	CapacityDiscovery
 	UsageDiscovery
+	NodeDiscovery
 }

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -30,11 +30,16 @@ func NewK8sWithGpuOperator(client client.Client) *K8sWithGpuOperator {
 	}
 }
 
-// Discover discovers GPU capacity by iterating over nodes and checking GFD labels.
-// It queries nodes for each GPU vendor (NVIDIA, AMD, Intel) separately since
-// Kubernetes LabelSelectors don't support OR logic across different label keys.
-func (d *K8sWithGpuOperator) Discover(ctx context.Context) (map[string]map[string]AcceleratorModelInfo, error) {
-	inv := make(map[string]map[string]AcceleratorModelInfo)
+// listGPUNodes queries GPU-bearing nodes across all supported vendors
+// (NVIDIA, AMD, Intel) and returns a canonical per-node view keyed by node name.
+// It queries per vendor because Kubernetes LabelSelectors don't support OR logic
+// across different label keys. Multi-vendor nodes (nodes with labels from more
+// than one vendor) are merged into a single NodeInfo entry.
+//
+// This is the single internal node-listing primitive; public methods Discover,
+// discoverNodeGPUTypes, and DiscoverNodes project from its result.
+func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeInfo, error) {
+	nodes := make(map[string]NodeInfo)
 
 	// Parse WVA_NODE_SELECTOR once for reuse across vendor queries
 	var userRequirements []labels.Requirement
@@ -46,12 +51,12 @@ func (d *K8sWithGpuOperator) Discover(ctx context.Context) (map[string]map[strin
 		userRequirements, _ = userSelector.Requirements()
 	}
 
-	// Query nodes for each GPU vendor separately
-	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd)
+	// Query nodes for each GPU vendor separately.
+	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd).
 	for _, vendor := range vendors {
 		prodKey := vendor + "/gpu.product"
+		memKey := vendor + "/gpu.memory"
 
-		// Create vendor-specific selector
 		req, err := labels.NewRequirement(prodKey, selection.Exists, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create label requirement for %s: %w", vendor, err)
@@ -68,34 +73,69 @@ func (d *K8sWithGpuOperator) Discover(ctx context.Context) (map[string]map[strin
 			return nil, fmt.Errorf("failed to list nodes for vendor %s: %w", vendor, err)
 		}
 
-		// Process nodes for this vendor
 		for _, node := range nodeList.Items {
-			nodeName := node.Name
-			memKey := vendor + "/gpu.memory"
-
 			model, ok := node.Labels[prodKey]
 			if !ok {
 				continue
 			}
 
-			mem := node.Labels[memKey]
 			count := 0
 			if cap, ok := node.Status.Allocatable[corev1.ResourceName(vendor+"/gpu")]; ok {
 				count = int(cap.Value())
 			}
 
-			if inv[nodeName] == nil {
-				inv[nodeName] = make(map[string]AcceleratorModelInfo)
+			ni, exists := nodes[node.Name]
+			if !exists {
+				ni = NodeInfo{
+					Name:         node.Name,
+					Labels:       copyStringMap(node.Labels),
+					Accelerators: make(map[string]AcceleratorModelInfo),
+				}
 			}
-
-			inv[nodeName][model] = AcceleratorModelInfo{
+			ni.Accelerators[model] = AcceleratorModelInfo{
 				Count:  count,
-				Memory: mem,
+				Memory: node.Labels[memKey],
 			}
+			nodes[node.Name] = ni
 		}
 	}
 
-	return inv, nil
+	return nodes, nil
+}
+
+// copyStringMap returns a shallow copy of m, or an empty map if m is nil.
+// Used to ensure the labels map returned in NodeInfo is independent of the
+// underlying corev1.Node object.
+func copyStringMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// Discover discovers GPU capacity by iterating over nodes and checking GFD labels.
+// It queries nodes for each GPU vendor (NVIDIA, AMD, Intel) separately since
+// Kubernetes LabelSelectors don't support OR logic across different label keys.
+//
+// This is a projection of listGPUNodes into the CapacityDiscovery shape
+// (per-node accelerator map without labels).
+func (d *K8sWithGpuOperator) Discover(ctx context.Context) (map[string]map[string]AcceleratorModelInfo, error) {
+	nodes, err := d.listGPUNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[string]AcceleratorModelInfo, len(nodes))
+	for name, n := range nodes {
+		out[name] = n.Accelerators
+	}
+	return out, nil
+}
+
+// DiscoverNodes returns per-node info (labels + accelerators) for all GPU-bearing
+// nodes. Used by label-aware features such as the namespace-scoped limiter.
+func (d *K8sWithGpuOperator) DiscoverNodes(ctx context.Context) (map[string]NodeInfo, error) {
+	return d.listGPUNodes(ctx)
 }
 
 // DiscoverUsage calculates current GPU usage by summing GPU requests from running pods.
@@ -143,48 +183,38 @@ func (d *K8sWithGpuOperator) DiscoverUsage(ctx context.Context) (map[string]int,
 }
 
 // discoverNodeGPUTypes returns a map of node name to GPU type (model name).
-// It queries nodes for each GPU vendor separately to support multi-vendor clusters.
+// For multi-vendor nodes (nodes labeled for more than one GPU vendor), the model
+// from the LAST matching vendor in `vendors` wins (order: nvidia.com, amd.com,
+// intel.com → intel wins if present, else amd, else nvidia).
+//
+// This preserves the pre-refactor behavior: the original implementation iterated
+// vendors in order and assigned `nodeGPUType[node] = model` on each match,
+// causing later assignments to overwrite earlier ones. Changing this would
+// silently affect usage attribution for multi-vendor nodes, so the refactor
+// keeps the exact same tie-break semantics.
+//
+// This is a projection of listGPUNodes into a single-model-per-node shape.
 func (d *K8sWithGpuOperator) discoverNodeGPUTypes(ctx context.Context) (map[string]string, error) {
-	nodeGPUType := make(map[string]string)
-
-	// Parse WVA_NODE_SELECTOR once for reuse across vendor queries
-	var userRequirements []labels.Requirement
-	if selectorStr := os.Getenv("WVA_NODE_SELECTOR"); selectorStr != "" {
-		userSelector, err := labels.Parse(selectorStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid WVA_NODE_SELECTOR: %w", err)
-		}
-		userRequirements, _ = userSelector.Requirements()
+	nodes, err := d.listGPUNodes(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	// Query nodes for each GPU vendor separately
-	for _, vendor := range vendors {
-		prodKey := vendor + "/gpu.product"
-
-		req, err := labels.NewRequirement(prodKey, selection.Exists, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create label requirement for %s: %w", vendor, err)
-		}
-		selector := labels.NewSelector().Add(*req)
-
-		// Add user requirements for sharding
-		for _, userReq := range userRequirements {
-			selector = selector.Add(userReq)
-		}
-
-		var nodeList corev1.NodeList
-		if err := d.Client.List(ctx, &nodeList, &client.ListOptions{LabelSelector: selector}); err != nil {
-			return nil, fmt.Errorf("failed to list nodes for vendor %s: %w", vendor, err)
-		}
-
-		for _, node := range nodeList.Items {
-			if model, ok := node.Labels[prodKey]; ok {
-				nodeGPUType[node.Name] = model
+	out := make(map[string]string, len(nodes))
+	for name, n := range nodes {
+		// Iterate vendors in REVERSE order and break on first match so the
+		// last vendor in `vendors` wins (intel > amd > nvidia). Relies on the
+		// listGPUNodes invariant that n.Accelerators[model] exists whenever
+		// n.Labels[vendor+"/gpu.product"] == model.
+		for i := len(vendors) - 1; i >= 0; i-- {
+			prodKey := vendors[i] + "/gpu.product"
+			if model, ok := n.Labels[prodKey]; ok {
+				out[name] = model
+				break
 			}
 		}
 	}
-
-	return nodeGPUType, nil
+	return out, nil
 }
 
 // getPodGPURequests returns the total GPU requests for a pod across all containers.

--- a/internal/discovery/k8s_with_gpu_operator_test.go
+++ b/internal/discovery/k8s_with_gpu_operator_test.go
@@ -449,3 +449,348 @@ func TestDiscover_NoGPUNodes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+func TestDiscoverNodeGPUTypes_MultiVendorNode_LastWins(t *testing.T) {
+	// Behavior preservation test: for a node labeled by multiple vendors,
+	// discoverNodeGPUTypes returns the LAST vendor in the iteration order
+	// (nvidia, amd, intel → intel wins if present). This matches the
+	// pre-refactor semantics where `nodeGPUType[name] = model` overwrote
+	// on each vendor iteration.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-nvidia-amd",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
+					"amd.com/gpu.product":    "AMD-MI300X-192G",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("2"),
+					"amd.com/gpu":    resource.MustParse("4"),
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-nvidia-intel",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB",
+					"intel.com/gpu.product":  "Intel-Gaudi-2-96GB",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("2"),
+					"intel.com/gpu":  resource.MustParse("8"),
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.discoverNodeGPUTypes(context.Background())
+	require.NoError(t, err)
+
+	// nvidia+amd → amd wins (later in vendor order)
+	assert.Equal(t, "AMD-MI300X-192G", result["node-nvidia-amd"])
+	// nvidia+intel → intel wins (latest in vendor order)
+	assert.Equal(t, "Intel-Gaudi-2-96GB", result["node-nvidia-intel"])
+}
+
+func TestDiscoverNodes_SingleVendor(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-nvidia",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product":      "NVIDIA-A100-PCIE-80GB",
+					"nvidia.com/gpu.memory":       "81920",
+					"topology.kubernetes.io/zone": "us-east-1a",
+					"team":                        "prod",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("4"),
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	ni, ok := result["node-nvidia"]
+	require.True(t, ok)
+	assert.Equal(t, "node-nvidia", ni.Name)
+
+	// Accelerators captured with correct count and memory
+	require.Contains(t, ni.Accelerators, "NVIDIA-A100-PCIE-80GB")
+	assert.Equal(t, 4, ni.Accelerators["NVIDIA-A100-PCIE-80GB"].Count)
+	assert.Equal(t, "81920", ni.Accelerators["NVIDIA-A100-PCIE-80GB"].Memory)
+
+	// All node labels copied (both GPU-related and non-GPU)
+	assert.Equal(t, "NVIDIA-A100-PCIE-80GB", ni.Labels["nvidia.com/gpu.product"])
+	assert.Equal(t, "us-east-1a", ni.Labels["topology.kubernetes.io/zone"])
+	assert.Equal(t, "prod", ni.Labels["team"])
+}
+
+func TestDiscoverNodes_MultiVendorNode(t *testing.T) {
+	// A single node labeled for two vendors (unusual but supported by the vendor-loop).
+	// The node should appear once with both accelerators merged.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-multi",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
+					"nvidia.com/gpu.memory":  "81920",
+					"amd.com/gpu.product":    "AMD-MI300X-192G",
+					"amd.com/gpu.memory":     "196608",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("2"),
+					"amd.com/gpu":    resource.MustParse("4"),
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+
+	// Node appears once, not twice
+	require.Len(t, result, 1)
+	ni, ok := result["node-multi"]
+	require.True(t, ok)
+
+	// Both accelerators present
+	require.Len(t, ni.Accelerators, 2)
+	assert.Equal(t, 2, ni.Accelerators["NVIDIA-A100-PCIE-80GB"].Count)
+	assert.Equal(t, "81920", ni.Accelerators["NVIDIA-A100-PCIE-80GB"].Memory)
+	assert.Equal(t, 4, ni.Accelerators["AMD-MI300X-192G"].Count)
+	assert.Equal(t, "196608", ni.Accelerators["AMD-MI300X-192G"].Memory)
+}
+
+func TestDiscoverNodes_RespectsWVANodeSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-shard-a",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB",
+					"wva.llmd.ai/shard":      "a",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("8"),
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-shard-b",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB",
+					"wva.llmd.ai/shard":      "b",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("8"),
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	t.Setenv("WVA_NODE_SELECTOR", "wva.llmd.ai/shard=a")
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+
+	// Only shard-a should be returned
+	require.Len(t, result, 1)
+	_, ok := result["node-shard-a"]
+	assert.True(t, ok)
+	_, ok = result["node-shard-b"]
+	assert.False(t, ok)
+}
+
+func TestDiscoverNodes_NodeWithGPULabelButNoAllocatable(t *testing.T) {
+	// A node labeled as GPU-bearing but with no Allocatable resource.
+	// Existing Discover() behavior: Count = 0, still included in result.
+	// DiscoverNodes should preserve that behavior.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-labeled-no-alloc",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
+				},
+			},
+			// No Allocatable
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	ni := result["node-labeled-no-alloc"]
+	require.Contains(t, ni.Accelerators, "NVIDIA-A100-PCIE-80GB")
+	assert.Equal(t, 0, ni.Accelerators["NVIDIA-A100-PCIE-80GB"].Count)
+}
+
+func TestDiscoverNodes_EmptyCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestDiscoverNodes_ExcludesCPUOnlyNodes(t *testing.T) {
+	// Nodes without any vendor/gpu.product label must not appear in DiscoverNodes output.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-gpu",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("8"),
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node-cpu-only",
+				Labels: map[string]string{"team": "prod"},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	_, ok := result["node-gpu"]
+	assert.True(t, ok)
+	_, ok = result["node-cpu-only"]
+	assert.False(t, ok)
+}
+
+func TestDiscoverNodes_InvalidWVANodeSelectorReturnsError(t *testing.T) {
+	// An invalid WVA_NODE_SELECTOR should cause the discovery to return an error
+	// rather than silently ignoring the selector.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	// A malformed selector string (empty operator).
+	t.Setenv("WVA_NODE_SELECTOR", "key!")
+
+	_, err := discoverer.DiscoverNodes(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WVA_NODE_SELECTOR")
+
+	// Same error path propagates through the Discover() projection.
+	_, err = discoverer.Discover(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WVA_NODE_SELECTOR")
+}
+
+func TestDiscoverNodes_LabelsAreIndependentCopy(t *testing.T) {
+	// Mutating NodeInfo.Labels must not affect the underlying corev1.Node labels.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	nodes := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-nvidia",
+				Labels: map[string]string{
+					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
+					"team":                   "prod",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("4"),
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(nodes...).Build()
+	discoverer := NewK8sWithGpuOperator(client)
+
+	result, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	ni := result["node-nvidia"]
+	// Mutate the returned Labels map — should have no effect on subsequent calls.
+	ni.Labels["team"] = "dev"
+	delete(ni.Labels, "nvidia.com/gpu.product")
+
+	// Re-fetch and verify the underlying node labels are untouched.
+	result2, err := discoverer.DiscoverNodes(context.Background())
+	require.NoError(t, err)
+	ni2 := result2["node-nvidia"]
+	assert.Equal(t, "prod", ni2.Labels["team"])
+	assert.Equal(t, "NVIDIA-A100-PCIE-80GB", ni2.Labels["nvidia.com/gpu.product"])
+}
+
+// Compile-time assertion that K8sWithGpuOperator satisfies FullDiscovery
+// (which now requires NodeDiscovery too).
+var _ FullDiscovery = (*K8sWithGpuOperator)(nil)

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -5,3 +5,17 @@ type AcceleratorModelInfo struct {
 	Count  int
 	Memory string
 }
+
+// NodeInfo is the canonical per-node view returned by NodeDiscovery.
+// It includes the node's labels and all discovered accelerator models,
+// enabling label-aware features (e.g., namespace-scoped inventory, node affinity)
+// without re-listing nodes.
+type NodeInfo struct {
+	// Name is the Kubernetes node name.
+	Name string
+	// Labels is a copy of the node's labels (safe to mutate).
+	Labels map[string]string
+	// Accelerators is a map of accelerator model name (e.g., "NVIDIA-A100-PCIE-80GB")
+	// to AcceleratorModelInfo (count, memory).
+	Accelerators map[string]AcceleratorModelInfo
+}

--- a/internal/engines/pipeline/type_inventory_test.go
+++ b/internal/engines/pipeline/type_inventory_test.go
@@ -45,6 +45,15 @@ func (m *mockFullDiscovery) DiscoverUsage(ctx context.Context) (map[string]int, 
 	return m.usage, nil
 }
 
+// DiscoverNodes is required by FullDiscovery. TypeInventory doesn't use per-node
+// info, so this mock returns an empty map.
+func (m *mockFullDiscovery) DiscoverNodes(ctx context.Context) (map[string]discovery.NodeInfo, error) {
+	if m.discErr != nil {
+		return nil, m.discErr
+	}
+	return map[string]discovery.NodeInfo{}, nil
+}
+
 var _ = Describe("TypeInventory", func() {
 	var ctx context.Context
 


### PR DESCRIPTION
## Summary

Pure refactor of `internal/discovery/k8s_with_gpu_operator.go` — no behavior change for existing callers. Extracts a single internal node-listing helper, adds a new `NodeDiscovery` interface that exposes per-node labels, and re-implements the existing `Discover` and `discoverNodeGPUTypes` methods as projections over the new helper.

This unblocks upcoming label-aware features (namespace-scoped limiter, node-aware bin packing) that need `node.Labels` alongside accelerator capacity, without forcing a third near-identical vendor-loop node query.

## Motivation

`K8sWithGpuOperator` currently has two near-identical vendor-loop node queries:

- `Discover()` (lines 33-99) — builds `map[nodeName]map[model]AcceleratorModelInfo`
- `discoverNodeGPUTypes()` (lines 147-188) — builds `map[nodeName]string`

Both loop over `vendors`, build the same selector, list nodes, iterate results, and differ only in the projection. Upcoming work ([namespace-scoped limiter](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/XXXX), epic [limiter improvements](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/XXXX)) needs a third projection — per-node info including `node.Labels`. Adding a third independent vendor-loop would lock in the duplication pattern. This PR consolidates node discovery into a single primitive with multiple public projections.

## Behavior preservation

This is a pure refactor. Verified invariants:

- `Discover()` output shape and contents unchanged — existing tests pass without modification
- `DiscoverUsage()` unchanged — still uses `discoverNodeGPUTypes` internally
- `discoverNodeGPUTypes()` multi-vendor tie-break preserved (intel > amd > nvidia if multiple labels present). Locked down by new `TestDiscoverNodeGPUTypes_MultiVendorNode_LastWins`.
- `WVA_NODE_SELECTOR` handling unchanged; error on invalid selector is now explicitly tested
- Vendor iteration order (`nvidia.com`, `amd.com`, `intel.com`) preserved
- Multi-vendor nodes merged into a single `NodeInfo` entry with both accelerators
- Nodes without `Allocatable` resource still included with `Count=0`
- Non-GPU nodes excluded from `DiscoverNodes` output (same as `Discover`)

## Tests

All existing discovery tests pass unchanged (behavior-equivalence check).

Eight new tests added:

- `TestDiscoverNodes_SingleVendor` — basic labels + accelerators capture
- `TestDiscoverNodes_MultiVendorNode` — merged single entry
- `TestDiscoverNodes_RespectsWVANodeSelector` — sharding env var respected
- `TestDiscoverNodes_NodeWithGPULabelButNoAllocatable` — `Count=0` preserved
- `TestDiscoverNodes_EmptyCluster` — empty input → empty output
- `TestDiscoverNodes_ExcludesCPUOnlyNodes` — filters consistent with `Discover`
- `TestDiscoverNodes_InvalidWVANodeSelectorReturnsError` — error path tested for both `DiscoverNodes` and `Discover`
- `TestDiscoverNodes_LabelsAreIndependentCopy` — mutation-safety contract
- `TestDiscoverNodeGPUTypes_MultiVendorNode_LastWins` — behavior-preservation regression test

## Verification

- `go build ./...` — clean
- `go test ./internal/...` — all packages pass (including envtest suites for actuator, controller, engines/saturation)
- `golangci-lint run ./internal/discovery/... ./internal/engines/pipeline/...` — `0 issues`

## Non-goals

- No new behavior for existing callers
- `DiscoverNodes` not consumed anywhere yet; consumption happens in the follow-up namespace-scoped limiter PR
- No changes outside `internal/discovery/` and the pipeline test mock

## Follow-ups (out of scope)

- Namespace-scoped GPU inventory and limiter ([issue](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1001)) — will consume `DiscoverNodes`
- Epic: [Limiter improvements](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1000)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/discovery/...` — 18/18 pass
- [x] `go test ./internal/engines/pipeline/...` — all pass (mock updated)
- [x] `go test ./internal/engines/saturation/...` (envtest) — all pass
- [x] `golangci-lint run ./internal/discovery/... ./internal/engines/pipeline/...` — 0 issues
- [ ] CI pipelines green on PR
