### PR TITLE
Multi-model deploy and test with wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ DEPLOY_LLM_D ?= true
 DELETE_CLUSTER ?= false
 DELETE_NAMESPACES ?= false
 
+# Multi-model deployment configuration (used by deploy-multi-model-infra)
+MODELS           ?= Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B
+NAMESPACE_SCOPED ?= false
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -214,6 +218,95 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		./deploy/install.sh; \
 	fi
 
+.PHONY: deploy-e2e-infra-multi-model
+deploy-e2e-infra-multi-model: ## Deploy e2e test infrastructure with two concurrent model services
+	@echo "Deploying multi-model e2e test infrastructure..."
+	./deploy/install-multi-model.sh
+
+# Configurable multi-model deployment for any environment.
+# Usage:
+#   make deploy-multi-model-infra \
+#     ENVIRONMENT=openshift \
+#     WVA_NS=my-namespace LLMD_NS=my-namespace \
+#     NAMESPACE_SCOPED=true \
+#     SKIP_BUILD=true DECODE_REPLICAS=1 \
+#     IMG_TAG=v0.6.0 LLM_D_RELEASE=v0.6.0 \
+#     MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"
+.PHONY: deploy-multi-model-infra
+deploy-multi-model-infra: ## Deploy multi-model infra with N models. Set MODELS=m1,m2,... (comma-separated).
+	@echo "Deploying multi-model infrastructure (MODELS=$(MODELS))..."
+	@if [ "$(SKIP_BUILD)" != "true" ]; then \
+		echo "Building WVA image $(IMG)..."; \
+		$(MAKE) docker-build IMG=$(IMG); \
+	else \
+		echo "Skipping image build (SKIP_BUILD=true)"; \
+	fi; \
+	if echo "$(IMG)" | grep -q ":"; then \
+		IMAGE_REPO=$$(echo "$(IMG)" | cut -d: -f1); \
+		IMAGE_TAG=$$(echo "$(IMG)" | cut -d: -f2); \
+	else \
+		IMAGE_REPO="$(IMG)"; \
+		IMAGE_TAG="latest"; \
+	fi; \
+	echo "Using WVA image: $$IMAGE_REPO:$$IMAGE_TAG"; \
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NS="$(WVA_NS)" \
+	LLMD_NS="$(LLMD_NS)" \
+	NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
+	DECODE_REPLICAS=$(DECODE_REPLICAS) \
+	LLM_D_RELEASE=$(LLM_D_RELEASE) \
+	WVA_IMAGE_REPO="$$IMAGE_REPO" \
+	WVA_IMAGE_TAG="$$IMAGE_TAG" \
+	WVA_IMAGE_PULL_POLICY=IfNotPresent \
+	MODELS="$(MODELS)" \
+	./deploy/install-multi-model.sh
+
+# Undeploy multi-model infrastructure.
+# Must use the same MODELS list that was used during deployment.
+.PHONY: undeploy-multi-model-infra
+undeploy-multi-model-infra: ## Undeploy multi-model infra. Use same MODELS=m1,m2,... as deploy.
+	@echo "Undeploying multi-model infrastructure (MODELS=$(MODELS))..."
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NS="$(WVA_NS)" \
+	LLMD_NS="$(LLMD_NS)" \
+	NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
+	DELETE_NAMESPACES=$(DELETE_NAMESPACES) \
+	MODELS="$(MODELS)" \
+	./deploy/install-multi-model.sh --undeploy
+
+# Multi-model scaling test parameters
+MM_MIN_REPLICAS ?= 1
+MM_MAX_REPLICAS ?= 5
+
+# TODO: Merge test-multi-model-scaling into test-benchmark by detecting MODELS env var:
+#   $(eval LABEL_FILTER := $(if $(MODELS),multi-model,phase3a))
+# Then: make test-benchmark MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"
+# This eliminates the need for a separate target.
+.PHONY: test-multi-model-scaling
+test-multi-model-scaling: manifests generate fmt vet ## Run multi-model scaling benchmark (VA + HPA + GuideLLM per model)
+	@echo "Running multi-model scaling benchmark (MODELS=$(MODELS))..."
+	KUBECONFIG=$(KUBECONFIG) \
+	ENVIRONMENT=$(ENVIRONMENT) \
+	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
+	LLMD_NAMESPACE=$(LLMD_NS) \
+	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
+	USE_SIMULATOR=$(USE_SIMULATOR) \
+	SCALER_BACKEND=$(SCALER_BACKEND) \
+	MODEL_ID=$(MODEL_ID) \
+	MODELS="$(MODELS)" \
+	MM_MIN_REPLICAS=$(MM_MIN_REPLICAS) \
+	MM_MAX_REPLICAS=$(MM_MAX_REPLICAS) \
+	GATEWAY_SERVICE_NAME=multi-model-inference-gateway-istio \
+	PROMETHEUS_TOKEN=$$(oc whoami -t 2>/dev/null || echo "") \
+	go test ./test/benchmark/ -timeout 75m -v -ginkgo.v \
+		-ginkgo.label-filter="multi-model"; \
+	TEST_EXIT_CODE=$$?; \
+	echo ""; \
+	echo "=========================================="; \
+	echo "Multi-model benchmark completed. Exit code: $$TEST_EXIT_CODE"; \
+	echo "=========================================="; \
+	exit $$TEST_EXIT_CODE
+
 # Deploy e2e infrastructure with KEDA as scaler backend (installs KEDA, skips Prometheus Adapter).
 # Runs a subset of smoke tests from the e2e suite.
 .PHONY: test-e2e-smoke
@@ -325,6 +418,7 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-deploy-scripts: ## Run bash -n for deploy/install.sh, deploy/lib/*.sh, and deploy plugins
 	@echo "Syntax-checking deploy shell scripts..."
 	@bash -n deploy/install.sh
+	@bash -n deploy/install-multi-model.sh
 	@for script in deploy/lib/*.sh; do bash -n "$$script"; done
 	@for script in deploy/*/install.sh; do if [ -f "$$script" ]; then bash -n "$$script"; fi; done
 	@for script in deploy/kind-emulator/*.sh; do if [ -f "$$script" ]; then bash -n "$$script"; fi; done

--- a/deploy/install-multi-model.sh
+++ b/deploy/install-multi-model.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+#
+# Multi-Model Deployment Orchestrator
+#
+# Thin wrapper around deploy/install.sh that deploys N models into the
+# same cluster, each with its own EPP and InferencePool, then creates a
+# shared HTTPRoute with URLRewrite rules so all models are reachable
+# through a single Gateway.
+#
+# Usage:
+#   MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B" ./deploy/install-multi-model.sh
+#
+# Architecture:
+#   install.sh  (call 1) → full stack: control plane, WVA, monitoring, Model 1
+#   install.sh  (call N) → model-only: skip WVA/monitoring/gateway, deploy Model N
+#   This script          → multi-model-specific: InferencePools, HTTPRoute, verification
+#
+
+set -e
+set -o pipefail
+
+# ── Logging ──────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# ── Utilities ────────────────────────────────────────────────────────
+# Convert a HuggingFace model ID into a k8s-safe resource slug.
+#   Qwen/Qwen3-0.6B        → qwen-qwen3-0-6b
+#   unsloth/Meta-Llama-3.1-8B → unsloth-meta-llama-3-1-8b
+model_to_slug() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's|/|-|g; s|\.|-|g'
+}
+
+# ── Configuration ────────────────────────────────────────────────────
+WVA_PROJECT=${WVA_PROJECT:-$PWD}
+DEPLOY_SCRIPT="$WVA_PROJECT/deploy/install.sh"
+LLMD_NS=${LLMD_NS:-"llm-d-inference-scheduler"}
+ENVIRONMENT=${ENVIRONMENT:-"kind-emulator"}
+DECODE_REPLICAS=${DECODE_REPLICAS:-1}
+MODELS=${MODELS:-"Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"}
+
+chmod +x "$DEPLOY_SCRIPT"
+
+# ── Parse model list ─────────────────────────────────────────────────
+IFS=',' read -ra MODEL_LIST <<< "$MODELS"
+if [ ${#MODEL_LIST[@]} -lt 1 ]; then
+    log_error "MODELS must contain at least 1 comma-separated model ID (got: $MODELS)"
+fi
+
+SLUG_LIST=()
+for model in "${MODEL_LIST[@]}"; do
+    SLUG_LIST+=("$(model_to_slug "$model")")
+done
+
+# ── Undeploy mode ────────────────────────────────────────────────────
+UNDEPLOY=false
+for arg in "$@"; do
+    case "$arg" in
+        -u|--undeploy) UNDEPLOY=true ;;
+    esac
+done
+
+if [ "$UNDEPLOY" = true ]; then
+    log_info "Starting Multi-Model Undeployment"
+    log_info "Models: ${MODEL_LIST[*]}"
+    log_info "═══════════════════════════════════════════════════════════"
+    echo ""
+
+    # 1. Delete multi-model HTTPRoute and shared Gateway
+    log_info "Deleting multi-model HTTPRoute..."
+    kubectl delete httproute multi-model-route -n "$LLMD_NS" --ignore-not-found
+    log_success "HTTPRoute deleted"
+
+    log_info "Deleting shared Gateway..."
+    kubectl delete gateway multi-model-inference-gateway -n "$LLMD_NS" --ignore-not-found
+    log_success "Shared Gateway deleted"
+
+    # 2. Delete InferencePools
+    log_info "Deleting InferencePool resources..."
+    for slug in "${SLUG_LIST[@]}"; do
+        kubectl delete inferencepool "gaie-${slug}" -n "$LLMD_NS" --ignore-not-found
+        log_success "InferencePool gaie-${slug} deleted"
+    done
+
+    # 3. Uninstall model-specific Helm releases directly.
+    #    install.sh --undeploy uses NAMESPACE_SUFFIX (not RELEASE_NAME_POSTFIX)
+    #    for its helm uninstall commands, so it won't find our slug-based releases.
+    #    We handle model cleanup here; install.sh handles WVA/monitoring/scaler.
+    log_info "Removing model-specific Helm releases..."
+    for slug in "${SLUG_LIST[@]}"; do
+        log_info "  Uninstalling releases for ${slug}..."
+        helm uninstall "ms-${slug}" -n "$LLMD_NS" 2>/dev/null || \
+            log_warning "  ms-${slug} not found"
+        helm uninstall "gaie-${slug}" -n "$LLMD_NS" 2>/dev/null || \
+            log_warning "  gaie-${slug} not found"
+        helm uninstall "infra-${slug}" -n "$LLMD_NS" 2>/dev/null || \
+            log_warning "  infra-${slug} not found"
+    done
+
+    # 4. Call install.sh --undeploy for the full stack (WVA, monitoring, scaler backend, namespaces).
+    #    Only need to call once for the first model since it deployed the control plane.
+    log_info "Undeploying control plane (WVA, monitoring, scaler backend)..."
+    ENVIRONMENT="$ENVIRONMENT" \
+    RELEASE_NAME_POSTFIX="${SLUG_LIST[0]}" \
+    INSTALL_GATEWAY_CTRLPLANE=true \
+    DEPLOY_WVA=true \
+    DEPLOY_PROMETHEUS=true \
+    DEPLOY_LLM_D=false \
+    DELETE_NAMESPACES="${DELETE_NAMESPACES:-false}" \
+    "$DEPLOY_SCRIPT" --undeploy
+
+    log_success "Multi-model Undeployment Completed!"
+    exit 0
+fi
+
+# ── Deploy mode ──────────────────────────────────────────────────────
+TOTAL_STEPS=$(( ${#MODEL_LIST[@]} + 2 ))  # N models + InferencePools + HTTPRoute
+log_info "Models to deploy (${#MODEL_LIST[@]}): ${MODEL_LIST[*]}"
+log_info "Resource slugs: ${SLUG_LIST[*]}"
+echo ""
+
+# ── Deploy models via install.sh ─────────────────────────────────────
+for i in "${!MODEL_LIST[@]}"; do
+    model="${MODEL_LIST[$i]}"
+    slug="${SLUG_LIST[$i]}"
+    step=$((i + 1))
+
+    log_info "═══════════════════════════════════════════════════════════"
+    if [ "$i" -eq 0 ]; then
+        log_info "Step ${step}/${TOTAL_STEPS}: Full stack + ${slug}"
+        log_info "═══════════════════════════════════════════════════════════"
+
+        # First model: deploy the full control plane, WVA, monitoring, and model
+        ENVIRONMENT="$ENVIRONMENT" \
+        MODEL_ID="$model" \
+        RELEASE_NAME_POSTFIX="$slug" \
+        INFRA_ONLY=false \
+        INSTALL_GATEWAY_CTRLPLANE=true \
+        DEPLOY_WVA=true \
+        DEPLOY_PROMETHEUS=true \
+        DEPLOY_LLM_D=true \
+        DECODE_REPLICAS="$DECODE_REPLICAS" \
+        E2E_TESTS_ENABLED=false \
+        "$DEPLOY_SCRIPT"
+
+        # Replace the model-specific Gateway with a shared, model-agnostic one.
+        # install.sh created infra-<slug>-inference-gateway; we replace it with
+        # a standalone Gateway named 'multi-model-inference-gateway'.
+        log_info "Creating shared Gateway (replacing model-specific infra-${slug})..."
+        cat <<GWEOF | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-model-inference-gateway
+  namespace: $LLMD_NS
+  labels:
+    istio.io/enable-inference-extproc: "true"
+spec:
+  gatewayClassName: istio
+  listeners:
+    - port: 80
+      protocol: HTTP
+      name: default
+      allowedRoutes:
+        namespaces:
+          from: All
+GWEOF
+        log_success "Shared Gateway 'multi-model-inference-gateway' created"
+
+        # Remove Model 1's model-specific Gateway resource. We keep the infra
+        # Helm release (it provides CRDs and other infra); only the Gateway
+        # resource is redundant since we created a shared one above.
+        log_info "Removing model-specific Gateway resource infra-${slug}-inference-gateway..."
+        kubectl delete gateway "infra-${slug}-inference-gateway" \
+            -n "$LLMD_NS" --ignore-not-found 2>/dev/null || true
+    else
+        log_info "Step ${step}/${TOTAL_STEPS}: Model-only ${slug}"
+        log_info "═══════════════════════════════════════════════════════════"
+
+        # Subsequent models: reuse existing control plane, deploy model only.
+        # Inherits WVA_NS, NAMESPACE_SCOPED, LLM_D_RELEASE, WVA_IMAGE_*
+        # from the process environment (set by Makefile or caller).
+        #
+        # E2E_TESTS_ENABLED=true suppresses the interactive Gateway prompt
+        # (safe here because INFRA_ONLY=false, so the modelservice-skip
+        # side effect does not activate).
+
+        # The gaie-* (inference-scheduler) chart creates a shared Secret with a
+        # fixed name that causes Helm ownership conflicts across releases.
+        # Delete it before deploying — the helmfile will recreate it.
+        log_info "Removing shared EPP Secret to avoid Helm ownership conflict..."
+        kubectl delete secret inference-scheduling-gateway-sa-metrics-reader-secret \
+            -n "$LLMD_NS" --ignore-not-found 2>/dev/null || true
+
+        ENVIRONMENT="$ENVIRONMENT" \
+        MODEL_ID="$model" \
+        RELEASE_NAME_POSTFIX="$slug" \
+        INFRA_ONLY=false \
+        INSTALL_GATEWAY_CTRLPLANE=false \
+        DEPLOY_WVA=false \
+        DEPLOY_PROMETHEUS=false \
+        DEPLOY_PROMETHEUS_ADAPTER=false \
+        SCALER_BACKEND=none \
+        DEPLOY_LLM_D=true \
+        DECODE_REPLICAS="$DECODE_REPLICAS" \
+        E2E_TESTS_ENABLED=true \
+        "$DEPLOY_SCRIPT"
+
+        # The helmfile creates an infra-<slug> release per model which includes
+        # a redundant Gateway resource. Delete only the Gateway resource (not the
+        # Helm release) to preserve CRDs that InferencePools depend on.
+        log_info "Removing redundant Gateway resource for ${slug}..."
+        kubectl delete gateway "infra-${slug}-inference-gateway" \
+            -n "$LLMD_NS" --ignore-not-found 2>/dev/null || true
+    fi
+done
+
+# ── Verify InferencePools ─────────────────────────────────────────────
+# The gaie-* helmfile releases already create InferencePool resources
+# for each model with the correct API version and labels. We just verify
+# they exist rather than trying to re-create them.
+POOL_STEP=$(( ${#MODEL_LIST[@]} + 1 ))
+log_info "═══════════════════════════════════════════════════════════"
+log_info "Step ${POOL_STEP}/${TOTAL_STEPS}: Verifying InferencePool resources"
+log_info "═══════════════════════════════════════════════════════════"
+
+for slug in "${SLUG_LIST[@]}"; do
+    if kubectl get inferencepool "gaie-${slug}" -n "$LLMD_NS" &>/dev/null; then
+        log_success "InferencePool gaie-${slug} exists"
+    else
+        log_warning "InferencePool gaie-${slug} not found — it should have been created by the gaie-${slug} Helm release"
+    fi
+done
+
+# ── Deploy HTTPRoute with URLRewrite ─────────────────────────────────
+ROUTE_STEP=$(( ${#MODEL_LIST[@]} + 2 ))
+# Shared Gateway created earlier, not tied to any specific model
+GATEWAY_NAME="multi-model-inference-gateway"
+
+log_info "═══════════════════════════════════════════════════════════"
+log_info "Step ${ROUTE_STEP}/${TOTAL_STEPS}: Deploying HTTPRoute (gateway=${GATEWAY_NAME})"
+log_info "═══════════════════════════════════════════════════════════"
+
+# Build the rules array dynamically — one rule per model with URLRewrite
+# Detect InferencePool API group (moved from x-k8s.io to k8s.io in v1.4.0)
+# Both CRDs may exist on the cluster; prefer the GA version.
+if kubectl get crd inferencepools.inference.networking.k8s.io &>/dev/null; then
+    POOL_API_GROUP="inference.networking.k8s.io"
+else
+    POOL_API_GROUP="inference.networking.x-k8s.io"
+fi
+log_info "Detected InferencePool API group: ${POOL_API_GROUP}"
+
+RULES_YAML=""
+for slug in "${SLUG_LIST[@]}"; do
+    RULES_YAML+="
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /${slug}/v1
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /v1
+      backendRefs:
+      - group: ${POOL_API_GROUP}
+        kind: InferencePool
+        name: gaie-${slug}
+        port: 8000
+      timeouts:
+        request: 300s"
+done
+
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: multi-model-route
+  namespace: $LLMD_NS
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: $GATEWAY_NAME
+  rules:${RULES_YAML}
+EOF
+
+log_success "HTTPRoute deployed with ${#SLUG_LIST[@]} URLRewrite rules"
+
+# ── Verification (in-cluster Job) ────────────────────────────────────
+log_info "Running in-cluster connectivity verification..."
+
+GW_SVC="${GATEWAY_NAME}-istio.${LLMD_NS}.svc.cluster.local"
+VERIFY_TIMEOUT=180
+VERIFY_INTERVAL=10
+JOB_NAME="multi-model-verify"
+
+# Build curl commands for all models
+CURL_CMDS=""
+for slug in "${SLUG_LIST[@]}"; do
+    CURL_CMDS+="CODE=\$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://${GW_SVC}/${slug}/v1/models 2>/dev/null || echo 000); "
+    CURL_CMDS+="if [ \"\$CODE\" != \"200\" ]; then ALL_OK=false; fi; "
+done
+
+RESULT_CMDS=""
+for slug in "${SLUG_LIST[@]}"; do
+    RESULT_CMDS+="CODE=\$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://${GW_SVC}/${slug}/v1/models 2>/dev/null || echo 000); "
+    RESULT_CMDS+="echo \"RESULT ${slug} \$CODE\"; "
+done
+
+# Delete any previous verification Job
+kubectl delete job "$JOB_NAME" -n "$LLMD_NS" --ignore-not-found 2>/dev/null || true
+
+cat <<JOBEOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: ${LLMD_NS}
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: verify
+        image: curlimages/curl:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          ELAPSED=0
+          while [ \$ELAPSED -lt ${VERIFY_TIMEOUT} ]; do
+            ALL_OK=true
+            ${CURL_CMDS}
+            if [ "\$ALL_OK" = true ]; then
+              echo "ALL_REACHABLE"
+              ${RESULT_CMDS}
+              exit 0
+            fi
+            echo "WAITING \${ELAPSED}/${VERIFY_TIMEOUT}s"
+            sleep ${VERIFY_INTERVAL}
+            ELAPSED=\$((ELAPSED + ${VERIFY_INTERVAL}))
+          done
+          echo "TIMED_OUT"
+          ${RESULT_CMDS}
+          exit 1
+JOBEOF
+
+log_info "Verification Job '${JOB_NAME}' launched (timeout=${VERIFY_TIMEOUT}s)"
+log_info "Testing: http://${GW_SVC}/{model-slug}/v1/models"
+
+# Wait for Job completion
+WAIT_TIMEOUT=$((VERIFY_TIMEOUT + 60))
+if kubectl wait --for=condition=complete job/"$JOB_NAME" -n "$LLMD_NS" --timeout="${WAIT_TIMEOUT}s" 2>/dev/null; then
+    echo ""
+    JOB_LOGS=$(kubectl logs job/"$JOB_NAME" -n "$LLMD_NS" 2>/dev/null || echo "")
+    for slug in "${SLUG_LIST[@]}"; do
+        log_success "✓ ${slug} reachable via Gateway"
+    done
+    echo ""
+    log_success "All ${#MODEL_LIST[@]} models reachable through the Gateway!"
+else
+    echo ""
+    JOB_LOGS=$(kubectl logs job/"$JOB_NAME" -n "$LLMD_NS" 2>/dev/null || echo "")
+    for slug in "${SLUG_LIST[@]}"; do
+        CODE=$(echo "$JOB_LOGS" | grep "RESULT ${slug}" | awk '{print $3}')
+        if [ "$CODE" = "200" ]; then
+            log_success "✓ ${slug} reachable (HTTP 200)"
+        else
+            log_warning "✗ ${slug} not reachable (HTTP ${CODE:-unknown})"
+        fi
+    done
+    echo ""
+    log_warning "Some models not reachable after ${VERIFY_TIMEOUT}s — they may still be loading."
+    log_info "Check manually: kubectl port-forward -n $LLMD_NS deployment/${GATEWAY_NAME}-istio 8080:80"
+fi
+
+# Cleanup
+kubectl delete job "$JOB_NAME" -n "$LLMD_NS" --ignore-not-found 2>/dev/null || true
+
+log_success "Multi-model Infrastructure Deployment Completed!"
+

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -89,6 +89,14 @@ deploy_llm_d_infrastructure() {
         log_info "Model ID matches guide default ($ACTUAL_DEFAULT_MODEL), no replacement needed"
     fi
 
+    # Ensure llm-d.ai/model label is unique per model for multi-model HPA isolation.
+    # The chart sets a default (e.g. "Qwen3-32B") that all deployments share,
+    # which causes AmbiguousSelector errors when multiple HPAs target different
+    # deployments with identical pod selectors.
+    local model_label_value
+    model_label_value=$(echo "$MODEL_ID" | sed 's|.*/||; s|\.|-|g')  # e.g. "Qwen3-0-6B", "Meta-Llama-3.1-8B"
+    log_info "Setting llm-d.ai/model label to: $model_label_value (unique per model)"
+    yq eval ".modelArtifacts.labels.\"llm-d.ai/model\" = \"$model_label_value\"" -i "$LLM_D_MODELSERVICE_VALUES"
     # Configure llm-d-inference-simulator if needed
     if [ "$DEPLOY_LLM_D_INFERENCE_SIM" == "true" ]; then
       log_info "Deploying llm-d-inference-simulator..."

--- a/test/benchmark/job_waiter.go
+++ b/test/benchmark/job_waiter.go
@@ -17,6 +17,9 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// conditionStatusTrue is the Kubernetes condition status value for a condition that is met.
+const conditionStatusTrue = "True"
+
 // WaitForJobCompletion waits for a job to complete successfully
 func WaitForJobCompletion(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, jobName string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
@@ -26,10 +29,10 @@ func WaitForJobCompletion(ctx context.Context, k8sClient *kubernetes.Clientset, 
 		}
 
 		for _, cond := range job.Status.Conditions {
-			if cond.Type == batchv1.JobComplete && cond.Status == "True" {
+			if cond.Type == batchv1.JobComplete && cond.Status == conditionStatusTrue {
 				return true, nil
 			}
-			if cond.Type == batchv1.JobFailed && cond.Status == "True" {
+			if cond.Type == batchv1.JobFailed && cond.Status == conditionStatusTrue {
 				return false, fmt.Errorf("job failed: %s", cond.Message)
 			}
 		}

--- a/test/benchmark/multi_model_benchmark_test.go
+++ b/test/benchmark/multi_model_benchmark_test.go
@@ -1,0 +1,623 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/testconfig"
+)
+
+// MultiModelResult holds per-model results for the multi-model benchmark.
+type MultiModelResult struct {
+	ModelID          string          `json:"model_id"`
+	Slug             string          `json:"slug"`
+	DeploymentName   string          `json:"deployment_name"`
+	AutoscalerType   string          `json:"autoscaler_type"`
+	VAName           string          `json:"va_name"`
+	HPAName          string          `json:"hpa_name"`
+	ReplicaTimeline  []ReplicaSnap   `json:"replica_timeline"`
+	MetricsTimeline  []MetricSnap    `json:"metrics_timeline"`
+	AvgReplicas      float64         `json:"avg_replicas"`
+	MaxReplicas      int32           `json:"max_replicas"`
+	AvgQueueDepth    float64         `json:"avg_queue_depth"`
+	AvgEPPQueueDepth float64         `json:"avg_epp_queue_depth"`
+	AvgKVCache       float64         `json:"avg_kv_cache"`
+	AchievedRPS      float64         `json:"achieved_rps"`
+	ErrorCount       int             `json:"error_count"`
+	IncompleteCount  int             `json:"incomplete_count"`
+	TTFT             json.RawMessage `json:"ttft,omitempty"`
+	ITL              json.RawMessage `json:"itl,omitempty"`
+	Throughput       json.RawMessage `json:"throughput,omitempty"`
+	GuideLLMRaw      json.RawMessage `json:"guidellm_raw,omitempty"`
+	DurationSec      float64         `json:"duration_sec"`
+	JobStatus        string          `json:"job_status"`
+}
+
+const multiModelResultsFile = "/tmp/multi-model-benchmark-results.json"
+
+// modelToSlug converts a model ID to a DNS-safe slug, matching the deploy script convention.
+func modelToSlug(modelID string) string {
+	s := strings.ToLower(modelID)
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, ".", "-")
+	return s
+}
+
+// modelInfo groups per-model resources discovered at runtime.
+type modelInfo struct {
+	ModelID        string
+	Slug           string
+	DeploymentName string
+	VAName         string
+	HPAName        string
+	JobName        string
+}
+
+var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "multi-model"), func() {
+	var (
+		testCtx    context.Context
+		testCancel context.CancelFunc
+		models     []modelInfo
+	)
+
+	BeforeAll(func() {
+		testCtx, testCancel = context.WithCancel(context.Background())
+
+		// Parse MODELS env var (comma-separated list of model IDs)
+		modelsEnv := testconfig.GetEnv("MODELS", "")
+		Expect(modelsEnv).NotTo(BeEmpty(), "MODELS env var is required (comma-separated model IDs)")
+
+		modelIDs := strings.Split(modelsEnv, ",")
+		for _, m := range modelIDs {
+			m = strings.TrimSpace(m)
+			if m == "" {
+				continue
+			}
+			slug := modelToSlug(m)
+			models = append(models, modelInfo{
+				ModelID: m,
+				Slug:    slug,
+				VAName:  "va-" + slug,
+				HPAName: "hpa-" + slug,
+				JobName: "load-" + slug,
+			})
+		}
+		Expect(models).NotTo(BeEmpty(), "At least one model must be specified in MODELS")
+
+		GinkgoWriter.Printf("Multi-model benchmark configured for %d models:\n", len(models))
+		for i, m := range models {
+			GinkgoWriter.Printf("  [%d] %s (slug: %s)\n", i+1, m.ModelID, m.Slug)
+		}
+	})
+
+	AfterAll(func() {
+		testCancel()
+	})
+
+	// discoverDeployments finds the Helm-deployed decode deployment for each model.
+	discoverDeployments := func() {
+		By("Discovering decode deployments for each model")
+		deployments, err := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).List(testCtx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to list deployments")
+
+		for i := range models {
+			slug := models[i].Slug
+			for j := range deployments.Items {
+				d := &deployments.Items[j]
+				if strings.Contains(d.Name, "ms-"+slug) && strings.HasSuffix(d.Name, "-decode") {
+					models[i].DeploymentName = d.Name
+					GinkgoWriter.Printf("  %s → %s\n", slug, d.Name)
+					break
+				}
+			}
+			Expect(models[i].DeploymentName).NotTo(BeEmpty(),
+				fmt.Sprintf("No decode deployment found for model slug %s", slug))
+		}
+	}
+
+	// patchAllEPPConfigs patches every EPP deployment's ConfigMap with flowControl
+	// enabled and scorer weights (queue=2, kv-cache=2, prefix-cache=3),
+	// matching the single-model test-benchmark behavior.
+	patchAllEPPConfigs := func() {
+		By("Patching all EPP ConfigMaps with flowControl + scorer weights (queue=2, kv-cache=2, prefix-cache=3)")
+		deployments, err := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).List(testCtx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for i := range deployments.Items {
+			d := &deployments.Items[i]
+			if !strings.Contains(d.Name, "epp") {
+				continue
+			}
+			GinkgoWriter.Printf("  Patching EPP: %s\n", d.Name)
+			patchErr := PatchEPPConfigMap(testCtx, k8sClient, benchCfg.LLMDNamespace, d.Name)
+			if patchErr != nil {
+				GinkgoWriter.Printf("  WARNING: EPP patch failed for %s (non-fatal): %v\n", d.Name, patchErr)
+			} else {
+				GinkgoWriter.Printf("  EPP %s patched — flowControl enabled, weights 2/2/3\n", d.Name)
+			}
+		}
+	}
+
+	// ensureDeploymentsReady scales each model deployment to 1 and waits for readiness.
+	ensureDeploymentsReady := func() {
+		By("Ensuring all decode deployments are ready")
+		for _, m := range models {
+			dep, err := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(testCtx, m.DeploymentName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if dep.Spec.Replicas == nil || *dep.Spec.Replicas < 1 {
+				one := int32(1)
+				dep.Spec.Replicas = &one
+				_, err = k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Update(testCtx, dep, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		for _, m := range models {
+			Eventually(func(g Gomega) {
+				d, err := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(testCtx, m.DeploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(d.Status.ReadyReplicas).To(BeNumerically(">=", 1))
+			}, 5*time.Minute, 10*time.Second).Should(Succeed(),
+				fmt.Sprintf("Deployment %s should have at least 1 ready replica", m.DeploymentName))
+			GinkgoWriter.Printf("  %s: ready\n", m.DeploymentName)
+		}
+	}
+
+	// createVAsAndHPAs creates a VA + HPA per model.
+	createVAsAndHPAs := func() {
+		By("Creating VariantAutoscaling and HPA resources for each model")
+		maxReplicas := int32(testconfig.GetEnvInt("MM_MAX_REPLICAS", 5))
+		minReplicas := int32(testconfig.GetEnvInt("MM_MIN_REPLICAS", 1))
+
+		for _, m := range models {
+			GinkgoWriter.Printf("  Creating VA %s → %s (model=%s)\n", m.VAName, m.DeploymentName, m.ModelID)
+			err := fixtures.EnsureVariantAutoscaling(
+				testCtx, crClient, benchCfg.LLMDNamespace,
+				m.VAName, m.DeploymentName, m.ModelID,
+				benchCfg.AcceleratorType, 10.0, benchCfg.ControllerInstance,
+				fixtures.WithMinReplicas(minReplicas),
+				fixtures.WithMaxReplicas(maxReplicas),
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create VA "+m.VAName)
+
+			GinkgoWriter.Printf("  Creating HPA %s → %s\n", m.HPAName, m.DeploymentName)
+			behavior := &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(0)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150},
+					},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(240)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150},
+					},
+				},
+			}
+			err = fixtures.EnsureHPA(testCtx, k8sClient, benchCfg.LLMDNamespace,
+				m.HPAName, m.DeploymentName, m.VAName,
+				minReplicas, maxReplicas, WithBehavior(behavior))
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA "+m.HPAName)
+		}
+	}
+
+	// waitForVASync waits for all VAs to have desiredOptimizedAlloc.numReplicas set.
+	waitForVASync := func() {
+		By("Waiting for all VariantAutoscaling resources to sync")
+		for _, m := range models {
+			Eventually(func(g Gomega) {
+				va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+				err := crClient.Get(testCtx, client.ObjectKey{
+					Namespace: benchCfg.LLMDNamespace,
+					Name:      m.VAName,
+				}, va)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(va.Status.DesiredOptimizedAlloc.NumReplicas).NotTo(BeNil())
+				g.Expect(*va.Status.DesiredOptimizedAlloc.NumReplicas).To(BeNumerically(">=", 1))
+				GinkgoWriter.Printf("  %s: desiredReplicas=%d\n", m.VAName, *va.Status.DesiredOptimizedAlloc.NumReplicas)
+			}, 5*time.Minute, 10*time.Second).Should(Succeed(),
+				fmt.Sprintf("VA %s should have NumReplicas set", m.VAName))
+		}
+	}
+
+	// launchLoadJobs creates a GuideLLM job for each model targeting the shared Gateway.
+	launchLoadJobs := func() {
+		By("Launching GuideLLM load jobs for each model")
+		gatewayName := testconfig.GetEnv("GATEWAY_SERVICE_NAME", "multi-model-inference-gateway-istio")
+		gwHost := fmt.Sprintf("%s.%s.svc.cluster.local", gatewayName, benchCfg.LLMDNamespace)
+
+		for _, m := range models {
+			targetURL := fmt.Sprintf("http://%s/%s", gwHost, m.Slug)
+			GinkgoWriter.Printf("  %s → %s\n", m.JobName, targetURL)
+
+			err := CreateGuideLLMJobWithArgs(
+				testCtx, k8sClient, benchCfg.LLMDNamespace,
+				m.JobName, targetURL, m.ModelID,
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create load job "+m.JobName)
+		}
+	}
+
+	// monitorAndCollect monitors scaling metrics and collects results for all models.
+	monitorAndCollect := func() []MultiModelResult {
+		// Wait for all load job pods to be Running before starting the monitor clock.
+		// The GuideLLM container sleeps 30s + pod scheduling/image pull can take time.
+		By("Waiting for all load job pods to enter Running state")
+		for _, m := range models {
+			jobName := m.JobName + "-load"
+			Eventually(func(g Gomega) {
+				pods, err := k8sClient.CoreV1().Pods(benchCfg.LLMDNamespace).List(testCtx, metav1.ListOptions{
+					LabelSelector: "job-name=" + jobName,
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).NotTo(BeEmpty(), "no pods for job "+jobName)
+				g.Expect(string(pods.Items[0].Status.Phase)).To(Equal("Running"))
+			}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+				fmt.Sprintf("job pod for %s should be Running", jobName))
+			GinkgoWriter.Printf("  %s pod is Running\n", jobName)
+		}
+
+		// Add 30s grace for the GuideLLM 'sleep 30' startup inside the container
+		GinkgoWriter.Println("Waiting 35s for GuideLLM in-container startup delay...")
+		time.Sleep(35 * time.Second)
+
+		By("Starting scaling monitor")
+		loadStart := time.Now()
+
+		// Per-model accumulators
+		type accumulator struct {
+			replicaSum, kvSum, qdSum, eppQDSum         float64
+			replicaCount, kvCount, qdCount, eppQDCount int
+			maxReplicas                                int32
+			timeline                                   []ReplicaSnap
+			metrics                                    []MetricSnap
+		}
+		accums := make(map[string]*accumulator, len(models))
+		for _, m := range models {
+			accums[m.Slug] = &accumulator{maxReplicas: 1}
+		}
+
+		// The GuideLLM job uses --max-seconds=600 (hardcoded in workload.go).
+		// Monitor timeout must exceed this to capture full run + allow job completion.
+		monitorTimeout := 780 * time.Second // 600s job + 180s buffer (startup + cooldown)
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Wait for all jobs to complete
+			for _, m := range models {
+				_ = WaitForJobCompletion(testCtx, k8sClient, benchCfg.LLMDNamespace, m.JobName+"-load", 25*time.Minute)
+			}
+		}()
+
+		deadline := time.After(monitorTimeout)
+	monitorLoop:
+		for {
+			select {
+			case <-done:
+				GinkgoWriter.Println("All load jobs completed.")
+				break monitorLoop
+			case <-deadline:
+				GinkgoWriter.Println("Monitor timeout reached.")
+				break monitorLoop
+			case <-ticker.C:
+				elapsed := time.Since(loadStart).Seconds()
+				for _, m := range models {
+					acc := accums[m.Slug]
+
+					// Deployment replicas
+					var spec, ready int32
+					dep, depErr := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(testCtx, m.DeploymentName, metav1.GetOptions{})
+					if depErr == nil && dep.Spec.Replicas != nil {
+						spec = *dep.Spec.Replicas
+						ready = dep.Status.ReadyReplicas
+						acc.replicaSum += float64(spec)
+						acc.replicaCount++
+						if spec > acc.maxReplicas {
+							acc.maxReplicas = spec
+						}
+						acc.timeline = append(acc.timeline, ReplicaSnap{ElapsedSec: elapsed, SpecReplicas: spec, ReadyReplicas: ready})
+					}
+
+					// Prometheus metrics — filter per model
+					snap := MetricSnap{ElapsedSec: elapsed}
+					qdQuery := fmt.Sprintf(`avg(vllm:num_requests_waiting{namespace="%s",model_name="%s"})`, benchCfg.LLMDNamespace, m.ModelID)
+					kvQuery := fmt.Sprintf(`avg(vllm:kv_cache_usage_perc{namespace="%s",model_name="%s"})`, benchCfg.LLMDNamespace, m.ModelID)
+					eppPoolName := fmt.Sprintf("gaie-%s", m.Slug)
+					eppQDQuery := fmt.Sprintf(`sum(inference_extension_flow_control_queue_size{namespace="%s",inference_pool="%s"})`, benchCfg.LLMDNamespace, eppPoolName)
+
+					if qdResult, _, qdErr := promClient.API().Query(testCtx, qdQuery, time.Now()); qdErr == nil {
+						if vec, ok := qdResult.(model.Vector); ok && len(vec) > 0 {
+							snap.QueueDepth = float64(vec[0].Value)
+							acc.qdSum += snap.QueueDepth
+							acc.qdCount++
+						}
+					}
+					if kvResult, _, kvErr := promClient.API().Query(testCtx, kvQuery, time.Now()); kvErr == nil {
+						if vec, ok := kvResult.(model.Vector); ok && len(vec) > 0 {
+							snap.KVCache = float64(vec[0].Value)
+							acc.kvSum += snap.KVCache
+							acc.kvCount++
+						}
+					}
+					if eppResult, _, eppErr := promClient.API().Query(testCtx, eppQDQuery, time.Now()); eppErr == nil {
+						if vec, ok := eppResult.(model.Vector); ok && len(vec) > 0 {
+							snap.EPPQueueDepth = float64(vec[0].Value)
+							acc.eppQDSum += snap.EPPQueueDepth
+							acc.eppQDCount++
+						}
+					}
+					acc.metrics = append(acc.metrics, snap)
+
+					// VA/HPA status
+					vaDesired := "?"
+					va := &variantautoscalingv1alpha1.VariantAutoscaling{}
+					if vaErr := crClient.Get(testCtx, client.ObjectKey{Namespace: benchCfg.LLMDNamespace, Name: m.VAName}, va); vaErr == nil {
+						if va.Status.DesiredOptimizedAlloc.NumReplicas != nil {
+							vaDesired = fmt.Sprintf("%d", *va.Status.DesiredOptimizedAlloc.NumReplicas)
+						}
+					}
+					hpaCurrent, hpaDesired := "?", "?"
+					hpa, hpaErr := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(benchCfg.LLMDNamespace).Get(testCtx, m.HPAName+"-hpa", metav1.GetOptions{})
+					if hpaErr == nil {
+						hpaCurrent = fmt.Sprintf("%d", hpa.Status.CurrentReplicas)
+						hpaDesired = fmt.Sprintf("%d", hpa.Status.DesiredReplicas)
+					}
+
+					GinkgoWriter.Printf("  [%s %.0fs] replicas: spec=%d ready=%d | va=%s hpa=%s→%s | kv=%.4f qd=%.1f epp_qd=%.1f\n",
+						m.Slug, elapsed, spec, ready, vaDesired, hpaCurrent, hpaDesired,
+						snap.KVCache, snap.QueueDepth, snap.EPPQueueDepth)
+				}
+			}
+		}
+
+		loadEnd := time.Now()
+		totalDuration := loadEnd.Sub(loadStart).Seconds()
+
+		// Ensure all jobs have completed before collecting results
+		By("Waiting for any remaining load jobs to complete")
+		for _, m := range models {
+			jobName := m.JobName + "-load"
+			if waitErr := WaitForJobCompletion(testCtx, k8sClient, benchCfg.LLMDNamespace, jobName, 5*time.Minute); waitErr != nil {
+				GinkgoWriter.Printf("  WARNING: job %s did not complete cleanly: %v\n", jobName, waitErr)
+			} else {
+				GinkgoWriter.Printf("  Job %s completed\n", jobName)
+			}
+		}
+
+		// Collect results per model
+		results := make([]MultiModelResult, 0, len(models))
+		for _, m := range models {
+			acc := accums[m.Slug]
+			jobName := m.JobName + "-load"
+
+			// Get GuideLLM output from pod logs
+			var guidellmRaw json.RawMessage
+			var ttftJSON, itlJSON, throughputJSON json.RawMessage
+			var errorCount, incompleteCount, completedCount int
+			var achievedRPS float64
+
+			logs, logErr := GetJobPodLogs(testCtx, k8sClient, benchCfg.LLMDNamespace, jobName)
+			if logErr == nil {
+				if idx := strings.Index(logs, "=== BENCHMARK JSON ==="); idx != -1 {
+					jsonStr := strings.TrimSpace(logs[idx+len("=== BENCHMARK JSON ==="):])
+					guidellmRaw = json.RawMessage(jsonStr)
+
+					var parsed map[string]interface{}
+					if jsonErr := json.Unmarshal([]byte(jsonStr), &parsed); jsonErr == nil {
+						extractGuideLLMMetric(&parsed, "time_to_first_token_ms", &ttftJSON)
+						extractGuideLLMMetric(&parsed, "inter_token_latency_ms", &itlJSON)
+						extractGuideLLMMetric(&parsed, "output_tokens_per_second", &throughputJSON)
+
+						if benchmarks, ok := parsed["benchmarks"].([]interface{}); ok && len(benchmarks) > 0 {
+							if bm, ok := benchmarks[0].(map[string]interface{}); ok {
+								if metrics, ok := bm["metrics"].(map[string]interface{}); ok {
+									if rt, ok := metrics["request_totals"].(map[string]interface{}); ok {
+										if f, ok := rt["errored"].(float64); ok {
+											errorCount = int(f)
+										}
+										if f, ok := rt["incomplete"].(float64); ok {
+											incompleteCount = int(f)
+										}
+										if f, ok := rt["successful"].(float64); ok {
+											completedCount = int(f)
+										}
+									}
+								}
+								if rateObj, ok := bm["rate"].(map[string]interface{}); ok {
+									if f, ok := rateObj["completed_rate"].(float64); ok {
+										achievedRPS = f
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			if achievedRPS == 0 && completedCount > 0 && totalDuration > 0 {
+				achievedRPS = float64(completedCount) / totalDuration
+			}
+
+			// Compute averages
+			avgReplicas := float64(0)
+			if acc.replicaCount > 0 {
+				avgReplicas = acc.replicaSum / float64(acc.replicaCount)
+			}
+			avgKV := float64(0)
+			if acc.kvCount > 0 {
+				avgKV = acc.kvSum / float64(acc.kvCount)
+			}
+			avgQD := float64(0)
+			if acc.qdCount > 0 {
+				avgQD = acc.qdSum / float64(acc.qdCount)
+			}
+			avgEPPQD := float64(0)
+			if acc.eppQDCount > 0 {
+				avgEPPQD = acc.eppQDSum / float64(acc.eppQDCount)
+			}
+
+			// Job status
+			jobStatus := "Unknown"
+			job, jobErr := k8sClient.BatchV1().Jobs(benchCfg.LLMDNamespace).Get(testCtx, jobName, metav1.GetOptions{})
+			if jobErr == nil {
+				for _, cond := range job.Status.Conditions {
+					if cond.Status == "True" {
+						jobStatus = string(cond.Type)
+						break
+					}
+				}
+			}
+
+			results = append(results, MultiModelResult{
+				ModelID:          m.ModelID,
+				Slug:             m.Slug,
+				DeploymentName:   m.DeploymentName,
+				AutoscalerType:   "WVA",
+				VAName:           m.VAName,
+				HPAName:          m.HPAName,
+				ReplicaTimeline:  acc.timeline,
+				MetricsTimeline:  acc.metrics,
+				AvgReplicas:      avgReplicas,
+				MaxReplicas:      acc.maxReplicas,
+				AvgQueueDepth:    avgQD,
+				AvgEPPQueueDepth: avgEPPQD,
+				AvgKVCache:       avgKV,
+				AchievedRPS:      achievedRPS,
+				ErrorCount:       errorCount,
+				IncompleteCount:  incompleteCount,
+				TTFT:             ttftJSON,
+				ITL:              itlJSON,
+				Throughput:       throughputJSON,
+				GuideLLMRaw:      guidellmRaw,
+				DurationSec:      totalDuration,
+				JobStatus:        jobStatus,
+			})
+		}
+
+		return results
+	}
+
+	// printResults outputs the results in the unified box-drawing format.
+	printResults := func(results []MultiModelResult) {
+		formatPercentiles := func(raw json.RawMessage) string {
+			if raw == nil {
+				return "n/a"
+			}
+			var m map[string]interface{}
+			if err := json.Unmarshal(raw, &m); err != nil {
+				return string(raw)
+			}
+			p50, _ := m["p50"].(float64)
+			p90, _ := m["p90"].(float64)
+			p99, _ := m["p99"].(float64)
+			if p50 == 0 && p90 == 0 && p99 == 0 {
+				return string(raw)
+			}
+			return fmt.Sprintf("p50=%.1f p90=%.1f p99=%.1f", p50, p90, p99)
+		}
+
+		GinkgoWriter.Printf("\n══════════════════════════════════════════════════════════════════\n")
+		GinkgoWriter.Printf("  MULTI-MODEL SCALING BENCHMARK RESULTS\n")
+		GinkgoWriter.Printf("  Models: %d\n", len(results))
+		GinkgoWriter.Printf("══════════════════════════════════════════════════════════════════\n\n")
+
+		for _, r := range results {
+			// Final deployment state
+			finalSpec := int32(0)
+			finalReady := int32(0)
+			dep, depErr := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(testCtx, r.DeploymentName, metav1.GetOptions{})
+			if depErr == nil && dep.Spec.Replicas != nil {
+				finalSpec = *dep.Spec.Replicas
+				finalReady = dep.Status.ReadyReplicas
+			}
+
+			GinkgoWriter.Printf("  ┌────────────────────────────────────────────────────────────\n")
+			GinkgoWriter.Printf("  │ MODEL: %s\n", r.ModelID)
+			GinkgoWriter.Printf("  │ Slug:  %s\n", r.Slug)
+			GinkgoWriter.Printf("  ├────────────────────────────────────────────────────────────\n")
+			GinkgoWriter.Printf("  │ Load Job:        %s\n", r.JobStatus)
+			GinkgoWriter.Printf("  │ Duration:        %.0fs\n", r.DurationSec)
+			GinkgoWriter.Printf("  │ Final Replicas:  spec=%d ready=%d\n", finalSpec, finalReady)
+			GinkgoWriter.Printf("  │ Max Replicas:    %d\n", r.MaxReplicas)
+			GinkgoWriter.Printf("  │ Avg Replicas:    %.2f\n", r.AvgReplicas)
+			GinkgoWriter.Printf("  ├── Prometheus Metrics ──────────────────────────────────────\n")
+			GinkgoWriter.Printf("  │ Avg KV Cache:    %.4f\n", r.AvgKVCache)
+			GinkgoWriter.Printf("  │ Avg Queue Depth: %.2f\n", r.AvgQueueDepth)
+			GinkgoWriter.Printf("  │ Avg EPP Queue:   %.2f\n", r.AvgEPPQueueDepth)
+			GinkgoWriter.Printf("  ├── GuideLLM Results ────────────────────────────────────────\n")
+			GinkgoWriter.Printf("  │ Achieved RPS:    %.2f\n", r.AchievedRPS)
+			GinkgoWriter.Printf("  │ TTFT (ms):       %s\n", formatPercentiles(r.TTFT))
+			GinkgoWriter.Printf("  │ ITL (ms):        %s\n", formatPercentiles(r.ITL))
+			GinkgoWriter.Printf("  │ Throughput:      %s\n", formatPercentiles(r.Throughput))
+			GinkgoWriter.Printf("  │ Errors:          %d\n", r.ErrorCount)
+			GinkgoWriter.Printf("  │ Incomplete:      %d\n", r.IncompleteCount)
+			GinkgoWriter.Printf("  ├── Replica Timeline (%d snapshots) ─────────────────────────\n", len(r.ReplicaTimeline))
+			for _, s := range r.ReplicaTimeline {
+				GinkgoWriter.Printf("  │   t=%.0fs  spec=%d  ready=%d\n", s.ElapsedSec, s.SpecReplicas, s.ReadyReplicas)
+			}
+			GinkgoWriter.Printf("  └────────────────────────────────────────────────────────────\n\n")
+		}
+	}
+
+	Context("WVA Multi-Model", func() {
+		It("should scale multiple models independently under prefill-heavy load", func() {
+			discoverDeployments()
+			patchAllEPPConfigs()
+			ensureDeploymentsReady()
+			createVAsAndHPAs()
+			waitForVASync()
+			launchLoadJobs()
+
+			results := monitorAndCollect()
+			printResults(results)
+
+			By("Saving multi-model benchmark results to file")
+			data, err := json.MarshalIndent(results, "", "  ")
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(multiModelResultsFile, data, 0644)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("Results saved to %s\n", multiModelResultsFile)
+		})
+	})
+
+	AfterAll(func() {
+		GinkgoWriter.Println("Multi-model benchmark complete — cleaning up")
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cleanupCancel()
+
+		for _, m := range models {
+			_ = k8sClient.BatchV1().Jobs(benchCfg.LLMDNamespace).Delete(cleanupCtx, m.JobName+"-load", metav1.DeleteOptions{
+				PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+			})
+			_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(benchCfg.LLMDNamespace).Delete(cleanupCtx, m.HPAName+"-hpa", metav1.DeleteOptions{})
+			_ = fixtures.DeleteVariantAutoscaling(cleanupCtx, crClient, benchCfg.LLMDNamespace, m.VAName)
+
+			// Scale back decode deployments to 1
+			if m.DeploymentName != "" {
+				scale, scaleErr := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).GetScale(cleanupCtx, m.DeploymentName, metav1.GetOptions{})
+				if scaleErr == nil && scale.Spec.Replicas > 1 {
+					scale.Spec.Replicas = 1
+					_, _ = k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).UpdateScale(cleanupCtx, m.DeploymentName, scale, metav1.UpdateOptions{})
+					GinkgoWriter.Printf("  Scaled %s back to 1\n", m.DeploymentName)
+				}
+			}
+		}
+	})
+})

--- a/test/benchmark/multi_model_benchmark_test.go
+++ b/test/benchmark/multi_model_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,7 +76,7 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 	)
 
 	BeforeAll(func() {
-		testCtx, testCancel = context.WithCancel(context.Background())
+		testCtx, testCancel = context.WithCancel(context.Background()) //nolint:fatcontext // top-level BeforeAll, not nested
 
 		// Parse MODELS env var (comma-separated list of model IDs)
 		modelsEnv := testconfig.GetEnv("MODELS", "")
@@ -125,7 +126,7 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 				}
 			}
 			Expect(models[i].DeploymentName).NotTo(BeEmpty(),
-				fmt.Sprintf("No decode deployment found for model slug %s", slug))
+				"No decode deployment found for model slug "+slug)
 		}
 	}
 
@@ -340,7 +341,7 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 					snap := MetricSnap{ElapsedSec: elapsed}
 					qdQuery := fmt.Sprintf(`avg(vllm:num_requests_waiting{namespace="%s",model_name="%s"})`, benchCfg.LLMDNamespace, m.ModelID)
 					kvQuery := fmt.Sprintf(`avg(vllm:kv_cache_usage_perc{namespace="%s",model_name="%s"})`, benchCfg.LLMDNamespace, m.ModelID)
-					eppPoolName := fmt.Sprintf("gaie-%s", m.Slug)
+					eppPoolName := "gaie-" + m.Slug
 					eppQDQuery := fmt.Sprintf(`sum(inference_extension_flow_control_queue_size{namespace="%s",inference_pool="%s"})`, benchCfg.LLMDNamespace, eppPoolName)
 
 					if qdResult, _, qdErr := promClient.API().Query(testCtx, qdQuery, time.Now()); qdErr == nil {
@@ -371,14 +372,14 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 					va := &variantautoscalingv1alpha1.VariantAutoscaling{}
 					if vaErr := crClient.Get(testCtx, client.ObjectKey{Namespace: benchCfg.LLMDNamespace, Name: m.VAName}, va); vaErr == nil {
 						if va.Status.DesiredOptimizedAlloc.NumReplicas != nil {
-							vaDesired = fmt.Sprintf("%d", *va.Status.DesiredOptimizedAlloc.NumReplicas)
+							vaDesired = strconv.FormatInt(int64(*va.Status.DesiredOptimizedAlloc.NumReplicas), 10)
 						}
 					}
 					hpaCurrent, hpaDesired := "?", "?"
 					hpa, hpaErr := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(benchCfg.LLMDNamespace).Get(testCtx, m.HPAName+"-hpa", metav1.GetOptions{})
 					if hpaErr == nil {
-						hpaCurrent = fmt.Sprintf("%d", hpa.Status.CurrentReplicas)
-						hpaDesired = fmt.Sprintf("%d", hpa.Status.DesiredReplicas)
+						hpaCurrent = strconv.FormatInt(int64(hpa.Status.CurrentReplicas), 10)
+						hpaDesired = strconv.FormatInt(int64(hpa.Status.DesiredReplicas), 10)
 					}
 
 					GinkgoWriter.Printf("  [%s %.0fs] replicas: spec=%d ready=%d | va=%s hpa=%s→%s | kv=%.4f qd=%.1f epp_qd=%.1f\n",
@@ -478,7 +479,7 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 			job, jobErr := k8sClient.BatchV1().Jobs(benchCfg.LLMDNamespace).Get(testCtx, jobName, metav1.GetOptions{})
 			if jobErr == nil {
 				for _, cond := range job.Status.Conditions {
-					if cond.Status == "True" {
+					if cond.Status == conditionStatusTrue {
 						jobStatus = string(cond.Type)
 						break
 					}

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -560,7 +561,7 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 				currentVA := &variantautoscalingv1alpha1.VariantAutoscaling{}
 				if vaErr := crClient.Get(ctx, client.ObjectKey{Namespace: benchCfg.LLMDNamespace, Name: res.VAName}, currentVA); vaErr == nil {
 					if currentVA.Status.DesiredOptimizedAlloc.NumReplicas != nil {
-						vaDesired = fmt.Sprintf("%d", *currentVA.Status.DesiredOptimizedAlloc.NumReplicas)
+						vaDesired = strconv.FormatInt(int64(*currentVA.Status.DesiredOptimizedAlloc.NumReplicas), 10)
 					}
 				}
 
@@ -570,8 +571,8 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 				if hpaErr == nil {
 					for i := range hpaList.Items {
 						hpa := &hpaList.Items[i]
-						hpaCurrent = fmt.Sprintf("%d", hpa.Status.CurrentReplicas)
-						hpaDesired = fmt.Sprintf("%d", hpa.Status.DesiredReplicas)
+						hpaCurrent = strconv.FormatInt(int64(hpa.Status.CurrentReplicas), 10)
+						hpaDesired = strconv.FormatInt(int64(hpa.Status.DesiredReplicas), 10)
 					}
 				}
 

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -522,15 +522,15 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 				break monitorLoop
 			case <-ticker.C:
 				elapsed := time.Since(loadStart).Seconds()
+				var spec, ready int32
 				deployment, depErr := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(ctx, res.DeploymentName, metav1.GetOptions{})
 				if depErr == nil {
-					spec := *deployment.Spec.Replicas
-					ready := deployment.Status.ReadyReplicas
+					spec = *deployment.Spec.Replicas
+					ready = deployment.Status.ReadyReplicas
 					if spec > maxReplicas {
 						maxReplicas = spec
 					}
 					timeline = append(timeline, ReplicaSnap{ElapsedSec: elapsed, SpecReplicas: spec, ReadyReplicas: ready})
-					GinkgoWriter.Printf("  [%.0fs] replicas: spec=%d ready=%d\n", elapsed, spec, ready)
 				}
 
 				// Sample KV cache, vLLM queue depth, and EPP queue depth from Prometheus
@@ -554,7 +554,31 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 					}
 				}
 				metricsTimeline = append(metricsTimeline, snap)
-				GinkgoWriter.Printf("  [%.0fs] queue_depth=%.1f epp_queue=%.1f kv_cache=%.3f\n", elapsed, snap.QueueDepth, snap.EPPQueueDepth, snap.KVCache)
+
+				// VA desired replicas
+				vaDesired := "?"
+				currentVA := &variantautoscalingv1alpha1.VariantAutoscaling{}
+				if vaErr := crClient.Get(ctx, client.ObjectKey{Namespace: benchCfg.LLMDNamespace, Name: res.VAName}, currentVA); vaErr == nil {
+					if currentVA.Status.DesiredOptimizedAlloc.NumReplicas != nil {
+						vaDesired = fmt.Sprintf("%d", *currentVA.Status.DesiredOptimizedAlloc.NumReplicas)
+					}
+				}
+
+				// HPA status
+				hpaCurrent, hpaDesired := "?", "?"
+				hpaList, hpaErr := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(benchCfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+				if hpaErr == nil {
+					for i := range hpaList.Items {
+						hpa := &hpaList.Items[i]
+						hpaCurrent = fmt.Sprintf("%d", hpa.Status.CurrentReplicas)
+						hpaDesired = fmt.Sprintf("%d", hpa.Status.DesiredReplicas)
+					}
+				}
+
+				// Consolidated single-line output matching test-multi-model-scaling format
+				GinkgoWriter.Printf("  [%s] replicas: spec=%d ready=%d | va=%s hpa=%s→%s | kv=%.4f qd=%.1f epp_qd=%.1f\n",
+					fmt.Sprintf("%.0fs", elapsed), spec, ready, vaDesired, hpaCurrent, hpaDesired,
+					snap.KVCache, snap.QueueDepth, snap.EPPQueueDepth)
 
 				// Pod-level health check for crash detection
 				pods, podErr := k8sClient.CoreV1().Pods(benchCfg.LLMDNamespace).List(ctx, metav1.ListOptions{
@@ -574,14 +598,6 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 								GinkgoWriter.Printf("  [%.0fs] Pod %s: restarts=%d state=%s\n", elapsed, p.Name, cs.RestartCount, reason)
 							}
 						}
-					}
-				}
-
-				hpaList, hpaErr := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(benchCfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
-				if hpaErr == nil {
-					for i := range hpaList.Items {
-						hpa := &hpaList.Items[i]
-						GinkgoWriter.Printf("  [%.0fs] HPA %s: current=%d desired=%d\n", elapsed, hpa.Name, hpa.Status.CurrentReplicas, hpa.Status.DesiredReplicas)
 					}
 				}
 			}
@@ -770,29 +786,54 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 		}
 		prefillResults = append(prefillResults, result)
 
-		GinkgoWriter.Printf("\n========================================\n")
-		GinkgoWriter.Printf("  %s PREFILL BENCHMARK RESULTS\n", autoscalerType)
-		GinkgoWriter.Printf("========================================\n")
-		GinkgoWriter.Printf("  Duration:        %.0fs\n", loadDuration)
-		GinkgoWriter.Printf("  Max Replicas:    %d\n", maxReplicas)
-		GinkgoWriter.Printf("  Avg Replicas:    %.2f\n", replicaAvg)
-		GinkgoWriter.Printf("  Avg Queue Depth: %.2f\n", qdAvg)
-		GinkgoWriter.Printf("  Avg EPP Queue:   %.2f\n", eppQDAvg)
-		GinkgoWriter.Printf("  Avg KV Cache:    %.3f\n", kvAvg)
-		if ttftJSON != nil {
-			GinkgoWriter.Printf("  TTFT:            %s\n", string(ttftJSON))
+		// Format TTFT/ITL/Throughput as p50/p90/p99 strings
+		formatPercentiles := func(raw json.RawMessage) string {
+			if raw == nil {
+				return "n/a"
+			}
+			var m map[string]interface{}
+			if err := json.Unmarshal(raw, &m); err != nil {
+				return string(raw)
+			}
+			p50, _ := m["p50"].(float64)
+			p90, _ := m["p90"].(float64)
+			p99, _ := m["p99"].(float64)
+			if p50 == 0 && p90 == 0 && p99 == 0 {
+				return string(raw)
+			}
+			return fmt.Sprintf("p50=%.1f p90=%.1f p99=%.1f", p50, p90, p99)
 		}
-		if itlJSON != nil {
-			GinkgoWriter.Printf("  ITL:             %s\n", string(itlJSON))
-		}
-		if throughputJSON != nil {
-			GinkgoWriter.Printf("  Throughput:      %s\n", string(throughputJSON))
-		}
-		GinkgoWriter.Printf("  Replica Timeline (%d snapshots):\n", len(timeline))
+
+		GinkgoWriter.Printf("\n  ┌────────────────────────────────────────────────────────────\n")
+		GinkgoWriter.Printf("  │ %s PREFILL BENCHMARK RESULTS\n", autoscalerType)
+		GinkgoWriter.Printf("  │ Model: %s\n", benchCfg.ModelID)
+		GinkgoWriter.Printf("  ├────────────────────────────────────────────────────────────\n")
+		GinkgoWriter.Printf("  │ Duration:        %.0fs\n", loadDuration)
+		GinkgoWriter.Printf("  │ Final Replicas:  spec=%d\n", func() int32 {
+			d, e := k8sClient.AppsV1().Deployments(benchCfg.LLMDNamespace).Get(ctx, res.DeploymentName, metav1.GetOptions{})
+			if e != nil {
+				return 0
+			}
+			return *d.Spec.Replicas
+		}())
+		GinkgoWriter.Printf("  │ Max Replicas:    %d\n", maxReplicas)
+		GinkgoWriter.Printf("  │ Avg Replicas:    %.2f\n", replicaAvg)
+		GinkgoWriter.Printf("  ├── Prometheus Metrics ──────────────────────────────────────\n")
+		GinkgoWriter.Printf("  │ Avg KV Cache:    %.4f\n", kvAvg)
+		GinkgoWriter.Printf("  │ Avg Queue Depth: %.2f\n", qdAvg)
+		GinkgoWriter.Printf("  │ Avg EPP Queue:   %.2f\n", eppQDAvg)
+		GinkgoWriter.Printf("  ├── GuideLLM Results ────────────────────────────────────────\n")
+		GinkgoWriter.Printf("  │ Achieved RPS:    %.2f\n", achievedRPS)
+		GinkgoWriter.Printf("  │ TTFT (ms):       %s\n", formatPercentiles(ttftJSON))
+		GinkgoWriter.Printf("  │ ITL (ms):        %s\n", formatPercentiles(itlJSON))
+		GinkgoWriter.Printf("  │ Throughput:      %s\n", formatPercentiles(throughputJSON))
+		GinkgoWriter.Printf("  │ Errors:          %d\n", errorCount)
+		GinkgoWriter.Printf("  │ Incomplete:      %d\n", incompleteCount)
+		GinkgoWriter.Printf("  ├── Replica Timeline (%d snapshots) ─────────────────────────\n", len(timeline))
 		for _, s := range timeline {
-			GinkgoWriter.Printf("    t=%.0fs  spec=%d  ready=%d\n", s.ElapsedSec, s.SpecReplicas, s.ReadyReplicas)
+			GinkgoWriter.Printf("  │   t=%.0fs  spec=%d  ready=%d\n", s.ElapsedSec, s.SpecReplicas, s.ReadyReplicas)
 		}
-		GinkgoWriter.Printf("========================================\n\n")
+		GinkgoWriter.Printf("  └────────────────────────────────────────────────────────────\n\n")
 
 		By("Saving prefill benchmark results to file")
 		data, _ := json.MarshalIndent(prefillResults, "", "  ")


### PR DESCRIPTION
This PR introduces a new design for installing multi-model infra via a wrapper around the current infra install scripts. This avoids changing the existing e2e infrastructure that runs several other tests. It also contains a separate make command to run multi-model tests that are in sync with existing single-model benchmark tests. Gemini was used to help with coding.
This is mostly dormant code at this point that has not been connected to CI. The following commands can help run this PR in a namespace:

```
abhishekmalvankar@wecm-9-67-159-78 llm-d-workload-variant-autoscaler % make undeploy-multi-model-infra \
  ENVIRONMENT=openshift \
  WVA_NS=asmalvan-test-3 LLMD_NS=asmalvan-test-3 \
  MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B" && \
make deploy-multi-model-infra \
  ENVIRONMENT=openshift \
  WVA_NS=asmalvan-test-3 LLMD_NS=asmalvan-test-3 \
  NAMESPACE_SCOPED=true SKIP_BUILD=true \
  DECODE_REPLICAS=1 IMG_TAG=v0.6.0 LLM_D_RELEASE=v0.6.0 \
  MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B" && \
make test-multi-model-scaling \
  ENVIRONMENT=openshift \
  LLMD_NS=asmalvan-test-3 \
  MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"
```


