### PR TITLE
Add decode hheavy mode for single model benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
+BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy)
+
+# Map scenario name to Ginkgo label filter
+ifeq ($(BENCHMARK_SCENARIO),decode_heavy)
+  BENCHMARK_LABEL_FILTER := decode-heavy
+else
+  BENCHMARK_LABEL_FILTER := phase3a
+endif
 
 # Flags for deploy/install.sh installation script
 # Full e2e / CI-style cluster infra (WVA + llm-d, no chart VA/HPA): prefer `make deploy-e2e-infra`
@@ -297,6 +305,7 @@ test-multi-model-scaling: manifests generate fmt vet ## Run multi-model scaling 
 	MM_MIN_REPLICAS=$(MM_MIN_REPLICAS) \
 	MM_MAX_REPLICAS=$(MM_MAX_REPLICAS) \
 	GATEWAY_SERVICE_NAME=multi-model-inference-gateway-istio \
+	BENCHMARK_SCENARIO=$(BENCHMARK_SCENARIO) \
 	PROMETHEUS_TOKEN=$$(oc whoami -t 2>/dev/null || echo "") \
 	go test ./test/benchmark/ -timeout 75m -v -ginkgo.v \
 		-ginkgo.label-filter="multi-model"; \
@@ -368,8 +377,8 @@ test-e2e-full-with-setup: deploy-e2e-infra test-e2e-full
 
 # Benchmark targets
 .PHONY: test-benchmark
-test-benchmark: manifests generate fmt vet ## Run benchmark tests (scale-up-latency scenario)
-	@echo "Running benchmark tests..."
+test-benchmark: manifests generate fmt vet ## Run benchmark tests. Use BENCHMARK_SCENARIO=decode_heavy for decode-heavy workload.
+	@echo "Running benchmark tests (scenario=$(BENCHMARK_SCENARIO), label=$(BENCHMARK_LABEL_FILTER))..."
 	KUBECONFIG=$(KUBECONFIG) \
 	ENVIRONMENT=$(ENVIRONMENT) \
 	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
@@ -378,9 +387,10 @@ test-benchmark: manifests generate fmt vet ## Run benchmark tests (scale-up-late
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
+	BENCHMARK_SCENARIO=$(BENCHMARK_SCENARIO) \
 	PROMETHEUS_TOKEN=$$(oc whoami -t 2>/dev/null || echo "") \
 	go test ./test/benchmark/ -timeout 75m -v -ginkgo.v \
-		-ginkgo.label-filter="phase3a"; \
+		-ginkgo.label-filter="$(BENCHMARK_LABEL_FILTER)"; \
 	TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \

--- a/test/benchmark/multi_model_benchmark_test.go
+++ b/test/benchmark/multi_model_benchmark_test.go
@@ -239,6 +239,11 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 	// launchLoadJobs creates a GuideLLM job for each model targeting the shared Gateway.
 	launchLoadJobs := func() {
 		By("Launching GuideLLM load jobs for each model")
+		scenarioName := testconfig.GetEnv("BENCHMARK_SCENARIO", "prefill_heavy")
+		scenario := LoadScenario(scenarioName)
+		GinkgoWriter.Printf("  Scenario: %s (prompt=%d, output=%d, rate=%d)\n",
+			scenario.Name, scenario.PromptTokens, scenario.OutputTokens, scenario.Rate)
+
 		gatewayName := testconfig.GetEnv("GATEWAY_SERVICE_NAME", "multi-model-inference-gateway-istio")
 		gwHost := fmt.Sprintf("%s.%s.svc.cluster.local", gatewayName, benchCfg.LLMDNamespace)
 
@@ -248,7 +253,7 @@ var _ = Describe("Multi-Model Scaling Benchmark", Ordered, Label("benchmark", "m
 
 			err := CreateGuideLLMJobWithArgs(
 				testCtx, k8sClient, benchCfg.LLMDNamespace,
-				m.JobName, targetURL, m.ModelID,
+				m.JobName, targetURL, m.ModelID, scenario,
 			)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create load job "+m.JobName)
 		}

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -75,7 +75,7 @@ var prefillResults []PrefillResult
 
 const prefillResultsFile = "/tmp/prefill-benchmark-results.json"
 
-var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark", "phase3a"), func() {
+var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -439,7 +439,7 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 		}
 	}
 
-	runPrefillBenchmark := func(autoscalerType string) {
+	runBenchmarkScenario := func(autoscalerType string, scenarioName string) {
 		ensureEPPConfig()
 		ensureInfraDeploymentReady()
 		verifyEPPConfig()
@@ -487,9 +487,13 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 
 		By("Launching GuideLLM Load Generator")
 
+		scenario := LoadScenario(scenarioName)
+		GinkgoWriter.Printf("  Scenario: %s (prompt=%d, output=%d, rate=%d)\n",
+			scenario.Name, scenario.PromptTokens, scenario.OutputTokens, scenario.Rate)
+
 		err = CreateGuideLLMJobWithArgs(
 			ctx, k8sClient, benchCfg.LLMDNamespace, res.ModelService,
-			targetURL, benchCfg.ModelID,
+			targetURL, benchCfg.ModelID, scenario,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create GuideLLM load job")
 
@@ -841,7 +845,7 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 		_ = os.WriteFile(prefillResultsFile, data, 0644)
 	}
 
-	Context("WVA", func() {
+	Context("WVA Prefill Heavy", Label("phase3a"), func() {
 		It("should run the prefill heavy workload against WVA", func() {
 			cleanupAutoscalers()
 			res.DeploymentName = findInfraDecodeDeployment()
@@ -872,7 +876,42 @@ var _ = Describe("Prefill Heavy Workload Benchmark", Ordered, Label("benchmark",
 
 			waitForVAAndMetrics()
 
-			runPrefillBenchmark("WVA")
+			runBenchmarkScenario("WVA", "prefill_heavy")
+		})
+	})
+
+	Context("WVA Decode Heavy", Label("decode-heavy"), func() {
+		It("should run the decode heavy workload against WVA", func() {
+			cleanupAutoscalers()
+			res.DeploymentName = findInfraDecodeDeployment()
+			ensureInfraDeploymentReady()
+
+			By("Creating VariantAutoscaling resource (max=10, cost=10)")
+			err := fixtures.EnsureVariantAutoscaling(
+				ctx, crClient, benchCfg.LLMDNamespace, res.VAName, res.DeploymentName,
+				benchCfg.ModelID, benchCfg.AcceleratorType, 10.0, benchCfg.ControllerInstance,
+				fixtures.WithMinReplicas(1),
+				fixtures.WithMaxReplicas(10),
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create VA")
+
+			By("Creating HPA (Scale Up: 0s/Pods/10/150, Scale Down: 240s/Pods/10/150)")
+			behavior := &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(0)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(240)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+			}
+			err = fixtures.EnsureHPA(ctx, k8sClient, benchCfg.LLMDNamespace, res.HPAName, res.DeploymentName, res.VAName, 1, 10, WithBehavior(behavior))
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA")
+
+			waitForVAAndMetrics()
+
+			runBenchmarkScenario("WVA", "decode_heavy")
 		})
 	})
 

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -810,7 +810,7 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 		}
 
 		GinkgoWriter.Printf("\n  ┌────────────────────────────────────────────────────────────\n")
-		GinkgoWriter.Printf("  │ %s PREFILL BENCHMARK RESULTS\n", autoscalerType)
+		GinkgoWriter.Printf("  │ %s %s BENCHMARK RESULTS\n", autoscalerType, strings.ToUpper(scenario.Name))
 		GinkgoWriter.Printf("  │ Model: %s\n", benchCfg.ModelID)
 		GinkgoWriter.Printf("  ├────────────────────────────────────────────────────────────\n")
 		GinkgoWriter.Printf("  │ Duration:        %.0fs\n", loadDuration)

--- a/test/benchmark/scenarios/decode_heavy.yaml
+++ b/test/benchmark/scenarios/decode_heavy.yaml
@@ -1,0 +1,8 @@
+name: "Decode Heavy"
+description: "Stress-tests decode (token generation) with short input, long output"
+promptTokens: 1000
+outputTokens: 4000
+rate: 20
+maxSeconds: 600
+profile: "poisson"
+requestType: "text_completions"

--- a/test/benchmark/scenarios/prefill_heavy.yaml
+++ b/test/benchmark/scenarios/prefill_heavy.yaml
@@ -1,0 +1,8 @@
+name: "Prefill Heavy"
+description: "Stress-tests prefill (prompt processing) with long input, short output"
+promptTokens: 4000
+outputTokens: 1000
+rate: 20
+maxSeconds: 600
+profile: "poisson"
+requestType: "text_completions"

--- a/test/benchmark/workload.go
+++ b/test/benchmark/workload.go
@@ -36,6 +36,20 @@ func scenariosDir() string {
 	return filepath.Join(filepath.Dir(thisFile), "scenarios")
 }
 
+// defaultScenario returns the fallback prefill_heavy defaults used when no
+// scenario file is found or when YAML parsing fails.
+func defaultScenario() WorkloadScenario {
+	return WorkloadScenario{
+		Name:         "Prefill Heavy (default)",
+		PromptTokens: 4000,
+		OutputTokens: 1000,
+		Rate:         20,
+		MaxSeconds:   600,
+		Profile:      "poisson",
+		RequestType:  "text_completions",
+	}
+}
+
 // LoadScenario loads a WorkloadScenario from test/benchmark/scenarios/<name>.yaml.
 // If the named file doesn't exist, it falls back to prefill_heavy defaults.
 func LoadScenario(name string) WorkloadScenario {
@@ -47,29 +61,13 @@ func LoadScenario(name string) WorkloadScenario {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		// Fallback to prefill_heavy defaults (preserves backward compatibility)
-		return WorkloadScenario{
-			Name:         "Prefill Heavy (default)",
-			PromptTokens: 4000,
-			OutputTokens: 1000,
-			Rate:         20,
-			MaxSeconds:   600,
-			Profile:      "poisson",
-			RequestType:  "text_completions",
-		}
+		return defaultScenario()
 	}
 
 	var scenario WorkloadScenario
 	if parseErr := yaml.Unmarshal(data, &scenario); parseErr != nil {
 		// On parse error, return defaults
-		return WorkloadScenario{
-			Name:         "Prefill Heavy (default)",
-			PromptTokens: 4000,
-			OutputTokens: 1000,
-			Rate:         20,
-			MaxSeconds:   600,
-			Profile:      "poisson",
-			RequestType:  "text_completions",
-		}
+		return defaultScenario()
 	}
 
 	return scenario

--- a/test/benchmark/workload.go
+++ b/test/benchmark/workload.go
@@ -3,6 +3,10 @@ package benchmark
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -11,26 +15,87 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
 )
 
-// CreateGuideLLMJobWithArgs launches a GuideLLM Job with the specified arguments.
+// WorkloadScenario defines the GuideLLM workload parameters loaded from scenarios/ YAML files.
+type WorkloadScenario struct {
+	Name         string `json:"name" yaml:"name"`
+	Description  string `json:"description,omitempty" yaml:"description,omitempty"`
+	PromptTokens int    `json:"promptTokens" yaml:"promptTokens"`
+	OutputTokens int    `json:"outputTokens" yaml:"outputTokens"`
+	Rate         int    `json:"rate" yaml:"rate"`
+	MaxSeconds   int    `json:"maxSeconds" yaml:"maxSeconds"`
+	Profile      string `json:"profile" yaml:"profile"`
+	RequestType  string `json:"requestType" yaml:"requestType"`
+}
+
+// scenariosDir returns the absolute path to the scenarios/ directory relative to this source file.
+func scenariosDir() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "scenarios")
+}
+
+// LoadScenario loads a WorkloadScenario from test/benchmark/scenarios/<name>.yaml.
+// If the named file doesn't exist, it falls back to prefill_heavy defaults.
+func LoadScenario(name string) WorkloadScenario {
+	if name == "" {
+		name = "prefill_heavy"
+	}
+
+	path := filepath.Join(scenariosDir(), name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Fallback to prefill_heavy defaults (preserves backward compatibility)
+		return WorkloadScenario{
+			Name:         "Prefill Heavy (default)",
+			PromptTokens: 4000,
+			OutputTokens: 1000,
+			Rate:         20,
+			MaxSeconds:   600,
+			Profile:      "poisson",
+			RequestType:  "text_completions",
+		}
+	}
+
+	var scenario WorkloadScenario
+	if parseErr := yaml.Unmarshal(data, &scenario); parseErr != nil {
+		// On parse error, return defaults
+		return WorkloadScenario{
+			Name:         "Prefill Heavy (default)",
+			PromptTokens: 4000,
+			OutputTokens: 1000,
+			Rate:         20,
+			MaxSeconds:   600,
+			Profile:      "poisson",
+			RequestType:  "text_completions",
+		}
+	}
+
+	return scenario
+}
+
+// CreateGuideLLMJobWithArgs launches a GuideLLM Job with parameters from the given WorkloadScenario.
 func CreateGuideLLMJobWithArgs(
 	ctx context.Context,
 	k8sClient *kubernetes.Clientset,
 	namespace, name, targetServiceURL, modelID string,
+	scenario WorkloadScenario,
 ) error {
 	image := "ghcr.io/vllm-project/guidellm:v0.5.4"
+
+	dataArg := "prompt_tokens=" + strconv.Itoa(scenario.PromptTokens) + ",output_tokens=" + strconv.Itoa(scenario.OutputTokens)
 
 	args := []string{
 		"benchmark",
 		"--target", targetServiceURL,
 		"--model", modelID,
-		"--profile", "poisson",
-		"--rate", "20",
-		"--max-seconds", "600",
+		"--profile", scenario.Profile,
+		"--rate", strconv.Itoa(scenario.Rate),
+		"--max-seconds", strconv.Itoa(scenario.MaxSeconds),
 		"--random-seed", "42",
-		"--request-type", "text_completions",
-		"--data", "prompt_tokens=4000,output_tokens=1000",
+		"--request-type", scenario.RequestType,
+		"--data", dataArg,
 		"--output-path", "/tmp/benchmarks.json",
 		"--backend-kwargs", `'{"validate_backend": false}'`,
 	}


### PR DESCRIPTION
This PR places the prefill and decode configs in a separate folder that can later be consumed by single or multi-model benchmarking mechanisms. All code changes are confined to benchmarking folders and do not touch e2e. It also adds a new decode-heavy benchmark for a single model or mult-model benchmark. Code co-authored by Gemini.

Benchmark can be run by below commands in a new namespace:

```
- make deploy-e2e-infra \
  ENVIRONMENT=openshift \
  WVA_NS=asmalvan-test-6 LLMD_NS=asmalvan-test-6 \
  E2E_EMULATED_LLMD_NAMESPACE=asmalvan-test-6 \
  NAMESPACE_SCOPED=true SKIP_BUILD=true \
  DECODE_REPLICAS=1 IMG_TAG=v0.6.0 LLM_D_RELEASE=v0.6.0
  
- make test-benchmark \
  ENVIRONMENT=openshift \
  E2E_EMULATED_LLMD_NAMESPACE=asmalvan-test-6 \
  BENCHMARK_SCENARIO=decode_heavy
  
```


benchmark passed locally:

```
STEP: Collecting pod placement details for report @ 04/19/26 21:46:23.457
    Found 4 pods with selector llm-d.ai/role=decode
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-77b55db85fdz9  Node: pokprod-b93r43s0  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-77b55db8lzq8x  Node: pokprod-b93r44s1  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-77b55db8n696w  Node: pokprod-b93r39s0  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s
    Pod: ms-inference-scheduling-llm-d-modelservice-decode-77b55db8rlkt5  Node: pokprod-b93r43s2  GPU: NVIDIA-H100-80GB-HBM3  Startup: 120s

    ┌────────────────────────────────────────────────────────────
    │ WVA PREFILL BENCHMARK RESULTS
    │ Model: unsloth/Meta-Llama-3.1-8B
    ├────────────────────────────────────────────────────────────
    │ Duration:        740s
    │ Final Replicas:  spec=4
    │ Max Replicas:    4
    │ Avg Replicas:    3.64
    ├── Prometheus Metrics ──────────────────────────────────────
    │ Avg KV Cache:    0.3340
    │ Avg Queue Depth: 10.11
    │ Avg EPP Queue:   9.92
    ├── GuideLLM Results ────────────────────────────────────────
    │ Achieved RPS:    5.40
    │ TTFT (ms):       {"count":3997,"max":32497.36762046814,"mean":1538.4853495816633,"median":285.92562675476074,"min":35.7210636138916,"mode":35.7210636138916,"pdf":null,"percentiles":{"p001":36.25035285949707,"p01":40.194034576416016,"p05":48.91467094421387,"p10":56.9915771484375,"p25":124.33409690856934,"p50":285.92562675476074,"p75":549.5150089263916,"p90":2056.1232566833496,"p95":9185.08243560791,"p99":28157.901763916016,"p999":31809.854745864868},"std_dev":4600.809631001824,"total_sum":6149325.942277908,"variance":21167449.26071914}
    │ ITL (ms):        {"count":15984003,"max":36.628584827176034,"mean":16.268019766942082,"median":15.266345661561111,"min":8.036307794924348,"mode":15.119546411871523,"pdf":null,"percentiles":{"p001":8.036380709633585,"p01":8.145714915075967,"p05":10.206220805212748,"p10":11.478933640556592,"p25":12.912144092179203,"p50":15.266345661561111,"p75":17.25071035167163,"p90":18.825635101593086,"p95":31.531479991236516,"p99":35.948614979958826,"p999":36.57885162971651},"std_dev":5.514197771448057,"total_sum":260028076.75886154,"variance":30.40637706264271}
    │ Throughput:      {"count":15988000,"max":182203.82187321634,"mean":26648.770882830493,"median":24083.194386352774,"min":50.96927957591864,"mode":7362.110045692165,"pdf":null,"percentiles":{"p001":148.20946267021733,"p01":763.9897996357013,"p05":2970.725944377201,"p10":4914.634311772007,"p25":11747.58576168231,"p50":24083.194386352774,"p75":37806.78691833575,"p90":52266.32550698138,"p95":61429.55990853658,"p99":80199.4248938429,"p999":104428.25088376697},"std_dev":18637.463416288127,"total_sum":426060548874.6939,"variance":347355042.5934783}
    │ Errors:          183
    │ Incomplete:      504
    ├── Replica Timeline (49 snapshots) ─────────────────────────
    │   t=15s  spec=4  ready=1
    │   t=30s  spec=4  ready=1
    │   t=45s  spec=4  ready=1
    │   t=60s  spec=4  ready=1
    │   t=75s  spec=4  ready=1
    │   t=90s  spec=4  ready=1
    │   t=105s  spec=4  ready=1
    │   t=120s  spec=4  ready=1
    │   t=135s  spec=4  ready=4
    │   t=150s  spec=4  ready=4
    │   t=165s  spec=4  ready=4
    │   t=180s  spec=4  ready=4
    │   t=195s  spec=4  ready=4
    │   t=210s  spec=4  ready=4
    │   t=225s  spec=4  ready=4
    │   t=240s  spec=4  ready=4
    │   t=255s  spec=4  ready=4
    │   t=270s  spec=4  ready=4
    │   t=285s  spec=4  ready=4
    │   t=300s  spec=4  ready=4
    │   t=315s  spec=4  ready=4
    │   t=330s  spec=4  ready=4
    │   t=345s  spec=4  ready=4
    │   t=360s  spec=4  ready=4
    │   t=375s  spec=4  ready=4
    │   t=390s  spec=4  ready=4
    │   t=405s  spec=4  ready=4
    │   t=420s  spec=4  ready=4
    │   t=435s  spec=4  ready=4
    │   t=450s  spec=4  ready=4
    │   t=465s  spec=4  ready=4
    │   t=480s  spec=4  ready=4
    │   t=495s  spec=4  ready=4
    │   t=510s  spec=4  ready=4
    │   t=525s  spec=4  ready=4
    │   t=540s  spec=4  ready=4
    │   t=555s  spec=4  ready=4
    │   t=570s  spec=4  ready=4
    │   t=585s  spec=4  ready=4
    │   t=600s  spec=4  ready=4
    │   t=615s  spec=4  ready=4
    │   t=630s  spec=4  ready=4
    │   t=645s  spec=4  ready=4
    │   t=660s  spec=4  ready=4
    │   t=675s  spec=4  ready=4
    │   t=690s  spec=4  ready=4
    │   t=705s  spec=4  ready=4
    │   t=720s  spec=4  ready=4
    │   t=735s  spec=4  ready=4
    └────────────────────────────────────────────────────────────

  STEP: Saving prefill benchmark results to file @ 04/19/26 21:46:24.271
  Prefill benchmark complete — cleaning up autoscalers and scaling to 1 for next test suite
  Scaled ms-inference-scheduling-llm-d-modelservice-decode back to 1 for next test suite
• [784.604 seconds]
------------------------------
[AfterSuite] 
/Users/abhishekmalvankar/multi-model-dep-ind/llm-d-workload-variant-autoscaler/test/benchmark/suite_test.go:131
  STEP: Killing Prometheus port-forward @ 04/19/26 21:46:25.43
[AfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 1 of 7 Specs in 785.954 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 6 Skipped
--- PASS: TestBenchmark (785.95s)
PASS
ok      github.com/llm-d/llm-d-workload-variant-autoscaler/test/benchmark       786.722s

```