### PR TITLE
tighten e2e fixture ensure correctness

### DIFF
--- a/test/e2e/fixtures/inference_objective.go
+++ b/test/e2e/fixtures/inference_objective.go
@@ -21,25 +21,32 @@ var inferenceObjectiveGVR = schema.GroupVersionResource{
 	Resource: "inferenceobjectives",
 }
 
-// EnsureInferenceObjective creates the e2e-default InferenceObjective for GIE flow-control
+const defaultInferenceObjectiveName = "e2e-default"
+
+// EnsureInferenceObjective creates the default InferenceObjective for GIE flow-control
 // queuing when the CRD exists. poolName must match the InferencePool metadata.name (typically the
 // EPP Service name with an "-epp" suffix removed, e.g. gaie-sim-epp → gaie-sim).
 //
 // Returns applied=true if the object exists or was created. If the InferenceObjective API is not
 // available on the cluster, returns (false, nil).
 func EnsureInferenceObjective(ctx context.Context, dc dynamic.Interface, namespace, poolName string) (applied bool, err error) {
+	return EnsureInferenceObjectiveNamed(ctx, dc, namespace, defaultInferenceObjectiveName, poolName)
+}
+
+// EnsureInferenceObjectiveNamed creates or updates a named InferenceObjective when the CRD exists.
+func EnsureInferenceObjectiveNamed(ctx context.Context, dc dynamic.Interface, namespace, objectiveName, poolName string) (applied bool, err error) {
 	ri := dc.Resource(inferenceObjectiveGVR).Namespace(namespace)
 	poolGroup, gErr := resolveInferencePoolGroup(ctx, dc, namespace, poolName)
 	if gErr != nil {
 		return false, gErr
 	}
-	obj := buildInferenceObjective(namespace, poolName, poolGroup)
+	obj := buildInferenceObjective(namespace, objectiveName, poolName, poolGroup)
 
 	if _, cErr := ri.Create(ctx, obj, metav1.CreateOptions{}); cErr != nil {
 		if apierrors.IsAlreadyExists(cErr) {
-			current, getErr := ri.Get(ctx, "e2e-default", metav1.GetOptions{})
+			current, getErr := ri.Get(ctx, objectiveName, metav1.GetOptions{})
 			if getErr != nil {
-				return false, fmt.Errorf("get existing InferenceObjective e2e-default: %w", getErr)
+				return false, fmt.Errorf("get existing InferenceObjective %s: %w", objectiveName, getErr)
 			}
 
 			currentSpec, _, specErr := unstructured.NestedMap(current.Object, "spec")
@@ -58,34 +65,39 @@ func EnsureInferenceObjective(ctx context.Context, dc dynamic.Interface, namespa
 				return false, fmt.Errorf("set desired InferenceObjective spec: %w", setErr)
 			}
 			if _, uErr := ri.Update(ctx, current, metav1.UpdateOptions{}); uErr != nil {
-				return false, fmt.Errorf("update InferenceObjective e2e-default: %w", uErr)
+				return false, fmt.Errorf("update InferenceObjective %s: %w", objectiveName, uErr)
 			}
 			return true, nil
 		}
 		if inferenceObjectiveAPIMissing(cErr) {
 			return false, nil
 		}
-		return false, fmt.Errorf("create InferenceObjective e2e-default: %w", cErr)
+		return false, fmt.Errorf("create InferenceObjective %s: %w", objectiveName, cErr)
 	}
 	return true, nil
 }
 
-// DeleteInferenceObjective removes e2e-default InferenceObjective if present.
+// DeleteInferenceObjective removes the default InferenceObjective if present.
 func DeleteInferenceObjective(ctx context.Context, dc dynamic.Interface, namespace string) error {
-	err := dc.Resource(inferenceObjectiveGVR).Namespace(namespace).Delete(ctx, "e2e-default", metav1.DeleteOptions{})
+	return DeleteInferenceObjectiveNamed(ctx, dc, namespace, defaultInferenceObjectiveName)
+}
+
+// DeleteInferenceObjectiveNamed removes a named InferenceObjective if present.
+func DeleteInferenceObjectiveNamed(ctx context.Context, dc dynamic.Interface, namespace, objectiveName string) error {
+	err := dc.Resource(inferenceObjectiveGVR).Namespace(namespace).Delete(ctx, objectiveName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) || inferenceObjectiveAPIMissing(err) {
 		return nil
 	}
 	return err
 }
 
-func buildInferenceObjective(namespace, poolName, poolGroup string) *unstructured.Unstructured {
+func buildInferenceObjective(namespace, objectiveName, poolName, poolGroup string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "inference.networking.x-k8s.io/v1alpha2",
 			"kind":       "InferenceObjective",
 			"metadata": map[string]interface{}{
-				"name":      "e2e-default",
+				"name":      objectiveName,
 				"namespace": namespace,
 			},
 			"spec": map[string]interface{}{
@@ -145,6 +157,5 @@ func resolveInferencePoolGroup(ctx context.Context, dc dynamic.Interface, namesp
 		return "", fmt.Errorf("detect InferencePool API group for %q: %w", poolName, err)
 	}
 
-	// Default to the primary group used by llm-d charts.
-	return "inference.networking.k8s.io", nil
+	return "", fmt.Errorf("detect InferencePool API group for %q: no supported InferencePool resource found", poolName)
 }

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,13 +18,14 @@ import (
 // EnsureModelServiceLWS creates or replaces a LeaderWorkerSet for model service (idempotent for test setup).
 func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32) error {
 	lwsName := name + "-decode"
+	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize)
 
 	// Check if LWS already exists
 	existingLWS := &lwsv1.LeaderWorkerSet{}
 	err := crClient.Get(ctx, client.ObjectKey{Name: lwsName, Namespace: namespace}, existingLWS)
 	if err == nil {
 		// LWS exists, check if it's ready
-		if existingLWS.Status.ReadyReplicas > 0 {
+		if existingLWS.Status.ReadyReplicas > 0 && modelServiceLWSMatchesDesired(existingLWS, desiredLWS) {
 			return nil
 		}
 		// Not ready, delete and recreate
@@ -31,10 +33,8 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClien
 		deleteErr := crClient.Delete(ctx, existingLWS, &client.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 		})
-		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
-			if !errors.IsConflict(deleteErr) {
-				return fmt.Errorf("delete existing LWS %s: %w", lwsName, deleteErr)
-			}
+		if deleteErr != nil && !errors.IsNotFound(deleteErr) && !errors.IsConflict(deleteErr) {
+			return fmt.Errorf("delete existing LWS %s: %w", lwsName, deleteErr)
 		}
 		// Wait for deletion
 		waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -53,17 +53,25 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClien
 		return fmt.Errorf("check existing LWS %s: %w", lwsName, err)
 	}
 
-	lws := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize)
-	err = crClient.Create(ctx, lws)
+	err = crClient.Create(ctx, desiredLWS)
 	if err != nil && errors.IsAlreadyExists(err) {
 		propagationPolicy := metav1.DeletePropagationForeground
-		_ = crClient.Delete(ctx, lws, &client.DeleteOptions{
+		_ = crClient.Delete(ctx, desiredLWS, &client.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 		})
 		time.Sleep(2 * time.Second)
-		err = crClient.Create(ctx, lws)
+		err = crClient.Create(ctx, desiredLWS)
 	}
 	return err
+}
+
+func modelServiceLWSMatchesDesired(existing, desired *lwsv1.LeaderWorkerSet) bool {
+	if existing == nil || desired == nil {
+		return false
+	}
+	return reflect.DeepEqual(existing.Spec, desired.Spec) &&
+		reflect.DeepEqual(existing.Labels, desired.Labels) &&
+		reflect.DeepEqual(existing.Annotations, desired.Annotations)
 }
 
 // DeleteModelServiceLWS deletes the LeaderWorkerSet for model service. Idempotent; ignores NotFound.

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -25,7 +25,7 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClien
 	err := crClient.Get(ctx, client.ObjectKey{Name: lwsName, Namespace: namespace}, existingLWS)
 	if err == nil {
 		// LWS exists, check if it's ready
-		if existingLWS.Status.ReadyReplicas > 0 && modelServiceLWSMatchesDesired(existingLWS, desiredLWS) {
+		if existingLWS.Status.ReadyReplicas > 0 && modelServiceLWSMatchesDesired(*existingLWS, *desiredLWS) {
 			return nil
 		}
 		// Not ready, delete and recreate
@@ -65,10 +65,7 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClien
 	return err
 }
 
-func modelServiceLWSMatchesDesired(existing, desired *lwsv1.LeaderWorkerSet) bool {
-	if existing == nil || desired == nil {
-		return false
-	}
+func modelServiceLWSMatchesDesired(existing, desired lwsv1.LeaderWorkerSet) bool {
 	return reflect.DeepEqual(existing.Spec, desired.Spec) &&
 		reflect.DeepEqual(existing.Labels, desired.Labels) &&
 		reflect.DeepEqual(existing.Annotations, desired.Annotations)

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -3,6 +3,7 @@ package fixtures
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -39,20 +40,19 @@ func DeleteModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) error {
 	appLabel := name + "-decode"
 	deploymentName := appLabel
+	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err == nil {
-		if existingDeployment.Status.ReadyReplicas > 0 {
+		if existingDeployment.Status.ReadyReplicas > 0 && modelServiceDeploymentMatchesDesired(existingDeployment, desiredDeployment) {
 			return nil
 		}
 		propagationPolicy := metav1.DeletePropagationForeground
 		deleteErr := k8sClient.AppsV1().Deployments(namespace).Delete(ctx, deploymentName, metav1.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 		})
-		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
-			if !errors.IsConflict(deleteErr) {
-				return fmt.Errorf("delete existing deployment %s: %w", deploymentName, deleteErr)
-			}
+		if deleteErr != nil && !errors.IsNotFound(deleteErr) && !errors.IsConflict(deleteErr) {
+			return fmt.Errorf("delete existing deployment %s: %w", deploymentName, deleteErr)
 		}
 		if err := WaitUntilDeploymentDeleted(ctx, k8sClient, namespace, deploymentName, 2*time.Minute); err != nil {
 			return fmt.Errorf("timeout waiting for deployment %s to be deleted: %w", deploymentName, err)
@@ -61,8 +61,7 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 		return fmt.Errorf("check existing deployment %s: %w", deploymentName, err)
 	}
 
-	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
-	_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, desiredDeployment, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
 		propagationPolicy := metav1.DeletePropagationForeground
 		_ = k8sClient.AppsV1().Deployments(namespace).Delete(ctx, deploymentName, metav1.DeleteOptions{
@@ -71,9 +70,18 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 		if waitErr := WaitUntilDeploymentDeleted(ctx, k8sClient, namespace, deploymentName, 2*time.Minute); waitErr != nil {
 			return fmt.Errorf("timeout waiting for deployment %s to be deleted before recreate: %w", deploymentName, waitErr)
 		}
-		_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, desiredDeployment, metav1.CreateOptions{})
 	}
 	return err
+}
+
+func modelServiceDeploymentMatchesDesired(existing, desired *appsv1.Deployment) bool {
+	if existing == nil || desired == nil {
+		return false
+	}
+	return reflect.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) &&
+		reflect.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) &&
+		reflect.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
 }
 
 func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) *appsv1.Deployment {

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -44,7 +44,7 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err == nil {
-		if existingDeployment.Status.ReadyReplicas > 0 && modelServiceDeploymentMatchesDesired(existingDeployment, desiredDeployment) {
+		if existingDeployment.Status.ReadyReplicas > 0 && modelServiceDeploymentMatchesDesired(*existingDeployment, *desiredDeployment) {
 			return nil
 		}
 		propagationPolicy := metav1.DeletePropagationForeground
@@ -75,10 +75,7 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 	return err
 }
 
-func modelServiceDeploymentMatchesDesired(existing, desired *appsv1.Deployment) bool {
-	if existing == nil || desired == nil {
-		return false
-	}
+func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) bool {
 	return reflect.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) &&
 		reflect.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) &&
 		reflect.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)


### PR DESCRIPTION
Tightens e2e fixture correctness so `Ensure*` helpers only no-op when resources are both ready and match the requested config. Also removes hardcoded InfObj identity paths (adds named variants with default compatibility) and makes InfPool group detection fail fast instead of silently defaulting.

Local full e2e pass:
```
[AfterSuite] PASSED [0.050 seconds]
------------------------------

Ran 60 of 63 Specs in 1018.360 seconds
SUCCESS! -- 60 Passed | 0 Failed | 0 Pending | 3 Skipped
--- PASS: TestE2E (1018.36s)
PASS
ok      github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e     1019.030s
```