### PR TITLE
Add ShareGPT real-dataset benchmark scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,13 @@ SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
-BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy)
+BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy), sharegpt (sharegpt)
 
 # Map scenario name to Ginkgo label filter
 ifeq ($(BENCHMARK_SCENARIO),decode_heavy)
   BENCHMARK_LABEL_FILTER := decode-heavy
+else ifeq ($(BENCHMARK_SCENARIO),sharegpt)
+  BENCHMARK_LABEL_FILTER := sharegpt
 else
   BENCHMARK_LABEL_FILTER := phase3a
 endif

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -915,6 +915,41 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 		})
 	})
 
+	Context("WVA ShareGPT", Label("sharegpt"), func() {
+		It("should run the ShareGPT real-data workload against WVA", func() {
+			cleanupAutoscalers()
+			res.DeploymentName = findInfraDecodeDeployment()
+			ensureInfraDeploymentReady()
+
+			By("Creating VariantAutoscaling resource (max=10, cost=10)")
+			err := fixtures.EnsureVariantAutoscaling(
+				ctx, crClient, benchCfg.LLMDNamespace, res.VAName, res.DeploymentName,
+				benchCfg.ModelID, benchCfg.AcceleratorType, 10.0, benchCfg.ControllerInstance,
+				fixtures.WithMinReplicas(1),
+				fixtures.WithMaxReplicas(10),
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create VA")
+
+			By("Creating HPA (Scale Up: 0s/Pods/10/150, Scale Down: 240s/Pods/10/150)")
+			behavior := &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(0)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(240)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+			}
+			err = fixtures.EnsureHPA(ctx, k8sClient, benchCfg.LLMDNamespace, res.HPAName, res.DeploymentName, res.VAName, 1, 10, WithBehavior(behavior))
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA")
+
+			waitForVAAndMetrics()
+
+			runBenchmarkScenario("WVA", "sharegpt")
+		})
+	})
+
 	AfterAll(func() {
 		GinkgoWriter.Println("Prefill benchmark complete — cleaning up autoscalers and scaling to 1 for next test suite")
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/benchmark/scenarios/sharegpt.yaml
+++ b/test/benchmark/scenarios/sharegpt.yaml
@@ -2,7 +2,7 @@ name: "ShareGPT"
 description: "Real-world decode-heavy workload using ShareGPT conversational dataset from HuggingFace"
 dataset: "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
 maxTokens: 1024
-rate: 10
+rate: 20
 maxSeconds: 600
 profile: "poisson"
 requestType: "text_completions"

--- a/test/benchmark/scenarios/sharegpt.yaml
+++ b/test/benchmark/scenarios/sharegpt.yaml
@@ -1,0 +1,8 @@
+name: "ShareGPT"
+description: "Real-world decode-heavy workload using ShareGPT conversational dataset from HuggingFace"
+dataset: "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+maxTokens: 1024
+rate: 10
+maxSeconds: 600
+profile: "poisson"
+requestType: "text_completions"

--- a/test/benchmark/workload.go
+++ b/test/benchmark/workload.go
@@ -22,12 +22,17 @@ import (
 type WorkloadScenario struct {
 	Name         string `json:"name" yaml:"name"`
 	Description  string `json:"description,omitempty" yaml:"description,omitempty"`
-	PromptTokens int    `json:"promptTokens" yaml:"promptTokens"`
-	OutputTokens int    `json:"outputTokens" yaml:"outputTokens"`
+	PromptTokens int    `json:"promptTokens,omitempty" yaml:"promptTokens,omitempty"`
+	OutputTokens int    `json:"outputTokens,omitempty" yaml:"outputTokens,omitempty"`
 	Rate         int    `json:"rate" yaml:"rate"`
 	MaxSeconds   int    `json:"maxSeconds" yaml:"maxSeconds"`
 	Profile      string `json:"profile" yaml:"profile"`
 	RequestType  string `json:"requestType" yaml:"requestType"`
+	// Dataset is an optional URL to a real dataset (e.g. ShareGPT JSON from HuggingFace).
+	// When set, the job downloads the file, converts it to JSONL (one prompt per line),
+	// and passes the JSONL path as GuideLLM's --data argument instead of synthetic data.
+	Dataset   string `json:"dataset,omitempty" yaml:"dataset,omitempty"`
+	MaxTokens int    `json:"maxTokens,omitempty" yaml:"maxTokens,omitempty"`
 }
 
 // scenariosDir returns the absolute path to the scenarios/ directory relative to this source file.
@@ -74,6 +79,8 @@ func LoadScenario(name string) WorkloadScenario {
 }
 
 // CreateGuideLLMJobWithArgs launches a GuideLLM Job with parameters from the given WorkloadScenario.
+// When scenario.Dataset is set (a URL), the job downloads and converts the dataset
+// to JSONL before running GuideLLM. Otherwise it uses synthetic prompt_tokens/output_tokens.
 func CreateGuideLLMJobWithArgs(
 	ctx context.Context,
 	k8sClient *kubernetes.Clientset,
@@ -81,8 +88,48 @@ func CreateGuideLLMJobWithArgs(
 	scenario WorkloadScenario,
 ) error {
 	image := "ghcr.io/vllm-project/guidellm:v0.5.4"
+	outputPath := "/tmp/benchmarks.json"
 
-	dataArg := "prompt_tokens=" + strconv.Itoa(scenario.PromptTokens) + ",output_tokens=" + strconv.Itoa(scenario.OutputTokens)
+	var dataArg, preamble string
+	cpuReq := "1"
+	memReq := "1Gi"
+
+	if scenario.Dataset != "" {
+		// Real dataset mode: download JSON, convert to JSONL with output_tokens_count
+		cpuReq = "2"
+		memReq = "4Gi"
+		maxTok := scenario.MaxTokens
+		if maxTok <= 0 {
+			maxTok = 1024
+		}
+		convertedPath := "/tmp/dataset.jsonl"
+		pyScript := "/tmp/convert_dataset.py"
+		preamble = fmt.Sprintf(
+			`cat > %s << 'PYEOF'
+import json, urllib.request, sys
+max_tokens = int(sys.argv[4])
+urllib.request.urlretrieve(sys.argv[1], sys.argv[2])
+with open(sys.argv[2]) as f:
+    data = json.load(f)
+count = 0
+with open(sys.argv[3], 'w') as out:
+    for item in data:
+        convs = item.get('conversations', [])
+        for turn in convs:
+            if turn.get('from') == 'human' and turn.get('value', '').strip():
+                rec = {'prompt': turn['value'].strip(), 'output_tokens_count': max_tokens}
+                out.write(json.dumps(rec) + '\n')
+                count += 1
+                break
+print(f'Converted {count} prompts to JSONL (output_tokens_count={max_tokens})')
+PYEOF
+echo 'Downloading and converting dataset...' && python3 %s %s /tmp/raw_dataset.json %s %d && `,
+			pyScript, pyScript, scenario.Dataset, convertedPath, maxTok,
+		)
+		dataArg = convertedPath
+	} else {
+		dataArg = "prompt_tokens=" + strconv.Itoa(scenario.PromptTokens) + ",output_tokens=" + strconv.Itoa(scenario.OutputTokens)
+	}
 
 	args := []string{
 		"benchmark",
@@ -94,9 +141,14 @@ func CreateGuideLLMJobWithArgs(
 		"--random-seed", "42",
 		"--request-type", scenario.RequestType,
 		"--data", dataArg,
-		"--output-path", "/tmp/benchmarks.json",
+		"--output-path", outputPath,
 		"--backend-kwargs", `'{"validate_backend": false}'`,
 	}
+
+	shellScript := fmt.Sprintf(
+		"echo 'Waiting 30s for gateway routing to propagate...' && sleep 30 && %sguidellm %s && echo '=== BENCHMARK JSON ===' && cat %s",
+		preamble, strings.Join(args, " "), outputPath,
+	)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -124,9 +176,7 @@ func CreateGuideLLMJobWithArgs(
 							Image:           image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"sh", "-c"},
-							Args: []string{
-								fmt.Sprintf("echo 'Waiting 30s for gateway routing to propagate...' && sleep 30 && guidellm %s && echo '=== BENCHMARK JSON ===' && cat /tmp/benchmarks.json", strings.Join(args, " ")),
-							},
+							Args:            []string{shellScript},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
 								{
@@ -142,8 +192,8 @@ func CreateGuideLLMJobWithArgs(
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1"),
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
+									corev1.ResourceCPU:    resource.MustParse(cpuReq),
+									corev1.ResourceMemory: resource.MustParse(memReq),
 								},
 							},
 						},


### PR DESCRIPTION
## Summary
- Extends the `WorkloadScenario` framework to support real datasets (via `dataset` URL field) alongside existing synthetic workloads
- Adds `scenarios/sharegpt.yaml` using the [ShareGPT_Vicuna dataset](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered) — a decode-heavy workload with variable-length real conversational prompts and `max_tokens=1024`
- When a scenario YAML includes a `dataset` URL, the GuideLLM job downloads, converts to JSONL (with per-record `output_tokens_count`), then benchmarks

## How to run

```bash
# Deploy infra first
make deploy-e2e-infra \
  ENVIRONMENT=openshift \
  WVA_NS=<namespace> LLMD_NS=<namespace> \
  E2E_EMULATED_LLMD_NAMESPACE=<namespace> \
  NAMESPACE_SCOPED=true SKIP_BUILD=true \
  DECODE_REPLICAS=1 IMG_TAG=v0.6.0 LLM_D_RELEASE=v0.6.0

# Run the ShareGPT benchmark
make test-benchmark \
  ENVIRONMENT=openshift \
  E2E_EMULATED_LLMD_NAMESPACE=<namespace> \
  BENCHMARK_SCENARIO=sharegpt
```

## Files changed
| File | Change |
|------|--------|
| `test/benchmark/workload.go` | Add `Dataset`/`MaxTokens` fields to `WorkloadScenario`; add dataset download/convert logic in `CreateGuideLLMJobWithArgs` |
| `test/benchmark/scenarios/sharegpt.yaml` | New scenario config for ShareGPT dataset |
| `test/benchmark/prefill_heavy_benchmark_test.go` | New `WVA ShareGPT` Ginkgo context with label `sharegpt` |
| `Makefile` | Map `BENCHMARK_SCENARIO=sharegpt` to Ginkgo label filter |

## Test plan
- [ ] Run `make test-benchmark BENCHMARK_SCENARIO=sharegpt` on OpenShift with real GPUs
- [ ] Verify dataset downloads and converts to JSONL correctly
- [ ] Verify GuideLLM completes and produces benchmark results
- [ ] Verify existing `prefill_heavy` and `decode_heavy` scenarios still work unchanged

Made with [Cursor](https://cursor.com)