### PR TITLE
fix: preserve default value for invalid bool

### DIFF
--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -52,12 +52,18 @@ func ParseIntFromConfig(data map[string]string, key string, defaultValue int, mi
 }
 
 // ParseBoolFromConfig parses a boolean from ConfigMap with default fallback
-// Accepts "true", "1", or "yes" as true values (case-sensitive)
+// Accepts "true", "1", or "yes" as true values and "false", "0", or "no" as false values (case-sensitive).
 // Returns the parsed boolean or the default value if key is missing or value is not recognized
 func ParseBoolFromConfig(data map[string]string, key string, defaultValue bool) bool {
 	if valStr := ConfigValue(data, key, ""); valStr != "" {
-		// Accept "true", "1", "yes" as true
-		return valStr == "true" || valStr == "1" || valStr == "yes"
+		switch valStr {
+		case "true", "1", "yes":
+			return true
+		case "false", "0", "no":
+			return false
+		default:
+			ctrl.Log.Info("Invalid boolean value in ConfigMap, using default", "value", valStr, "key", key, "default", defaultValue)
+		}
 	}
 	return defaultValue
 }

--- a/internal/config/helpers_test.go
+++ b/internal/config/helpers_test.go
@@ -4,6 +4,84 @@ import (
 	"testing"
 )
 
+func TestParseBoolFromConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         map[string]string
+		defaultValue bool
+		want         bool
+	}{
+		{
+			name:         "missing key keeps true default",
+			data:         map[string]string{},
+			defaultValue: true,
+			want:         true,
+		},
+		{
+			name:         "missing key keeps false default",
+			data:         map[string]string{},
+			defaultValue: false,
+			want:         false,
+		},
+		{
+			name:         "invalid value keeps true default",
+			data:         map[string]string{"enabled": "maybe"},
+			defaultValue: true,
+			want:         true,
+		},
+		{
+			name:         "invalid value keeps false default",
+			data:         map[string]string{"enabled": "maybe"},
+			defaultValue: false,
+			want:         false,
+		},
+		{
+			name:         "literal true",
+			data:         map[string]string{"enabled": "true"},
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "numeric true",
+			data:         map[string]string{"enabled": "1"},
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "yes true",
+			data:         map[string]string{"enabled": "yes"},
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "literal false",
+			data:         map[string]string{"enabled": "false"},
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "numeric false",
+			data:         map[string]string{"enabled": "0"},
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "no false",
+			data:         map[string]string{"enabled": "no"},
+			defaultValue: true,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseBoolFromConfig(tt.data, "enabled", tt.defaultValue); got != tt.want {
+				t.Fatalf("ParseBoolFromConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestQMAnalyzerConfigMapName_Default(t *testing.T) {
 	t.Setenv("QUEUEING_MODEL_CONFIG_MAP_NAME", "")
 	if got := QMAnalyzerConfigMapName(); got != "wva-queueing-model-config" {


### PR DESCRIPTION
As the comment says, default values should be used for meaningless values.

> // Returns the parsed boolean or the default value if key is missing or value is not recognized