### PR TITLE
 feat: add P/D role-aware grouping to V1 saturation analyzer path

### DIFF
--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -19,6 +19,7 @@ package saturation
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -317,6 +318,12 @@ func (e *Engine) optimize(ctx context.Context) error {
 
 // optimizeV1 runs the V1 percentage-based saturation analysis path (saturation-percentage-based).
 // Processes each model independently: analyze → enforce → convert → limiter.
+//
+// For P/D disaggregation: within each model, variants are sub-grouped by role
+// (prefill, decode, both). Each role group gets its own saturation analysis,
+// transition blocking, and scale-up/down decisions. This ensures that a prefill
+// variant transitioning doesn't block decode scaling, and that spare-capacity
+// averaging doesn't mix semantically different workload stages.
 func (e *Engine) optimizeV1(
 	ctx context.Context,
 	modelGroups map[string][]llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
@@ -344,29 +351,89 @@ func (e *Engine) optimizeV1(
 		}
 
 		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
-		saturationTargets, saturationAnalysis, data, err := e.RunSaturationAnalysis(ctx, modelID, modelVAs, saturationConfig, e.client)
+		saturationConfig.ApplyDefaults()
+
+		// Prepare model data once per model (single metrics collection pass).
+		data, err := e.prepareModelData(ctx, modelID, modelVAs, e.client)
 		if err != nil {
-			logger.Error(err, "Saturation analysis failed", "modelID", modelID)
-			if data == nil {
-				e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, nil)
-			} else {
-				e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, data.scaleTargets)
-			}
+			logger.Error(err, "Saturation data preparation failed", "modelID", modelID)
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, nil)
+			continue
+		}
+		if data == nil {
+			logger.Info("No saturation metrics available for model, skipping analysis",
+				"modelID", modelID, "namespace", namespace)
+			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, nil)
 			continue
 		}
 
-		var finalDecisions []interfaces.VariantDecision
-		if saturationAnalysis != nil && data != nil {
-			// Convert saturation targets to decisions first, then apply enforcer
-			finalDecisions = e.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, data.variantStates)
+		// Sub-group variants by role for P/D-aware analysis.
+		// Each role group gets its own saturation analysis and transition blocking
+		// so prefill and decode pipelines scale independently.
+		roleGroups := groupByRole(data.variantStates)
+		sortedRoles := sortedRoleKeys(roleGroups)
 
-			// Check if any variant has minReplicas > 0 — if so, skip scale-to-zero enforcement
+		// Per-role saturation analysis: each role group gets independent
+		// analysis, transition blocking, and scale-up/down decisions.
+		var modelDecisions []interfaces.VariantDecision
+		for _, role := range sortedRoles {
+			roleStates := roleGroups[role]
+			roleMetrics := filterReplicaMetricsByVariants(data.replicaMetrics, roleStates)
+
+			if len(roleMetrics) == 0 {
+				logger.V(logging.DEBUG).Info("No metrics for role group, skipping",
+					"modelID", modelID, "role", role,
+					"variants", variantNames(roleStates))
+				continue
+			}
+
+			// Run saturation analysis on this role sub-group.
+			// A new analyzer instance is cheap (stateless struct); avoids shared state
+			// between role groups.
+			roleAnalyzer := saturation.NewAnalyzer()
+			saturationAnalysis, err := roleAnalyzer.AnalyzeModelSaturation(
+				ctx, modelID, namespace, roleMetrics, saturationConfig)
+			if err != nil {
+				logger.Error(err, "Saturation analysis failed for role group",
+					"modelID", modelID, "role", role)
+				// Emit safety-net metrics for this role group's variants so
+				// HPA/KEDA still gets fallback signals even when analysis fails.
+				roleVAs := filterVAsByVariantStates(modelVAs, roleStates)
+				e.emitSafetyNetMetrics(ctx, roleVAs, currentAllocations, data.scaleTargets)
+				continue
+			}
+
+			logger.Info("Saturation analysis completed",
+				"modelID", modelID,
+				"role", role,
+				"totalReplicas", saturationAnalysis.TotalReplicas,
+				"nonSaturated", saturationAnalysis.NonSaturatedCount,
+				"avgSpareKv", saturationAnalysis.AvgSpareKvCapacity,
+				"avgSpareQueue", saturationAnalysis.AvgSpareQueueLength,
+				"shouldScaleUp", saturationAnalysis.ShouldScaleUp,
+				"scaleUpReason", saturationAnalysis.ScaleUpReason,
+				"scaleDownSafe", saturationAnalysis.ScaleDownSafe)
+
+			// Calculate targets and convert to decisions (transition blocking is per role group)
+			saturationTargets := roleAnalyzer.CalculateSaturationTargets(ctx, saturationAnalysis, roleStates)
+			roleDecisions := e.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, roleStates)
+
+			logger.Info("Saturation-only decisions made for role group",
+				"modelID", modelID, "role", role,
+				"decisionCount", len(roleDecisions))
+			modelDecisions = append(modelDecisions, roleDecisions...)
+		}
+
+		// Scale-to-zero enforcement is applied per MODEL (all roles together),
+		// not per role group. In P/D deployments, scaling prefill to zero while
+		// keeping decode (or vice versa) makes the model non-functional — both
+		// stages must scale together.
+		if len(modelDecisions) > 0 {
 			if !hasMinReplicasAboveZero(data.variantStates) {
-				// Apply scale-to-zero enforcement on decisions
 				scaleToZeroConfig := e.Config.ScaleToZeroConfigForNamespace(namespace)
 				scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
 					ctx, modelID, namespace,
-					finalDecisions, scaleToZeroConfig, "v1-saturation",
+					modelDecisions, scaleToZeroConfig, "v1-saturation",
 				)
 				if scaledToZero {
 					logger.Info("Scale-to-zero enforcement applied",
@@ -376,15 +443,9 @@ func (e *Engine) optimizeV1(
 				logger.V(logging.DEBUG).Info("Skipping scale-to-zero enforcement: variant has minReplicas > 0",
 					"modelID", modelID)
 			}
-
-			logger.Info("Saturation-only decisions made for model",
-				"modelID", modelID,
-				"decisionCount", len(finalDecisions))
-			allDecisions = append(allDecisions, finalDecisions...)
-		} else {
-			logger.V(logging.DEBUG).Info("Skipping decision application for model: saturation analysis is nil (likely no metrics)",
-				"modelID", modelID)
 		}
+
+		allDecisions = append(allDecisions, modelDecisions...)
 	}
 
 	// Apply GPU limiter if enabled
@@ -689,6 +750,7 @@ func (e *Engine) convertSaturationTargetsToDecisions(
 			VariantName:            variantName,
 			Namespace:              saturationAnalysis.Namespace,
 			ModelID:                saturationAnalysis.ModelID,
+			Role:                   state.Role,
 			CurrentReplicas:        state.CurrentReplicas,
 			TargetReplicas:         targetReplicas,
 			OriginalTargetReplicas: targetReplicas, // Store original before limiter modifies it
@@ -728,6 +790,86 @@ func hasMinReplicasAboveZero(states []interfaces.VariantReplicaState) bool {
 		}
 	}
 	return false
+}
+
+// normalizeRole maps empty and "both" roles to the same canonical key so that
+// non-disaggregated variants are grouped together regardless of whether the
+// deployment carries a role label.
+func normalizeRole(role string) string {
+	if role == "" {
+		return interfaces.RoleBoth
+	}
+	return role
+}
+
+// groupByRole sub-groups variant states by their P/D role.
+// Returns a map keyed by normalized role ("both", "prefill", "decode").
+// For non-disaggregated models (all "both"/""), the map contains a single entry.
+func groupByRole(states []interfaces.VariantReplicaState) map[string][]interfaces.VariantReplicaState {
+	groups := make(map[string][]interfaces.VariantReplicaState)
+	for _, s := range states {
+		key := normalizeRole(s.Role)
+		groups[key] = append(groups[key], s)
+	}
+	return groups
+}
+
+// sortedRoleKeys returns the keys of a role group map in sorted order so that
+// role processing order is deterministic across cycles (stable log output, easier
+// debugging). The sort order is lexicographic: "both" < "decode" < "prefill".
+func sortedRoleKeys(groups map[string][]interfaces.VariantReplicaState) []string {
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// filterReplicaMetricsByVariants returns only the replica metrics whose VariantName
+// appears in the given variant state slice. Used to split per-model metrics into
+// per-role subsets without re-querying Prometheus.
+func filterReplicaMetricsByVariants(metrics []interfaces.ReplicaMetrics, states []interfaces.VariantReplicaState) []interfaces.ReplicaMetrics {
+	allowed := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		allowed[s.VariantName] = struct{}{}
+	}
+	filtered := make([]interfaces.ReplicaMetrics, 0, len(metrics))
+	for _, m := range metrics {
+		if _, ok := allowed[m.VariantName]; ok {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+// filterVAsByVariantStates returns the subset of VAs whose Name appears in the
+// given variant states. Used to map a role group back to its source VAs for
+// safety-net metric emission.
+func filterVAsByVariantStates(
+	vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	states []interfaces.VariantReplicaState,
+) []llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
+	allowed := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		allowed[s.VariantName] = struct{}{}
+	}
+	filtered := make([]llmdVariantAutoscalingV1alpha1.VariantAutoscaling, 0, len(states))
+	for _, va := range vas {
+		if _, ok := allowed[va.Name]; ok {
+			filtered = append(filtered, va)
+		}
+	}
+	return filtered
+}
+
+// variantNames returns variant names from states for logging.
+func variantNames(states []interfaces.VariantReplicaState) []string {
+	names := make([]string, len(states))
+	for i, s := range states {
+		names[i] = s.VariantName
+	}
+	return names
 }
 
 // modelData holds the pre-processed data for a model, shared between V1 and V2 paths.
@@ -822,52 +964,6 @@ func (e *Engine) prepareModelData(
 		variantCosts:        variantCosts,
 		variantStates:       variantStates,
 	}, nil
-}
-
-// RunSaturationAnalysis performs V1 saturation analysis for a model and returns targets.
-// This is the V1 path only — V2 uses the optimizer flow in optimize().
-func (e *Engine) RunSaturationAnalysis(
-	ctx context.Context,
-	modelID string,
-	modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-	saturationConfig config.SaturationScalingConfig,
-	k8sClient client.Client,
-) (map[string]int, *interfaces.ModelSaturationAnalysis, *modelData, error) {
-	logger := ctrl.LoggerFrom(ctx)
-
-	saturationConfig.ApplyDefaults()
-
-	data, err := e.prepareModelData(ctx, modelID, modelVAs, k8sClient)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if data == nil {
-		return nil, nil, nil, nil // No metrics available
-	}
-
-	saturationAnalyzer := saturation.NewAnalyzer()
-	saturationAnalysis, err := saturationAnalyzer.AnalyzeModelSaturation(ctx, modelID, data.namespace, data.replicaMetrics, saturationConfig)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to analyze Saturation for model %s: %w", modelID, err)
-	}
-
-	logger.Info("Saturation analysis completed",
-		"modelID", modelID,
-		"totalReplicas", saturationAnalysis.TotalReplicas,
-		"nonSaturated", saturationAnalysis.NonSaturatedCount,
-		"avgSpareKv", saturationAnalysis.AvgSpareKvCapacity,
-		"avgSpareQueue", saturationAnalysis.AvgSpareQueueLength,
-		"shouldScaleUp", saturationAnalysis.ShouldScaleUp,
-		"scaleUpReason", saturationAnalysis.ScaleUpReason,
-		"scaleDownSafe", saturationAnalysis.ScaleDownSafe)
-
-	saturationTargets := saturationAnalyzer.CalculateSaturationTargets(ctx, saturationAnalysis, data.variantStates)
-
-	logger.V(logging.DEBUG).Info("Saturation targets calculated",
-		"modelID", modelID,
-		"targets", saturationTargets)
-
-	return saturationTargets, saturationAnalysis, data, nil
 }
 
 // applySaturationDecisions updates VA status and emits metrics based on Saturation decisions.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -49,6 +49,38 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
+// v1Analyzer is the minimal surface of *saturation.Analyzer that optimizeV1
+// depends on. Defined here so tests can substitute a stub via Engine's
+// v1AnalyzerFactory field without exposing a public interface.
+type v1Analyzer interface {
+	AnalyzeModelSaturation(
+		ctx context.Context,
+		modelID, namespace string,
+		replicaMetrics []interfaces.ReplicaMetrics,
+		config config.SaturationScalingConfig,
+	) (*interfaces.ModelSaturationAnalysis, error)
+	CalculateSaturationTargets(
+		ctx context.Context,
+		saturationAnalysis *interfaces.ModelSaturationAnalysis,
+		variantStates []interfaces.VariantReplicaState,
+	) map[string]int
+}
+
+// defaultV1AnalyzerFactory returns a fresh production V1 saturation analyzer.
+// NewEngine wires this into Engine.v1AnalyzerFactory; tests can swap the
+// factory per-instance without touching shared state.
+func defaultV1AnalyzerFactory() v1Analyzer { return saturation.NewAnalyzer() }
+
+// safetyNetEmitter reports a per-role analysis failure to the saturation
+// engine's safety-net metrics path. Extracted as a function type so the
+// per-role loop can be unit-tested with a spy.
+type safetyNetEmitter func(
+	ctx context.Context,
+	roleVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	currentAllocations map[string]*interfaces.Allocation,
+	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
+)
+
 // resolveSaturationConfig resolves config for a model.
 // Lookup: "{modelID}#{namespace}" → "default" → zero-value with defaults.
 func resolveSaturationConfig(
@@ -103,6 +135,11 @@ type Engine struct {
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
 	// CostAwareOptimizer (unlimited) or GreedyByScoreOptimizer (limited).
 	optimizer pipeline.ScalingOptimizer
+
+	// v1AnalyzerFactory produces a fresh V1 saturation analyzer for each
+	// role group in optimizeV1. NewEngine sets defaultV1AnalyzerFactory;
+	// tests can replace this per-instance to inject stubs or spies.
+	v1AnalyzerFactory func() v1Analyzer
 }
 
 // NewEngine creates a new instance of the saturation engine.
@@ -145,6 +182,7 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
+		v1AnalyzerFactory:       defaultV1AnalyzerFactory,
 	}
 
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
@@ -351,7 +389,6 @@ func (e *Engine) optimizeV1(
 		}
 
 		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
-		saturationConfig.ApplyDefaults()
 
 		// Prepare model data once per model (single metrics collection pass).
 		data, err := e.prepareModelData(ctx, modelID, modelVAs, e.client)
@@ -367,62 +404,13 @@ func (e *Engine) optimizeV1(
 			continue
 		}
 
-		// Sub-group variants by role for P/D-aware analysis.
-		// Each role group gets its own saturation analysis and transition blocking
-		// so prefill and decode pipelines scale independently.
-		roleGroups := groupByRole(data.variantStates)
-		sortedRoles := sortedRoleKeys(roleGroups)
-
 		// Per-role saturation analysis: each role group gets independent
 		// analysis, transition blocking, and scale-up/down decisions.
-		var modelDecisions []interfaces.VariantDecision
-		for _, role := range sortedRoles {
-			roleStates := roleGroups[role]
-			roleMetrics := filterReplicaMetricsByVariants(data.replicaMetrics, roleStates)
-
-			if len(roleMetrics) == 0 {
-				logger.V(logging.DEBUG).Info("No metrics for role group, skipping",
-					"modelID", modelID, "role", role,
-					"variants", variantNames(roleStates))
-				continue
-			}
-
-			// Run saturation analysis on this role sub-group.
-			// A new analyzer instance is cheap (stateless struct); avoids shared state
-			// between role groups.
-			roleAnalyzer := saturation.NewAnalyzer()
-			saturationAnalysis, err := roleAnalyzer.AnalyzeModelSaturation(
-				ctx, modelID, namespace, roleMetrics, saturationConfig)
-			if err != nil {
-				logger.Error(err, "Saturation analysis failed for role group",
-					"modelID", modelID, "role", role)
-				// Emit safety-net metrics for this role group's variants so
-				// HPA/KEDA still gets fallback signals even when analysis fails.
-				roleVAs := filterVAsByVariantStates(modelVAs, roleStates)
-				e.emitSafetyNetMetrics(ctx, roleVAs, currentAllocations, data.scaleTargets)
-				continue
-			}
-
-			logger.Info("Saturation analysis completed",
-				"modelID", modelID,
-				"role", role,
-				"totalReplicas", saturationAnalysis.TotalReplicas,
-				"nonSaturated", saturationAnalysis.NonSaturatedCount,
-				"avgSpareKv", saturationAnalysis.AvgSpareKvCapacity,
-				"avgSpareQueue", saturationAnalysis.AvgSpareQueueLength,
-				"shouldScaleUp", saturationAnalysis.ShouldScaleUp,
-				"scaleUpReason", saturationAnalysis.ScaleUpReason,
-				"scaleDownSafe", saturationAnalysis.ScaleDownSafe)
-
-			// Calculate targets and convert to decisions (transition blocking is per role group)
-			saturationTargets := roleAnalyzer.CalculateSaturationTargets(ctx, saturationAnalysis, roleStates)
-			roleDecisions := e.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, roleStates)
-
-			logger.Info("Saturation-only decisions made for role group",
-				"modelID", modelID, "role", role,
-				"decisionCount", len(roleDecisions))
-			modelDecisions = append(modelDecisions, roleDecisions...)
-		}
+		modelDecisions := e.analyzeRoleGroups(
+			ctx, modelID, namespace, saturationConfig,
+			data, modelVAs, currentAllocations,
+			e.emitSafetyNetMetrics,
+		)
 
 		// Scale-to-zero enforcement is applied per MODEL (all roles together),
 		// not per role group. In P/D deployments, scaling prefill to zero while
@@ -482,6 +470,93 @@ func (e *Engine) optimizeV1(
 	}
 
 	return allDecisions
+}
+
+// analyzeRoleGroups runs the per-role saturation analysis loop for one model.
+// It sub-groups variants by role (prefill/decode/both), runs an independent
+// saturation analysis per role group, converts each group's targets to
+// VariantDecisions, and returns the merged set for model-level scale-to-zero
+// enforcement.
+//
+// A fresh analyzer is created per group via e.v1AnalyzerFactory
+// (overridable in tests). On per-role analysis failure, emitSafetyNet is
+// invoked with that role's VAs only so the failure does not poison sibling
+// role groups.
+func (e *Engine) analyzeRoleGroups(
+	ctx context.Context,
+	modelID, namespace string,
+	saturationConfig config.SaturationScalingConfig,
+	data *modelData,
+	modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	currentAllocations map[string]*interfaces.Allocation,
+	emitSafetyNet safetyNetEmitter,
+) []interfaces.VariantDecision {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// Sub-group variants by role for P/D-aware analysis.
+	// Each role group gets its own saturation analysis and transition blocking
+	// so prefill and decode pipelines scale independently.
+	roleGroups := groupByRole(data.variantStates)
+	sortedRoles := sortedRoleKeys(roleGroups)
+
+	var modelDecisions []interfaces.VariantDecision
+	for _, role := range sortedRoles {
+		roleStates := roleGroups[role]
+		roleMetrics := filterReplicaMetricsByVariants(data.replicaMetrics, roleStates)
+
+		if len(roleMetrics) == 0 {
+			// A role group with states but no metrics is a new partial case
+			// introduced by P/D grouping (prefill has metrics, decode does
+			// not, or vice versa). Emit safety-net signals for this role's
+			// VAs so HPA/KEDA doesn't go dark while we wait for metrics to
+			// appear; model-level scale-to-zero still sees sibling-group
+			// decisions unchanged.
+			logger.Info("No metrics for role group, emitting safety-net signals",
+				"modelID", modelID, "role", role,
+				"variants", variantNames(roleStates))
+			roleVAs := filterVAsByVariantStates(modelVAs, roleStates)
+			emitSafetyNet(ctx, roleVAs, currentAllocations, data.scaleTargets)
+			continue
+		}
+
+		// A new analyzer instance is cheap (stateless struct); avoids shared
+		// state between role groups.
+		roleAnalyzer := e.v1AnalyzerFactory()
+		saturationAnalysis, err := roleAnalyzer.AnalyzeModelSaturation(
+			ctx, modelID, namespace, roleMetrics, saturationConfig)
+		if err != nil {
+			logger.Error(err, "Saturation analysis failed for role group",
+				"modelID", modelID, "role", role)
+			// Scope safety-net emission to this role group's variants only so
+			// a failure in one stage does not trigger fallback metrics for a
+			// healthy sibling stage.
+			roleVAs := filterVAsByVariantStates(modelVAs, roleStates)
+			emitSafetyNet(ctx, roleVAs, currentAllocations, data.scaleTargets)
+			continue
+		}
+
+		logger.Info("Saturation analysis completed",
+			"modelID", modelID,
+			"role", role,
+			"totalReplicas", saturationAnalysis.TotalReplicas,
+			"nonSaturated", saturationAnalysis.NonSaturatedCount,
+			"avgSpareKv", saturationAnalysis.AvgSpareKvCapacity,
+			"avgSpareQueue", saturationAnalysis.AvgSpareQueueLength,
+			"shouldScaleUp", saturationAnalysis.ShouldScaleUp,
+			"scaleUpReason", saturationAnalysis.ScaleUpReason,
+			"scaleDownSafe", saturationAnalysis.ScaleDownSafe)
+
+		// Calculate targets and convert to decisions (transition blocking is per role group)
+		saturationTargets := roleAnalyzer.CalculateSaturationTargets(ctx, saturationAnalysis, roleStates)
+		roleDecisions := e.convertSaturationTargetsToDecisions(ctx, saturationTargets, saturationAnalysis, roleStates)
+
+		logger.Info("Saturation-only decisions made for role group",
+			"modelID", modelID, "role", role,
+			"decisionCount", len(roleDecisions))
+		modelDecisions = append(modelDecisions, roleDecisions...)
+	}
+
+	return modelDecisions
 }
 
 // optimizeV2 runs the V2 token-based optimizer path (saturation-token-based).
@@ -815,8 +890,10 @@ func groupByRole(states []interfaces.VariantReplicaState) map[string][]interface
 }
 
 // sortedRoleKeys returns the keys of a role group map in sorted order so that
-// role processing order is deterministic across cycles (stable log output, easier
-// debugging). The sort order is lexicographic: "both" < "decode" < "prefill".
+// role processing order is deterministic across cycles (stable log output,
+// easier debugging). The caller is expected to pass a map whose keys were
+// produced by groupByRole, which has already canonicalized empty roles to
+// "both"; the resulting lexicographic order is then "both" < "decode" < "prefill".
 func sortedRoleKeys(groups map[string][]interfaces.VariantReplicaState) []string {
 	keys := make([]string, 0, len(groups))
 	for k := range groups {

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -263,10 +263,12 @@ var _ = Describe("Saturation Engine", func() {
 				},
 			}
 
+			// Populate Role to verify it propagates to VariantDecision in the
+			// P/D-aware path (empty, prefill, decode cover the common cases).
 			variantStates := []interfaces.VariantReplicaState{
-				{VariantName: "variant-a", CurrentReplicas: 3, DesiredReplicas: 3},
-				{VariantName: "variant-b", CurrentReplicas: 3, DesiredReplicas: 3},
-				{VariantName: "variant-c", CurrentReplicas: 2, DesiredReplicas: 2},
+				{VariantName: "variant-a", CurrentReplicas: 3, DesiredReplicas: 3, Role: ""},
+				{VariantName: "variant-b", CurrentReplicas: 3, DesiredReplicas: 3, Role: "prefill"},
+				{VariantName: "variant-c", CurrentReplicas: 2, DesiredReplicas: 2, Role: "decode"},
 			}
 
 			By("Converting saturation targets to decisions")
@@ -290,6 +292,11 @@ var _ = Describe("Saturation Engine", func() {
 			Expect(decisionMap["variant-a"].Action).To(Equal(interfaces.ActionNoChange))
 			Expect(decisionMap["variant-b"].Action).To(Equal(interfaces.ActionScaleUp))
 			Expect(decisionMap["variant-c"].Action).To(Equal(interfaces.ActionNoChange))
+
+			By("Verifying Role propagates from VariantReplicaState to VariantDecision")
+			Expect(decisionMap["variant-a"].Role).To(Equal(""), "empty role must pass through unchanged")
+			Expect(decisionMap["variant-b"].Role).To(Equal("prefill"))
+			Expect(decisionMap["variant-c"].Role).To(Equal("decode"))
 		})
 	})
 

--- a/internal/engines/saturation/role_grouping_loop_test.go
+++ b/internal/engines/saturation/role_grouping_loop_test.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// stubAnalyzer is a controllable v1Analyzer for loop-coverage tests.
+// It records every AnalyzeModelSaturation call. The analysis (or error)
+// returned per call is looked up by walking replicaMetrics in slice order
+// and returning on the first VariantName found in errByVariant or
+// analysisByVariant; tests keep each role group's metrics to exactly one
+// variant so the lookup is unambiguous.
+type stubAnalyzer struct {
+	// callMetrics captures the replicaMetrics slice handed to each call so
+	// tests can assert per-role scoping of analyzer input.
+	callMetrics [][]interfaces.ReplicaMetrics
+	// analysisByVariant returns the ModelSaturationAnalysis the stub should
+	// produce when a matching variant name appears in the incoming metrics.
+	analysisByVariant map[string]*interfaces.ModelSaturationAnalysis
+	// errByVariant returns an error when a matching variant name appears
+	// in the incoming metrics.
+	errByVariant map[string]error
+	// targetsByVariant overrides CalculateSaturationTargets outputs keyed on
+	// the first variant name present in variantStates.
+	targetsByVariant map[string]map[string]int
+}
+
+func (s *stubAnalyzer) AnalyzeModelSaturation(
+	_ context.Context,
+	modelID, namespace string,
+	replicaMetrics []interfaces.ReplicaMetrics,
+	_ config.SaturationScalingConfig,
+) (*interfaces.ModelSaturationAnalysis, error) {
+	s.callMetrics = append(s.callMetrics, append([]interfaces.ReplicaMetrics(nil), replicaMetrics...))
+	for _, m := range replicaMetrics {
+		if err, ok := s.errByVariant[m.VariantName]; ok {
+			return nil, err
+		}
+		if a, ok := s.analysisByVariant[m.VariantName]; ok {
+			return a, nil
+		}
+	}
+	return &interfaces.ModelSaturationAnalysis{ModelID: modelID, Namespace: namespace}, nil
+}
+
+func (s *stubAnalyzer) CalculateSaturationTargets(
+	_ context.Context,
+	_ *interfaces.ModelSaturationAnalysis,
+	variantStates []interfaces.VariantReplicaState,
+) map[string]int {
+	if len(variantStates) > 0 {
+		if t, ok := s.targetsByVariant[variantStates[0].VariantName]; ok {
+			return t
+		}
+	}
+	// Default: target == current replicas for every state.
+	out := make(map[string]int, len(variantStates))
+	for _, st := range variantStates {
+		out[st.VariantName] = st.CurrentReplicas
+	}
+	return out
+}
+
+// engineWithStub returns an Engine whose v1AnalyzerFactory yields stub on
+// every call. Kept per-instance (no package-level state) so tests are
+// naturally isolated.
+func engineWithStub(stub *stubAnalyzer) *Engine {
+	return &Engine{v1AnalyzerFactory: func() v1Analyzer { return stub }}
+}
+
+// uniqueVariantCount returns the number of distinct VariantNames in m,
+// used to assert that each role group's metrics are scoped to exactly the
+// variants in that role.
+func uniqueVariantCount(m []interfaces.ReplicaMetrics) int {
+	seen := map[string]struct{}{}
+	for _, r := range m {
+		seen[r.VariantName] = struct{}{}
+	}
+	return len(seen)
+}
+
+// pdFixture is the standard prefill+decode fixture shared by the P/D
+// role-grouping tests. Individual tests mutate the returned slices in
+// place if they need different CurrentReplicas, etc.
+type pdFixture struct {
+	data     *modelData
+	modelVAs []llmdVariantAutoscalingV1alpha1.VariantAutoscaling
+}
+
+func newPDFixture() pdFixture {
+	return pdFixture{
+		data: &modelData{
+			variantStates: []interfaces.VariantReplicaState{
+				{VariantName: "prefill-h100", Role: "prefill", CurrentReplicas: 1},
+				{VariantName: "decode-l4", Role: "decode", CurrentReplicas: 1},
+			},
+			replicaMetrics: []interfaces.ReplicaMetrics{
+				{VariantName: "prefill-h100", PodName: "pod-p1"},
+				{VariantName: "decode-l4", PodName: "pod-d1"},
+			},
+		},
+		modelVAs: []llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+			{ObjectMeta: metav1.ObjectMeta{Name: "prefill-h100", Namespace: "ns"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "decode-l4", Namespace: "ns"}},
+		},
+	}
+}
+
+// collectSafetyNetVAs returns a spy emitSafetyNet closure that appends each
+// call's VA name set into calls.
+func collectSafetyNetVAs(calls *[][]string) safetyNetEmitter {
+	return func(
+		_ context.Context,
+		vas []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+		_ map[string]*interfaces.Allocation,
+		_ map[string]scaletarget.ScaleTargetAccessor,
+	) {
+		names := make([]string, 0, len(vas))
+		for _, v := range vas {
+			names = append(names, v.Name)
+		}
+		*calls = append(*calls, names)
+	}
+}
+
+// noopSafetyNet is used when a test does not exercise the failure path.
+func noopSafetyNet(
+	_ context.Context,
+	_ []llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	_ map[string]*interfaces.Allocation,
+	_ map[string]scaletarget.ScaleTargetAccessor,
+) {
+}
+
+func TestAnalyzeRoleGroups_DisaggregatedModel_TwoIndependentAnalyses(t *testing.T) {
+	stub := &stubAnalyzer{
+		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+			"prefill-h100": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "prefill-h100", ReplicaCount: 1},
+				},
+			},
+			"decode-l4": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "decode-l4", ReplicaCount: 1},
+				},
+			},
+		},
+		targetsByVariant: map[string]map[string]int{
+			"prefill-h100": {"prefill-h100": 2}, // scale up
+			"decode-l4":    {"decode-l4": 1},    // no change
+		},
+	}
+	fx := newPDFixture()
+	e := engineWithStub(stub)
+
+	decisions := e.analyzeRoleGroups(
+		context.Background(),
+		"m", "ns",
+		config.SaturationScalingConfig{},
+		fx.data, fx.modelVAs, nil,
+		noopSafetyNet,
+	)
+
+	// Two independent analyzer invocations, one per role group, each scoped
+	// to its own variant's metrics only.
+	require.Len(t, stub.callMetrics, 2, "expected one AnalyzeModelSaturation call per role group")
+	for _, m := range stub.callMetrics {
+		require.Equal(t, 1, uniqueVariantCount(m), "each role group should receive exactly one variant's metrics")
+	}
+
+	// Both role groups must produce a decision; Role field must propagate.
+	byVariant := map[string]interfaces.VariantDecision{}
+	for _, d := range decisions {
+		byVariant[d.VariantName] = d
+	}
+	require.Contains(t, byVariant, "prefill-h100")
+	require.Contains(t, byVariant, "decode-l4")
+	assert.Equal(t, "prefill", byVariant["prefill-h100"].Role)
+	assert.Equal(t, "decode", byVariant["decode-l4"].Role)
+	assert.Equal(t, interfaces.ActionScaleUp, byVariant["prefill-h100"].Action)
+	assert.Equal(t, interfaces.ActionNoChange, byVariant["decode-l4"].Action)
+}
+
+func TestAnalyzeRoleGroups_HomogeneousModel_SingleGroup(t *testing.T) {
+	stub := &stubAnalyzer{
+		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+			"variant-a": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "variant-a", ReplicaCount: 2},
+					{VariantName: "variant-b", ReplicaCount: 1},
+				},
+			},
+		},
+		targetsByVariant: map[string]map[string]int{
+			"variant-a": {"variant-a": 2, "variant-b": 1},
+		},
+	}
+	e := engineWithStub(stub)
+
+	data := &modelData{
+		variantStates: []interfaces.VariantReplicaState{
+			{VariantName: "variant-a", Role: "", CurrentReplicas: 2},
+			{VariantName: "variant-b", Role: "", CurrentReplicas: 1},
+		},
+		replicaMetrics: []interfaces.ReplicaMetrics{
+			{VariantName: "variant-a", PodName: "a-1"},
+			{VariantName: "variant-a", PodName: "a-2"},
+			{VariantName: "variant-b", PodName: "b-1"},
+		},
+	}
+	modelVAs := []llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		{ObjectMeta: metav1.ObjectMeta{Name: "variant-a", Namespace: "ns"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "variant-b", Namespace: "ns"}},
+	}
+
+	decisions := e.analyzeRoleGroups(
+		context.Background(),
+		"m", "ns",
+		config.SaturationScalingConfig{},
+		data, modelVAs, nil,
+		noopSafetyNet,
+	)
+
+	require.Len(t, stub.callMetrics, 1, "homogeneous-role model should collapse to a single analyzer call")
+	require.Len(t, decisions, 2)
+	// Role defaults to empty for non-disaggregated variants; propagated verbatim.
+	byVariant := map[string]interfaces.VariantDecision{}
+	for _, d := range decisions {
+		byVariant[d.VariantName] = d
+	}
+	assert.Equal(t, "", byVariant["variant-a"].Role)
+	assert.Equal(t, "", byVariant["variant-b"].Role)
+}
+
+func TestAnalyzeRoleGroups_PerRoleFailure_SafetyNetScopedToFailingRole(t *testing.T) {
+	analysisErr := errors.New("prefill analyzer blew up")
+	stub := &stubAnalyzer{
+		errByVariant: map[string]error{"prefill-h100": analysisErr},
+		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+			"decode-l4": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "decode-l4", ReplicaCount: 1},
+				},
+			},
+		},
+		targetsByVariant: map[string]map[string]int{
+			"decode-l4": {"decode-l4": 1},
+		},
+	}
+	fx := newPDFixture()
+	e := engineWithStub(stub)
+
+	var safetyVAs [][]string
+	decisions := e.analyzeRoleGroups(
+		context.Background(),
+		"m", "ns",
+		config.SaturationScalingConfig{},
+		fx.data, fx.modelVAs, nil,
+		collectSafetyNetVAs(&safetyVAs),
+	)
+
+	// Safety-net must be invoked exactly once, with only the failing role's VAs.
+	require.Len(t, safetyVAs, 1, "safety-net should fire once for the failing role group")
+	assert.Equal(t, []string{"prefill-h100"}, safetyVAs[0],
+		"safety-net scope must be limited to the failing role's VAs")
+
+	// Sibling role group still produces its decision.
+	require.Len(t, decisions, 1)
+	assert.Equal(t, "decode-l4", decisions[0].VariantName)
+	assert.Equal(t, "decode", decisions[0].Role)
+}
+
+func TestAnalyzeRoleGroups_MergesDecisionsAcrossRoles(t *testing.T) {
+	// Covers the reviewer's "scale-to-zero with mixed roles" scenario at the
+	// analyzeRoleGroups boundary: both role groups produce decisions, and the
+	// merged slice (which optimizeV1 forwards to ScaleToZeroEnforcer) contains
+	// entries from every group.
+	stub := &stubAnalyzer{
+		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+			"prefill-h100": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "prefill-h100", ReplicaCount: 1},
+				},
+			},
+			"decode-l4": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "decode-l4", ReplicaCount: 1},
+				},
+			},
+		},
+		targetsByVariant: map[string]map[string]int{
+			"prefill-h100": {"prefill-h100": 0}, // scale to zero
+			"decode-l4":    {"decode-l4": 0},    // scale to zero
+		},
+	}
+	fx := newPDFixture()
+	e := engineWithStub(stub)
+
+	decisions := e.analyzeRoleGroups(
+		context.Background(),
+		"m", "ns",
+		config.SaturationScalingConfig{},
+		fx.data, fx.modelVAs, nil,
+		noopSafetyNet,
+	)
+
+	require.Len(t, decisions, 2, "merged decisions must include both role groups for scale-to-zero enforcement")
+	roles := map[string]struct{}{}
+	for _, d := range decisions {
+		roles[d.Role] = struct{}{}
+		assert.Equal(t, interfaces.ActionScaleDown, d.Action)
+	}
+	assert.Contains(t, roles, "prefill")
+	assert.Contains(t, roles, "decode")
+}
+
+func TestAnalyzeRoleGroups_RoleGroupWithoutMetrics_EmitsSafetyNet(t *testing.T) {
+	stub := &stubAnalyzer{
+		analysisByVariant: map[string]*interfaces.ModelSaturationAnalysis{
+			"decode-l4": {
+				ModelID:   "m",
+				Namespace: "ns",
+				VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+					{VariantName: "decode-l4", ReplicaCount: 1},
+				},
+			},
+		},
+		targetsByVariant: map[string]map[string]int{
+			"decode-l4": {"decode-l4": 1},
+		},
+	}
+	e := engineWithStub(stub)
+
+	// prefill has states but no metrics; decode has both. The metric-less
+	// role must still get safety-net emission (scoped to its own VAs) so
+	// HPA/KEDA does not go dark while prefill waits for metrics to appear.
+	fx := newPDFixture()
+	fx.data.replicaMetrics = []interfaces.ReplicaMetrics{
+		{VariantName: "decode-l4", PodName: "pod-d1"},
+	}
+
+	var safetyVAs [][]string
+	decisions := e.analyzeRoleGroups(
+		context.Background(),
+		"m", "ns",
+		config.SaturationScalingConfig{},
+		fx.data, fx.modelVAs, nil,
+		collectSafetyNetVAs(&safetyVAs),
+	)
+
+	require.Len(t, stub.callMetrics, 1, "analyzer should only be invoked for the role group that has metrics")
+	require.Len(t, safetyVAs, 1, "the metric-less role group must trigger one safety-net emission")
+	assert.Equal(t, []string{"prefill-h100"}, safetyVAs[0],
+		"safety-net scope must be limited to the metric-less role's VAs")
+	require.Len(t, decisions, 1)
+	assert.Equal(t, "decode-l4", decisions[0].VariantName)
+}
+
+func TestSortedRoleKeys_DeterministicOrder(t *testing.T) {
+	// Exercises the precondition promised in sortedRoleKeys: callers pass
+	// keys that groupByRole has already normalized, so the resulting order
+	// is stable lexicographic.
+	groups := map[string][]interfaces.VariantReplicaState{
+		"prefill": nil,
+		"both":    nil,
+		"decode":  nil,
+	}
+	got := sortedRoleKeys(groups)
+	assert.Equal(t, []string{"both", "decode", "prefill"}, got)
+
+	// Single-group and empty-map cases.
+	assert.Equal(t, []string{interfaces.RoleBoth},
+		sortedRoleKeys(map[string][]interfaces.VariantReplicaState{interfaces.RoleBoth: nil}))
+	assert.Empty(t, sortedRoleKeys(map[string][]interfaces.VariantReplicaState{}))
+}

--- a/internal/engines/saturation/role_grouping_test.go
+++ b/internal/engines/saturation/role_grouping_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func TestNormalizeRole(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"empty maps to both", "", interfaces.RoleBoth},
+		{"both stays both", "both", interfaces.RoleBoth},
+		{"prefill stays prefill", "prefill", "prefill"},
+		{"decode stays decode", "decode", "decode"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, normalizeRole(tc.input))
+		})
+	}
+}
+
+func TestGroupByRole(t *testing.T) {
+	t.Run("non-disaggregated model produces single group", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "v1", Role: "both"},
+			{VariantName: "v2", Role: ""},
+			{VariantName: "v3", Role: "both"},
+		}
+		groups := groupByRole(states)
+		require.Len(t, groups, 1)
+		require.Contains(t, groups, "both")
+		assert.Len(t, groups["both"], 3)
+	})
+
+	t.Run("disaggregated model produces per-role groups", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100", Role: "prefill"},
+			{VariantName: "prefill-a100", Role: "prefill"},
+			{VariantName: "decode-l4", Role: "decode"},
+		}
+		groups := groupByRole(states)
+		require.Len(t, groups, 2)
+		assert.Len(t, groups["prefill"], 2)
+		assert.Len(t, groups["decode"], 1)
+	})
+
+	t.Run("mixed roles produce three groups", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100", Role: "prefill"},
+			{VariantName: "decode-l4", Role: "decode"},
+			{VariantName: "both-a100", Role: "both"},
+		}
+		groups := groupByRole(states)
+		require.Len(t, groups, 3)
+		assert.Len(t, groups["prefill"], 1)
+		assert.Len(t, groups["decode"], 1)
+		assert.Len(t, groups["both"], 1)
+	})
+
+	t.Run("empty states produce empty map", func(t *testing.T) {
+		groups := groupByRole(nil)
+		assert.Empty(t, groups)
+	})
+}
+
+func TestFilterReplicaMetricsByVariants(t *testing.T) {
+	metrics := []interfaces.ReplicaMetrics{
+		{VariantName: "prefill-h100", PodName: "pod-1"},
+		{VariantName: "prefill-h100", PodName: "pod-2"},
+		{VariantName: "decode-l4", PodName: "pod-3"},
+		{VariantName: "decode-l4", PodName: "pod-4"},
+		{VariantName: "both-a100", PodName: "pod-5"},
+	}
+
+	t.Run("filter prefill only", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100"},
+		}
+		filtered := filterReplicaMetricsByVariants(metrics, states)
+		assert.Len(t, filtered, 2)
+		for _, m := range filtered {
+			assert.Equal(t, "prefill-h100", m.VariantName)
+		}
+	})
+
+	t.Run("filter decode only", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "decode-l4"},
+		}
+		filtered := filterReplicaMetricsByVariants(metrics, states)
+		assert.Len(t, filtered, 2)
+		for _, m := range filtered {
+			assert.Equal(t, "decode-l4", m.VariantName)
+		}
+	})
+
+	t.Run("filter all variants returns all metrics", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100"},
+			{VariantName: "decode-l4"},
+			{VariantName: "both-a100"},
+		}
+		filtered := filterReplicaMetricsByVariants(metrics, states)
+		assert.Len(t, filtered, 5)
+	})
+
+	t.Run("filter no variants returns empty", func(t *testing.T) {
+		filtered := filterReplicaMetricsByVariants(metrics, nil)
+		assert.Empty(t, filtered)
+	})
+}
+
+func TestFilterVAsByVariantStates(t *testing.T) {
+	vas := []llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		{ObjectMeta: metav1.ObjectMeta{Name: "prefill-h100"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "decode-l4"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "both-a100"}},
+	}
+
+	t.Run("filter to prefill only", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100"},
+		}
+		filtered := filterVAsByVariantStates(vas, states)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "prefill-h100", filtered[0].Name)
+	})
+
+	t.Run("filter to all returns all", func(t *testing.T) {
+		states := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-h100"},
+			{VariantName: "decode-l4"},
+			{VariantName: "both-a100"},
+		}
+		filtered := filterVAsByVariantStates(vas, states)
+		assert.Len(t, filtered, 3)
+	})
+
+	t.Run("empty states returns empty", func(t *testing.T) {
+		filtered := filterVAsByVariantStates(vas, nil)
+		assert.Empty(t, filtered)
+	})
+}
+
+func TestVariantNames(t *testing.T) {
+	states := []interfaces.VariantReplicaState{
+		{VariantName: "v1"},
+		{VariantName: "v2"},
+		{VariantName: "v3"},
+	}
+	names := variantNames(states)
+	assert.Equal(t, []string{"v1", "v2", "v3"}, names)
+}


### PR DESCRIPTION
### Summary

The V1 saturation analyzer grouped variants by model only. In P/D-disaggregated deployments (separate prefill and decode variants serving the same model), this produced incorrect scaling: spare capacity averaging mixed roles, transition blocking was too broad, and scale-up/down targeted the wrong pipeline stage.

This PR sub-groups variants by `(model, role)` for saturation analysis and scaling decisions, while keeping scale-to-zero enforcement at the model level (both P/D stages must scale together).

### Problem

In a P/D deployment with `prefill-h100` and `decode-l4` variants serving `llama-70b`:

1. **Mixed averaging** — prefill KV-cache usage averaged with decode KV-cache usage produces a signal that doesn't accurately represent either stage
2. **Over-broad blocking** — a prefill variant transitioning (desired ≠ current) blocked ALL variants of the model from scaling, including decode variants that could have responded to their own saturation
3. **Wrong target** — scale-up picked the cheapest variant across the entire model, not within the saturated pipeline stage (e.g., cheapest prefill variant when decode was the bottleneck)

### Design: three-level enforcement

```
Per role:   analyze → targets → decisions    (independent per role)
Per model:  scale-to-zero enforcement        (all roles together)
Per cycle:  GPU limiter                      (all models together)
```

- **Saturation analysis, transition blocking, scale-up/down** are per `(model, role)` — prefill and decode scale independently based on their own metrics.
- **Scale-to-zero** is per model — scaling prefill to zero while keeping decode (or vice versa) makes the model non-functional, so both stages must scale together. The enforcer sees all decisions for the model across all roles.
- **GPU limiter** is per cycle — unchanged, applied globally after all models.

### Changes

**`internal/engines/saturation/engine.go`**

- `optimizeV1` refactored: after `prepareModelData` collects metrics once per model (single Prometheus query pass preserved), variants are sub-grouped by role via `groupByRole`. Each role group runs `AnalyzeModelSaturation` + `CalculateSaturationTargets` + `convertSaturationTargetsToDecisions` independently.
- Transition blocking now operates per `(model, role)` — prefill transitioning does not block decode.
- Scale-up targets the cheapest variant within the role; scale-down targets the most expensive within the role.
- Scale-to-zero enforcement applied per model after role loop — `hasMinReplicasAboveZero` checks all variants regardless of role, enforcer sees all decisions across roles.
- Safety-net metrics emitted per role group on analysis failure (via `filterVAsByVariantStates`).
- Role group iteration is deterministic (sorted keys via `sortedRoleKeys`).
- `scaleToZeroConfig` read once per model (hoisted out of role loop).
- `Role` field set on V1 `VariantDecision` (was previously unset).
- Removed dead `RunSaturationAnalysis` method (no callers after refactor).

New helper functions:
- `groupByRole(states)` — sub-groups by normalized role (`""` and `"both"` treated identically)
- `filterReplicaMetricsByVariants(metrics, states)` — filters metrics to a role's variant set without re-querying Prometheus
- `filterVAsByVariantStates(vas, states)` — maps role group back to source VAs for safety-net emission
- `sortedRoleKeys(groups)` — deterministic iteration order
- `normalizeRole(role)` — `""` → `"both"`
- `variantNames(states)` — for logging

**`internal/engines/saturation/role_grouping_test.go`** (new)

16 unit tests covering all helper functions:
- `TestNormalizeRole` — 4 cases (empty, both, prefill, decode)
- `TestGroupByRole` — 4 cases (non-P/D, P/D, mixed, empty)
- `TestFilterReplicaMetricsByVariants` — 4 cases (single role, all, none)
- `TestFilterVAsByVariantStates` — 3 cases (single role, all, empty)
- `TestVariantNames` — 1 case

### Backward compatibility

For non-disaggregated models (all variants have role `"both"` or `""`):
- `groupByRole` produces a single entry `{"both": [all states]}`
- `filterReplicaMetricsByVariants` returns all metrics (identity)
- Single call to `AnalyzeModelSaturation` with the same inputs → same analysis
- Single call to `CalculateSaturationTargets` with the same states → same targets, same transition blocking
- Scale-to-zero applied to the single group's decisions → same as before
- **Behavior is identical to pre-refactor**

Verified by: existing envtest suite passes unchanged.

### Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/engines/saturation/...` (envtest via WSL) — all pass (existing suite + 16 new unit tests)
- [x] `go test ./internal/saturation/...` — pass
- [x] `golangci-lint run ./internal/engines/saturation/...` — 0 issues
- [x] CI pipelines green on PR
