### PR TITLE
Add DEPLOY_PROMETHEUS_ADAPTER=false to multi-model benchmark guide

### DIFF
--- a/docs/developer-guide/multi-model-benchmark-guide.md
+++ b/docs/developer-guide/multi-model-benchmark-guide.md
@@ -129,6 +129,7 @@ make deploy-multi-model-infra \
   WVA_NS=<your-namespace> LLMD_NS=<your-namespace> \
   NAMESPACE_SCOPED=true SKIP_BUILD=true \
   DECODE_REPLICAS=1 IMG_TAG=v0.6.0 LLM_D_RELEASE=v0.6.0 \
+  DEPLOY_PROMETHEUS_ADAPTER=false \
   MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"
 
 # 3. Run the benchmark


### PR DESCRIPTION
## Summary
- Adds `DEPLOY_PROMETHEUS_ADAPTER=false` to the multi-model deploy command in the benchmark guide

## Files changed
| File | Change |
|------|--------|
| `docs/developer-guide/multi-model-benchmark-guide.md` | Add `DEPLOY_PROMETHEUS_ADAPTER=false` flag to deploy command |

Made with [Cursor](https://cursor.com)