### PR TITLE
docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -51,12 +51,17 @@ Summary of WVA benchmark runs with configuration details.
 ## Prefill Heavy Scenario
 
 **llm-d Release:** v0.6.0
+<<<<<<< HEAD
 **Model:** meta-llama/Llama-3.1-8B-Instruct
+=======
+**Model:** unsloth/Meta-Llama-3.1-8B
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
 | Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (prefill) |
 |--------|----------------|------------------------|
+<<<<<<< HEAD
 | P99 TTFT (ms) | _TBD_ | _TBD_ |
 | P99 ITL (ms) | _TBD_ | _TBD_ |
 | Avg replicas | _TBD_ | _TBD_ |
@@ -65,16 +70,31 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | _TBD_ | _TBD_ |
 | Error count | _TBD_ | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
+=======
+| P99 TTFT (ms) | 64,968 | _TBD_ |
+| P99 ITL (ms) | 68.45 | _TBD_ |
+| Avg replicas | 1.91 | _TBD_ |
+| Max replicas | 2 | _TBD_ |
+| Avg KV cache utilization | 0.4307 | _TBD_ |
+| Avg queue depth (EPP) | 158.36 | _TBD_ |
+| Error count | 361 (510 incomplete) | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.91 | _TBD_ |
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
+<<<<<<< HEAD
 **Model:** meta-llama/Llama-3.1-8B-Instruct
+=======
+**Model:** unsloth/Meta-Llama-3.1-8B
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
 | Metric |WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (decode) |
 |--------|----------------|------------------------|
+<<<<<<< HEAD
 | P99 TTFT (ms) | _TBD_ | _TBD_ |
 | P99 ITL (ms) | _TBD_ | _TBD_ |
 | Avg replicas | _TBD_ | _TBD_ |
@@ -83,16 +103,31 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | _TBD_ | _TBD_ |
 | Error count | _TBD_ | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
+=======
+| P99 TTFT (ms) | 41,361 | _TBD_ |
+| P99 ITL (ms) | 38.03 | _TBD_ |
+| Avg replicas | 1.92 | _TBD_ |
+| Max replicas | 2 | _TBD_ |
+| Avg KV cache utilization | 0.5155 | _TBD_ |
+| Avg queue depth (EPP) | 34.25 | _TBD_ |
+| Error count | 192 (511 incomplete) | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.92 | _TBD_ |
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0
+<<<<<<< HEAD
 **Model:** meta-llama/Llama-3.1-8B-Instruct
+=======
+**Model:** unsloth/Meta-Llama-3.1-8B
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1)
 
 | Metric | WVA v0.6.0 Default(v1) |
 |--------|----------------|
+<<<<<<< HEAD
 | P99 TTFT (ms) | _TBD_ |
 | P99 ITL (ms) | _TBD_ |
 | Avg replicas | _TBD_ |
@@ -101,3 +136,13 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | _TBD_ |
 | Error count | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ |
+=======
+| P99 TTFT (ms) | 2,188 |
+| P99 ITL (ms) | 35.09 |
+| Avg replicas | 1.92 |
+| Max replicas | 2 |
+| Avg KV cache utilization | 0.2110 |
+| Avg queue depth (EPP) | 4.38 |
+| Error count | 0 (343 incomplete) |
+| Cost (avg replicas × GPU/hr) | 1.92 |
+>>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -51,26 +51,12 @@ Summary of WVA benchmark runs with configuration details.
 ## Prefill Heavy Scenario
 
 **llm-d Release:** v0.6.0
-<<<<<<< HEAD
-**Model:** meta-llama/Llama-3.1-8B-Instruct
-=======
 **Model:** unsloth/Meta-Llama-3.1-8B
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
 | Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (prefill) |
 |--------|----------------|------------------------|
-<<<<<<< HEAD
-| P99 TTFT (ms) | _TBD_ | _TBD_ |
-| P99 ITL (ms) | _TBD_ | _TBD_ |
-| Avg replicas | _TBD_ | _TBD_ |
-| Max replicas | _TBD_ | _TBD_ |
-| Avg KV cache utilization | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | _TBD_ | _TBD_ |
-| Error count | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
-=======
 | P99 TTFT (ms) | 64,968 | _TBD_ |
 | P99 ITL (ms) | 68.45 | _TBD_ |
 | Avg replicas | 1.91 | _TBD_ |
@@ -79,31 +65,16 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | 158.36 | _TBD_ |
 | Error count | 361 (510 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.91 | _TBD_ |
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
-<<<<<<< HEAD
-**Model:** meta-llama/Llama-3.1-8B-Instruct
-=======
 **Model:** unsloth/Meta-Llama-3.1-8B
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
 | Metric |WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (decode) |
 |--------|----------------|------------------------|
-<<<<<<< HEAD
-| P99 TTFT (ms) | _TBD_ | _TBD_ |
-| P99 ITL (ms) | _TBD_ | _TBD_ |
-| Avg replicas | _TBD_ | _TBD_ |
-| Max replicas | _TBD_ | _TBD_ |
-| Avg KV cache utilization | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | _TBD_ | _TBD_ |
-| Error count | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
-=======
 | P99 TTFT (ms) | 41,361 | _TBD_ |
 | P99 ITL (ms) | 38.03 | _TBD_ |
 | Avg replicas | 1.92 | _TBD_ |
@@ -112,31 +83,16 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | 34.25 | _TBD_ |
 | Error count | 192 (511 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.92 | _TBD_ |
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0
-<<<<<<< HEAD
-**Model:** meta-llama/Llama-3.1-8B-Instruct
-=======
 **Model:** unsloth/Meta-Llama-3.1-8B
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1)
 
 | Metric | WVA v0.6.0 Default(v1) |
 |--------|----------------|
-<<<<<<< HEAD
-| P99 TTFT (ms) | _TBD_ |
-| P99 ITL (ms) | _TBD_ |
-| Avg replicas | _TBD_ |
-| Max replicas | _TBD_ |
-| Avg KV cache utilization | _TBD_ |
-| Avg queue depth (EPP) | _TBD_ |
-| Error count | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ |
-=======
 | P99 TTFT (ms) | 2,188 |
 | P99 ITL (ms) | 35.09 |
 | Avg replicas | 1.92 |
@@ -145,4 +101,3 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | 4.38 |
 | Error count | 0 (343 incomplete) |
 | Cost (avg replicas × GPU/hr) | 1.92 |
->>>>>>> 5f2f280 (docs: Add WVA benchmark results for prefill heavy, decode heavy, and symmetrical scenarios)

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -66,6 +66,21 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 361 (510 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.91 | _TBD_ |
 
+### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
+
+All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 97,988 | 98,770 | 98,575 | 98,444 |
+| P99 ITL (ms/token) | 54.49 | 54.56 | 54.60 | 54.55 |
+| Avg replicas | 1.68 | 1.73 | 1.73 | 1.71 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 68.7% | 67.5% | 63.5% | 66.6% |
+| Avg queue depth (EPP) | 242.1 | 242.6 | 231.1 | 238.6 |
+| Error count | 4,185 / 4,890 | 4,174 / 4,874 | 4,171 / 4,871 | 4,177 / 4,878 |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
@@ -84,6 +99,21 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 192 (511 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.92 | _TBD_ |
 
+### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
+
+All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 98,271 | 98,100 | 98,368 | 98,246 |
+| P99 ITL (ms/token) | 54.64 | 54.87 | 54.26 | 54.59 |
+| Avg replicas | 1.75 | 1.75 | 1.75 | 1.75 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 64.8% | 63.5% | 65.4% | 64.5% |
+| Avg queue depth (EPP) | 226.1 | 228.4 | 231.9 | 228.8 |
+| Error count | 4,180 / 4,860 | 4,194 / 4,893 | 4,180 / 4,880 | 4,185 / 4,878 |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0
@@ -101,3 +131,18 @@ Summary of WVA benchmark runs with configuration details.
 | Avg queue depth (EPP) | 4.38 |
 | Error count | 0 (343 incomplete) |
 | Cost (avg replicas × GPU/hr) | 1.92 |
+
+### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
+
+All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 98,403 | 98,847 | 98,622 | 98,624 |
+| P99 ITL (ms/token) | 54.41 | 54.58 | 54.48 | 54.49 |
+| Avg replicas | 1.73 | 1.75 | 1.75 | 1.74 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 68.4% | 65.4% | 63.4% | 65.7% |
+| Avg queue depth (EPP) | 231.9 | 223.3 | 213.2 | 222.8 |
+| Error count | 4,171 / 4,871 | 4,174 / 4,874 | 4,171 / 4,871 | 4,172 / 4,872 |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -66,21 +66,6 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 361 (510 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.91 | _TBD_ |
 
-### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
-
-All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
-
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 97,988 | 98,770 | 98,575 | 98,444 |
-| P99 ITL (ms/token) | 54.49 | 54.56 | 54.60 | 54.55 |
-| Avg replicas | 1.68 | 1.73 | 1.73 | 1.71 |
-| Max replicas | 3 | 3 | 3 | 3 |
-| Avg KV cache utilization | 68.7% | 67.5% | 63.5% | 66.6% |
-| Avg queue depth (EPP) | 242.1 | 242.6 | 231.1 | 238.6 |
-| Error count | 4,185 / 4,890 | 4,174 / 4,874 | 4,171 / 4,871 | 4,177 / 4,878 |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
@@ -99,21 +84,6 @@ All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShi
 | Error count | 192 (511 incomplete) | _TBD_ |
 | Cost (avg replicas × GPU/hr) | 1.92 | _TBD_ |
 
-### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
-
-All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
-
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 98,271 | 98,100 | 98,368 | 98,246 |
-| P99 ITL (ms/token) | 54.64 | 54.87 | 54.26 | 54.59 |
-| Avg replicas | 1.75 | 1.75 | 1.75 | 1.75 |
-| Max replicas | 3 | 3 | 3 | 3 |
-| Avg KV cache utilization | 64.8% | 63.5% | 65.4% | 64.5% |
-| Avg queue depth (EPP) | 226.1 | 228.4 | 231.9 | 228.8 |
-| Error count | 4,180 / 4,860 | 4,194 / 4,893 | 4,180 / 4,880 | 4,185 / 4,878 |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0
@@ -131,18 +101,3 @@ All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShi
 | Avg queue depth (EPP) | 4.38 |
 | Error count | 0 (343 incomplete) |
 | Cost (avg replicas × GPU/hr) | 1.92 |
-
-### 3-Run Validation — Qwen/Qwen3-32B (WVA v0.6.0 Default(v1))
-
-All runs use WVA v0.6.0 Default(v1) configuration with Qwen/Qwen3-32B on OpenShift with NVIDIA H100 GPUs.
-
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 98,403 | 98,847 | 98,622 | 98,624 |
-| P99 ITL (ms/token) | 54.41 | 54.58 | 54.48 | 54.49 |
-| Avg replicas | 1.73 | 1.75 | 1.75 | 1.74 |
-| Max replicas | 3 | 3 | 3 | 3 |
-| Avg KV cache utilization | 68.4% | 65.4% | 63.4% | 65.7% |
-| Avg queue depth (EPP) | 231.9 | 223.3 | 213.2 | 222.8 |
-| Error count | 4,171 / 4,871 | 4,174 / 4,874 | 4,171 / 4,871 | 4,172 / 4,872 |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |


### PR DESCRIPTION
## Summary

- Adds `docs/benchmark.md` with benchmark result tables for three WVA workload scenarios: **Prefill Heavy**, **Decode Heavy**, and **Symmetrical**.
- Tables currently contain TBD placeholders — results will be filled in after running benchmarks on OpenShift with real H100 GPUs.
- Tracks environment, EPP, WVA (v1 default + tuned), and HPA configurations alongside per-scenario metrics (TTFT p99, ITL p99, replicas, KV cache, queue depth, errors, cost).

## Test plan

- [ ] Run prefill heavy benchmark (`BENCHMARK_SCENARIO=prefill_heavy`) and collect results
- [ ] Run decode heavy benchmark (`BENCHMARK_SCENARIO=decode_heavy`) and collect results
- [ ] Run symmetrical benchmark (`BENCHMARK_SCENARIO=symmetrical`) and collect results
- [ ] Fill in all TBD fields with actual metrics
- [ ] Verify markdown renders correctly on GitHub


Made with [Cursor](https://cursor.com)