### PR TITLE
engines/analyzers/throughput: add state management package (PR-3)

### DIFF
--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -239,8 +239,8 @@ Per-variant state is minimal:
 
 | Field | What it holds |
 |---|---|
-| `ShapeTracker` | Three EMA floats: IL, OL, prefix hit rate |
-| `ObservationWindow` | Rolling slice of ≤ 10 `(k*, ITL_obs)` pairs + timestamps |
+| `ShapeTracker` | Current workload shape snapshot (IL, OL, hit rate); overwritten each cycle |
+| `ObservationWindow` | Rolling slice of ≤ 20 `(k*, ITL_obs)` pairs + timestamps |
 | `lastSanityReport` | Most recent sanity check result |
 | `lastObservedAt` | Timestamp of last observation |
 
@@ -479,7 +479,7 @@ use the same decode-rate framework.
 | `DefaultKSat` | 0.85 | KV utilization at which μ_dec_sat is evaluated |
 | `DefaultBaselineITLSec` | 0.006 | B in tier-2 ITL model (H100 near-zero-load baseline) |
 | `DefaultQueueDrainFactor` | 2.0 | Bounds queueing time to ≤ factor × ITL(k_sat) × OL |
-| `DefaultWindowMaxSize` | 100 | Max (k*, ITL) pairs in ObservationWindow |
+| `DefaultWindowMaxSize` | 20 | Max (k*, ITL) pairs in ObservationWindow |
 | `DefaultObservationMaxAge` | 30m | Observations older than this are pruned |
 | `DefaultMinSamples` | 10 | Minimum samples for OLS Ready flag |
 | `DefaultMinKSpread` | 0.30 | Minimum k-spread for OLS Ready flag |

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -197,11 +197,26 @@ The remaining TA fields (`TotalKvCapacityTokens`, `AvgITL`, `AvgOutputTokens`, `
 `PrefixCacheHitRate`, `ArrivalRate`) are populated by saturation and queueing model queries.
 
 **ShapeTracker (`shape_tracker.go`)**  
-Maintains the current workload shape bucket `(IL, OL, IL_eff, KVreq)`. Detects shape changes
+Maintains the current workload shape bucket `(IL, OL, H%, IL_eff, KVreq)`. Detects shape changes
 (>20% shift in IL or OL) and triggers observation window reset.
 
-- `IL_eff = IL × (1 − PrefixCacheHitRate)` — effective input length after prefix cache
+- `IL_eff = IL × (1 − H%)` — effective input length after prefix cache
 - `KVreq = IL_eff + OL/2` — time-averaged KV footprint per decode request
+
+**Shape dimensions — design note:**  
+The tracker stores IL, OL, and H% but change detection uses only IL and OL (see `Within()`).
+H% is stored because it feeds IL_eff and KVreq; a H%-only change does not reset the window.
+
+The minimal sufficient representation for KVreq is `(OL, IL_eff)` rather than `(IL, OL, H%)`
+separately — we track all three because it is not yet clear whether IL and H% should be treated
+as independent shape dimensions or collapsed into IL_eff alone.
+
+Likewise, the slope A in `ITL(k) = A·k + B` may be independent of H%: A captures how quickly
+decode latency grows with KV load, which is driven by hardware and concurrency, not by the
+fraction of input tokens served from cache. We do not have enough data to confirm this yet.
+If it holds, a H%-only shift would warrant updating only B (via a new Tier-2 constrained fit)
+while carrying over the previous A — avoiding a full window reset.  
+*(This is a potential future optimization; the current implementation resets nothing on H%-only changes.)*
 
 **ObservationWindow (`observation_window.go`)**  
 Rolling window of `(k*, ITL_obs)` pairs collected per replica per cycle. Filters observations

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -15,10 +15,10 @@ operating point, and scales before demand exceeds that supply.
 - **λ_dec** — decode token demand: how many tokens/sec the scheduler is dispatching to this model
 - **ITL(k)** — inter-token latency as a function of KV utilization k: fitted as `A·k + B` via OLS
 
-> **Status (PR-1/PR-2 — query registration + collector wiring):** Three PromQL queries
-> registered; `GenerationTokenRate`, `KvUsageInstant`, and `VLLMRequestRate` fields wired in the
-> collector. Full analyzer implementation (ShapeTracker, ObservationWindow, ITL model,
-> `ThroughputAnalyzer`) and engine wiring are pending PR-3 through PR-5.
+> **Implementation status:** Query registration, collector wiring (three PromQL queries +
+> `GenerationTokenRate`, `KvUsageInstant`, `VLLMRequestRate` fields), ShapeTracker,
+> ObservationWindow, and SanityReport are implemented. ITL model fitting, supply/demand estimation,
+> scaling signal (full `ThroughputAnalyzer`), and engine wiring are not yet implemented.
 
 ## Table of Contents
 
@@ -162,9 +162,9 @@ namespace filtering limitation of the scheduler metric.
 
 ## Architecture
 
-> **Note:** The Query Registration and Metrics Collector components below are implemented in
-> PR-1/PR-2. All other components — Package Structure, ShapeTracker, ObservationWindow, ITLModel,
-> ThroughputAnalyzer, Analysis Pipeline, and Data Flow — are **pending PR-3/PR-4**.
+> **Note:** Query Registration, Metrics Collector, Package Structure, ShapeTracker,
+> ObservationWindow, and SanityReport are implemented. ITLModel, full ThroughputAnalyzer,
+> Analysis Pipeline, and Data Flow are **not yet implemented**.
 
 ### Package Structure
 
@@ -342,7 +342,7 @@ On leader failover the incoming leader starts with an empty analyzer. During war
 
 ## ITL Model Calibration
 
-> **Pending: PR-3/PR-4.**
+> **Not yet implemented.**
 
 The ITL model `ITL(k) = A·k + B` captures how inter-token latency grows with KV cache
 utilization k. It is calibrated independently per variant (different hardware → different A, B).
@@ -374,7 +374,7 @@ zero-replica fallback using the last successful tier-1 fit. It is not wired into
 
 ## Supply Estimation
 
-> **Pending: PR-3/PR-4.**
+> **Not yet implemented.**
 
 Per replica `r`:
 
@@ -392,7 +392,7 @@ per-analyzer constant pending alignment with the EPP system-wide k_sat (see open
 
 ## Demand Estimation
 
-> **Pending: PR-3/PR-4.**
+> **Not yet implemented.**
 
 ### Priority Chain
 
@@ -441,7 +441,7 @@ variant** — `Σ VariantCapacity.TotalDemand ≤ result.TotalDemand` when a que
 
 ## Scaling Signal
 
-> **Pending: PR-3/PR-4.**
+> **Not yet implemented.**
 
 ### Model-Level Aggregation
 

--- a/docs/developer-guide/throughput-analyzer.md
+++ b/docs/developer-guide/throughput-analyzer.md
@@ -216,6 +216,25 @@ Implements `interfaces.Analyzer`. Groups replicas by `VariantName`, runs sanity 
 updates per-variant shape tracker and observation window in `Observe()`, then computes
 supply, demand, and model-level RC/SC signals in `Analyze()`.
 
+### State and High Availability
+
+`ThroughputAnalyzer` is stateful across reconcile cycles: it accumulates `(k*, ITL)` observations until the window is ready to fit the ITL model. The state is **in-memory only** — a `map[string]*variantState` held inside the analyzer instance, with no persistence to etcd or Kubernetes.
+
+Per-variant state is minimal:
+
+| Field | What it holds |
+|---|---|
+| `ShapeTracker` | Three EMA floats: IL, OL, prefix hit rate |
+| `ObservationWindow` | Rolling slice of ≤ 10 `(k*, ITL_obs)` pairs + timestamps |
+| `lastSanityReport` | Most recent sanity check result |
+| `lastObservedAt` | Timestamp of last observation |
+
+**In HA mode**, the engine reconciliation loops run only on the elected leader (gated in `main.go`). The `ThroughputAnalyzer` instance lives inside that loop — state is local to the leader process and is never shared across replicas.
+
+On leader failover the incoming leader starts with an empty analyzer. During warm-up (until the observation window re-accumulates ≥ 10 samples with ≥ 0.30 k-spread), the TA emits no scaling signal (`RC = 0, SC = 0`). The saturation analyzer runs unaffected and provides coverage throughout. Warm-up completes within a few minutes at normal traffic levels.
+
+**No external state store is needed.** State loss on failover is equivalent to a workload shape change (which already clears the window by design). The gap is bounded and temporary; adding a ConfigMap or lease annotation to persist calibration state would not be worth the added complexity at this stage.
+
 ### Analysis Pipeline
 
 ```

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -1,0 +1,217 @@
+package throughput
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+// ThroughputAnalyzer accumulates per-variant workload shape and ITL observations
+// across reconcile cycles. It implements interfaces.Analyzer; in the current phase
+// it produces no scaling signal (RequiredCapacity=0, SpareCapacity=0). The OLS fit,
+// μ_dec supply estimation, and λ_dec vs μ_dec scaling signal are added in PR-4.
+//
+// State is tracked per variant (keyed by "namespace|modelID|variantName") because
+// different variants may run on different hardware with different ITL coefficients,
+// and all replicas of the same variant are expected to share OL, IL, and KV_max.
+type ThroughputAnalyzer struct {
+	mu            sync.Mutex
+	variantStates map[string]*variantState
+}
+
+// variantState holds the cross-cycle calibration state for a single variant.
+type variantState struct {
+	shapeTracker      *ShapeTracker
+	observationWindow *ObservationWindow
+	lastSanityReport  SanityReport
+	lastObservedAt    time.Time
+}
+
+// NewThroughputAnalyzer creates a ThroughputAnalyzer with default configuration.
+func NewThroughputAnalyzer() *ThroughputAnalyzer {
+	return &ThroughputAnalyzer{
+		variantStates: make(map[string]*variantState),
+	}
+}
+
+// Name returns the canonical name for this analyzer.
+func (a *ThroughputAnalyzer) Name() string {
+	return AnalyzerName
+}
+
+// Observe processes one reconcile cycle for a model. It groups metrics by
+// VariantName and, for each variant:
+//  1. Runs sanity checks; skips the variant if any issue is found.
+//  2. Computes the variant-average IL, OL, and prefix hit rate.
+//  3. Updates the shape tracker; clears the observation window on shape change.
+//  4. Adds one (k, ITL) observation per replica to the window.
+//  5. Prunes observations older than DefaultObservationMaxAge.
+//
+// Returns a map of variantName → SanityReport for logging. An empty SanityReport
+// (report.OK() == true) means that variant's metrics were healthy this cycle.
+func (a *ThroughputAnalyzer) Observe(
+	ctx context.Context,
+	modelID, namespace string,
+	metrics []interfaces.ReplicaMetrics,
+) map[string]SanityReport {
+	now := time.Now()
+	byVariant := groupByVariant(metrics)
+	reports := make(map[string]SanityReport, len(byVariant))
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for variantName, variantMetrics := range byVariant {
+		report := CheckModelMetrics(variantMetrics)
+		reports[variantName] = report
+
+		key := variantKey(namespace, modelID, variantName)
+		state := a.getOrCreateVariantState(key)
+		state.lastSanityReport = report
+		state.lastObservedAt = now
+
+		if !report.OK() {
+			ctrl.Log.V(logging.DEBUG).Info("throughput analyzer: sanity issues detected, skipping variant",
+				"namespace", namespace,
+				"modelID", modelID,
+				"variant", variantName,
+				"issues", report.Issues,
+				"affectedPods", report.AffectedPods,
+			)
+			continue
+		}
+
+		// Compute variant-average shape metrics. All replicas of the same variant
+		// are expected to have the same OL and IL (same model, same config); the
+		// mean handles any minor per-pod variation.
+		il, ol, hitRate := averageShapeMetrics(variantMetrics)
+
+		shape, changed := state.shapeTracker.Observe(il, ol, hitRate)
+		if changed {
+			ctrl.Log.V(logging.DEBUG).Info("throughput analyzer: workload shape changed, clearing observation window",
+				"namespace", namespace,
+				"modelID", modelID,
+				"variant", variantName,
+				"newKVreq", shape.KVreq,
+			)
+			state.observationWindow.Clear()
+		}
+
+		// Collect one (k, ITL) observation per replica. Per-replica variation in k
+		// provides the k-spread needed for a reliable OLS fit.
+		for _, m := range variantMetrics {
+			state.observationWindow.Add(m.KvCacheUsage, m.AvgITL, now)
+		}
+		state.observationWindow.Prune(now)
+	}
+
+	return reports
+}
+
+// Analyze implements interfaces.Analyzer. It calls Observe to update internal
+// state and returns an AnalyzerResult with no scaling signal (PR-3 scope).
+// The OLS fit and μ_dec vs λ_dec scaling signal are added in PR-4.
+func (a *ThroughputAnalyzer) Analyze(
+	ctx context.Context,
+	input interfaces.AnalyzerInput,
+) (*interfaces.AnalyzerResult, error) {
+	a.Observe(ctx, input.ModelID, input.Namespace, input.ReplicaMetrics)
+
+	return &interfaces.AnalyzerResult{
+		AnalyzerName: AnalyzerName,
+		ModelID:      input.ModelID,
+		Namespace:    input.Namespace,
+		AnalyzedAt:   time.Now(),
+		// RequiredCapacity and SpareCapacity are zero until PR-4 adds the
+		// ITL model fit and μ_dec vs λ_dec computation.
+	}, nil
+}
+
+// VariantState returns a read-only snapshot of the per-variant calibration state.
+// Returns (zero ThroughputVariantState, false) if no data has been observed yet
+// for the given variant.
+func (a *ThroughputAnalyzer) VariantState(modelID, namespace, variantName string) (ThroughputVariantState, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	key := variantKey(namespace, modelID, variantName)
+	state, ok := a.variantStates[key]
+	if !ok {
+		return ThroughputVariantState{}, false
+	}
+
+	shape, _ := state.shapeTracker.Current()
+	return ThroughputVariantState{
+		Shape:            shape,
+		ObservationReady: state.observationWindow.Ready(),
+		KSpread:          state.observationWindow.KSpread(),
+		SampleCount:      state.observationWindow.Len(),
+		LastSanityReport: state.lastSanityReport,
+	}, true
+}
+
+// --- helpers ---
+
+// variantKey builds the map key for a variant. The pipe delimiter is safe because
+// Kubernetes resource names follow DNS rules and cannot contain "|".
+func variantKey(namespace, modelID, variantName string) string {
+	return fmt.Sprintf("%s|%s|%s", namespace, modelID, variantName)
+}
+
+// getOrCreateVariantState returns the variantState for the given key, creating
+// it with default configuration if it does not exist yet.
+// Must be called with a.mu held.
+func (a *ThroughputAnalyzer) getOrCreateVariantState(key string) *variantState {
+	if state, ok := a.variantStates[key]; ok {
+		return state
+	}
+	state := &variantState{
+		shapeTracker: newShapeTracker(DefaultShapeChangeTolerance),
+		observationWindow: newObservationWindow(
+			DefaultWindowMaxSize,
+			DefaultObservationMaxAge,
+			DefaultMinSamples,
+			DefaultMinKSpread,
+			DefaultMinObservableK,
+			DefaultMaxObservableK,
+		),
+	}
+	a.variantStates[key] = state
+	return state
+}
+
+// groupByVariant partitions a slice of ReplicaMetrics by VariantName.
+func groupByVariant(metrics []interfaces.ReplicaMetrics) map[string][]interfaces.ReplicaMetrics {
+	groups := make(map[string][]interfaces.ReplicaMetrics)
+	for _, m := range metrics {
+		groups[m.VariantName] = append(groups[m.VariantName], m)
+	}
+	return groups
+}
+
+// averageShapeMetrics computes the mean IL, OL, and prefix hit rate across a
+// slice of replica metrics. Replicas with zero OL or IL are excluded from the
+// average (they lack workload data this cycle).
+func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate float64) {
+	var sumIL, sumOL, sumHitRate float64
+	var count float64
+	for _, m := range metrics {
+		if m.AvgInputTokens <= 0 || m.AvgOutputTokens <= 0 {
+			continue
+		}
+		sumIL += m.AvgInputTokens
+		sumOL += m.AvgOutputTokens
+		sumHitRate += m.PrefixCacheHitRate
+		count++
+	}
+	if count == 0 {
+		return 0, 0, 0
+	}
+	return sumIL / count, sumOL / count, sumHitRate / count
+}

--- a/internal/engines/analyzers/throughput/analyzer.go
+++ b/internal/engines/analyzers/throughput/analyzer.go
@@ -2,7 +2,6 @@ package throughput
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -57,10 +56,10 @@ func (a *ThroughputAnalyzer) Name() string {
 // (report.OK() == true) means that variant's metrics were healthy this cycle.
 func (a *ThroughputAnalyzer) Observe(
 	ctx context.Context,
+	now time.Time,
 	modelID, namespace string,
 	metrics []interfaces.ReplicaMetrics,
 ) map[string]SanityReport {
-	now := time.Now()
 	byVariant := groupByVariant(metrics)
 	reports := make(map[string]SanityReport, len(byVariant))
 
@@ -111,6 +110,15 @@ func (a *ThroughputAnalyzer) Observe(
 		state.observationWindow.Prune(now)
 	}
 
+	// Evict variant states not observed for longer than twice the observation
+	// max age. Prevents stale entries from deleted/recreated VAs from
+	// accumulating in memory and causing false shape-change signals on recreate.
+	for key, state := range a.variantStates {
+		if now.Sub(state.lastObservedAt) > 2*DefaultObservationMaxAge {
+			delete(a.variantStates, key)
+		}
+	}
+
 	return reports
 }
 
@@ -121,13 +129,14 @@ func (a *ThroughputAnalyzer) Analyze(
 	ctx context.Context,
 	input interfaces.AnalyzerInput,
 ) (*interfaces.AnalyzerResult, error) {
-	a.Observe(ctx, input.ModelID, input.Namespace, input.ReplicaMetrics)
+	now := time.Now()
+	a.Observe(ctx, now, input.ModelID, input.Namespace, input.ReplicaMetrics)
 
 	return &interfaces.AnalyzerResult{
 		AnalyzerName: AnalyzerName,
 		ModelID:      input.ModelID,
 		Namespace:    input.Namespace,
-		AnalyzedAt:   time.Now(),
+		AnalyzedAt:   now,
 		// RequiredCapacity and SpareCapacity are zero until PR-4 adds the
 		// ITL model fit and μ_dec vs λ_dec computation.
 	}, nil
@@ -158,10 +167,11 @@ func (a *ThroughputAnalyzer) VariantState(modelID, namespace, variantName string
 
 // --- helpers ---
 
-// variantKey builds the map key for a variant. The pipe delimiter is safe because
-// Kubernetes resource names follow DNS rules and cannot contain "|".
+// variantKey builds the map key for a variant. The null-byte delimiter is safe
+// because neither Kubernetes resource names nor operator-provided model IDs can
+// contain a null byte.
 func variantKey(namespace, modelID, variantName string) string {
-	return fmt.Sprintf("%s|%s|%s", namespace, modelID, variantName)
+	return namespace + "\x00" + modelID + "\x00" + variantName
 }
 
 // getOrCreateVariantState returns the variantState for the given key, creating
@@ -195,23 +205,34 @@ func groupByVariant(metrics []interfaces.ReplicaMetrics) map[string][]interfaces
 	return groups
 }
 
-// averageShapeMetrics computes the mean IL, OL, and prefix hit rate across a
-// slice of replica metrics. Replicas with zero OL or IL are excluded from the
-// average (they lack workload data this cycle).
+// averageShapeMetrics computes the VLLMRequestRate-weighted mean IL, OL, and
+// prefix hit rate across a slice of replica metrics. Replicas with zero or
+// negative IL or OL are excluded. When all eligible replicas have zero
+// VLLMRequestRate, falls back to an unweighted mean.
 func averageShapeMetrics(metrics []interfaces.ReplicaMetrics) (il, ol, hitRate float64) {
-	var sumIL, sumOL, sumHitRate float64
-	var count float64
+	var sumIL, sumOL, sumHitRate float64 // weighted accumulators
+	var sumILu, sumOLu, sumHRu float64   // unweighted fallback
+	var totalWeight, count float64
 	for _, m := range metrics {
-		if m.AvgInputTokens <= 0 || m.AvgOutputTokens <= 0 {
+		if m.AvgInputTokens <= DefaultMinTokensPerRequest || m.AvgOutputTokens <= DefaultMinTokensPerRequest {
 			continue
 		}
-		sumIL += m.AvgInputTokens
-		sumOL += m.AvgOutputTokens
-		sumHitRate += m.PrefixCacheHitRate
 		count++
+		sumILu += m.AvgInputTokens
+		sumOLu += m.AvgOutputTokens
+		sumHRu += m.PrefixCacheHitRate
+		if m.VLLMRequestRate > 0 {
+			sumIL += m.VLLMRequestRate * m.AvgInputTokens
+			sumOL += m.VLLMRequestRate * m.AvgOutputTokens
+			sumHitRate += m.VLLMRequestRate * m.PrefixCacheHitRate
+			totalWeight += m.VLLMRequestRate
+		}
 	}
 	if count == 0 {
 		return 0, 0, 0
 	}
-	return sumIL / count, sumOL / count, sumHitRate / count
+	if totalWeight == 0 {
+		return sumILu / count, sumOLu / count, sumHRu / count
+	}
+	return sumIL / totalWeight, sumOL / totalWeight, sumHitRate / totalWeight
 }

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -1,0 +1,237 @@
+package throughput
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// makeMetrics builds a slice of healthy ReplicaMetrics for a single variant,
+// each with a distinct KvCacheUsage to provide k-spread.
+func makeMetrics(variant string, count int, baseK float64, kStep float64) []interfaces.ReplicaMetrics {
+	metrics := make([]interfaces.ReplicaMetrics, count)
+	for i := range metrics {
+		metrics[i] = interfaces.ReplicaMetrics{
+			PodName:               "pod-" + variant + "-" + string(rune('0'+i)),
+			VariantName:           variant,
+			KvCacheUsage:          baseK + float64(i)*kStep,
+			TotalKvCapacityTokens: 65536,
+			AvgInputTokens:        1024,
+			AvgOutputTokens:       256,
+			PrefixCacheHitRate:    0.0,
+			AvgITL:                0.030 + (baseK+float64(i)*kStep)*0.05,
+		}
+	}
+	return metrics
+}
+
+var _ = Describe("ThroughputAnalyzer", func() {
+	var (
+		analyzer  *ThroughputAnalyzer
+		ctx       context.Context
+		modelID   string
+		namespace string
+	)
+
+	BeforeEach(func() {
+		analyzer = NewThroughputAnalyzer()
+		ctx = context.Background()
+		modelID = "llama3-8b"
+		namespace = "default"
+	})
+
+	Describe("Name", func() {
+		It("returns the analyzer name", func() {
+			Expect(analyzer.Name()).To(Equal(AnalyzerName))
+		})
+	})
+
+	Describe("VariantState before any observations", func() {
+		It("returns false when no data has been observed", func() {
+			_, ok := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("Observe — basic state creation", func() {
+		It("creates variant state on first Observe", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.15)
+			analyzer.Observe(ctx, modelID, namespace, metrics)
+
+			_, ok := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(ok).To(BeTrue())
+		})
+
+		It("records shape from first call", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.15)
+			analyzer.Observe(ctx, modelID, namespace, metrics)
+
+			state, _ := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(state.Shape.AvgInputTokens).To(BeNumerically("~", 1024.0, 0.01))
+			Expect(state.Shape.AvgOutputTokens).To(BeNumerically("~", 256.0, 0.01))
+		})
+
+		It("adds observations to the window on each Observe call", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.15)
+			analyzer.Observe(ctx, modelID, namespace, metrics)
+
+			state, _ := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(state.SampleCount).To(Equal(3))
+		})
+	})
+
+	Describe("Observe — multi-cycle accumulation", func() {
+		It("accumulates observations across multiple cycles until Ready", func() {
+			// Each call adds 2 replicas with different k values.
+			// After enough cycles the window should become Ready.
+			for i := range 6 {
+				baseK := 0.20 + float64(i)*0.10
+				metrics := makeMetrics("v1", 2, baseK, 0.05)
+				analyzer.Observe(ctx, modelID, namespace, metrics)
+			}
+
+			state, _ := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(state.SampleCount).To(BeNumerically(">=", DefaultMinSamples))
+			Expect(state.KSpread).To(BeNumerically(">=", DefaultMinKSpread))
+			Expect(state.ObservationReady).To(BeTrue())
+		})
+	})
+
+	Describe("Observe — shape change clears window", func() {
+		It("clears the observation window when workload shape changes significantly", func() {
+			// Build up some observations.
+			for i := range 3 {
+				metrics := makeMetrics("v1", 3, 0.20+float64(i)*0.10, 0.05)
+				analyzer.Observe(ctx, modelID, namespace, metrics)
+			}
+			stateBefore, _ := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(stateBefore.SampleCount).To(BeNumerically(">", 0))
+
+			// Now shift IL by 50% — well beyond the 20% tolerance.
+			shifted := makeMetrics("v1", 3, 0.20, 0.10)
+			for i := range shifted {
+				shifted[i].AvgInputTokens = 1024 * 1.5 // +50%
+			}
+			analyzer.Observe(ctx, modelID, namespace, shifted)
+
+			stateAfter, _ := analyzer.VariantState(modelID, namespace, "v1")
+			// The window was cleared on shape change, then one cycle of 3 observations was added.
+			Expect(stateAfter.SampleCount).To(Equal(3))
+		})
+	})
+
+	Describe("Observe — sanity short-circuit", func() {
+		It("skips a variant entirely when sanity checks fail", func() {
+			bad := makeMetrics("v1", 3, 0.20, 0.10)
+			for i := range bad {
+				bad[i].AvgITL = 0 // fails SanityIssueITLNonPositive
+			}
+			reports := analyzer.Observe(ctx, modelID, namespace, bad)
+
+			Expect(reports["v1"].OK()).To(BeFalse())
+			Expect(reports["v1"].Has(SanityIssueITLNonPositive)).To(BeTrue())
+
+			// No state should be created when all metrics are bad.
+			// (State IS created but window remains empty because we skipped after sanity fail.)
+			state, ok := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(ok).To(BeTrue()) // state record was created
+			Expect(state.SampleCount).To(Equal(0))
+			Expect(state.ObservationReady).To(BeFalse())
+		})
+
+		It("returns an OK report for a healthy variant", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.10)
+			reports := analyzer.Observe(ctx, modelID, namespace, metrics)
+			Expect(reports["v1"].OK()).To(BeTrue())
+		})
+	})
+
+	Describe("Observe — multi-variant isolation", func() {
+		It("tracks variants independently", func() {
+			metricsV1 := makeMetrics("v1", 3, 0.20, 0.10)
+			metricsV2 := makeMetrics("v2", 3, 0.30, 0.10)
+			metricsV2[0].AvgInputTokens = 2048 // different shape
+			metricsV2[1].AvgInputTokens = 2048
+			metricsV2[2].AvgInputTokens = 2048
+
+			combined := append(metricsV1, metricsV2...)
+			analyzer.Observe(ctx, modelID, namespace, combined)
+
+			stateV1, okV1 := analyzer.VariantState(modelID, namespace, "v1")
+			stateV2, okV2 := analyzer.VariantState(modelID, namespace, "v2")
+
+			Expect(okV1).To(BeTrue())
+			Expect(okV2).To(BeTrue())
+			Expect(stateV1.Shape.AvgInputTokens).To(BeNumerically("~", 1024.0, 0.01))
+			Expect(stateV2.Shape.AvgInputTokens).To(BeNumerically("~", 2048.0, 0.01))
+			Expect(stateV1.SampleCount).To(Equal(3))
+			Expect(stateV2.SampleCount).To(Equal(3))
+		})
+	})
+
+	Describe("Analyze", func() {
+		It("returns an AnalyzerResult with the correct identifiers", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.10)
+			input := interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: metrics,
+			}
+			result, err := analyzer.Analyze(ctx, input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.AnalyzerName).To(Equal(AnalyzerName))
+			Expect(result.ModelID).To(Equal(modelID))
+			Expect(result.Namespace).To(Equal(namespace))
+		})
+
+		It("returns zero RequiredCapacity and SpareCapacity (no scaling signal in PR-3)", func() {
+			metrics := makeMetrics("v1", 3, 0.20, 0.10)
+			input := interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: metrics,
+			}
+			result, _ := analyzer.Analyze(ctx, input)
+			Expect(result.RequiredCapacity).To(Equal(0.0))
+			Expect(result.SpareCapacity).To(Equal(0.0))
+		})
+
+		It("updates internal state on each Analyze call", func() {
+			for i := range 4 {
+				input := interfaces.AnalyzerInput{
+					ModelID:        modelID,
+					Namespace:      namespace,
+					ReplicaMetrics: makeMetrics("v1", 3, 0.20+float64(i)*0.10, 0.05),
+				}
+				_, err := analyzer.Analyze(ctx, input)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			state, ok := analyzer.VariantState(modelID, namespace, "v1")
+			Expect(ok).To(BeTrue())
+			Expect(state.SampleCount).To(BeNumerically(">", 0))
+		})
+
+		It("sets AnalyzedAt to a recent timestamp", func() {
+			before := time.Now()
+			input := interfaces.AnalyzerInput{
+				ModelID:        modelID,
+				Namespace:      namespace,
+				ReplicaMetrics: makeMetrics("v1", 3, 0.20, 0.10),
+			}
+			result, _ := analyzer.Analyze(ctx, input)
+			Expect(result.AnalyzedAt).To(BeTemporally(">=", before))
+		})
+	})
+
+	Describe("Observe — empty metrics list", func() {
+		It("handles an empty metrics slice gracefully", func() {
+			reports := analyzer.Observe(ctx, modelID, namespace, []interfaces.ReplicaMetrics{})
+			Expect(reports).To(BeEmpty())
+		})
+	})
+})

--- a/internal/engines/analyzers/throughput/analyzer_test.go
+++ b/internal/engines/analyzers/throughput/analyzer_test.go
@@ -2,6 +2,8 @@ package throughput
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -60,7 +62,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 	Describe("Observe — basic state creation", func() {
 		It("creates variant state on first Observe", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.15)
-			analyzer.Observe(ctx, modelID, namespace, metrics)
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 
 			_, ok := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(ok).To(BeTrue())
@@ -68,7 +70,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("records shape from first call", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.15)
-			analyzer.Observe(ctx, modelID, namespace, metrics)
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 
 			state, _ := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(state.Shape.AvgInputTokens).To(BeNumerically("~", 1024.0, 0.01))
@@ -77,7 +79,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("adds observations to the window on each Observe call", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.15)
-			analyzer.Observe(ctx, modelID, namespace, metrics)
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 
 			state, _ := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(state.SampleCount).To(Equal(3))
@@ -91,7 +93,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			for i := range 6 {
 				baseK := 0.20 + float64(i)*0.10
 				metrics := makeMetrics("v1", 2, baseK, 0.05)
-				analyzer.Observe(ctx, modelID, namespace, metrics)
+				analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 			}
 
 			state, _ := analyzer.VariantState(modelID, namespace, "v1")
@@ -106,7 +108,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			// Build up some observations.
 			for i := range 3 {
 				metrics := makeMetrics("v1", 3, 0.20+float64(i)*0.10, 0.05)
-				analyzer.Observe(ctx, modelID, namespace, metrics)
+				analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 			}
 			stateBefore, _ := analyzer.VariantState(modelID, namespace, "v1")
 			Expect(stateBefore.SampleCount).To(BeNumerically(">", 0))
@@ -116,7 +118,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			for i := range shifted {
 				shifted[i].AvgInputTokens = 1024 * 1.5 // +50%
 			}
-			analyzer.Observe(ctx, modelID, namespace, shifted)
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, shifted)
 
 			stateAfter, _ := analyzer.VariantState(modelID, namespace, "v1")
 			// The window was cleared on shape change, then one cycle of 3 observations was added.
@@ -130,7 +132,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			for i := range bad {
 				bad[i].AvgITL = 0 // fails SanityIssueITLNonPositive
 			}
-			reports := analyzer.Observe(ctx, modelID, namespace, bad)
+			reports := analyzer.Observe(ctx, time.Now(), modelID, namespace, bad)
 
 			Expect(reports["v1"].OK()).To(BeFalse())
 			Expect(reports["v1"].Has(SanityIssueITLNonPositive)).To(BeTrue())
@@ -145,7 +147,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 		It("returns an OK report for a healthy variant", func() {
 			metrics := makeMetrics("v1", 3, 0.20, 0.10)
-			reports := analyzer.Observe(ctx, modelID, namespace, metrics)
+			reports := analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
 			Expect(reports["v1"].OK()).To(BeTrue())
 		})
 	})
@@ -159,7 +161,7 @@ var _ = Describe("ThroughputAnalyzer", func() {
 			metricsV2[2].AvgInputTokens = 2048
 
 			combined := append(metricsV1, metricsV2...)
-			analyzer.Observe(ctx, modelID, namespace, combined)
+			analyzer.Observe(ctx, time.Now(), modelID, namespace, combined)
 
 			stateV1, okV1 := analyzer.VariantState(modelID, namespace, "v1")
 			stateV2, okV2 := analyzer.VariantState(modelID, namespace, "v2")
@@ -230,8 +232,34 @@ var _ = Describe("ThroughputAnalyzer", func() {
 
 	Describe("Observe — empty metrics list", func() {
 		It("handles an empty metrics slice gracefully", func() {
-			reports := analyzer.Observe(ctx, modelID, namespace, []interfaces.ReplicaMetrics{})
+			reports := analyzer.Observe(ctx, time.Now(), modelID, namespace, []interfaces.ReplicaMetrics{})
 			Expect(reports).To(BeEmpty())
+		})
+	})
+
+	Describe("Observe — concurrent safety", func() {
+		It("is safe for concurrent Observe and VariantState calls", func() {
+			const goroutines = 10
+			var wg sync.WaitGroup
+			wg.Add(goroutines + 1)
+
+			for i := range goroutines {
+				go func(i int) {
+					defer wg.Done()
+					variant := fmt.Sprintf("v%d", i%3)
+					metrics := makeMetrics(variant, 2, 0.20+float64(i)*0.05, 0.05)
+					analyzer.Observe(ctx, time.Now(), modelID, namespace, metrics)
+				}(i)
+			}
+
+			go func() {
+				defer wg.Done()
+				analyzer.VariantState(modelID, namespace, "v0")
+			}()
+
+			wg.Wait()
+			_, ok := analyzer.VariantState(modelID, namespace, "v0")
+			Expect(ok).To(BeTrue())
 		})
 	})
 })

--- a/internal/engines/analyzers/throughput/constants.go
+++ b/internal/engines/analyzers/throughput/constants.go
@@ -1,0 +1,51 @@
+package throughput
+
+import "time"
+
+const (
+	// AnalyzerName is the canonical name for the throughput analyzer.
+	AnalyzerName = "throughput"
+
+	// DefaultShapeChangeTolerance is the fractional change in IL or OL that
+	// triggers a shape bucket change, clearing the observation window and
+	// scheduling a new ITL model fit.
+	// A value of 0.20 means a 20% shift in either dimension resets calibration.
+	DefaultShapeChangeTolerance = 0.20
+
+	// DefaultWindowMaxSize is the maximum number of (k, ITL) observations
+	// retained in the rolling window. When the window is full, the oldest
+	// observation is evicted on each new Add call.
+	DefaultWindowMaxSize = 20
+
+	// DefaultObservationMaxAge is the maximum age of an observation in the
+	// window. Observations older than this are pruned regardless of window
+	// fullness, ensuring that stale data from a previous load pattern does
+	// not contaminate the current fit.
+	DefaultObservationMaxAge = 30 * time.Minute
+
+	// DefaultMinSamples is the minimum number of valid observations required
+	// before the window is considered Ready for OLS fitting.
+	DefaultMinSamples = 10
+
+	// DefaultMinKSpread is the minimum required spread (max_k - min_k) across
+	// observations in the window before the window is considered Ready.
+	// A spread of at least 0.30 ensures the linear fit spans a meaningful
+	// portion of the KV utilization range and is not extrapolating from a
+	// single operating point.
+	DefaultMinKSpread = 0.30
+
+	// DefaultMinObservableK is the lower bound on KV utilization for accepted
+	// observations. Below this threshold the ITL signal is noisy (few
+	// concurrent requests, high variance) and unreliable for fitting.
+	DefaultMinObservableK = 0.15
+
+	// DefaultMaxObservableK is the upper bound on KV utilization for accepted
+	// observations. Above this threshold the system approaches saturation and
+	// the linear ITL model may no longer hold.
+	DefaultMaxObservableK = 0.85
+
+	// DefaultMinTokensPerRequest is the minimum plausible value for AvgOutputTokens
+	// or AvgInputTokens. Values at or below this threshold indicate the metric
+	// is unavailable or zero-padded and are flagged as a sanity issue.
+	DefaultMinTokensPerRequest = 1.0
+)

--- a/internal/engines/analyzers/throughput/observation_window.go
+++ b/internal/engines/analyzers/throughput/observation_window.go
@@ -1,0 +1,103 @@
+package throughput
+
+import (
+	"math"
+	"time"
+)
+
+// ObservationWindow is a rolling window of (k, ITL_obs) pairs for one variant.
+// It accumulates observations from all replicas of the variant across reconcile
+// cycles to calibrate the linear ITL model: ITL(k) = A·k + B.
+//
+// The window is cleared when the workload shape changes (see ShapeTracker).
+// Observations outside the valid k range [minK, maxK] are silently ignored.
+type ObservationWindow struct {
+	observations []ITLObservation
+	maxSize      int
+	maxAge       time.Duration
+	minSamples   int
+	minKSpread   float64
+	minK         float64
+	maxK         float64
+}
+
+// newObservationWindow creates a window with the given configuration.
+func newObservationWindow(maxSize int, maxAge time.Duration, minSamples int, minKSpread, minK, maxK float64) *ObservationWindow {
+	return &ObservationWindow{
+		observations: make([]ITLObservation, 0, maxSize),
+		maxSize:      maxSize,
+		maxAge:       maxAge,
+		minSamples:   minSamples,
+		minKSpread:   minKSpread,
+		minK:         minK,
+		maxK:         maxK,
+	}
+}
+
+// Add appends a (k, itl) observation if k ∈ [minK, maxK] and itl > 0.
+// When the window is at capacity, the oldest observation is evicted first.
+func (w *ObservationWindow) Add(k, itl float64, ts time.Time) {
+	if k < w.minK || k > w.maxK {
+		return
+	}
+	if itl <= 0 || math.IsNaN(itl) {
+		return
+	}
+	if len(w.observations) >= w.maxSize {
+		w.observations = w.observations[1:]
+	}
+	w.observations = append(w.observations, ITLObservation{K: k, ITLSec: itl, Timestamp: ts})
+}
+
+// Prune removes observations older than maxAge relative to now.
+func (w *ObservationWindow) Prune(now time.Time) {
+	cutoff := now.Add(-w.maxAge)
+	i := 0
+	for i < len(w.observations) && w.observations[i].Timestamp.Before(cutoff) {
+		i++
+	}
+	w.observations = w.observations[i:]
+}
+
+// KSpread returns max_k − min_k over the current observations.
+// Returns 0 when the window is empty.
+func (w *ObservationWindow) KSpread() float64 {
+	if len(w.observations) == 0 {
+		return 0
+	}
+	minK, maxK := w.observations[0].K, w.observations[0].K
+	for _, o := range w.observations[1:] {
+		if o.K < minK {
+			minK = o.K
+		}
+		if o.K > maxK {
+			maxK = o.K
+		}
+	}
+	return maxK - minK
+}
+
+// Ready returns true when the window contains at least minSamples observations
+// AND the k-spread is at least minKSpread. Both conditions must hold before the
+// window is suitable for OLS fitting.
+func (w *ObservationWindow) Ready() bool {
+	return len(w.observations) >= w.minSamples && w.KSpread() >= w.minKSpread
+}
+
+// Observations returns a copy of the current window contents.
+// The caller may mutate the returned slice without affecting the window.
+func (w *ObservationWindow) Observations() []ITLObservation {
+	out := make([]ITLObservation, len(w.observations))
+	copy(out, w.observations)
+	return out
+}
+
+// Len returns the number of observations currently in the window.
+func (w *ObservationWindow) Len() int {
+	return len(w.observations)
+}
+
+// Clear discards all observations. Called when the workload shape changes.
+func (w *ObservationWindow) Clear() {
+	w.observations = w.observations[:0]
+}

--- a/internal/engines/analyzers/throughput/observation_window.go
+++ b/internal/engines/analyzers/throughput/observation_window.go
@@ -3,6 +3,10 @@ package throughput
 import (
 	"math"
 	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
 // ObservationWindow is a rolling window of (k, ITL_obs) pairs for one variant.
@@ -38,6 +42,8 @@ func newObservationWindow(maxSize int, maxAge time.Duration, minSamples int, min
 // When the window is at capacity, the oldest observation is evicted first.
 func (w *ObservationWindow) Add(k, itl float64, ts time.Time) {
 	if k < w.minK || k > w.maxK {
+		ctrl.Log.V(logging.DEBUG).Info("throughput analyzer: k-value outside observable range, observation dropped",
+			"k", k, "minK", w.minK, "maxK", w.maxK)
 		return
 	}
 	if itl <= 0 || math.IsNaN(itl) {

--- a/internal/engines/analyzers/throughput/observation_window_test.go
+++ b/internal/engines/analyzers/throughput/observation_window_test.go
@@ -1,0 +1,205 @@
+package throughput
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ObservationWindow", func() {
+	var (
+		window *ObservationWindow
+		now    time.Time
+	)
+
+	BeforeEach(func() {
+		now = time.Now()
+		window = newObservationWindow(
+			DefaultWindowMaxSize,
+			DefaultObservationMaxAge,
+			DefaultMinSamples,
+			DefaultMinKSpread,
+			DefaultMinObservableK,
+			DefaultMaxObservableK,
+		)
+	})
+
+	Describe("Add", func() {
+		It("accepts observations within [minK, maxK]", func() {
+			window.Add(0.50, 0.040, now)
+			Expect(window.Len()).To(Equal(1))
+		})
+
+		It("rejects k below minK (0.15)", func() {
+			window.Add(0.10, 0.040, now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("rejects k above maxK (0.85)", func() {
+			window.Add(0.90, 0.040, now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("rejects zero ITL", func() {
+			window.Add(0.50, 0.0, now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("rejects negative ITL", func() {
+			window.Add(0.50, -0.001, now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("rejects NaN ITL", func() {
+			window.Add(0.50, float64NaN(), now)
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("accepts k exactly at minK boundary", func() {
+			window.Add(DefaultMinObservableK, 0.040, now)
+			Expect(window.Len()).To(Equal(1))
+		})
+
+		It("accepts k exactly at maxK boundary", func() {
+			window.Add(DefaultMaxObservableK, 0.040, now)
+			Expect(window.Len()).To(Equal(1))
+		})
+
+		It("evicts the oldest observation when at capacity", func() {
+			small := newObservationWindow(3, DefaultObservationMaxAge,
+				DefaultMinSamples, DefaultMinKSpread, DefaultMinObservableK, DefaultMaxObservableK)
+
+			t0 := now
+			small.Add(0.20, 0.020, t0)
+			small.Add(0.40, 0.035, t0.Add(time.Second))
+			small.Add(0.60, 0.050, t0.Add(2*time.Second))
+			Expect(small.Len()).To(Equal(3))
+
+			// Adding a 4th evicts the first (k=0.20)
+			small.Add(0.75, 0.060, t0.Add(3*time.Second))
+			Expect(small.Len()).To(Equal(3))
+
+			obs := small.Observations()
+			Expect(obs[0].K).To(Equal(0.40)) // oldest remaining
+		})
+	})
+
+	Describe("Prune", func() {
+		It("removes observations older than maxAge", func() {
+			old := now.Add(-35 * time.Minute)
+			window.Add(0.40, 0.035, old)
+			window.Add(0.60, 0.050, now)
+
+			window.Prune(now)
+			Expect(window.Len()).To(Equal(1))
+			Expect(window.Observations()[0].K).To(Equal(0.60))
+		})
+
+		It("keeps observations younger than maxAge", func() {
+			window.Add(0.40, 0.035, now.Add(-10*time.Minute))
+			window.Add(0.60, 0.050, now)
+
+			window.Prune(now)
+			Expect(window.Len()).To(Equal(2))
+		})
+
+		It("removes all observations if all are stale", func() {
+			old := now.Add(-60 * time.Minute)
+			window.Add(0.40, 0.035, old)
+			window.Add(0.60, 0.050, old)
+
+			window.Prune(now)
+			Expect(window.Len()).To(Equal(0))
+		})
+	})
+
+	Describe("KSpread", func() {
+		It("returns 0 when window is empty", func() {
+			Expect(window.KSpread()).To(Equal(0.0))
+		})
+
+		It("returns 0 when all observations have the same k", func() {
+			window.Add(0.50, 0.040, now)
+			window.Add(0.50, 0.042, now)
+			Expect(window.KSpread()).To(Equal(0.0))
+		})
+
+		It("returns max_k - min_k", func() {
+			window.Add(0.20, 0.020, now)
+			window.Add(0.50, 0.040, now)
+			window.Add(0.75, 0.060, now)
+			Expect(window.KSpread()).To(BeNumerically("~", 0.55, 0.001))
+		})
+	})
+
+	Describe("Ready", func() {
+		It("returns false when window is empty", func() {
+			Expect(window.Ready()).To(BeFalse())
+		})
+
+		It("returns false when sample count is below minimum", func() {
+			// Add 9 samples with wide spread — not enough samples
+			for i := 0; i < 9; i++ {
+				k := 0.20 + float64(i)*0.07
+				window.Add(k, 0.030+k*0.04, now)
+			}
+			Expect(window.Len()).To(BeNumerically("<", DefaultMinSamples))
+			Expect(window.Ready()).To(BeFalse())
+		})
+
+		It("returns false when spread is below minimum (all observations clustered)", func() {
+			for i := 0; i < DefaultMinSamples; i++ {
+				// All k values close together: 0.40 to 0.45
+				k := 0.40 + float64(i)*0.005
+				window.Add(k, 0.035+k*0.01, now)
+			}
+			Expect(window.KSpread()).To(BeNumerically("<", DefaultMinKSpread))
+			Expect(window.Ready()).To(BeFalse())
+		})
+
+		It("returns true when both sample count and spread requirements are met", func() {
+			// 10 samples spanning k = 0.20 to 0.70 (spread = 0.50 > 0.30)
+			for i := 0; i < DefaultMinSamples; i++ {
+				k := 0.20 + float64(i)*0.05
+				window.Add(k, 0.020+k*0.05, now)
+			}
+			Expect(window.Len()).To(BeNumerically(">=", DefaultMinSamples))
+			Expect(window.KSpread()).To(BeNumerically(">=", DefaultMinKSpread))
+			Expect(window.Ready()).To(BeTrue())
+		})
+	})
+
+	Describe("Clear", func() {
+		It("removes all observations", func() {
+			window.Add(0.40, 0.035, now)
+			window.Add(0.60, 0.050, now)
+			window.Clear()
+			Expect(window.Len()).To(Equal(0))
+		})
+
+		It("resets KSpread to 0", func() {
+			window.Add(0.20, 0.020, now)
+			window.Add(0.80, 0.070, now)
+			window.Clear()
+			Expect(window.KSpread()).To(Equal(0.0))
+		})
+
+		It("allows new observations to be added after Clear", func() {
+			window.Add(0.40, 0.035, now)
+			window.Clear()
+			window.Add(0.55, 0.045, now)
+			Expect(window.Len()).To(Equal(1))
+		})
+	})
+
+	Describe("Observations", func() {
+		It("returns a copy that does not affect the window", func() {
+			window.Add(0.40, 0.035, now)
+			obs := window.Observations()
+			obs[0].K = 999.0 // mutate the copy
+
+			Expect(window.Observations()[0].K).To(Equal(0.40)) // original unchanged
+		})
+	})
+})

--- a/internal/engines/analyzers/throughput/sanity.go
+++ b/internal/engines/analyzers/throughput/sanity.go
@@ -1,0 +1,80 @@
+package throughput
+
+import (
+	"math"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// CheckModelMetrics validates the replica metrics for a set of replicas belonging
+// to the same variant. It returns a SanityReport summarising any quality issues.
+//
+// Callers should check report.OK() before proceeding with Observe; a non-OK
+// report means the metrics are not reliable enough for shape tracking or
+// ITL calibration this cycle.
+//
+// Issues are deduplicated: the same SanityIssue type appears at most once in
+// the report even if multiple pods trigger it.
+func CheckModelMetrics(metrics []interfaces.ReplicaMetrics) SanityReport {
+	if len(metrics) == 0 {
+		return SanityReport{Issues: []SanityIssue{SanityIssueNoReplicas}}
+	}
+
+	issueSet := make(map[SanityIssue]struct{})
+	var affectedPods []string
+
+	for _, m := range metrics {
+		podIssues := checkReplicaMetrics(m)
+		if len(podIssues) > 0 {
+			affectedPods = append(affectedPods, m.PodName)
+			for _, issue := range podIssues {
+				issueSet[issue] = struct{}{}
+			}
+		}
+	}
+
+	if len(issueSet) == 0 {
+		return SanityReport{}
+	}
+
+	issues := make([]SanityIssue, 0, len(issueSet))
+	for issue := range issueSet {
+		issues = append(issues, issue)
+	}
+	return SanityReport{Issues: issues, AffectedPods: affectedPods}
+}
+
+// checkReplicaMetrics validates a single replica's metrics and returns the
+// list of issues found. An empty slice means the replica is healthy.
+func checkReplicaMetrics(m interfaces.ReplicaMetrics) []SanityIssue {
+	var issues []SanityIssue
+
+	// Stale metrics: FreshnessStatus == "stale" means the scrape is behind.
+	if m.Metadata != nil && m.Metadata.FreshnessStatus == "stale" {
+		issues = append(issues, SanityIssueStaleMetrics)
+	}
+
+	// KV cache configuration must be available for capacity calculations.
+	if m.TotalKvCapacityTokens <= 0 {
+		issues = append(issues, SanityIssueMissingKV)
+	}
+
+	// KV utilization must be a valid fraction.
+	if m.KvCacheUsage < 0 || m.KvCacheUsage > 1 || math.IsNaN(m.KvCacheUsage) {
+		issues = append(issues, SanityIssueKVOutOfRange)
+	}
+
+	// ITL must be positive for calibration.
+	if m.AvgITL <= 0 || math.IsNaN(m.AvgITL) {
+		issues = append(issues, SanityIssueITLNonPositive)
+	}
+
+	// Shape metrics (OL, IL) must be plausible for shape tracking.
+	if m.AvgOutputTokens <= DefaultMinTokensPerRequest ||
+		m.AvgInputTokens <= DefaultMinTokensPerRequest ||
+		math.IsNaN(m.AvgOutputTokens) || math.IsNaN(m.AvgInputTokens) {
+		issues = append(issues, SanityIssueMissingShape)
+	}
+
+	return issues
+}

--- a/internal/engines/analyzers/throughput/sanity_test.go
+++ b/internal/engines/analyzers/throughput/sanity_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 // healthyReplica returns a ReplicaMetrics with all fields valid.
-func healthyReplica(podName, variant string) interfaces.ReplicaMetrics {
+func healthyReplica(podName string) interfaces.ReplicaMetrics {
 	return interfaces.ReplicaMetrics{
 		PodName:               podName,
-		VariantName:           variant,
+		VariantName:           "v1",
 		KvCacheUsage:          0.50,
 		TotalKvCapacityTokens: 65536,
 		AvgInputTokens:        1024,
@@ -38,7 +38,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("healthy metrics", func() {
 		It("returns OK for a single healthy replica", func() {
-			metrics := []interfaces.ReplicaMetrics{healthyReplica("pod-0", "v1")}
+			metrics := []interfaces.ReplicaMetrics{healthyReplica("pod-0")}
 			report := CheckModelMetrics(metrics)
 			Expect(report.OK()).To(BeTrue())
 			Expect(report.Issues).To(BeEmpty())
@@ -47,9 +47,9 @@ var _ = Describe("CheckModelMetrics", func() {
 
 		It("returns OK for multiple healthy replicas", func() {
 			metrics := []interfaces.ReplicaMetrics{
-				healthyReplica("pod-0", "v1"),
-				healthyReplica("pod-1", "v1"),
-				healthyReplica("pod-2", "v1"),
+				healthyReplica("pod-0"),
+				healthyReplica("pod-1"),
+				healthyReplica("pod-2"),
 			}
 			report := CheckModelMetrics(metrics)
 			Expect(report.OK()).To(BeTrue())
@@ -58,7 +58,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("stale metrics", func() {
 		It("flags SanityIssueStaleMetrics when FreshnessStatus is stale", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "stale"}
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeTrue())
@@ -66,14 +66,14 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("does not flag stale when FreshnessStatus is fresh", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "fresh"}
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
 		})
 
 		It("does not flag stale when Metadata is nil", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			// Metadata is nil by default in healthyReplica
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
@@ -82,7 +82,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("missing KV capacity", func() {
 		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is zero", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.TotalKvCapacityTokens = 0
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
@@ -90,7 +90,7 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is negative", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.TotalKvCapacityTokens = -1
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
@@ -99,7 +99,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("KV utilization out of range", func() {
 		It("flags SanityIssueKVOutOfRange when KvCacheUsage is negative", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.KvCacheUsage = -0.01
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
@@ -107,23 +107,23 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("flags SanityIssueKVOutOfRange when KvCacheUsage exceeds 1.0", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.KvCacheUsage = 1.01
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
 		})
 
 		It("flags SanityIssueKVOutOfRange for NaN KvCacheUsage", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.KvCacheUsage = float64NaN()
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
 		})
 
 		It("accepts KvCacheUsage at the boundary values 0.0 and 1.0", func() {
-			m0 := healthyReplica("pod-0", "v1")
+			m0 := healthyReplica("pod-0")
 			m0.KvCacheUsage = 0.0
-			m1 := healthyReplica("pod-1", "v1")
+			m1 := healthyReplica("pod-1")
 			m1.KvCacheUsage = 1.0
 			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m0}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
 			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m1}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
@@ -132,7 +132,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("non-positive ITL", func() {
 		It("flags SanityIssueITLNonPositive when AvgITL is zero", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgITL = 0
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
@@ -140,14 +140,14 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("flags SanityIssueITLNonPositive when AvgITL is negative", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgITL = -0.001
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
 		})
 
 		It("flags SanityIssueITLNonPositive when AvgITL is NaN", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgITL = float64NaN()
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
@@ -156,7 +156,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("missing shape metrics", func() {
 		It("flags SanityIssueMissingShape when AvgOutputTokens is at threshold", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgOutputTokens = DefaultMinTokensPerRequest
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
@@ -164,21 +164,21 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("flags SanityIssueMissingShape when AvgOutputTokens is zero", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgOutputTokens = 0
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 		})
 
 		It("flags SanityIssueMissingShape when AvgInputTokens is at threshold", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgInputTokens = DefaultMinTokensPerRequest
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
 		})
 
 		It("flags SanityIssueMissingShape when AvgInputTokens is NaN", func() {
-			m := healthyReplica("pod-0", "v1")
+			m := healthyReplica("pod-0")
 			m.AvgInputTokens = float64NaN()
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
 			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
@@ -187,9 +187,9 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("issue deduplication", func() {
 		It("reports the same issue once even when multiple pods trigger it", func() {
-			m0 := healthyReplica("pod-0", "v1")
+			m0 := healthyReplica("pod-0")
 			m0.AvgITL = 0
-			m1 := healthyReplica("pod-1", "v1")
+			m1 := healthyReplica("pod-1")
 			m1.AvgITL = 0
 
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
@@ -204,9 +204,9 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("collects multiple distinct issues from different pods", func() {
-			m0 := healthyReplica("pod-0", "v1")
+			m0 := healthyReplica("pod-0")
 			m0.AvgITL = 0 // ITL issue
-			m1 := healthyReplica("pod-1", "v1")
+			m1 := healthyReplica("pod-1")
 			m1.TotalKvCapacityTokens = 0 // KV issue
 
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
@@ -216,8 +216,8 @@ var _ = Describe("CheckModelMetrics", func() {
 		})
 
 		It("a pod with no issues does not appear in AffectedPods", func() {
-			good := healthyReplica("pod-good", "v1")
-			bad := healthyReplica("pod-bad", "v1")
+			good := healthyReplica("pod-good")
+			bad := healthyReplica("pod-bad")
 			bad.AvgITL = 0
 
 			report := CheckModelMetrics([]interfaces.ReplicaMetrics{good, bad})
@@ -228,7 +228,7 @@ var _ = Describe("CheckModelMetrics", func() {
 
 	Describe("SanityReport helpers", func() {
 		It("Has returns false for an issue not in the report", func() {
-			report := CheckModelMetrics([]interfaces.ReplicaMetrics{healthyReplica("pod-0", "v1")})
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{healthyReplica("pod-0")})
 			Expect(report.Has(SanityIssueNoReplicas)).To(BeFalse())
 		})
 	})

--- a/internal/engines/analyzers/throughput/sanity_test.go
+++ b/internal/engines/analyzers/throughput/sanity_test.go
@@ -1,0 +1,235 @@
+package throughput
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// healthyReplica returns a ReplicaMetrics with all fields valid.
+func healthyReplica(podName, variant string) interfaces.ReplicaMetrics {
+	return interfaces.ReplicaMetrics{
+		PodName:               podName,
+		VariantName:           variant,
+		KvCacheUsage:          0.50,
+		TotalKvCapacityTokens: 65536,
+		AvgInputTokens:        1024,
+		AvgOutputTokens:       256,
+		PrefixCacheHitRate:    0.0,
+		AvgITL:                0.040,
+	}
+}
+
+var _ = Describe("CheckModelMetrics", func() {
+	Describe("no replicas", func() {
+		It("returns SanityIssueNoReplicas", func() {
+			report := CheckModelMetrics(nil)
+			Expect(report.OK()).To(BeFalse())
+			Expect(report.Has(SanityIssueNoReplicas)).To(BeTrue())
+		})
+
+		It("returns SanityIssueNoReplicas for empty slice", func() {
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{})
+			Expect(report.OK()).To(BeFalse())
+			Expect(report.Has(SanityIssueNoReplicas)).To(BeTrue())
+		})
+	})
+
+	Describe("healthy metrics", func() {
+		It("returns OK for a single healthy replica", func() {
+			metrics := []interfaces.ReplicaMetrics{healthyReplica("pod-0", "v1")}
+			report := CheckModelMetrics(metrics)
+			Expect(report.OK()).To(BeTrue())
+			Expect(report.Issues).To(BeEmpty())
+			Expect(report.AffectedPods).To(BeEmpty())
+		})
+
+		It("returns OK for multiple healthy replicas", func() {
+			metrics := []interfaces.ReplicaMetrics{
+				healthyReplica("pod-0", "v1"),
+				healthyReplica("pod-1", "v1"),
+				healthyReplica("pod-2", "v1"),
+			}
+			report := CheckModelMetrics(metrics)
+			Expect(report.OK()).To(BeTrue())
+		})
+	})
+
+	Describe("stale metrics", func() {
+		It("flags SanityIssueStaleMetrics when FreshnessStatus is stale", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "stale"}
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueStaleMetrics)).To(BeTrue())
+			Expect(report.AffectedPods).To(ContainElement("pod-0"))
+		})
+
+		It("does not flag stale when FreshnessStatus is fresh", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.Metadata = &interfaces.ReplicaMetricsMetadata{FreshnessStatus: "fresh"}
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
+		})
+
+		It("does not flag stale when Metadata is nil", func() {
+			m := healthyReplica("pod-0", "v1")
+			// Metadata is nil by default in healthyReplica
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueStaleMetrics)).To(BeFalse())
+		})
+	})
+
+	Describe("missing KV capacity", func() {
+		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is zero", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.TotalKvCapacityTokens = 0
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
+			Expect(report.AffectedPods).To(ContainElement("pod-0"))
+		})
+
+		It("flags SanityIssueMissingKV when TotalKvCapacityTokens is negative", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.TotalKvCapacityTokens = -1
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
+		})
+	})
+
+	Describe("KV utilization out of range", func() {
+		It("flags SanityIssueKVOutOfRange when KvCacheUsage is negative", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.KvCacheUsage = -0.01
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
+			Expect(report.AffectedPods).To(ContainElement("pod-0"))
+		})
+
+		It("flags SanityIssueKVOutOfRange when KvCacheUsage exceeds 1.0", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.KvCacheUsage = 1.01
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
+		})
+
+		It("flags SanityIssueKVOutOfRange for NaN KvCacheUsage", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.KvCacheUsage = float64NaN()
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueKVOutOfRange)).To(BeTrue())
+		})
+
+		It("accepts KvCacheUsage at the boundary values 0.0 and 1.0", func() {
+			m0 := healthyReplica("pod-0", "v1")
+			m0.KvCacheUsage = 0.0
+			m1 := healthyReplica("pod-1", "v1")
+			m1.KvCacheUsage = 1.0
+			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m0}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
+			Expect(CheckModelMetrics([]interfaces.ReplicaMetrics{m1}).Has(SanityIssueKVOutOfRange)).To(BeFalse())
+		})
+	})
+
+	Describe("non-positive ITL", func() {
+		It("flags SanityIssueITLNonPositive when AvgITL is zero", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgITL = 0
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
+			Expect(report.AffectedPods).To(ContainElement("pod-0"))
+		})
+
+		It("flags SanityIssueITLNonPositive when AvgITL is negative", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgITL = -0.001
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
+		})
+
+		It("flags SanityIssueITLNonPositive when AvgITL is NaN", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgITL = float64NaN()
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
+		})
+	})
+
+	Describe("missing shape metrics", func() {
+		It("flags SanityIssueMissingShape when AvgOutputTokens is at threshold", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgOutputTokens = DefaultMinTokensPerRequest
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
+			Expect(report.AffectedPods).To(ContainElement("pod-0"))
+		})
+
+		It("flags SanityIssueMissingShape when AvgOutputTokens is zero", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgOutputTokens = 0
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
+		})
+
+		It("flags SanityIssueMissingShape when AvgInputTokens is at threshold", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgInputTokens = DefaultMinTokensPerRequest
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
+		})
+
+		It("flags SanityIssueMissingShape when AvgInputTokens is NaN", func() {
+			m := healthyReplica("pod-0", "v1")
+			m.AvgInputTokens = float64NaN()
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m})
+			Expect(report.Has(SanityIssueMissingShape)).To(BeTrue())
+		})
+	})
+
+	Describe("issue deduplication", func() {
+		It("reports the same issue once even when multiple pods trigger it", func() {
+			m0 := healthyReplica("pod-0", "v1")
+			m0.AvgITL = 0
+			m1 := healthyReplica("pod-1", "v1")
+			m1.AvgITL = 0
+
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
+			count := 0
+			for _, issue := range report.Issues {
+				if issue == SanityIssueITLNonPositive {
+					count++
+				}
+			}
+			Expect(count).To(Equal(1))
+			Expect(report.AffectedPods).To(ConsistOf("pod-0", "pod-1"))
+		})
+
+		It("collects multiple distinct issues from different pods", func() {
+			m0 := healthyReplica("pod-0", "v1")
+			m0.AvgITL = 0 // ITL issue
+			m1 := healthyReplica("pod-1", "v1")
+			m1.TotalKvCapacityTokens = 0 // KV issue
+
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{m0, m1})
+			Expect(report.Has(SanityIssueITLNonPositive)).To(BeTrue())
+			Expect(report.Has(SanityIssueMissingKV)).To(BeTrue())
+			Expect(report.AffectedPods).To(ConsistOf("pod-0", "pod-1"))
+		})
+
+		It("a pod with no issues does not appear in AffectedPods", func() {
+			good := healthyReplica("pod-good", "v1")
+			bad := healthyReplica("pod-bad", "v1")
+			bad.AvgITL = 0
+
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{good, bad})
+			Expect(report.AffectedPods).To(ConsistOf("pod-bad"))
+			Expect(report.AffectedPods).NotTo(ContainElement("pod-good"))
+		})
+	})
+
+	Describe("SanityReport helpers", func() {
+		It("Has returns false for an issue not in the report", func() {
+			report := CheckModelMetrics([]interfaces.ReplicaMetrics{healthyReplica("pod-0", "v1")})
+			Expect(report.Has(SanityIssueNoReplicas)).To(BeFalse())
+		})
+	})
+})

--- a/internal/engines/analyzers/throughput/shape_tracker.go
+++ b/internal/engines/analyzers/throughput/shape_tracker.go
@@ -1,0 +1,55 @@
+package throughput
+
+// ShapeTracker maintains the current workload shape bucket for one variant and
+// detects when the workload has shifted enough to require a new ITL model fit.
+//
+// The shape is characterised by the variant-average (IL, OL) across all replicas.
+// A shape change is declared when either IL or OL deviates from the stored shape
+// by more than the configured tolerance fraction.
+type ShapeTracker struct {
+	current   WorkloadShape
+	hasShape  bool
+	tolerance float64
+}
+
+// newShapeTracker creates a ShapeTracker with the given fractional tolerance.
+// For example, tolerance=0.20 means a ≥20% change in IL or OL triggers a reset.
+func newShapeTracker(tolerance float64) *ShapeTracker {
+	return &ShapeTracker{tolerance: tolerance}
+}
+
+// Observe updates the tracker with the variant-averaged (il, ol, hitRate) for
+// this reconcile cycle and reports whether the shape bucket changed.
+//
+// On the first call (no prior shape), the shape is set and changed=false is
+// returned — there is nothing to refit against yet.
+//
+// On subsequent calls, changed=true is returned when the new shape falls outside
+// the tolerance band of the stored shape. The stored shape is updated to the new
+// value regardless.
+func (t *ShapeTracker) Observe(il, ol, hitRate float64) (shape WorkloadShape, changed bool) {
+	next := newWorkloadShape(il, ol, hitRate)
+
+	if !t.hasShape {
+		t.current = next
+		t.hasShape = true
+		return next, false
+	}
+
+	changed = !next.Within(t.current, t.tolerance)
+	t.current = next
+	return next, changed
+}
+
+// Current returns the most recently stored shape and whether any shape has been
+// observed yet. Returns (zero WorkloadShape, false) before the first Observe call.
+func (t *ShapeTracker) Current() (WorkloadShape, bool) {
+	return t.current, t.hasShape
+}
+
+// Reset clears the stored shape, as if the tracker had just been created.
+// The next Observe call will set a fresh shape without triggering a change event.
+func (t *ShapeTracker) Reset() {
+	t.current = WorkloadShape{}
+	t.hasShape = false
+}

--- a/internal/engines/analyzers/throughput/shape_tracker_test.go
+++ b/internal/engines/analyzers/throughput/shape_tracker_test.go
@@ -1,0 +1,139 @@
+package throughput
+
+import (
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ShapeTracker", func() {
+	var tracker *ShapeTracker
+
+	BeforeEach(func() {
+		tracker = newShapeTracker(DefaultShapeChangeTolerance)
+	})
+
+	Describe("first Observe call", func() {
+		It("sets the shape without reporting a change", func() {
+			shape, changed := tracker.Observe(5000, 200, 0.1)
+
+			Expect(changed).To(BeFalse())
+			Expect(shape.AvgInputTokens).To(Equal(5000.0))
+			Expect(shape.AvgOutputTokens).To(Equal(200.0))
+			Expect(shape.PrefixHitRate).To(Equal(0.1))
+		})
+
+		It("computes ILeff and KVreq correctly", func() {
+			shape, _ := tracker.Observe(5000, 200, 0.3)
+
+			// ILeff = 5000 × (1 - 0.3) = 3500
+			Expect(shape.ILeff).To(BeNumerically("~", 3500.0, 0.01))
+			// KVreq = 3500 + 200/2 = 3600
+			Expect(shape.KVreq).To(BeNumerically("~", 3600.0, 0.01))
+		})
+
+		It("reports no shape before first call", func() {
+			_, hasShape := tracker.Current()
+			Expect(hasShape).To(BeFalse())
+		})
+	})
+
+	Describe("subsequent calls within tolerance", func() {
+		BeforeEach(func() {
+			tracker.Observe(5000, 200, 0.0)
+		})
+
+		It("does not report a change for identical values", func() {
+			_, changed := tracker.Observe(5000, 200, 0.0)
+			Expect(changed).To(BeFalse())
+		})
+
+		It("does not report a change for 15% IL shift (within 20% tolerance)", func() {
+			_, changed := tracker.Observe(5750, 200, 0.0) // +15% IL
+			Expect(changed).To(BeFalse())
+		})
+
+		It("does not report a change for 15% OL shift (within 20% tolerance)", func() {
+			_, changed := tracker.Observe(5000, 230, 0.0) // +15% OL
+			Expect(changed).To(BeFalse())
+		})
+
+		It("does not report a change at exactly the tolerance boundary", func() {
+			_, changed := tracker.Observe(6000, 200, 0.0) // exactly +20% IL
+			Expect(changed).To(BeFalse())
+		})
+	})
+
+	Describe("shape change detection", func() {
+		BeforeEach(func() {
+			tracker.Observe(5000, 200, 0.0)
+		})
+
+		It("reports a change for >20% IL increase", func() {
+			_, changed := tracker.Observe(6100, 200, 0.0) // +22% IL
+			Expect(changed).To(BeTrue())
+		})
+
+		It("reports a change for >20% IL decrease", func() {
+			_, changed := tracker.Observe(3900, 200, 0.0) // -22% IL
+			Expect(changed).To(BeTrue())
+		})
+
+		It("reports a change for >20% OL increase", func() {
+			_, changed := tracker.Observe(5000, 245, 0.0) // +22.5% OL
+			Expect(changed).To(BeTrue())
+		})
+
+		It("updates the stored shape after a change", func() {
+			tracker.Observe(6500, 300, 0.0)
+			shape, hasShape := tracker.Current()
+			Expect(hasShape).To(BeTrue())
+			Expect(shape.AvgInputTokens).To(Equal(6500.0))
+			Expect(shape.AvgOutputTokens).To(Equal(300.0))
+		})
+	})
+
+	Describe("Reset", func() {
+		It("clears the stored shape", func() {
+			tracker.Observe(5000, 200, 0.0)
+			tracker.Reset()
+
+			_, hasShape := tracker.Current()
+			Expect(hasShape).To(BeFalse())
+		})
+
+		It("treats the next call as a fresh first call after Reset", func() {
+			tracker.Observe(5000, 200, 0.0)
+			tracker.Reset()
+
+			_, changed := tracker.Observe(9999, 999, 0.0)
+			Expect(changed).To(BeFalse())
+		})
+	})
+
+	Describe("NaN and edge case hit rates", func() {
+		It("treats NaN hit rate as 0.0", func() {
+			shape, _ := tracker.Observe(5000, 200, float64NaN())
+			Expect(shape.PrefixHitRate).To(Equal(0.0))
+			Expect(shape.ILeff).To(BeNumerically("~", 5000.0, 0.01))
+		})
+
+		It("clamps hit rate above 1.0 to 1.0", func() {
+			shape, _ := tracker.Observe(5000, 200, 1.5)
+			Expect(shape.PrefixHitRate).To(Equal(1.0))
+			Expect(shape.ILeff).To(BeNumerically("~", 0.0, 0.01))
+		})
+
+		It("clamps negative hit rate to 0.0", func() {
+			shape, _ := tracker.Observe(5000, 200, -0.3)
+			Expect(shape.PrefixHitRate).To(Equal(0.0))
+			Expect(shape.ILeff).To(BeNumerically("~", 5000.0, 0.01))
+		})
+	})
+})
+
+// float64NaN returns a NaN value for use in tests.
+func float64NaN() float64 {
+	return math.NaN()
+}

--- a/internal/engines/analyzers/throughput/suite_test.go
+++ b/internal/engines/analyzers/throughput/suite_test.go
@@ -1,0 +1,13 @@
+package throughput
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestThroughput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Throughput Analyzer Suite")
+}

--- a/internal/engines/analyzers/throughput/types.go
+++ b/internal/engines/analyzers/throughput/types.go
@@ -1,0 +1,151 @@
+package throughput
+
+import (
+	"math"
+	"time"
+)
+
+// WorkloadShape captures the stable (IL, OL) characterization for a calibration period.
+//
+// KVreq = ILeff + OL/2 is the time-averaged per-in-flight-request KV footprint.
+// ILeff is used for both N(k*) (current fleet) and N(k_sat) (new replica capacity).
+//
+// Rationale for using ILeff for new replicas: with cache-aware scheduling (EPP
+// prefix routing), a new replica warms up quickly and operates at approximately
+// fleet-average ILeff in steady state. Using IL (cold-cache pessimism) would
+// chronically over-estimate KV demand per request and lead to over-scaling.
+// When prefix caching is disabled, PrefixHitRate=0 and ILeff=IL automatically,
+// so the formula is correct in that case without special handling.
+type WorkloadShape struct {
+	// AvgInputTokens is the average prompt length per request in tokens (IL, tok/req).
+	AvgInputTokens float64
+	// AvgOutputTokens is the average generation length per request in tokens (OL, tok/req).
+	AvgOutputTokens float64
+	// PrefixHitRate is the prefix cache hit fraction (0.0–1.0).
+	// Zero when prefix caching is disabled or hit-rate metrics are unavailable.
+	PrefixHitRate float64
+	// ILeff is the effective input length after prefix cache reduction:
+	//   ILeff = AvgInputTokens × (1 − PrefixHitRate)
+	ILeff float64
+	// KVreq is the time-averaged KV token footprint per in-flight request:
+	//   KVreq = ILeff + AvgOutputTokens/2
+	KVreq float64
+}
+
+// newWorkloadShape constructs a WorkloadShape and computes the derived fields.
+// hitRate values outside [0, 1] are clamped; NaN is treated as 0.0.
+func newWorkloadShape(il, ol, hitRate float64) WorkloadShape {
+	if math.IsNaN(hitRate) || hitRate < 0 {
+		hitRate = 0
+	}
+	if hitRate > 1 {
+		hitRate = 1
+	}
+	ileff := il * (1 - hitRate)
+	return WorkloadShape{
+		AvgInputTokens:  il,
+		AvgOutputTokens: ol,
+		PrefixHitRate:   hitRate,
+		ILeff:           ileff,
+		KVreq:           ileff + ol/2,
+	}
+}
+
+// IsZero returns true when the shape has not been populated (zero IL and OL).
+func (s WorkloadShape) IsZero() bool {
+	return s.AvgInputTokens == 0 && s.AvgOutputTokens == 0
+}
+
+// Within returns true if both IL and OL of s are within ±tolerance of other.
+// tolerance is fractional: 0.20 means ±20%.
+func (s WorkloadShape) Within(other WorkloadShape, tolerance float64) bool {
+	return withinTolerance(s.AvgInputTokens, other.AvgInputTokens, tolerance) &&
+		withinTolerance(s.AvgOutputTokens, other.AvgOutputTokens, tolerance)
+}
+
+// withinTolerance returns true if |a - b| / b ≤ tolerance, or if both are zero.
+func withinTolerance(a, b, tolerance float64) bool {
+	if b == 0 {
+		return a == 0
+	}
+	return math.Abs(a-b)/b <= tolerance
+}
+
+// ITLObservation is a single (k, ITL_obs) data point collected from one replica
+// during one reconcile cycle. Used to calibrate the linear ITL model: ITL(k) = A·k + B.
+type ITLObservation struct {
+	// K is the KV cache utilization fraction (0.0–1.0) observed on the replica.
+	K float64
+	// ITLSec is the observed average inter-token latency in seconds/token.
+	ITLSec float64
+	// Timestamp is when this observation was collected.
+	Timestamp time.Time
+}
+
+// SanityIssue is a diagnostic tag describing a metric quality problem detected
+// during a reconcile cycle.
+type SanityIssue string
+
+const (
+	// SanityIssueNoReplicas indicates the model has no replica metrics at all.
+	SanityIssueNoReplicas SanityIssue = "no_replicas"
+
+	// SanityIssueMissingKV indicates TotalKvCapacityTokens is zero or negative,
+	// meaning the KV cache configuration metric (cache_config_info) is unavailable.
+	SanityIssueMissingKV SanityIssue = "missing_kv_capacity"
+
+	// SanityIssueKVOutOfRange indicates KvCacheUsage is outside [0, 1].
+	SanityIssueKVOutOfRange SanityIssue = "kv_utilization_out_of_range"
+
+	// SanityIssueITLNonPositive indicates AvgITL is zero, negative, or NaN.
+	// This prevents adding any (k, ITL) observations from affected pods.
+	SanityIssueITLNonPositive SanityIssue = "itl_non_positive"
+
+	// SanityIssueMissingShape indicates AvgOutputTokens or AvgInputTokens is
+	// at or below DefaultMinTokensPerRequest, making shape tracking unreliable.
+	SanityIssueMissingShape SanityIssue = "missing_shape_metrics"
+
+	// SanityIssueStaleMetrics indicates the replica's metrics are marked stale
+	// (Metadata.FreshnessStatus == "stale"). Stale data should not be used
+	// for calibration.
+	SanityIssueStaleMetrics SanityIssue = "stale_metrics"
+)
+
+// SanityReport summarises metric quality issues detected across a set of replica
+// metrics during one reconcile cycle.
+type SanityReport struct {
+	// Issues lists the distinct issue types found. Empty when all metrics are healthy.
+	Issues []SanityIssue
+	// AffectedPods lists the pod names that had at least one issue.
+	AffectedPods []string
+}
+
+// OK returns true when no issues were found.
+func (r SanityReport) OK() bool {
+	return len(r.Issues) == 0
+}
+
+// Has returns true when the report contains the given issue type.
+func (r SanityReport) Has(issue SanityIssue) bool {
+	for _, i := range r.Issues {
+		if i == issue {
+			return true
+		}
+	}
+	return false
+}
+
+// ThroughputVariantState is a read-only snapshot of per-variant state.
+// Returned by ThroughputAnalyzer.VariantState for tests and logging.
+type ThroughputVariantState struct {
+	// Shape is the current workload shape bucket for this variant.
+	Shape WorkloadShape
+	// ObservationReady is true when the window has enough data for OLS fitting.
+	ObservationReady bool
+	// KSpread is max_k - min_k over current observations (0 when window is empty).
+	KSpread float64
+	// SampleCount is the number of observations currently in the window.
+	SampleCount int
+	// LastSanityReport is the sanity report from the most recent Observe call.
+	LastSanityReport SanityReport
+}


### PR DESCRIPTION
## Summary

- Implements the per-variant calibration state layer for the Throughput Analyzer (`internal/engines/analyzers/throughput/`)
- `ShapeTracker` — tracks current workload shape (IL, OL, IL_eff, KV_req); detects >20% shift and triggers observation window reset
- `ObservationWindow` — rolling window of (k, ITL_obs) pairs per replica; reports `Ready()` when ≥10 samples with ≥0.30 k-spread are accumulated
- `ThroughputAnalyzer` — implements `interfaces.Analyzer`; groups replicas by variant, runs sanity checks, updates shape and window each cycle; zero scaling signal until PR-4 adds the OLS fit
- 78 Ginkgo tests covering all components and multi-cycle integration
- Updates `docs/user-guide/throughput-analyzer.md` with PR-3 component descriptions and diagram fixes

**Scope:** state management only — no OLS regression, no μ_dec/λ_dec computation, no scaling signal (PR-4).

## Dependencies

> ⚠️ This PR is stacked on #1051 (PR-1/PR-2: query registration). Please review/merge that first. The diff against `main` includes both until #1051 lands.

## Related

- Part of #1005

## Test plan

- [ ] `make test` passes (78 new tests in `internal/engines/analyzers/throughput/`)
- [ ] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)