### PR TITLE
fix(collector): wrong ITL metric name and dispatch rate pod label

### DIFF
--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -18,7 +18,7 @@ const (
 	QueryAvgTTFT = "avg_ttft"
 
 	// QueryAvgITL is the query name for average inter-token latency per pod (in seconds).
-	// Source: vllm:time_per_output_token_seconds histogram
+	// Source: vllm:inter_token_latency_seconds histogram
 	QueryAvgITL = "avg_itl"
 )
 
@@ -46,7 +46,7 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	})
 
 	// Average time-to-first-token per pod (seconds).
-	// Uses histogram _sum/_count from vLLM over a 1m rate window.
+	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed TTFT for Kalman filter updates.
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgTTFT,
@@ -58,12 +58,12 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	})
 
 	// Average inter-token latency per pod (seconds).
-	// Uses histogram _sum/_count from vLLM over a 1m rate window.
+	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed ITL for Kalman filter updates.
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgITL,
 		Type:     source.QueryTypePromQL,
-		Template: `max by (pod) (rate(vllm:time_per_output_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:time_per_output_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template: `max by (pod) (rate(vllm:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:   []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average inter-token latency per pod (seconds), " +
 			"used by queueing model tuner for parameter learning",

--- a/internal/collector/registration/queueing_model_test.go
+++ b/internal/collector/registration/queueing_model_test.go
@@ -1,0 +1,66 @@
+package registration
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
+)
+
+var _ = Describe("RegisterQueueingModelQueries", func() {
+	var (
+		ctx      context.Context
+		registry *source.SourceRegistry
+		mockAPI  *mockPrometheusAPI
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		registry = source.NewSourceRegistry()
+		mockAPI = &mockPrometheusAPI{}
+		metricsSource := prometheus.NewPrometheusSource(ctx, mockAPI, prometheus.DefaultPrometheusSourceConfig())
+		err := registry.Register("prometheus", metricsSource)
+		Expect(err).NotTo(HaveOccurred())
+		RegisterQueueingModelQueries(registry)
+	})
+
+	Describe("scheduler dispatch rate query", func() {
+		It("uses pod_name label to identify the vLLM endpoint pod", func() {
+			q := registry.Get("prometheus").QueryList().Get(QuerySchedulerDispatchRate)
+			Expect(q).NotTo(BeNil())
+			// The metric labels both "pod" (EPP scrape target) and "pod_name" (vLLM endpoint).
+			// We must group by pod_name so results join correctly with vLLM TTFT/ITL metrics.
+			Expect(q.Template).To(ContainSubstring("pod_name"))
+			Expect(q.Template).To(ContainSubstring("inference_extension_scheduler_attempts_total"))
+			Expect(q.Template).To(ContainSubstring(`status="success"`))
+		})
+	})
+
+	Describe("average TTFT query", func() {
+		It("queries vllm:time_to_first_token_seconds histogram", func() {
+			q := registry.Get("prometheus").QueryList().Get(QueryAvgTTFT)
+			Expect(q).NotTo(BeNil())
+			Expect(q.Template).To(ContainSubstring("vllm:time_to_first_token_seconds_sum"))
+			Expect(q.Template).To(ContainSubstring("vllm:time_to_first_token_seconds_count"))
+		})
+	})
+
+	Describe("average ITL query", func() {
+		It("queries vllm:inter_token_latency_seconds histogram", func() {
+			q := registry.Get("prometheus").QueryList().Get(QueryAvgITL)
+			Expect(q).NotTo(BeNil())
+			// vLLM exports inter-token latency as inter_token_latency_seconds.
+			Expect(q.Template).To(ContainSubstring("vllm:inter_token_latency_seconds_sum"))
+			Expect(q.Template).To(ContainSubstring("vllm:inter_token_latency_seconds_count"))
+		})
+
+		It("does not use the old time_per_output_token_seconds metric name", func() {
+			q := registry.Get("prometheus").QueryList().Get(QueryAvgITL)
+			Expect(q).NotTo(BeNil())
+			Expect(q.Template).NotTo(ContainSubstring("time_per_output_token_seconds"))
+		})
+	})
+})

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -311,9 +311,11 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QuerySchedulerDispatchRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
+				// The scheduler metric has both "pod" (EPP scrape target) and "pod_name"
+				// (the vLLM endpoint pod). Prefer pod_name so we join with vLLM metrics.
+				podName := value.Labels["pod_name"]
 				if podName == "" {
-					podName = value.Labels["pod_name"]
+					podName = value.Labels["pod"]
 				}
 				if podName == "" {
 					logger.Info("Scheduler dispatch rate metric missing both 'pod' and 'pod_name' labels, skipping",


### PR DESCRIPTION
## Summary

Fixes two bugs in the queueing model metrics collector that prevented the EKF tuner from receiving valid observations. Both fixes are confined to the collector layer.

- **ITL metric name**: Changed from `vllm:time_per_output_token_seconds` to `vllm:inter_token_latency_seconds` (the name actually exported by vLLM). Without this, the ITL query returned no data → `env.Valid()` failed → tuner never updated.

- **Dispatch rate pod label**: `inference_extension_scheduler_attempts_total` carries both `pod` (EPP scrape target) and `pod_name` (vLLM endpoint). The collector was keying by `pod` (EPP name), so arrival rate and latency metrics never joined. Fixed to prefer `pod_name`, falling back to `pod`.

## Test plan

- [ ] Deploy with a vLLM server and send traffic; verify WVA logs show `Queueing model observed vs. predicted` with non-zero `arrivalRate_rps`, `observedTTFT_ms`, `observedITL_ms`
- [ ] Verify EKF `updateCount` increments each cycle (no longer stuck at 0)
- [ ] Verify `inference_extension_scheduler_attempts_total` dispatch rate joins correctly with vLLM pod metrics

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)