### PR TITLE
Add symmetrical benchmark scenario (1000/1000 tokens, 20 RPS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), k
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
 E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
-BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy)
+BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy), symmetrical
 
 # Map scenario name to Ginkgo label filter
 ifeq ($(BENCHMARK_SCENARIO),decode_heavy)
   BENCHMARK_LABEL_FILTER := decode-heavy
+else ifeq ($(BENCHMARK_SCENARIO),symmetrical)
+  BENCHMARK_LABEL_FILTER := symmetrical
 else
   BENCHMARK_LABEL_FILTER := phase3a
 endif

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -915,6 +915,41 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 		})
 	})
 
+	Context("WVA Symmetrical", Label("symmetrical"), func() {
+		It("should run the symmetrical workload against WVA", func() {
+			cleanupAutoscalers()
+			res.DeploymentName = findInfraDecodeDeployment()
+			ensureInfraDeploymentReady()
+
+			By("Creating VariantAutoscaling resource (max=10, cost=10)")
+			err := fixtures.EnsureVariantAutoscaling(
+				ctx, crClient, benchCfg.LLMDNamespace, res.VAName, res.DeploymentName,
+				benchCfg.ModelID, benchCfg.AcceleratorType, 10.0, benchCfg.ControllerInstance,
+				fixtures.WithMinReplicas(1),
+				fixtures.WithMaxReplicas(10),
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create VA")
+
+			By("Creating HPA (Scale Up: 0s/Pods/10/150, Scale Down: 240s/Pods/10/150)")
+			behavior := &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(0)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To(int32(240)),
+					Policies:                   []autoscalingv2.HPAScalingPolicy{{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 150}},
+				},
+			}
+			err = fixtures.EnsureHPA(ctx, k8sClient, benchCfg.LLMDNamespace, res.HPAName, res.DeploymentName, res.VAName, 1, 10, WithBehavior(behavior))
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA")
+
+			waitForVAAndMetrics()
+
+			runBenchmarkScenario("WVA", "symmetrical")
+		})
+	})
+
 	AfterAll(func() {
 		GinkgoWriter.Println("Prefill benchmark complete — cleaning up autoscalers and scaling to 1 for next test suite")
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/benchmark/scenarios/symmetrical.yaml
+++ b/test/benchmark/scenarios/symmetrical.yaml
@@ -1,0 +1,8 @@
+name: "Symmetrical"
+description: "Balanced workload with equal input and output token lengths"
+promptTokens: 1000
+outputTokens: 1000
+rate: 20
+maxSeconds: 600
+profile: "poisson"
+requestType: "text_completions"


### PR DESCRIPTION
## Summary

- Adds the symmetrical workload scenario for balanced input/output benchmarking (1000 prompt tokens, 1000 output tokens, 20 RPS)
- New `test/benchmark/scenarios/symmetrical.yaml` config file
- Ginkgo test context with `symmetrical` label in `prefill_heavy_benchmark_test.go`
- Makefile `BENCHMARK_SCENARIO=symmetrical` mapping

## Test plan

- [ ] Run `make test-benchmark ENVIRONMENT=openshift E2E_EMULATED_LLMD_NAMESPACE=<ns> BENCHMARK_SCENARIO=symmetrical`
- [ ] Verify benchmark completes successfully and reports results


Made with [Cursor](https://cursor.com)