### PR TITLE
add configurable defaults for fixtures services and model workloads

### DIFF
--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -13,16 +13,87 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type infraFixtureConfig struct {
+	serviceSuffix             string
+	serviceMonitorSuffix      string
+	servicePortName           string
+	serviceMonitorMetricsPath string
+	releaseLabelValue         string
+	testLabelValue            string
+}
+
+// InfraOption overrides fixture conventions used by Service and ServiceMonitor helpers.
+type InfraOption func(*infraFixtureConfig)
+
+// WithServiceSuffix overrides the generated Service name suffix.
+func WithServiceSuffix(suffix string) InfraOption {
+	return func(cfg *infraFixtureConfig) {
+		if suffix != "" {
+			cfg.serviceSuffix = suffix
+		}
+	}
+}
+
+// WithServiceMonitorSuffix overrides the generated ServiceMonitor name suffix.
+func WithServiceMonitorSuffix(suffix string) InfraOption {
+	return func(cfg *infraFixtureConfig) {
+		if suffix != "" {
+			cfg.serviceMonitorSuffix = suffix
+		}
+	}
+}
+
+// WithServicePortName overrides the Service port name used by ServiceMonitor endpoints.
+func WithServicePortName(portName string) InfraOption {
+	return func(cfg *infraFixtureConfig) {
+		if portName != "" {
+			cfg.servicePortName = portName
+		}
+	}
+}
+
+// WithServiceMonitorDefaults overrides monitor-specific convention values.
+func WithServiceMonitorDefaults(metricsPath, releaseLabelValue string) InfraOption {
+	return func(cfg *infraFixtureConfig) {
+		if metricsPath != "" {
+			cfg.serviceMonitorMetricsPath = metricsPath
+		}
+		if releaseLabelValue != "" {
+			cfg.releaseLabelValue = releaseLabelValue
+		}
+	}
+}
+
+func defaultInfraFixtureConfig() infraFixtureConfig {
+	return infraFixtureConfig{
+		serviceSuffix:             serviceNameSuffix,
+		serviceMonitorSuffix:      serviceMonitorNameSuffix,
+		servicePortName:           defaultServicePortName,
+		serviceMonitorMetricsPath: defaultServiceMonitorMetricsPath,
+		releaseLabelValue:         kubePrometheusStackReleaseLabelValue,
+		testLabelValue:            defaultTestResourceLabelValue,
+	}
+}
+
+func resolveInfraFixtureConfig(opts ...InfraOption) infraFixtureConfig {
+	cfg := defaultInfraFixtureConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
 // CreateService creates a Kubernetes Service for the model server. Fails if the service already exists.
-func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
-	service := buildService(namespace, name, appLabel, port)
+func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int, opts ...InfraOption) error {
+	service := buildService(namespace, name, appLabel, port, opts...)
 	_, err := k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteService deletes the Kubernetes Service. Idempotent; ignores NotFound.
-func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string) error {
-	serviceName := name + "-service"
+func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string, opts ...InfraOption) error {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceName := name + cfg.serviceSuffix
 	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete service %s: %w", serviceName, err)
@@ -31,8 +102,9 @@ func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 }
 
 // EnsureService creates or replaces the Service (idempotent for test setup).
-func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
-	serviceName := name + "-service"
+func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int, opts ...InfraOption) error {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceName := name + cfg.serviceSuffix
 	_, err := k8sClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err == nil {
 		deleteErr := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -45,7 +117,7 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing service %s: %w", serviceName, err)
 	}
-	service := buildService(namespace, name, appLabel, port)
+	service := buildService(namespace, name, appLabel, port, opts...)
 	_, err = k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
 		_ = k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -57,25 +129,26 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	return err
 }
 
-func buildService(namespace, name, appLabel string, port int) *corev1.Service {
-	serviceName := name + "-service"
+func buildService(namespace, name, appLabel string, port int, opts ...InfraOption) *corev1.Service {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceName := name + cfg.serviceSuffix
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
-				"test-resource":             "true",
+				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
+				"test-resource":             cfg.testLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": "true",
+				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
 			},
 			Ports: []corev1.ServicePort{
-				{Name: "http", Port: int32(port), Protocol: corev1.ProtocolTCP},
+				{Name: cfg.servicePortName, Port: int32(port), Protocol: corev1.ProtocolTCP},
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},
@@ -83,14 +156,15 @@ func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 }
 
 // CreateServiceMonitor creates a ServiceMonitor for Prometheus. Fails if it already exists.
-func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
+func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) error {
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel, opts...)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
 // DeleteServiceMonitor deletes the ServiceMonitor. Idempotent; ignores NotFound.
-func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string) error {
-	serviceMonitorName := name + "-monitor"
+func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string, opts ...InfraOption) error {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceMonitorName := name + cfg.serviceMonitorSuffix
 	sm := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -102,8 +176,9 @@ func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 }
 
 // EnsureServiceMonitor creates or replaces the ServiceMonitor (idempotent for test setup).
-func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
-	serviceMonitorName := name + "-monitor"
+func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) error {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceMonitorName := name + cfg.serviceMonitorSuffix
 	existingSM := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -119,26 +194,27 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing ServiceMonitor %s: %w", serviceMonitorName, err)
 	}
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel, opts...)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
-func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string) *promoperator.ServiceMonitor {
-	serviceMonitorName := name + "-monitor"
+func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) *promoperator.ServiceMonitor {
+	cfg := resolveInfraFixtureConfig(opts...)
+	serviceMonitorName := name + cfg.serviceMonitorSuffix
 	return &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceMonitorName,
 			Namespace: monitoringNamespace,
 			Labels: map[string]string{
 				"app":           appLabel,
-				"release":       "kube-prometheus-stack",
-				"test-resource": "true",
+				"release":       cfg.releaseLabelValue,
+				"test-resource": cfg.testLabelValue,
 			},
 		},
 		Spec: promoperator.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
 			Endpoints: []promoperator.Endpoint{
-				{Port: "http", Path: "/metrics", Interval: promoperator.Duration("15s")},
+				{Port: cfg.servicePortName, Path: cfg.serviceMonitorMetricsPath, Interval: promoperator.Duration("15s")},
 			},
 			NamespaceSelector: promoperator.NamespaceSelector{MatchNames: []string{targetNamespace}},
 		},

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -65,14 +65,14 @@ func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
+				"llm-d.ai/inferenceServing": defaultLabelValueTrue,
 				"test-resource":             defaultTestResourceLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app":                       appLabel,
-				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
+				"llm-d.ai/inferenceServing": defaultLabelValueTrue,
 			},
 			Ports: []corev1.ServicePort{
 				{Name: defaultServicePortName, Port: int32(port), Protocol: corev1.ProtocolTCP},

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -14,34 +14,11 @@ import (
 )
 
 type infraFixtureConfig struct {
-	serviceSuffix             string
-	serviceMonitorSuffix      string
-	servicePortName           string
-	serviceMonitorMetricsPath string
-	releaseLabelValue         string
-	testLabelValue            string
+	servicePortName string
 }
 
 // InfraOption overrides fixture conventions used by Service and ServiceMonitor helpers.
 type InfraOption func(*infraFixtureConfig)
-
-// WithServiceSuffix overrides the generated Service name suffix.
-func WithServiceSuffix(suffix string) InfraOption {
-	return func(cfg *infraFixtureConfig) {
-		if suffix != "" {
-			cfg.serviceSuffix = suffix
-		}
-	}
-}
-
-// WithServiceMonitorSuffix overrides the generated ServiceMonitor name suffix.
-func WithServiceMonitorSuffix(suffix string) InfraOption {
-	return func(cfg *infraFixtureConfig) {
-		if suffix != "" {
-			cfg.serviceMonitorSuffix = suffix
-		}
-	}
-}
 
 // WithServicePortName overrides the Service port name used by ServiceMonitor endpoints.
 func WithServicePortName(portName string) InfraOption {
@@ -52,26 +29,9 @@ func WithServicePortName(portName string) InfraOption {
 	}
 }
 
-// WithServiceMonitorDefaults overrides monitor-specific convention values.
-func WithServiceMonitorDefaults(metricsPath, releaseLabelValue string) InfraOption {
-	return func(cfg *infraFixtureConfig) {
-		if metricsPath != "" {
-			cfg.serviceMonitorMetricsPath = metricsPath
-		}
-		if releaseLabelValue != "" {
-			cfg.releaseLabelValue = releaseLabelValue
-		}
-	}
-}
-
 func defaultInfraFixtureConfig() infraFixtureConfig {
 	return infraFixtureConfig{
-		serviceSuffix:             serviceNameSuffix,
-		serviceMonitorSuffix:      serviceMonitorNameSuffix,
-		servicePortName:           defaultServicePortName,
-		serviceMonitorMetricsPath: defaultServiceMonitorMetricsPath,
-		releaseLabelValue:         kubePrometheusStackReleaseLabelValue,
-		testLabelValue:            defaultTestResourceLabelValue,
+		servicePortName: defaultServicePortName,
 	}
 }
 
@@ -92,8 +52,7 @@ func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 
 // DeleteService deletes the Kubernetes Service. Idempotent; ignores NotFound.
 func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string, opts ...InfraOption) error {
-	cfg := resolveInfraFixtureConfig(opts...)
-	serviceName := name + cfg.serviceSuffix
+	serviceName := name + serviceNameSuffix
 	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete service %s: %w", serviceName, err)
@@ -103,8 +62,7 @@ func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 
 // EnsureService creates or replaces the Service (idempotent for test setup).
 func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int, opts ...InfraOption) error {
-	cfg := resolveInfraFixtureConfig(opts...)
-	serviceName := name + cfg.serviceSuffix
+	serviceName := name + serviceNameSuffix
 	_, err := k8sClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err == nil {
 		deleteErr := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -131,7 +89,7 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 
 func buildService(namespace, name, appLabel string, port int, opts ...InfraOption) *corev1.Service {
 	cfg := resolveInfraFixtureConfig(opts...)
-	serviceName := name + cfg.serviceSuffix
+	serviceName := name + serviceNameSuffix
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -139,7 +97,7 @@ func buildService(namespace, name, appLabel string, port int, opts ...InfraOptio
 			Labels: map[string]string{
 				"app":                       appLabel,
 				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
-				"test-resource":             cfg.testLabelValue,
+				"test-resource":             defaultTestResourceLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -163,8 +121,7 @@ func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 
 // DeleteServiceMonitor deletes the ServiceMonitor. Idempotent; ignores NotFound.
 func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string, opts ...InfraOption) error {
-	cfg := resolveInfraFixtureConfig(opts...)
-	serviceMonitorName := name + cfg.serviceMonitorSuffix
+	serviceMonitorName := name + serviceMonitorNameSuffix
 	sm := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -177,8 +134,7 @@ func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 
 // EnsureServiceMonitor creates or replaces the ServiceMonitor (idempotent for test setup).
 func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) error {
-	cfg := resolveInfraFixtureConfig(opts...)
-	serviceMonitorName := name + cfg.serviceMonitorSuffix
+	serviceMonitorName := name + serviceMonitorNameSuffix
 	existingSM := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -200,21 +156,21 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 
 func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) *promoperator.ServiceMonitor {
 	cfg := resolveInfraFixtureConfig(opts...)
-	serviceMonitorName := name + cfg.serviceMonitorSuffix
+	serviceMonitorName := name + serviceMonitorNameSuffix
 	return &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceMonitorName,
 			Namespace: monitoringNamespace,
 			Labels: map[string]string{
 				"app":           appLabel,
-				"release":       cfg.releaseLabelValue,
-				"test-resource": cfg.testLabelValue,
+				"release":       kubePrometheusStackReleaseLabelValue,
+				"test-resource": defaultTestResourceLabelValue,
 			},
 		},
 		Spec: promoperator.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
 			Endpoints: []promoperator.Endpoint{
-				{Port: cfg.servicePortName, Path: cfg.serviceMonitorMetricsPath, Interval: promoperator.Duration("15s")},
+				{Port: cfg.servicePortName, Path: defaultServiceMonitorMetricsPath, Interval: promoperator.Duration("15s")},
 			},
 			NamespaceSelector: promoperator.NamespaceSelector{MatchNames: []string{targetNamespace}},
 		},

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -14,15 +14,15 @@ import (
 )
 
 // CreateService creates a Kubernetes Service for the model server. Fails if the service already exists.
-func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
-	service := buildService(namespace, name, appLabel, port)
+func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, baseName, appLabel string, port int) error {
+	service := buildService(namespace, baseName, appLabel, port)
 	_, err := k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteService deletes the Kubernetes Service. Idempotent; ignores NotFound.
-func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string) error {
-	serviceName := name + serviceNameSuffix
+func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, baseName string) error {
+	serviceName := baseName + serviceNameSuffix
 	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete service %s: %w", serviceName, err)
@@ -31,8 +31,8 @@ func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 }
 
 // EnsureService creates or replaces the Service (idempotent for test setup).
-func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
-	serviceName := name + serviceNameSuffix
+func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, baseName, appLabel string, port int) error {
+	serviceName := baseName + serviceNameSuffix
 	_, err := k8sClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err == nil {
 		deleteErr := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -45,7 +45,7 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing service %s: %w", serviceName, err)
 	}
-	service := buildService(namespace, name, appLabel, port)
+	service := buildService(namespace, baseName, appLabel, port)
 	_, err = k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
 		_ = k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -57,8 +57,8 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	return err
 }
 
-func buildService(namespace, name, appLabel string, port int) *corev1.Service {
-	serviceName := name + serviceNameSuffix
+func buildService(namespace, baseName, appLabel string, port int) *corev1.Service {
+	serviceName := baseName + serviceNameSuffix
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -83,14 +83,14 @@ func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 }
 
 // CreateServiceMonitor creates a ServiceMonitor for Prometheus. Fails if it already exists.
-func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
+func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, baseName, appLabel string) error {
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, baseName, appLabel)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
 // DeleteServiceMonitor deletes the ServiceMonitor. Idempotent; ignores NotFound.
-func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string) error {
-	serviceMonitorName := name + serviceMonitorNameSuffix
+func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, baseName string) error {
+	serviceMonitorName := baseName + serviceMonitorNameSuffix
 	sm := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -102,8 +102,8 @@ func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 }
 
 // EnsureServiceMonitor creates or replaces the ServiceMonitor (idempotent for test setup).
-func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
-	serviceMonitorName := name + serviceMonitorNameSuffix
+func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, baseName, appLabel string) error {
+	serviceMonitorName := baseName + serviceMonitorNameSuffix
 	existingSM := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
@@ -119,12 +119,12 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing ServiceMonitor %s: %w", serviceMonitorName, err)
 	}
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, baseName, appLabel)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
-func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string) *promoperator.ServiceMonitor {
-	serviceMonitorName := name + serviceMonitorNameSuffix
+func buildServiceMonitor(monitoringNamespace, targetNamespace, baseName, appLabel string) *promoperator.ServiceMonitor {
+	serviceMonitorName := baseName + serviceMonitorNameSuffix
 	return &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceMonitorName,

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -13,45 +13,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type infraFixtureConfig struct {
-	servicePortName string
-}
-
-// InfraOption overrides fixture conventions used by Service and ServiceMonitor helpers.
-type InfraOption func(*infraFixtureConfig)
-
-// WithServicePortName overrides the Service port name used by ServiceMonitor endpoints.
-func WithServicePortName(portName string) InfraOption {
-	return func(cfg *infraFixtureConfig) {
-		if portName != "" {
-			cfg.servicePortName = portName
-		}
-	}
-}
-
-func defaultInfraFixtureConfig() infraFixtureConfig {
-	return infraFixtureConfig{
-		servicePortName: defaultServicePortName,
-	}
-}
-
-func resolveInfraFixtureConfig(opts ...InfraOption) infraFixtureConfig {
-	cfg := defaultInfraFixtureConfig()
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return cfg
-}
-
 // CreateService creates a Kubernetes Service for the model server. Fails if the service already exists.
-func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int, opts ...InfraOption) error {
-	service := buildService(namespace, name, appLabel, port, opts...)
+func CreateService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
+	service := buildService(namespace, name, appLabel, port)
 	_, err := k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteService deletes the Kubernetes Service. Idempotent; ignores NotFound.
-func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string, opts ...InfraOption) error {
+func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string) error {
 	serviceName := name + serviceNameSuffix
 	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
@@ -61,7 +31,7 @@ func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 }
 
 // EnsureService creates or replaces the Service (idempotent for test setup).
-func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int, opts ...InfraOption) error {
+func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, appLabel string, port int) error {
 	serviceName := name + serviceNameSuffix
 	_, err := k8sClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err == nil {
@@ -75,7 +45,7 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing service %s: %w", serviceName, err)
 	}
-	service := buildService(namespace, name, appLabel, port, opts...)
+	service := buildService(namespace, name, appLabel, port)
 	_, err = k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
 		_ = k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
@@ -87,8 +57,7 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 	return err
 }
 
-func buildService(namespace, name, appLabel string, port int, opts ...InfraOption) *corev1.Service {
-	cfg := resolveInfraFixtureConfig(opts...)
+func buildService(namespace, name, appLabel string, port int) *corev1.Service {
 	serviceName := name + serviceNameSuffix
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +75,7 @@ func buildService(namespace, name, appLabel string, port int, opts ...InfraOptio
 				"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
 			},
 			Ports: []corev1.ServicePort{
-				{Name: cfg.servicePortName, Port: int32(port), Protocol: corev1.ProtocolTCP},
+				{Name: defaultServicePortName, Port: int32(port), Protocol: corev1.ProtocolTCP},
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},
@@ -114,13 +83,13 @@ func buildService(namespace, name, appLabel string, port int, opts ...InfraOptio
 }
 
 // CreateServiceMonitor creates a ServiceMonitor for Prometheus. Fails if it already exists.
-func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) error {
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel, opts...)
+func CreateServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
 // DeleteServiceMonitor deletes the ServiceMonitor. Idempotent; ignores NotFound.
-func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string, opts ...InfraOption) error {
+func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, name string) error {
 	serviceMonitorName := name + serviceMonitorNameSuffix
 	sm := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
@@ -133,7 +102,7 @@ func DeleteServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 }
 
 // EnsureServiceMonitor creates or replaces the ServiceMonitor (idempotent for test setup).
-func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) error {
+func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitoringNamespace, targetNamespace, name, appLabel string) error {
 	serviceMonitorName := name + serviceMonitorNameSuffix
 	existingSM := &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
@@ -150,12 +119,11 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing ServiceMonitor %s: %w", serviceMonitorName, err)
 	}
-	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel, opts...)
+	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel)
 	return crClient.Create(ctx, serviceMonitor)
 }
 
-func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string, opts ...InfraOption) *promoperator.ServiceMonitor {
-	cfg := resolveInfraFixtureConfig(opts...)
+func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel string) *promoperator.ServiceMonitor {
 	serviceMonitorName := name + serviceMonitorNameSuffix
 	return &promoperator.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,7 +138,7 @@ func buildServiceMonitor(monitoringNamespace, targetNamespace, name, appLabel st
 		Spec: promoperator.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
 			Endpoints: []promoperator.Endpoint{
-				{Port: cfg.servicePortName, Path: defaultServiceMonitorMetricsPath, Interval: promoperator.Duration("15s")},
+				{Port: defaultServicePortName, Path: defaultServiceMonitorMetricsPath, Interval: promoperator.Duration("15s")},
 			},
 			NamespaceSelector: promoperator.NamespaceSelector{MatchNames: []string{targetNamespace}},
 		},

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -96,7 +96,7 @@ func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulato
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                       appLabel,
-		"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
+		"llm-d.ai/inferenceServing": defaultLabelValueTrue,
 		"llm-d.ai/model":            defaultModelServiceLabelValue,
 		"llm-d.ai/model-pool":       poolName,
 		"test-resource":             defaultTestResourceLabelValue,

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -3,12 +3,13 @@ package fixtures
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -35,18 +36,18 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) && !errors.IsConflict(deleteErr) {
 			return fmt.Errorf("delete existing LWS %s: %w", lwsName, deleteErr)
 		}
-		// Wait for deletion
-		waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer cancel()
-		for {
-			checkErr := crClient.Get(waitCtx, client.ObjectKey{Name: lwsName, Namespace: namespace}, &lwsv1.LeaderWorkerSet{})
+		waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			checkErr := crClient.Get(ctx, client.ObjectKey{Name: lwsName, Namespace: namespace}, &lwsv1.LeaderWorkerSet{})
 			if errors.IsNotFound(checkErr) {
-				break
+				return true, nil
 			}
-			if waitCtx.Err() != nil {
-				return fmt.Errorf("timeout waiting for LWS %s to be deleted", lwsName)
+			if checkErr != nil {
+				return false, checkErr
 			}
-			time.Sleep(2 * time.Second)
+			return false, nil
+		})
+		if waitErr != nil {
+			return fmt.Errorf("timeout waiting for LWS %s to be deleted: %w", lwsName, waitErr)
 		}
 	} else if !errors.IsNotFound(err) {
 		return fmt.Errorf("check existing LWS %s: %w", lwsName, err)
@@ -65,9 +66,9 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 }
 
 func modelServiceLWSMatchesDesired(existing, desired lwsv1.LeaderWorkerSet) bool {
-	return reflect.DeepEqual(existing.Spec, desired.Spec) &&
-		reflect.DeepEqual(existing.Labels, desired.Labels) &&
-		reflect.DeepEqual(existing.Annotations, desired.Annotations)
+	return apiequality.Semantic.DeepEqual(existing.Spec, desired.Spec) &&
+		apiequality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(existing.Annotations, desired.Annotations)
 }
 
 // DeleteModelServiceLWS deletes the LeaderWorkerSet for model service. Idempotent; ignores NotFound.

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -16,9 +16,9 @@ import (
 )
 
 // EnsureModelServiceLWS creates or replaces a LeaderWorkerSet for model service (idempotent for test setup).
-func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) error {
+func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32) error {
 	lwsName := name + decodeNameSuffix
-	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize, opts...)
+	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize)
 
 	// Check if LWS already exists
 	existingLWS := &lwsv1.LeaderWorkerSet{}
@@ -87,8 +87,7 @@ func DeleteModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 	return nil
 }
 
-func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) *lwsv1.LeaderWorkerSet {
-	cfg := resolveModelServiceFixtureConfig(opts...)
+func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32) *lwsv1.LeaderWorkerSet {
 	appLabel := name + decodeNameSuffix
 	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
@@ -116,8 +115,8 @@ func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulato
 			corev1.EnvVar{Name: "HF_HOME", Value: "/model-cache"},
 			corev1.EnvVar{Name: "HF_TOKEN", ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.hfTokenSecret},
-					Key:                  cfg.hfTokenKey,
+					LocalObjectReference: corev1.LocalObjectReference{Name: defaultHFTokenSecretName},
+					Key:                  defaultHFTokenSecretKey,
 				},
 			}},
 		)

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -9,14 +9,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
 // EnsureModelServiceLWS creates or replaces a LeaderWorkerSet for model service (idempotent for test setup).
-func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) error {
+func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) error {
 	lwsName := name + decodeNameSuffix
 	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize, opts...)
 
@@ -90,17 +89,17 @@ func DeleteModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) *lwsv1.LeaderWorkerSet {
 	cfg := resolveModelServiceFixtureConfig(opts...)
 	appLabel := name + decodeNameSuffix
-	image := cfg.simulatorImage
+	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
-		image = cfg.runtimeImage
+		image = defaultModelServiceRuntimeImage
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                       appLabel,
 		"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
-		"llm-d.ai/model":            cfg.modelLabel,
+		"llm-d.ai/model":            defaultModelServiceLabelValue,
 		"llm-d.ai/model-pool":       poolName,
-		"test-resource":             cfg.testLabelValue,
+		"test-resource":             defaultTestResourceLabelValue,
 	}
 
 	envVars := []corev1.EnvVar{
@@ -146,7 +145,7 @@ func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulato
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args:            args,
 					Ports: []corev1.ContainerPort{
-						{Name: defaultServicePortName, ContainerPort: cfg.containerPort, Protocol: corev1.ProtocolTCP},
+						{Name: defaultServicePortName, ContainerPort: defaultModelServiceContainerPort, Protocol: corev1.ProtocolTCP},
 					},
 					Env:          envVars,
 					Resources:    buildModelServiceResources(useSimulator),

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -16,9 +16,9 @@ import (
 )
 
 // EnsureModelServiceLWS creates or replaces a LeaderWorkerSet for model service (idempotent for test setup).
-func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32) error {
-	lwsName := name + "-decode"
-	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize)
+func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) error {
+	lwsName := name + decodeNameSuffix
+	desiredLWS := buildModelServiceLWS(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, groupSize, opts...)
 
 	// Check if LWS already exists
 	existingLWS := &lwsv1.LeaderWorkerSet{}
@@ -73,7 +73,7 @@ func modelServiceLWSMatchesDesired(existing, desired lwsv1.LeaderWorkerSet) bool
 
 // DeleteModelServiceLWS deletes the LeaderWorkerSet for model service. Idempotent; ignores NotFound.
 func DeleteModelServiceLWS(ctx context.Context, crClient client.Client, namespace, name string) error {
-	lwsName := name + "-decode"
+	lwsName := name + decodeNameSuffix
 	lws := &lwsv1.LeaderWorkerSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      lwsName,
@@ -87,19 +87,20 @@ func DeleteModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 	return nil
 }
 
-func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32) *lwsv1.LeaderWorkerSet {
-	appLabel := name + "-decode"
-	image := "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, groupSize int32, opts ...ModelServiceOption) *lwsv1.LeaderWorkerSet {
+	cfg := resolveModelServiceFixtureConfig(opts...)
+	appLabel := name + decodeNameSuffix
+	image := cfg.simulatorImage
 	if !useSimulator {
-		image = "ghcr.io/llm-d/llm-d-cuda-dev:latest"
+		image = cfg.runtimeImage
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                       appLabel,
-		"llm-d.ai/inferenceServing": "true",
-		"llm-d.ai/model":            "ms-sim-llm-d-modelservice",
+		"llm-d.ai/inferenceServing": defaultInferenceServingLabelValue,
+		"llm-d.ai/model":            cfg.modelLabel,
 		"llm-d.ai/model-pool":       poolName,
-		"test-resource":             "true",
+		"test-resource":             cfg.testLabelValue,
 	}
 
 	envVars := []corev1.EnvVar{
@@ -115,8 +116,8 @@ func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulato
 			corev1.EnvVar{Name: "HF_HOME", Value: "/model-cache"},
 			corev1.EnvVar{Name: "HF_TOKEN", ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "llm-d-hf-token"},
-					Key:                  "HF_TOKEN",
+					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.hfTokenSecret},
+					Key:                  cfg.hfTokenKey,
 				},
 			}},
 		)
@@ -145,7 +146,7 @@ func buildModelServiceLWS(namespace, name, poolName, modelID string, useSimulato
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args:            args,
 					Ports: []corev1.ContainerPort{
-						{Name: "http", ContainerPort: 8000, Protocol: corev1.ProtocolTCP},
+						{Name: defaultServicePortName, ContainerPort: cfg.containerPort, Protocol: corev1.ProtocolTCP},
 					},
 					Env:          envVars,
 					Resources:    buildModelServiceResources(useSimulator),

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -19,15 +19,15 @@ import (
 // CreateModelService creates the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; callers must use CreateService or EnsureService
 // (typically naming the Service name + "-service") to expose the deployment.
-func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) error {
-	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
+func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) error {
+	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, opts...)
 	_, err := k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteModelService deletes the model service deployment. Idempotent; ignores NotFound.
 func DeleteModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name string) error {
-	deploymentName := name + "-decode"
+	deploymentName := name + decodeNameSuffix
 	err := k8sClient.AppsV1().Deployments(namespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete model service deployment %s: %w", deploymentName, err)
@@ -37,10 +37,10 @@ func DeleteModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 
 // EnsureModelService creates or replaces the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; pair with EnsureService for a ClusterIP Service.
-func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) error {
-	appLabel := name + "-decode"
+func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) error {
+	appLabel := name + decodeNameSuffix
 	deploymentName := appLabel
-	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
+	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, opts...)
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err == nil {
@@ -81,21 +81,22 @@ func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) b
 		reflect.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
 }
 
-func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) *appsv1.Deployment {
-	appLabel := name + "-decode"
-	image := "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) *appsv1.Deployment {
+	cfg := resolveModelServiceFixtureConfig(opts...)
+	appLabel := name + decodeNameSuffix
+	image := cfg.simulatorImage
 	if !useSimulator {
-		image = "ghcr.io/llm-d/llm-d-cuda-dev:latest"
+		image = cfg.runtimeImage
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                        appLabel,
-		"llm-d.ai/inferenceServing":  "true",
-		"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
+		"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
+		"llm-d.ai/model":             cfg.modelLabel,
 		"llm-d.ai/model-pool":        poolName,
-		"test-resource":              "true",
-		"llm-d.ai/guide":             "workload-autoscaling",
-		"llm-d.ai/inference-serving": "true",
+		"test-resource":              cfg.testLabelValue,
+		"llm-d.ai/guide":             cfg.guideLabel,
+		"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
 	}
 
 	envVars := []corev1.EnvVar{
@@ -111,8 +112,8 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			corev1.EnvVar{Name: "HF_HOME", Value: "/model-cache"},
 			corev1.EnvVar{Name: "HF_TOKEN", ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "llm-d-hf-token"},
-					Key:                  "HF_TOKEN",
+					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.hfTokenSecret},
+					Key:                  cfg.hfTokenKey,
 				},
 			}},
 		)
@@ -140,11 +141,11 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                        appLabel,
-					"llm-d.ai/inferenceServing":  "true",
-					"llm-d.ai/model":             "ms-sim-llm-d-modelservice",
+					"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
+					"llm-d.ai/model":             cfg.modelLabel,
 					"llm-d.ai/model-pool":        poolName,
-					"llm-d.ai/guide":             "workload-autoscaling",
-					"llm-d.ai/inference-serving": "true",
+					"llm-d.ai/guide":             cfg.guideLabel,
+					"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -157,7 +158,7 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            args,
 							Ports: []corev1.ContainerPort{
-								{Name: "http", ContainerPort: 8000, Protocol: corev1.ProtocolTCP},
+								{Name: defaultServicePortName, ContainerPort: cfg.containerPort, Protocol: corev1.ProtocolTCP},
 							},
 							Env:          envVars,
 							Resources:    buildModelServiceResources(useSimulator),

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -3,12 +3,12 @@ package fixtures
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,9 +76,9 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 }
 
 func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) bool {
-	return reflect.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) &&
-		reflect.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) &&
-		reflect.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
+	return apiequality.Semantic.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) &&
+		apiequality.Semantic.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) &&
+		apiequality.Semantic.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
 }
 
 func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) *appsv1.Deployment {

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -84,18 +84,18 @@ func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) b
 func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) *appsv1.Deployment {
 	cfg := resolveModelServiceFixtureConfig(opts...)
 	appLabel := name + decodeNameSuffix
-	image := cfg.simulatorImage
+	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
-		image = cfg.runtimeImage
+		image = defaultModelServiceRuntimeImage
 	}
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                        appLabel,
 		"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
-		"llm-d.ai/model":             cfg.modelLabel,
+		"llm-d.ai/model":             defaultModelServiceLabelValue,
 		"llm-d.ai/model-pool":        poolName,
-		"test-resource":              cfg.testLabelValue,
-		"llm-d.ai/guide":             cfg.guideLabel,
+		"test-resource":              defaultTestResourceLabelValue,
+		"llm-d.ai/guide":             defaultGuideLabelValue,
 		"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
 	}
 
@@ -142,9 +142,9 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 				MatchLabels: map[string]string{
 					"app":                        appLabel,
 					"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
-					"llm-d.ai/model":             cfg.modelLabel,
+					"llm-d.ai/model":             defaultModelServiceLabelValue,
 					"llm-d.ai/model-pool":        poolName,
-					"llm-d.ai/guide":             cfg.guideLabel,
+					"llm-d.ai/guide":             defaultGuideLabelValue,
 					"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
 				},
 			},
@@ -158,7 +158,7 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            args,
 							Ports: []corev1.ContainerPort{
-								{Name: defaultServicePortName, ContainerPort: cfg.containerPort, Protocol: corev1.ProtocolTCP},
+								{Name: defaultServicePortName, ContainerPort: defaultModelServiceContainerPort, Protocol: corev1.ProtocolTCP},
 							},
 							Env:          envVars,
 							Resources:    buildModelServiceResources(useSimulator),

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -19,8 +19,8 @@ import (
 // CreateModelService creates the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; callers must use CreateService or EnsureService
 // (typically naming the Service name + "-service") to expose the deployment.
-func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) error {
-	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, opts...)
+func CreateModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) error {
+	deployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
 	_, err := k8sClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	return err
 }
@@ -37,10 +37,10 @@ func DeleteModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 
 // EnsureModelService creates or replaces the model-server Deployment only (name + "-decode").
 // It does not create a Kubernetes Service; pair with EnsureService for a ClusterIP Service.
-func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) error {
+func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) error {
 	appLabel := name + decodeNameSuffix
 	deploymentName := appLabel
-	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs, opts...)
+	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err == nil {
@@ -81,8 +81,7 @@ func modelServiceDeploymentMatchesDesired(existing, desired appsv1.Deployment) b
 		apiequality.Semantic.DeepEqual(existing.Spec.Template.Spec, desired.Spec.Template.Spec)
 }
 
-func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int, opts ...ModelServiceOption) *appsv1.Deployment {
-	cfg := resolveModelServiceFixtureConfig(opts...)
+func buildModelServiceDeployment(namespace, name, poolName, modelID string, useSimulator bool, maxNumSeqs int) *appsv1.Deployment {
 	appLabel := name + decodeNameSuffix
 	image := defaultModelServiceSimulatorImage
 	if !useSimulator {
@@ -112,8 +111,8 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			corev1.EnvVar{Name: "HF_HOME", Value: "/model-cache"},
 			corev1.EnvVar{Name: "HF_TOKEN", ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.hfTokenSecret},
-					Key:                  cfg.hfTokenKey,
+					LocalObjectReference: corev1.LocalObjectReference{Name: defaultHFTokenSecretName},
+					Key:                  defaultHFTokenSecretKey,
 				},
 			}},
 		)

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -90,12 +90,12 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 	args := buildModelServerArgs(modelID, useSimulator, maxNumSeqs)
 	labels := map[string]string{
 		"app":                        appLabel,
-		"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
+		"llm-d.ai/inferenceServing":  defaultLabelValueTrue,
 		"llm-d.ai/model":             defaultModelServiceLabelValue,
 		"llm-d.ai/model-pool":        poolName,
 		"test-resource":              defaultTestResourceLabelValue,
 		"llm-d.ai/guide":             defaultGuideLabelValue,
-		"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
+		"llm-d.ai/inference-serving": defaultLabelValueTrue,
 	}
 
 	envVars := []corev1.EnvVar{
@@ -140,11 +140,11 @@ func buildModelServiceDeployment(namespace, name, poolName, modelID string, useS
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                        appLabel,
-					"llm-d.ai/inferenceServing":  defaultInferenceServingLabelValue,
+					"llm-d.ai/inferenceServing":  defaultLabelValueTrue,
 					"llm-d.ai/model":             defaultModelServiceLabelValue,
 					"llm-d.ai/model-pool":        poolName,
 					"llm-d.ai/guide":             defaultGuideLabelValue,
-					"llm-d.ai/inference-serving": defaultInferenceServingLabelValue,
+					"llm-d.ai/inference-serving": defaultLabelValueTrue,
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/test/e2e/fixtures/model_service_conventions.go
+++ b/test/e2e/fixtures/model_service_conventions.go
@@ -28,39 +28,12 @@ const (
 )
 
 type modelServiceFixtureConfig struct {
-	simulatorImage string
-	runtimeImage   string
-	containerPort  int32
-	hfTokenSecret  string
-	hfTokenKey     string
-	modelLabel     string
-	guideLabel     string
-	testLabelValue string
+	hfTokenSecret string
+	hfTokenKey    string
 }
 
 // ModelServiceOption overrides fixture conventions used by model-service resources.
 type ModelServiceOption func(*modelServiceFixtureConfig)
-
-// WithModelServiceImages overrides simulator/runtime container images.
-func WithModelServiceImages(simulatorImage, runtimeImage string) ModelServiceOption {
-	return func(cfg *modelServiceFixtureConfig) {
-		if simulatorImage != "" {
-			cfg.simulatorImage = simulatorImage
-		}
-		if runtimeImage != "" {
-			cfg.runtimeImage = runtimeImage
-		}
-	}
-}
-
-// WithModelServiceContainerPort overrides the model server container port.
-func WithModelServiceContainerPort(port int32) ModelServiceOption {
-	return func(cfg *modelServiceFixtureConfig) {
-		if port > 0 {
-			cfg.containerPort = port
-		}
-	}
-}
 
 // WithModelServiceHFTokenSecret overrides the Hugging Face token secret reference.
 func WithModelServiceHFTokenSecret(secretName, secretKey string) ModelServiceOption {
@@ -74,31 +47,10 @@ func WithModelServiceHFTokenSecret(secretName, secretKey string) ModelServiceOpt
 	}
 }
 
-// WithModelServiceLabelValues overrides convention label values used by fixtures.
-func WithModelServiceLabelValues(modelLabel, guideLabel, testLabelValue string) ModelServiceOption {
-	return func(cfg *modelServiceFixtureConfig) {
-		if modelLabel != "" {
-			cfg.modelLabel = modelLabel
-		}
-		if guideLabel != "" {
-			cfg.guideLabel = guideLabel
-		}
-		if testLabelValue != "" {
-			cfg.testLabelValue = testLabelValue
-		}
-	}
-}
-
 func defaultModelServiceFixtureConfig() modelServiceFixtureConfig {
 	return modelServiceFixtureConfig{
-		simulatorImage: defaultModelServiceSimulatorImage,
-		runtimeImage:   defaultModelServiceRuntimeImage,
-		containerPort:  defaultModelServiceContainerPort,
-		hfTokenSecret:  defaultHFTokenSecretName,
-		hfTokenKey:     defaultHFTokenSecretKey,
-		modelLabel:     defaultModelServiceLabelValue,
-		guideLabel:     defaultGuideLabelValue,
-		testLabelValue: defaultTestResourceLabelValue,
+		hfTokenSecret: defaultHFTokenSecretName,
+		hfTokenKey:    defaultHFTokenSecretKey,
 	}
 }
 

--- a/test/e2e/fixtures/model_service_conventions.go
+++ b/test/e2e/fixtures/model_service_conventions.go
@@ -18,11 +18,11 @@ const (
 
 	defaultModelServiceSimulatorImage = "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
 	defaultModelServiceRuntimeImage   = "ghcr.io/llm-d/llm-d-cuda-dev:latest"
-	defaultModelServiceContainerPort  = int32(8000)
+	defaultModelServiceContainerPort  = 8000
 	defaultHFTokenSecretName          = "llm-d-hf-token"
 	defaultHFTokenSecretKey           = "HF_TOKEN"
 	defaultModelServiceLabelValue     = "ms-sim-llm-d-modelservice"
-	defaultInferenceServingLabelValue = "true"
+	defaultLabelValueTrue             = "true"
 	defaultGuideLabelValue            = "workload-autoscaling"
-	defaultTestResourceLabelValue     = "true"
+	defaultTestResourceLabelValue     = defaultLabelValueTrue
 )

--- a/test/e2e/fixtures/model_service_conventions.go
+++ b/test/e2e/fixtures/model_service_conventions.go
@@ -26,38 +26,3 @@ const (
 	defaultGuideLabelValue            = "workload-autoscaling"
 	defaultTestResourceLabelValue     = "true"
 )
-
-type modelServiceFixtureConfig struct {
-	hfTokenSecret string
-	hfTokenKey    string
-}
-
-// ModelServiceOption overrides fixture conventions used by model-service resources.
-type ModelServiceOption func(*modelServiceFixtureConfig)
-
-// WithModelServiceHFTokenSecret overrides the Hugging Face token secret reference.
-func WithModelServiceHFTokenSecret(secretName, secretKey string) ModelServiceOption {
-	return func(cfg *modelServiceFixtureConfig) {
-		if secretName != "" {
-			cfg.hfTokenSecret = secretName
-		}
-		if secretKey != "" {
-			cfg.hfTokenKey = secretKey
-		}
-	}
-}
-
-func defaultModelServiceFixtureConfig() modelServiceFixtureConfig {
-	return modelServiceFixtureConfig{
-		hfTokenSecret: defaultHFTokenSecretName,
-		hfTokenKey:    defaultHFTokenSecretKey,
-	}
-}
-
-func resolveModelServiceFixtureConfig(opts ...ModelServiceOption) modelServiceFixtureConfig {
-	cfg := defaultModelServiceFixtureConfig()
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return cfg
-}

--- a/test/e2e/fixtures/model_service_conventions.go
+++ b/test/e2e/fixtures/model_service_conventions.go
@@ -1,0 +1,111 @@
+package fixtures
+
+const (
+	// decodeNameSuffix follows the llm-d fixture convention where model-serving
+	// workloads are named with "<base>-decode".
+	decodeNameSuffix = "-decode"
+	// serviceNameSuffix follows the fixture convention where Service names are
+	// derived from "<base>-service".
+	serviceNameSuffix = "-service"
+	// serviceMonitorNameSuffix follows the fixture convention "<base>-monitor".
+	serviceMonitorNameSuffix = "-monitor"
+
+	// kubePrometheusStackReleaseLabelValue matches the Helm release label used by
+	// kube-prometheus-stack ServiceMonitor discovery.
+	kubePrometheusStackReleaseLabelValue = "kube-prometheus-stack"
+	defaultServicePortName               = "http"
+	defaultServiceMonitorMetricsPath     = "/metrics"
+
+	defaultModelServiceSimulatorImage = "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+	defaultModelServiceRuntimeImage   = "ghcr.io/llm-d/llm-d-cuda-dev:latest"
+	defaultModelServiceContainerPort  = int32(8000)
+	defaultHFTokenSecretName          = "llm-d-hf-token"
+	defaultHFTokenSecretKey           = "HF_TOKEN"
+	defaultModelServiceLabelValue     = "ms-sim-llm-d-modelservice"
+	defaultInferenceServingLabelValue = "true"
+	defaultGuideLabelValue            = "workload-autoscaling"
+	defaultTestResourceLabelValue     = "true"
+)
+
+type modelServiceFixtureConfig struct {
+	simulatorImage string
+	runtimeImage   string
+	containerPort  int32
+	hfTokenSecret  string
+	hfTokenKey     string
+	modelLabel     string
+	guideLabel     string
+	testLabelValue string
+}
+
+// ModelServiceOption overrides fixture conventions used by model-service resources.
+type ModelServiceOption func(*modelServiceFixtureConfig)
+
+// WithModelServiceImages overrides simulator/runtime container images.
+func WithModelServiceImages(simulatorImage, runtimeImage string) ModelServiceOption {
+	return func(cfg *modelServiceFixtureConfig) {
+		if simulatorImage != "" {
+			cfg.simulatorImage = simulatorImage
+		}
+		if runtimeImage != "" {
+			cfg.runtimeImage = runtimeImage
+		}
+	}
+}
+
+// WithModelServiceContainerPort overrides the model server container port.
+func WithModelServiceContainerPort(port int32) ModelServiceOption {
+	return func(cfg *modelServiceFixtureConfig) {
+		if port > 0 {
+			cfg.containerPort = port
+		}
+	}
+}
+
+// WithModelServiceHFTokenSecret overrides the Hugging Face token secret reference.
+func WithModelServiceHFTokenSecret(secretName, secretKey string) ModelServiceOption {
+	return func(cfg *modelServiceFixtureConfig) {
+		if secretName != "" {
+			cfg.hfTokenSecret = secretName
+		}
+		if secretKey != "" {
+			cfg.hfTokenKey = secretKey
+		}
+	}
+}
+
+// WithModelServiceLabelValues overrides convention label values used by fixtures.
+func WithModelServiceLabelValues(modelLabel, guideLabel, testLabelValue string) ModelServiceOption {
+	return func(cfg *modelServiceFixtureConfig) {
+		if modelLabel != "" {
+			cfg.modelLabel = modelLabel
+		}
+		if guideLabel != "" {
+			cfg.guideLabel = guideLabel
+		}
+		if testLabelValue != "" {
+			cfg.testLabelValue = testLabelValue
+		}
+	}
+}
+
+func defaultModelServiceFixtureConfig() modelServiceFixtureConfig {
+	return modelServiceFixtureConfig{
+		simulatorImage: defaultModelServiceSimulatorImage,
+		runtimeImage:   defaultModelServiceRuntimeImage,
+		containerPort:  defaultModelServiceContainerPort,
+		hfTokenSecret:  defaultHFTokenSecretName,
+		hfTokenKey:     defaultHFTokenSecretKey,
+		modelLabel:     defaultModelServiceLabelValue,
+		guideLabel:     defaultGuideLabelValue,
+		testLabelValue: defaultTestResourceLabelValue,
+	}
+}
+
+func resolveModelServiceFixtureConfig(opts ...ModelServiceOption) modelServiceFixtureConfig {
+	cfg := defaultModelServiceFixtureConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -668,7 +668,7 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet", Serial, Label("
 		}).Should(Succeed(), "EPP pods should be ready")
 
 		By("Creating model service LeaderWorkerSet with 0 initial replicas")
-		err := fixtures.EnsureModelServiceLWS(ctx, crClient, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
+		err := fixtures.EnsureModelServiceLWS(ctx, crClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service LWS")
 
 		// Register cleanup for LWS
@@ -1089,7 +1089,7 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet (single-node)", S
 		}).Should(Succeed(), "EPP pods should be ready")
 
 		By("Creating model service LeaderWorkerSet with single-node (leader only) with 0 initial replicas")
-		err := fixtures.EnsureModelServiceLWS(ctx, crClient, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
+		err := fixtures.EnsureModelServiceLWS(ctx, crClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create model service LWS")
 
 		// Register cleanup for LWS

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -975,7 +975,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			cleanupSmokeTestResources()
 
 			By("Creating model service LeaderWorkerSet")
-			err := fixtures.EnsureModelServiceLWS(ctx, crClient, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
+			err := fixtures.EnsureModelServiceLWS(ctx, crClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create model service LWS")
 
 			// Register cleanup for LWS (runs even if test fails)
@@ -1798,7 +1798,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			cleanupSmokeTestResources()
 
 			By("Creating model service LeaderWorkerSet with single-node (leader only)")
-			err := fixtures.EnsureModelServiceLWS(ctx, crClient, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
+			err := fixtures.EnsureModelServiceLWS(ctx, crClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs, lwsGroupSize)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create model service LWS")
 
 			// Register cleanup for LWS (runs even if test fails)


### PR DESCRIPTION
- Add minimal fixture cleanup while preserving existing e2e defaults.
- Our e2e fixtures encode environment conventions that work for the main CI path. This change keeps those defaults intact
- Also aligns fixture behavior checks and wait logic with k8s machinery helpers for consistency.