### PR TITLE
fix(deploy): skip LWS installation when already present or not needed

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -141,6 +141,11 @@ export DEPLOY_LLM_D=true                    # Deploy llm-d infrastructure
 export DEPLOY_PROMETHEUS_ADAPTER=true       # Deploy Prometheus Adapter
 export DEPLOY_VA=true                       # Chart-managed VariantAutoscaling (default off; e2e often creates its own)
 export DEPLOY_HPA=true                      # Chart-managed HPA (default off; enable with DEPLOY_VA for demos)
+export DEPLOY_LWS=true                      # Deploy LeaderWorkerSet (set false if already installed)
+
+# LeaderWorkerSet Configuration
+export LWS_NAMESPACE="lws-system"           # Namespace for LWS installation
+export LWS_CHART_VERSION="0.8.0"            # LWS Helm chart version
 
 # HPA Configuration
 export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window (default: 240s)
@@ -218,7 +223,14 @@ export DEPLOY_HPA=false
 make deploy-wva-on-k8s
 ```
 
-##### Example 4: Fast HPA scaling for development/testing
+##### Example 4: Skip LeaderWorkerSet installation (LWS already on cluster)
+
+```bash
+export DEPLOY_LWS=false  # Skip LWS when it is already installed cluster-wide
+make deploy-wva-on-k8s
+```
+
+##### Example 5: Fast HPA scaling for development/testing
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
@@ -228,7 +240,7 @@ export HPA_STABILIZATION_SECONDS=30  # Fast scaling for dev/test (default: 240)
 make deploy-wva-on-k8s
 ```
 
-##### Example 5: E2E testing with very fast scaling
+##### Example 6: E2E testing with very fast scaling
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
@@ -239,7 +251,7 @@ export VLLM_MAX_NUM_SEQS=8           # Low batch size for easy saturation
 make deploy-wva-on-k8s
 ```
 
-##### Example 6: Parameter estimation with specific batch size
+##### Example 7: Parameter estimation with specific batch size
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
@@ -250,7 +262,7 @@ export DEPLOY_HPA=true
 make deploy-wva-on-k8s
 ```
 
-##### Example 7: Infra-only mode for e2e testing
+##### Example 8: Infra-only mode for e2e testing
 
 Deploy only the llm-d infrastructure and WVA controller without creating VariantAutoscaling or HPA resources. This is useful for e2e testing where tests dynamically create their own VA/HPA resources.
 
@@ -664,6 +676,7 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | `DEPLOY_PROMETHEUS_ADAPTER` | Deploy Prometheus Adapter | `true` |
 | `DEPLOY_VA` | Deploy VariantAutoscaling CR via WVA Helm chart | `false` |
 | `DEPLOY_HPA` | Deploy HPA via WVA Helm chart | `false` |
+| `DEPLOY_LWS` | Deploy LeaderWorkerSet (skip if already installed or not needed) | `true` |
 | `INFRA_ONLY` | Deploy only infrastructure (skip VA/HPA) | `false` |
 | `SKIP_CHECKS` | Skip prerequisite checks | `false` |
 
@@ -699,6 +712,8 @@ HPA_STABILIZATION_SECONDS=30 ./deploy/install.sh
 | `VLLM_SVC_ENABLED` | Enable vLLM Service | `true` |
 | `VLLM_SVC_NODEPORT` | vLLM NodePort | `30000` |
 | `LLM_D_RELEASE` | llm-d version | `v0.6.0` |
+| `LWS_NAMESPACE` | Namespace for LeaderWorkerSet installation | `lws-system` |
+| `LWS_CHART_VERSION` | LeaderWorkerSet Helm chart version | `0.8.0` |
 | `VLLM_MAX_NUM_SEQS` | vLLM max concurrent sequences per replica | (unset - uses vLLM default) |
 
 **vLLM Performance Tuning:**

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -123,6 +123,13 @@ KEDA_CHART_VERSION=${KEDA_CHART_VERSION:-2.19.0}
 # kubernetes: default false (cluster-managed KEDA); set true to let this script install/upgrade KEDA via Helm
 KEDA_HELM_INSTALL=${KEDA_HELM_INSTALL:-false}
 
+# LeaderWorkerSet (LWS) configuration
+# Set DEPLOY_LWS=false to skip LWS installation (e.g., when running benchmarks
+# locally or when LWS is already installed cluster-wide)
+DEPLOY_LWS=${DEPLOY_LWS:-true}
+LWS_NAMESPACE=${LWS_NAMESPACE:-"lws-system"}
+LWS_CHART_VERSION=${LWS_CHART_VERSION:-"0.8.0"}
+
 # Environment-related variables
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT=${ENVIRONMENT:-"kubernetes"}

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -194,13 +194,20 @@ deploy_wva_prerequisites_kube_like() {
     fi
 
     # LeaderWorkerSet (WVA dependency; see upstream chart / #910).
-    CHART_VERSION=0.8.0
-    log_info "Installing LeaderWorkerSet version $CHART_VERSION into lws-system namespace"
-    helm upgrade -i lws oci://registry.k8s.io/lws/charts/lws \
-        --version="$CHART_VERSION" \
-        --namespace lws-system \
-        --create-namespace \
-        --wait --timeout 300s
+    if [ "${DEPLOY_LWS:-true}" = "true" ]; then
+        if kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &> /dev/null; then
+            log_info "LeaderWorkerSet CRD already installed, skipping LWS deployment"
+        else
+            log_info "Installing LeaderWorkerSet version ${LWS_CHART_VERSION} into ${LWS_NAMESPACE} namespace"
+            helm upgrade -i lws oci://registry.k8s.io/lws/charts/lws \
+                --version="${LWS_CHART_VERSION}" \
+                --namespace "${LWS_NAMESPACE}" \
+                --create-namespace \
+                --wait --timeout 300s
+        fi
+    else
+        log_info "Skipping LeaderWorkerSet installation (DEPLOY_LWS=false)"
+    fi
 
     log_success "WVA prerequisites complete"
 }

--- a/deploy/openshift/install.sh
+++ b/deploy/openshift/install.sh
@@ -123,13 +123,20 @@ deploy_wva_prerequisites() {
     log_info "Deploying Workload-Variant-Autoscaler..."
     extract_openshift_prometheus_ca
 
-    CHART_VERSION=0.8.0
-    log_info "Installing LeaderWorkerSet version $CHART_VERSION into lws-system namespace"
-    helm upgrade -i lws oci://registry.k8s.io/lws/charts/lws \
-        --version=$CHART_VERSION \
-        --namespace lws-system \
-        --create-namespace \
-        --wait --timeout 300s
+    if [ "${DEPLOY_LWS:-true}" = "true" ]; then
+        if kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &> /dev/null; then
+            log_info "LeaderWorkerSet CRD already installed, skipping LWS deployment"
+        else
+            log_info "Installing LeaderWorkerSet version ${LWS_CHART_VERSION} into ${LWS_NAMESPACE} namespace"
+            helm upgrade -i lws oci://registry.k8s.io/lws/charts/lws \
+                --version="${LWS_CHART_VERSION}" \
+                --namespace "${LWS_NAMESPACE}" \
+                --create-namespace \
+                --wait --timeout 300s
+        fi
+    else
+        log_info "Skipping LeaderWorkerSet installation (DEPLOY_LWS=false)"
+    fi
 
     log_success "WVA prerequisites deployed"
 }


### PR DESCRIPTION
## What does this PR do?

Makes LeaderWorkerSet (LWS) installation configurable and idempotent in the deploy scripts. The scripts now:

- **Skip LWS installation** when `DEPLOY_LWS=false` is set
- **Skip if LWS CRD already exists** on the cluster (avoids redundant `helm upgrade` on every run)
- Use configurable `LWS_NAMESPACE` and `LWS_CHART_VERSION` variables instead of hardcoded values

**Files changed:**
- `deploy/install.sh` — added `DEPLOY_LWS`, `LWS_NAMESPACE`, `LWS_CHART_VERSION` configuration variables
- `deploy/lib/infra_wva.sh` — updated `deploy_wva_prerequisites_kube_like()` with skip/idempotency logic
- `deploy/openshift/install.sh` — updated `deploy_wva_prerequisites()` with the same logic

## Why is this change needed?

The install scripts unconditionally installed LWS into the global `lws-system` namespace on every run via `helm upgrade -i`. This caused problems when:

- **Running benchmarks locally** — the script would modify a shared cluster's LWS installation, potentially upgrading/downgrading it and disrupting other users
- **LWS was already installed** — redundant `helm upgrade` on every deployment added unnecessary latency and risk
- **The namespace was not configurable** — operators couldn't control where LWS was installed

From the issue:
```
[INFO] Installing LeaderWorkerSet version 0.8.0 into lws-system namespace
Release "lws" has been upgraded. Happy Helming!
REVISION: 31
```

Revision 31 indicates this has been running repeatedly on the same cluster.

## How was this tested?

- [x] Manual testing performed

- `bash -n` syntax validation passes for all three modified scripts
- `make lint-deploy-scripts` passes
- Verified all three code paths with mock tests:
  - `DEPLOY_LWS=false` → skips installation with info log
  - `DEPLOY_LWS=true` + CRD exists → skips with "already installed" message
  - `DEPLOY_LWS=true` + no CRD → proceeds with installation using `LWS_CHART_VERSION` and `LWS_NAMESPACE`
- Default behavior (no env vars set) is unchanged — `DEPLOY_LWS` defaults to `true`, `LWS_NAMESPACE` defaults to `lws-system`

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Code follows project contributing guidelines
- [x] Linters pass (`make lint-deploy-scripts`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #1011