### PR TITLE
fix: use scenario name in benchmark results filename

### DIFF
--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -841,7 +841,7 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 		GinkgoWriter.Printf("  └────────────────────────────────────────────────────────────\n\n")
 
 		benchmarkResultsFile = fmt.Sprintf("/tmp/%s-benchmark-results.json", scenarioName)
-		By(fmt.Sprintf("Saving benchmark results to %s", benchmarkResultsFile))
+		By("Saving benchmark results to " + benchmarkResultsFile)
 		data, _ := json.MarshalIndent(prefillResults, "", "  ")
 		_ = os.WriteFile(benchmarkResultsFile, data, 0644)
 	}
@@ -952,7 +952,7 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 	})
 
 	AfterAll(func() {
-		GinkgoWriter.Println("Prefill benchmark complete — cleaning up autoscalers and scaling to 1 for next test suite")
+		GinkgoWriter.Println("Benchmark complete — cleaning up autoscalers and scaling to 1 for next test suite")
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cleanupCancel()
 

--- a/test/benchmark/prefill_heavy_benchmark_test.go
+++ b/test/benchmark/prefill_heavy_benchmark_test.go
@@ -73,7 +73,7 @@ type MetricSnap struct {
 
 var prefillResults []PrefillResult
 
-const prefillResultsFile = "/tmp/prefill-benchmark-results.json"
+var benchmarkResultsFile string
 
 var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 	var (
@@ -840,9 +840,10 @@ var _ = Describe("Scaling Benchmark", Ordered, Label("benchmark"), func() {
 		}
 		GinkgoWriter.Printf("  └────────────────────────────────────────────────────────────\n\n")
 
-		By("Saving prefill benchmark results to file")
+		benchmarkResultsFile = fmt.Sprintf("/tmp/%s-benchmark-results.json", scenarioName)
+		By(fmt.Sprintf("Saving benchmark results to %s", benchmarkResultsFile))
 		data, _ := json.MarshalIndent(prefillResults, "", "  ")
-		_ = os.WriteFile(prefillResultsFile, data, 0644)
+		_ = os.WriteFile(benchmarkResultsFile, data, 0644)
 	}
 
 	Context("WVA Prefill Heavy", Label("phase3a"), func() {


### PR DESCRIPTION
## Summary

- Fixes an issue where all benchmark scenarios (prefill_heavy, decode_heavy, symmetrical) wrote results to the same file `/tmp/prefill-benchmark-results.json`, causing later runs to overwrite earlier results
- Each scenario now writes to `/tmp/<scenario>-benchmark-results.json` (e.g., `/tmp/decode_heavy-benchmark-results.json`)

## Test plan

- [ ] Run prefill_heavy then decode_heavy and verify both `/tmp/prefill_heavy-benchmark-results.json` and `/tmp/decode_heavy-benchmark-results.json` exist with correct data


Made with [Cursor](https://cursor.com)