### PR TITLE
improve pr-review skill: idempotent comments with checkbox diff

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-review
 description: Review an open pull request for this project. Checks Go code quality (AGENTS.md), test coverage, and Kubernetes security. Posts findings as a GitHub PR comment (idempotent: creates on first run, updates with resolved/new diff on re-runs). Use when the user asks to review a PR. Invoke with /pr-review [PR-number] or /pr-review to auto-detect the current branch's PR.
 disable-model-invocation: true
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(gh api repos/*/issues/*/comments:*), Bash(gh api repos/*/issues/comments/*:*), Bash(git rev-parse:*), Bash(git log:*), Agent, TodoWrite
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(gh api repos/*/issues/*/comments:*), Bash(gh api repos/*/issues/comments/*:*), Bash(git rev-parse:*), Bash(git log:*), Bash(mktemp:*), Agent, TodoWrite
 ---
 
 # PR Review
@@ -25,13 +25,16 @@ Record: PR number, title, URL, base branch, head SHA.
 git rev-parse HEAD
 ```
 
-Also check if the PR already has a review comment from Claude Code, identified by the `<!-- claude-pr-review -->` sentinel at the start of the body. Use `last` to get the most recent one if multiple exist:
+Also check if the PR already has a review comment from Claude Code. First look for the `<!-- claude-pr-review -->` sentinel (new-style); if not found, fall back to the legacy marker `Generated with [Claude Code]` (pre-sentinel comments). Use `last` to get the most recent match:
 
 ```bash
+# New-style sentinel
 gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | startswith("<!-- claude-pr-review -->"))] | last | select(. != null) | {id: .id, body: .body}'
+# Legacy fallback (run only if the above produces no output)
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | contains("Generated with [Claude Code]"))] | last | select(. != null) | {id: .id, body: .body}'
 ```
 
-If an existing Claude review comment is found, record its **comment ID** and **full body text** — do not stop, continue the review in "update" mode.
+If both produce no output, no prior review comment exists — treat this as the first run. If a JSON object is returned by either query, record its **comment ID** and **full body text** and continue in "update" mode.
 
 ## Step 2: Fetch PR Context
 
@@ -82,25 +85,44 @@ Collect findings from all four agents. Only include issues with confidence >= 80
 
 ### Idempotent comment posting
 
-**If no existing Claude review comment was found** (first run): create a new comment with `gh pr comment`.
-
-**If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment. Write the body to a temp file first to avoid shell expansion corrupting multi-line Markdown:
+**If no existing Claude review comment was found** (first run): write the body to a temp file and post with `gh pr comment --body-file`:
 
 ```bash
 BODY_FILE=$(mktemp /tmp/review_body_XXXXXX.txt)
+# Write the fully rendered Markdown (replace everything below with actual content)
 cat > "$BODY_FILE" << 'EOF'
-<updated body>
+<actual comment body>
+EOF
+gh pr comment <number> --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
+```
+
+**If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment using the same temp-file approach:
+
+```bash
+BODY_FILE=$(mktemp /tmp/review_body_XXXXXX.txt)
+# Write the fully rendered Markdown (replace everything below with actual content)
+cat > "$BODY_FILE" << 'EOF'
+<actual comment body>
 EOF
 gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body=@"$BODY_FILE"
 rm -f "$BODY_FILE"
 ```
+
+**Important**: In both snippets, replace only the `<actual comment body>` placeholder line with the fully rendered Markdown — leave the `EOF` terminator line intact. The heredoc delimiter is quoted (`'EOF'`) so no shell expansion occurs inside it.
 
 To compute the diff from the old comment body:
 - **Resolved**: old issue absent from new findings → `- [x] ~~<description>~~ *(resolved)*`
 - **Still open**: issue present in both old and new findings → `- [ ] <description>`
 - **New**: issue in new findings but absent from old comment → `- [ ] <description> *(new)*`
 
-**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches. If no exact `file.go#Lnn` match is found (e.g. after a rebase shifted line numbers), fall back to: same file path **and** more than 80% of the whitespace-delimited words from the shorter description appear in the longer description (case-insensitive) → treat as the same issue at its new location.
+**Matching key** (applied in order, stop at first match). Before computing word overlap in any rule, strip the trailing `` — `...` `` anchor suffix from the bullet line (e.g. `` — `path/to/file.go#L42` ``), then tokenize on whitespace (case-insensitive):
+1. **Exact anchor**: `file.go#Lnn` references are identical → same issue.
+2. **Shifted anchor**: same file path **and** >80% word overlap on the stripped descriptions → same issue at its new location (handles rebases).
+3. **No anchor** (e.g. Test Coverage items with only a file path): same file path **and** >80% word overlap on the stripped descriptions → same issue.
+4. **No anchor and no file match**: >80% word overlap on the stripped descriptions alone → same issue.
+
+Do not treat a reworded description as new if any of the above rules match.
 
 Preserve per-category section headings. Omit a section entirely if it has no items.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -28,7 +28,7 @@ git rev-parse HEAD
 Also check if the PR already has a review comment from Claude Code, identified by the `claude.ai/code` URL in its signature. Use `last` to get the most recent one if multiple exist:
 
 ```bash
-gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | contains("claude.ai/code"))] | last | {id: .id, body: .body}'
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | contains("claude.ai/code"))] | last | select(. != null) | {id: .id, body: .body}'
 ```
 
 If an existing Claude review comment is found, record its **comment ID** and **full body text** — do not stop, continue the review in "update" mode.
@@ -84,10 +84,13 @@ Collect findings from all four agents. Only include issues with confidence >= 80
 
 **If no existing Claude review comment was found** (first run): create a new comment with `gh pr comment`.
 
-**If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment using:
+**If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment. Write the body to a temp file first to avoid shell expansion corrupting multi-line Markdown:
 
 ```bash
-gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body="<updated body>"
+cat > /tmp/review_body.txt << 'EOF'
+<updated body>
+EOF
+gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body=@/tmp/review_body.txt
 ```
 
 To compute the diff from the old comment body:
@@ -95,7 +98,7 @@ To compute the diff from the old comment body:
 - **Still open**: issue present in both old and new findings → `- [ ] <description>`
 - **New**: issue in new findings but absent from old comment → `- [ ] <description> *(new)*`
 
-**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches.
+**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches. If no exact `file.go#Lnn` match is found (e.g. after a rebase shifted line numbers), fall back to: same file path **and** ≥80% description similarity → treat as the same issue at its new location.
 
 Preserve per-category section headings. Omit a section entirely if it has no items.
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-review
 description: Review an open pull request for this project. Checks Go code quality (AGENTS.md), test coverage, and Kubernetes security. Posts findings as a GitHub PR comment (idempotent: creates on first run, updates with resolved/new diff on re-runs). Use when the user asks to review a PR. Invoke with /pr-review [PR-number] or /pr-review to auto-detect the current branch's PR.
 disable-model-invocation: true
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(gh api:*), Bash(git rev-parse:*), Bash(git log:*), Agent, TodoWrite
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(gh api repos/*/issues/*/comments:*), Bash(gh api repos/*/issues/comments/*:*), Bash(git rev-parse:*), Bash(git log:*), Agent, TodoWrite
 ---
 
 # PR Review
@@ -25,10 +25,10 @@ Record: PR number, title, URL, base branch, head SHA.
 git rev-parse HEAD
 ```
 
-Also check if the PR already has a review comment from Claude Code, identified by the `🤖 Generated with [Claude Code]` signature:
+Also check if the PR already has a review comment from Claude Code, identified by the `claude.ai/code` URL in its signature. Use `last` to get the most recent one if multiple exist:
 
 ```bash
-gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[] | select(.body | contains("Generated with [Claude Code]")) | {id: .id, body: .body}' | head -1
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | contains("claude.ai/code"))] | last | {id: .id, body: .body}'
 ```
 
 If an existing Claude review comment is found, record its **comment ID** and **full body text** — do not stop, continue the review in "update" mode.
@@ -95,6 +95,8 @@ To compute the diff from the old comment body:
 - **Still open**: issue present in both old and new findings → `- [ ] <description>`
 - **New**: issue in new findings but absent from old comment → `- [ ] <description> *(new)*`
 
+**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches.
+
 Preserve per-category section headings. Omit a section entirely if it has no items.
 
 ### Comment format — new comment
@@ -146,7 +148,18 @@ No issues found. Checked Go conventions, test coverage, security, and library re
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-If no issues meet the threshold **and** there IS an existing comment, update it to mark all previously open items as resolved.
+If no issues meet the threshold **and** there IS an existing comment, update it using PATCH to mark all previously open items as resolved:
+
+```
+### Code Review
+
+**<Category>**
+- [x] ~~<previously open issue>~~ *(resolved)*
+
+No new issues found.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
 
 When linking to specific lines, use the full commit SHA:
 `https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/<full-sha>/path/to/file.go#L42-L45`

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -25,10 +25,10 @@ Record: PR number, title, URL, base branch, head SHA.
 git rev-parse HEAD
 ```
 
-Also check if the PR already has a review comment from Claude Code, identified by the `claude.ai/code` URL in its signature. Use `last` to get the most recent one if multiple exist:
+Also check if the PR already has a review comment from Claude Code, identified by the `<!-- claude-pr-review -->` sentinel at the start of the body. Use `last` to get the most recent one if multiple exist:
 
 ```bash
-gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | contains("claude.ai/code"))] | last | select(. != null) | {id: .id, body: .body}'
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '[.[] | select(.body | startswith("<!-- claude-pr-review -->"))] | last | select(. != null) | {id: .id, body: .body}'
 ```
 
 If an existing Claude review comment is found, record its **comment ID** and **full body text** — do not stop, continue the review in "update" mode.
@@ -87,10 +87,12 @@ Collect findings from all four agents. Only include issues with confidence >= 80
 **If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment. Write the body to a temp file first to avoid shell expansion corrupting multi-line Markdown:
 
 ```bash
-cat > /tmp/review_body.txt << 'EOF'
+BODY_FILE=$(mktemp /tmp/review_body_XXXXXX.txt)
+cat > "$BODY_FILE" << 'EOF'
 <updated body>
 EOF
-gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body=@/tmp/review_body.txt
+gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body=@"$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
 To compute the diff from the old comment body:
@@ -98,13 +100,14 @@ To compute the diff from the old comment body:
 - **Still open**: issue present in both old and new findings → `- [ ] <description>`
 - **New**: issue in new findings but absent from old comment → `- [ ] <description> *(new)*`
 
-**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches. If no exact `file.go#Lnn` match is found (e.g. after a rebase shifted line numbers), fall back to: same file path **and** ≥80% description similarity → treat as the same issue at its new location.
+**Matching key**: two issues are the same if their `file.go#Lnn` reference is identical. Use description as a tiebreaker only when multiple issues share the same reference. Do not treat a reworded or rebased description as a new issue if the file+line anchor matches. If no exact `file.go#Lnn` match is found (e.g. after a rebase shifted line numbers), fall back to: same file path **and** more than 80% of the whitespace-delimited words from the shorter description appear in the longer description (case-insensitive) → treat as the same issue at its new location.
 
 Preserve per-category section headings. Omit a section entirely if it has no items.
 
 ### Comment format — new comment
 
 ```
+<!-- claude-pr-review -->
 ### Code Review
 
 **Go Code Quality**
@@ -126,6 +129,7 @@ Preserve per-category section headings. Omit a section entirely if it has no ite
 ### Comment format — updated comment (re-run diff example)
 
 ```
+<!-- claude-pr-review -->
 ### Code Review
 
 **Go Code Quality**
@@ -144,6 +148,7 @@ Preserve per-category section headings. Omit a section entirely if it has no ite
 If no issues meet the threshold **and** there is no existing review comment, post:
 
 ```
+<!-- claude-pr-review -->
 ### Code Review
 
 No issues found. Checked Go conventions, test coverage, security, and library reuse.
@@ -154,6 +159,7 @@ No issues found. Checked Go conventions, test coverage, security, and library re
 If no issues meet the threshold **and** there IS an existing comment, update it using PATCH to mark all previously open items as resolved:
 
 ```
+<!-- claude-pr-review -->
 ### Code Review
 
 **<Category>**

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pr-review
-description: Review an open pull request for this project. Checks Go code quality (AGENTS.md), test coverage, and Kubernetes security. Posts findings as a GitHub PR comment. Use when the user asks to review a PR. Invoke with /pr-review [PR-number] or /pr-review to auto-detect the current branch's PR.
+description: Review an open pull request for this project. Checks Go code quality (AGENTS.md), test coverage, and Kubernetes security. Posts findings as a GitHub PR comment (idempotent: creates on first run, updates with resolved/new diff on re-runs). Use when the user asks to review a PR. Invoke with /pr-review [PR-number] or /pr-review to auto-detect the current branch's PR.
 disable-model-invocation: true
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(git rev-parse:*), Bash(git log:*), Agent, TodoWrite
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr list:*), Bash(gh api:*), Bash(git rev-parse:*), Bash(git log:*), Agent, TodoWrite
 ---
 
 # PR Review
@@ -24,6 +24,14 @@ Record: PR number, title, URL, base branch, head SHA.
 ```bash
 git rev-parse HEAD
 ```
+
+Also check if the PR already has a review comment from Claude Code, identified by the `🤖 Generated with [Claude Code]` signature:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[] | select(.body | contains("Generated with [Claude Code]")) | {id: .id, body: .body}' | head -1
+```
+
+If an existing Claude review comment is found, record its **comment ID** and **full body text** — do not stop, continue the review in "update" mode.
 
 ## Step 2: Fetch PR Context
 
@@ -70,9 +78,65 @@ Wait for all four to complete before proceeding.
 
 ## Step 4: Aggregate and Post
 
-Collect findings from all three agents. Only include issues with confidence >= 80.
+Collect findings from all four agents. Only include issues with confidence >= 80.
 
-If no issues meet the threshold, post:
+### Idempotent comment posting
+
+**If no existing Claude review comment was found** (first run): create a new comment with `gh pr comment`.
+
+**If an existing Claude review comment was found** (re-run): diff the old issues against the new findings and update the existing comment using:
+
+```bash
+gh api --method PATCH repos/{owner}/{repo}/issues/comments/<comment_id> --field body="<updated body>"
+```
+
+To compute the diff from the old comment body:
+- **Resolved**: old issue absent from new findings → `- [x] ~~<description>~~ *(resolved)*`
+- **Still open**: issue present in both old and new findings → `- [ ] <description>`
+- **New**: issue in new findings but absent from old comment → `- [ ] <description> *(new)*`
+
+Preserve per-category section headings. Omit a section entirely if it has no items.
+
+### Comment format — new comment
+
+```
+### Code Review
+
+**Go Code Quality**
+- [ ] <brief description> — `path/to/file.go#L42`
+  > AGENTS.md: "<relevant rule>"
+
+**Test Coverage**
+- [ ] <brief description> — `path/to/file_test.go`
+
+**Security**
+- [ ] <brief description> — `path/to/file.go#L10`
+
+**Library Reuse**
+- [ ] <brief description> — `path/to/file.go#L10`
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+### Comment format — updated comment (re-run diff example)
+
+```
+### Code Review
+
+**Go Code Quality**
+- [x] ~~<previously reported issue>~~ *(resolved)*
+- [ ] <still-open issue> — `path/to/file.go#L42`
+- [ ] <newly found issue> *(new)* — `path/to/file.go#L55`
+
+**Security**
+- [ ] <still-open security issue> — `path/to/file.go#L10`
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+### No issues
+
+If no issues meet the threshold **and** there is no existing review comment, post:
 
 ```
 ### Code Review
@@ -82,38 +146,9 @@ No issues found. Checked Go conventions, test coverage, security, and library re
 🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
-Otherwise post:
-
-```
-### Code Review
-
-Found N issues:
-
-**Go Code Quality**
-1. <brief description> — `path/to/file.go#L42`
-   > AGENTS.md: "<relevant rule>"
-
-**Test Coverage**
-2. <brief description> — `path/to/file_test.go`
-
-**Security**
-3. <brief description> — `path/to/file.go#L10`
-
-**Library Reuse**
-4. <brief description> — `path/to/file.go#L10`
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-```
+If no issues meet the threshold **and** there IS an existing comment, update it to mark all previously open items as resolved.
 
 When linking to specific lines, use the full commit SHA:
 `https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/<full-sha>/path/to/file.go#L42-L45`
-
-Post the comment:
-```bash
-gh pr comment <number> --body "$(cat <<'REVIEW_EOF'
-<aggregated findings>
-REVIEW_EOF
-)"
-```
 
 Print the PR URL when done.


### PR DESCRIPTION
## Summary

- `/pr-review` now checks for an existing Claude Code review comment on the PR (identified by the `🤖 Generated with [Claude Code]` signature) before posting
- **First run**: creates a new comment as before, but using markdown checkboxes (`- [ ]`) instead of a numbered list
- **Re-run**: updates the existing comment in-place via `gh api PATCH`, diffing old issues against new findings:
  - `- [x] ~~issue~~` for items that are no longer found (resolved)
  - `- [ ] issue` for items still present
  - `- [ ] issue *(new)*` for newly discovered items
- Added `Bash(gh api:*)` to `allowed-tools` so the PATCH call is permitted

## Test plan

- [ ] Run `/pr-review` on a PR with no existing Claude comment → new comment created with checkboxes
- [ ] Fix one of the reported issues, then re-run `/pr-review` on the same PR → existing comment updated, fixed item marked `[x]`
- [ ] Run `/pr-review` on a PR where all issues have been fixed → all items marked resolved

---

Assisted-by: Claude Code (claude-sonnet-4-6)