### PR TITLE
Make targets that consume llmd-benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ gpu.cluster
 llm-d/
 llm-d-infra/
 llm-d-benchmark/
+# llmdbenchmark workspace directories (created by benchmark runs)
+*-*-*-*-*-*/
 llmd/
 llmd-infra/
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ gpu.cluster
 # llm-d and llm-d-infra directories
 llm-d/
 llm-d-infra/
+llm-d-benchmark/
 llmd/
 llmd-infra/
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
 E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
 BENCHMARK_SCENARIO          ?= prefill_heavy  # Options: prefill_heavy (phase3a), decode_heavy (decode-heavy), symmetrical
 
+# llm-d-benchmark CLI configuration
+BENCHMARK_REPO_URL   ?= https://github.com/llm-d/llm-d-benchmark.git
+BENCHMARK_REPO_DIR   ?= $(CURDIR)/llm-d-benchmark
+BENCHMARK_SPEC       ?= guides/inference-scheduling-wva
+BENCHMARK_NAMESPACE  ?= # set via BENCHMARK_NAMESPACE=<namespace>
+BENCHMARK_WORKSPACE  ?= $(CURDIR)
+BENCHMARK_HARNESS    ?= guidellm
+BENCHMARK_WORKLOAD   ?= prefill_heavy.yaml
+BENCHMARK_FORCE      ?= true
+BENCHMARK_MONITORING ?= true
+BENCHMARK_SCENARIOS_DIR ?= $(CURDIR)/test/benchmark/scenarios
+
 # Map scenario name to Ginkgo label filter
 ifeq ($(BENCHMARK_SCENARIO),decode_heavy)
   BENCHMARK_LABEL_FILTER := decode-heavy
@@ -406,6 +418,81 @@ test-benchmark: manifests generate fmt vet ## Run benchmark tests. Use BENCHMARK
 # Convenience target that deploys infra + runs benchmark tests.
 .PHONY: test-benchmark-with-setup
 test-benchmark-with-setup: deploy-e2e-infra test-benchmark
+
+##@ llm-d-benchmark CLI (standup / run / teardown)
+
+# Common llmdbenchmark flags (spec + workspace)
+BENCHMARK_CLI_FLAGS = --spec $(BENCHMARK_SPEC) --workspace $(BENCHMARK_WORKSPACE)
+
+.PHONY: benchmark-install
+benchmark-install: ## Clone llm-d-benchmark and install the llmdbenchmark CLI
+	@if [ ! -d "$(BENCHMARK_REPO_DIR)" ]; then \
+		echo "Cloning llm-d-benchmark..."; \
+		git clone $(BENCHMARK_REPO_URL) $(BENCHMARK_REPO_DIR); \
+	else \
+		echo "llm-d-benchmark already cloned at $(BENCHMARK_REPO_DIR)"; \
+	fi
+	@cd $(BENCHMARK_REPO_DIR) && ./install.sh --no-uv
+
+.PHONY: benchmark-standup
+benchmark-standup: ## Stand up the benchmark environment (set BENCHMARK_NAMESPACE=<namespace>)
+	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
+		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-standup BENCHMARK_NAMESPACE=<namespace>"; \
+		exit 1; \
+	fi
+	llmdbenchmark $(BENCHMARK_CLI_FLAGS) standup \
+		-p $(BENCHMARK_NAMESPACE) \
+		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
+
+.PHONY: benchmark-run
+benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<namespace>)
+	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
+		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run BENCHMARK_NAMESPACE=<namespace>"; \
+		exit 1; \
+	fi
+	llmdbenchmark $(BENCHMARK_CLI_FLAGS) run \
+		-p $(BENCHMARK_NAMESPACE) \
+		-l $(BENCHMARK_HARNESS) \
+		-w $(BENCHMARK_WORKLOAD) \
+		$(if $(filter true,$(BENCHMARK_FORCE)),-f,)
+
+.PHONY: benchmark-run-all
+benchmark-run-all: ## Run all scenarios from test/benchmark/scenarios/ (set BENCHMARK_NAMESPACE=<namespace>)
+	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
+		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run-all BENCHMARK_NAMESPACE=<namespace>"; \
+		exit 1; \
+	fi
+	@for scenario in $(BENCHMARK_SCENARIOS_DIR)/*.yaml; do \
+		scenario_name=$$(basename "$$scenario"); \
+		echo ""; \
+		echo "=========================================="; \
+		echo "Running scenario: $$scenario_name"; \
+		echo "=========================================="; \
+		llmdbenchmark $(BENCHMARK_CLI_FLAGS) run \
+			-p $(BENCHMARK_NAMESPACE) \
+			-l $(BENCHMARK_HARNESS) \
+			-w "$$scenario_name" \
+			$(if $(filter true,$(BENCHMARK_FORCE)),-f,) || { \
+			echo "ERROR: Scenario $$scenario_name failed"; \
+			exit 1; \
+		}; \
+	done
+	@echo ""
+	@echo "=========================================="
+	@echo "All scenarios completed successfully"
+	@echo "=========================================="
+
+.PHONY: benchmark-teardown
+benchmark-teardown: ## Tear down the benchmark environment (set BENCHMARK_NAMESPACE=<namespace>)
+	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
+		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-teardown BENCHMARK_NAMESPACE=<namespace>"; \
+		exit 1; \
+	fi
+	llmdbenchmark $(BENCHMARK_CLI_FLAGS) teardown \
+		-p $(BENCHMARK_NAMESPACE)
+
+.PHONY: benchmark-full
+benchmark-full: benchmark-standup benchmark-run-all benchmark-teardown ## Full lifecycle: standup -> run all scenarios -> teardown
 
 # Stub for llm-d nightly reusable workflows (test_target=nightly-test-llm-d)
 # No-op; temporarily satisfies nightly CI make invocation

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ BENCHMARK_HARNESS    ?= guidellm
 BENCHMARK_WORKLOAD   ?= prefill_heavy.yaml
 BENCHMARK_FORCE      ?= true
 BENCHMARK_MONITORING ?= true
+BENCHMARK_UV         ?= false
 BENCHMARK_SCENARIOS_DIR ?= $(CURDIR)/test/benchmark/scenarios
 
 # Map scenario name to Ginkgo label filter
@@ -436,7 +437,7 @@ benchmark-install: ## Clone llm-d-benchmark and install the llmdbenchmark CLI
 	else \
 		echo "llm-d-benchmark already cloned at $(BENCHMARK_REPO_DIR)"; \
 	fi
-	@cd $(BENCHMARK_REPO_DIR) && ./install.sh --no-uv
+	@cd $(BENCHMARK_REPO_DIR) && ./install.sh $(if $(filter true,$(BENCHMARK_UV)),--uv,--no-uv)
 
 .PHONY: benchmark-standup
 benchmark-standup: ## Stand up the benchmark environment (set BENCHMARK_NAMESPACE=<namespace>)
@@ -454,10 +455,15 @@ benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<name
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
 	fi
+	@if [ -f "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD)" ]; then \
+		cp "$(BENCHMARK_SCENARIOS_DIR)/$(BENCHMARK_WORKLOAD)" \
+		   "$(BENCHMARK_REPO_DIR)/workload/profiles/$(BENCHMARK_HARNESS)/$(BENCHMARK_WORKLOAD)"; \
+	fi
 	$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) run \
 		-p $(BENCHMARK_NAMESPACE) \
 		-l $(BENCHMARK_HARNESS) \
-		-w $(BENCHMARK_WORKLOAD)
+		-w $(BENCHMARK_WORKLOAD) \
+		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
 
 .PHONY: benchmark-run-all
 benchmark-run-all: ## Run all scenarios: teardown → standup → run per scenario (set BENCHMARK_NAMESPACE=<namespace>)

--- a/Makefile
+++ b/Makefile
@@ -421,8 +421,12 @@ test-benchmark-with-setup: deploy-e2e-infra test-benchmark
 
 ##@ llm-d-benchmark CLI (standup / run / teardown)
 
-# Common llmdbenchmark flags (spec + workspace)
-BENCHMARK_CLI_FLAGS = --spec $(BENCHMARK_SPEC) --workspace $(BENCHMARK_WORKSPACE)
+# llmdbenchmark binary from the benchmark repo venv
+BENCHMARK_VENV       = $(BENCHMARK_REPO_DIR)/.venv
+LLMDBENCHMARK        = $(BENCHMARK_VENV)/bin/llmdbenchmark
+
+# Common llmdbenchmark flags (spec + workspace + base dir for config resolution)
+BENCHMARK_CLI_FLAGS = --spec $(BENCHMARK_SPEC) --workspace $(BENCHMARK_WORKSPACE) --base-dir $(BENCHMARK_REPO_DIR)
 
 .PHONY: benchmark-install
 benchmark-install: ## Clone llm-d-benchmark and install the llmdbenchmark CLI
@@ -440,7 +444,7 @@ benchmark-standup: ## Stand up the benchmark environment (set BENCHMARK_NAMESPAC
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-standup BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
 	fi
-	llmdbenchmark $(BENCHMARK_CLI_FLAGS) standup \
+	$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) standup \
 		-p $(BENCHMARK_NAMESPACE) \
 		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
 
@@ -450,14 +454,13 @@ benchmark-run: ## Run a single benchmark workload (set BENCHMARK_NAMESPACE=<name
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
 	fi
-	llmdbenchmark $(BENCHMARK_CLI_FLAGS) run \
+	$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) run \
 		-p $(BENCHMARK_NAMESPACE) \
 		-l $(BENCHMARK_HARNESS) \
-		-w $(BENCHMARK_WORKLOAD) \
-		$(if $(filter true,$(BENCHMARK_FORCE)),-f,)
+		-w $(BENCHMARK_WORKLOAD)
 
 .PHONY: benchmark-run-all
-benchmark-run-all: ## Run all scenarios from test/benchmark/scenarios/ (set BENCHMARK_NAMESPACE=<namespace>)
+benchmark-run-all: ## Run all scenarios: teardown → standup → run per scenario (set BENCHMARK_NAMESPACE=<namespace>)
 	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run-all BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
@@ -466,13 +469,28 @@ benchmark-run-all: ## Run all scenarios from test/benchmark/scenarios/ (set BENC
 		scenario_name=$$(basename "$$scenario"); \
 		echo ""; \
 		echo "=========================================="; \
-		echo "Running scenario: $$scenario_name"; \
+		echo "[1/3] Tearing down before: $$scenario_name"; \
 		echo "=========================================="; \
-		llmdbenchmark $(BENCHMARK_CLI_FLAGS) run \
+		$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) teardown \
+			-p $(BENCHMARK_NAMESPACE) || true; \
+		echo ""; \
+		echo "=========================================="; \
+		echo "[2/3] Standing up for: $$scenario_name"; \
+		echo "=========================================="; \
+		$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) standup \
+			-p $(BENCHMARK_NAMESPACE) \
+			$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,) || { \
+			echo "ERROR: Standup failed for $$scenario_name"; \
+			exit 1; \
+		}; \
+		echo ""; \
+		echo "=========================================="; \
+		echo "[3/3] Running scenario: $$scenario_name"; \
+		echo "=========================================="; \
+		$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) run \
 			-p $(BENCHMARK_NAMESPACE) \
 			-l $(BENCHMARK_HARNESS) \
-			-w "$$scenario_name" \
-			$(if $(filter true,$(BENCHMARK_FORCE)),-f,) || { \
+			-w "$$scenario_name" || { \
 			echo "ERROR: Scenario $$scenario_name failed"; \
 			exit 1; \
 		}; \
@@ -488,7 +506,7 @@ benchmark-teardown: ## Tear down the benchmark environment (set BENCHMARK_NAMESP
 		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-teardown BENCHMARK_NAMESPACE=<namespace>"; \
 		exit 1; \
 	fi
-	llmdbenchmark $(BENCHMARK_CLI_FLAGS) teardown \
+	$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) teardown \
 		-p $(BENCHMARK_NAMESPACE)
 
 .PHONY: benchmark-full

--- a/test/benchmark/scenarios/decode_heavy.yaml
+++ b/test/benchmark/scenarios/decode_heavy.yaml
@@ -2,9 +2,11 @@ target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
 model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 name: "Decode Heavy"
 description: "Stress-tests decode (token generation) with short input, long output"
-promptTokens: 1000
-outputTokens: 4000
+request_type: text_completions
+profile: poisson
 rate: 20
-maxSeconds: 600
-profile: "poisson"
-requestType: "text_completions"
+max_seconds: 600
+data:
+  prompt_tokens: 1000
+  output_tokens: 4000
+  seed: 42

--- a/test/benchmark/scenarios/decode_heavy.yaml
+++ b/test/benchmark/scenarios/decode_heavy.yaml
@@ -1,3 +1,5 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 name: "Decode Heavy"
 description: "Stress-tests decode (token generation) with short input, long output"
 promptTokens: 1000

--- a/test/benchmark/scenarios/prefill_heavy.yaml
+++ b/test/benchmark/scenarios/prefill_heavy.yaml
@@ -1,3 +1,5 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 name: "Prefill Heavy"
 description: "Stress-tests prefill (prompt processing) with long input, short output"
 promptTokens: 4000

--- a/test/benchmark/scenarios/prefill_heavy.yaml
+++ b/test/benchmark/scenarios/prefill_heavy.yaml
@@ -2,9 +2,11 @@ target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
 model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 name: "Prefill Heavy"
 description: "Stress-tests prefill (prompt processing) with long input, short output"
-promptTokens: 4000
-outputTokens: 1000
+request_type: text_completions
+profile: poisson
 rate: 20
-maxSeconds: 600
-profile: "poisson"
-requestType: "text_completions"
+max_seconds: 600
+data:
+  prompt_tokens: 4000
+  output_tokens: 1000
+  seed: 42

--- a/test/benchmark/scenarios/symmetrical.yaml
+++ b/test/benchmark/scenarios/symmetrical.yaml
@@ -1,9 +1,12 @@
 target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
-model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODELname: "Symmetrical"
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+name: "Symmetrical"
 description: "Balanced workload with equal input and output token lengths"
-promptTokens: 1000
-outputTokens: 1000
+request_type: text_completions
+profile: poisson
 rate: 20
-maxSeconds: 600
-profile: "poisson"
-requestType: "text_completions"
+max_seconds: 600
+data:
+  prompt_tokens: 1000
+  output_tokens: 1000
+  seed: 42

--- a/test/benchmark/scenarios/symmetrical.yaml
+++ b/test/benchmark/scenarios/symmetrical.yaml
@@ -1,4 +1,5 @@
-name: "Symmetrical"
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODELname: "Symmetrical"
 description: "Balanced workload with equal input and output token lengths"
 promptTokens: 1000
 outputTokens: 1000


### PR DESCRIPTION
Run the following commands in your namespace:

- make benchmark-install required only once per repo clone.
- make benchmark-teardown BENCHMARK_NAMESPACE=asmalvan-test-9  
- make benchmark-standup BENCHMARK_NAMESPACE=asmalvan-test-9 
- make benchmark-run BENCHMARK_NAMESPACE=asmalvan-test-9 BENCHMARK_WORKLOAD=prefill_heavy.yaml

Code generated by Gemini 