### PR TITLE
E2e fixtures: clearer defaults, simpler helpers, light docs

### DIFF
--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -144,6 +144,20 @@ WVA provides a **single consolidated E2E suite** that runs on multiple environme
 
 E2E is intended to be a **deterministic correctness signal**: resource wiring, reconciliation, and stable invariants (e.g., CRs reconcile, status conditions are set, scalers are created and point at the right targets/metrics). Traffic generation and performance/benchmarking scenarios should live outside `test/e2e/`.
 
+### E2E shared fixtures
+
+Code lives under `test/e2e/fixtures`. The `fixtures` package holds reusable helpers to create, ensure (idempotent setup), and delete Kubernetes objects used by the e2e suite (VariantAutoscaling, HPA, KEDA ScaledObject, model services, Services, ServiceMonitors, InferenceObjective, etc.). Package-level documentation and naming conventions (`Create*` / `Ensure*` / `Delete*`, `baseName` vs full resource names) live in the package doc:
+
+```bash
+go doc ./test/e2e/fixtures
+```
+
+After changing fixture APIs or generated object shape, compile e2e without running specs:
+
+```bash
+go test ./test/e2e/... -run TestDoesNotExist
+```
+
 ### Infra-Only Setup (Required Before Running Tests)
 
 Tests expect **only** the WVA controller and llm-d infrastructure to be deployed; they create VariantAutoscaling resources, HPAs, and model services themselves. Use the install script in **infra-only** mode:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,6 +20,10 @@ If a test needs **high traffic**, long “wait and see” timing, or performance
 4. **Tiered Testing**: Smoke tests for quick validation, full suite for comprehensive coverage
 5. **Serialize If Needed**: Since the scope is **deterministic correctness**, if there are tests that should be run serially then make them as such, and make sure the environment is clean in each `BeforeAll`. Running tests such as for Deployment, LWS with 1 leader+1 worker, LWS with 1 leader+0 worker in parallel pointing to the same model can have issues with conflicting resources and can be hard to track.
 
+### Shared fixtures (`fixtures/`)
+
+Cluster object builders and ensure/delete helpers live in [`fixtures/`](./fixtures/). See package documentation with `go doc ./test/e2e/fixtures` or the [developer testing guide](../../docs/developer-guide/testing.md#e2e-shared-fixtures).
+
 ## Prerequisites
 
 ### Infrastructure Setup

--- a/test/e2e/fixtures/doc.go
+++ b/test/e2e/fixtures/doc.go
@@ -1,0 +1,16 @@
+// Package fixtures provides shared Kubernetes helpers for the consolidated e2e suite.
+//
+// Helpers follow a small set of conventions:
+//   - Create* fails if the object already exists.
+//   - Ensure* is idempotent for test setup: delete-then-recreate (or no-op when ready and spec matches).
+//   - Delete* ignores NotFound.
+//   - Parameters named baseName are logical names; fixture code may append suffixes (for example
+//     "-service", "-monitor", "-decode") to form the actual resource name.
+//   - Shared literals such as test-resource and common ports live in model_service_conventions.go.
+//
+// After changing fixture contracts or generated object shape, compile e2e packages with:
+//
+//	go test ./test/e2e/... -run TestDoesNotExist
+//
+// Full e2e runs use make targets (see docs/developer-guide/testing.md and test/e2e/README.md).
+package fixtures

--- a/test/e2e/fixtures/hpa_builder.go
+++ b/test/e2e/fixtures/hpa_builder.go
@@ -72,8 +72,12 @@ func EnsureHPA(
 	opts ...HPAOption,
 ) error {
 	hpa := buildHPA(namespace, name, deploymentName, vaName, minReplicas, maxReplicas, opts...)
-	existing, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
-	if err == nil && existing != nil {
+	_, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(ctx, hpa.Name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing HPA %s: %w", hpa.Name, err)
+		}
+	} else {
 		deleteErr := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Delete(ctx, hpa.Name, metav1.DeleteOptions{})
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing HPA %s: %w", hpa.Name, deleteErr)
@@ -85,8 +89,6 @@ func EnsureHPA(
 		if waitErr != nil {
 			return fmt.Errorf("timeout waiting for HPA %s deletion: %w", hpa.Name, waitErr)
 		}
-	} else if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing HPA %s: %w", hpa.Name, err)
 	}
 	_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(ctx, hpa, metav1.CreateOptions{})
 	return err
@@ -97,7 +99,7 @@ func buildHPA(namespace, name, deploymentName, vaName string, minReplicas, maxRe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-hpa",
 			Namespace: namespace,
-			Labels:    map[string]string{"test-resource": "true"},
+			Labels:    map[string]string{"test-resource": defaultTestResourceLabelValue},
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{

--- a/test/e2e/fixtures/infra_builder.go
+++ b/test/e2e/fixtures/infra_builder.go
@@ -34,7 +34,11 @@ func DeleteService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespace, baseName, appLabel string, port int) error {
 	serviceName := baseName + serviceNameSuffix
 	_, err := k8sClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing service %s: %w", serviceName, err)
+		}
+	} else {
 		deleteErr := k8sClient.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing service %s: %w", serviceName, deleteErr)
@@ -42,8 +46,6 @@ func EnsureService(ctx context.Context, k8sClient *kubernetes.Clientset, namespa
 		if waitErr := WaitUntilServiceDeleted(ctx, k8sClient, namespace, serviceName, 30*time.Second); waitErr != nil {
 			return fmt.Errorf("timeout waiting for service %s to be deleted: %w", serviceName, waitErr)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing service %s: %w", serviceName, err)
 	}
 	service := buildService(namespace, baseName, appLabel, port)
 	_, err = k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
@@ -108,7 +110,11 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 		ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorName, Namespace: monitoringNamespace},
 	}
 	err := crClient.Get(ctx, client.ObjectKey{Name: serviceMonitorName, Namespace: monitoringNamespace}, existingSM)
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing ServiceMonitor %s: %w", serviceMonitorName, err)
+		}
+	} else {
 		deleteErr := crClient.Delete(ctx, existingSM)
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing ServiceMonitor %s: %w", serviceMonitorName, deleteErr)
@@ -116,8 +122,6 @@ func EnsureServiceMonitor(ctx context.Context, crClient client.Client, monitorin
 		if waitErr := WaitUntilServiceMonitorDeleted(ctx, crClient, monitoringNamespace, serviceMonitorName, 30*time.Second); waitErr != nil {
 			return fmt.Errorf("timeout waiting for ServiceMonitor %s to be deleted: %w", serviceMonitorName, waitErr)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing ServiceMonitor %s: %w", serviceMonitorName, err)
 	}
 	serviceMonitor := buildServiceMonitor(monitoringNamespace, targetNamespace, baseName, appLabel)
 	return crClient.Create(ctx, serviceMonitor)

--- a/test/e2e/fixtures/lws_builder.go
+++ b/test/e2e/fixtures/lws_builder.go
@@ -23,7 +23,11 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 	// Check if LWS already exists
 	existingLWS := &lwsv1.LeaderWorkerSet{}
 	err := crClient.Get(ctx, client.ObjectKey{Name: lwsName, Namespace: namespace}, existingLWS)
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing LWS %s: %w", lwsName, err)
+		}
+	} else {
 		// LWS exists, check if it's ready
 		if existingLWS.Status.ReadyReplicas > 0 && modelServiceLWSMatchesDesired(*existingLWS, *desiredLWS) {
 			return nil
@@ -49,8 +53,6 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 		if waitErr != nil {
 			return fmt.Errorf("timeout waiting for LWS %s to be deleted: %w", lwsName, waitErr)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing LWS %s: %w", lwsName, err)
 	}
 
 	err = crClient.Create(ctx, desiredLWS)
@@ -59,7 +61,19 @@ func EnsureModelServiceLWS(ctx context.Context, crClient client.Client, namespac
 		_ = crClient.Delete(ctx, desiredLWS, &client.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,
 		})
-		time.Sleep(2 * time.Second)
+		waitErr := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			checkErr := crClient.Get(ctx, client.ObjectKey{Name: lwsName, Namespace: namespace}, &lwsv1.LeaderWorkerSet{})
+			if errors.IsNotFound(checkErr) {
+				return true, nil
+			}
+			if checkErr != nil {
+				return false, checkErr
+			}
+			return false, nil
+		})
+		if waitErr != nil {
+			return fmt.Errorf("timeout waiting for LWS %s to be deleted before recreate: %w", lwsName, waitErr)
+		}
 		err = crClient.Create(ctx, desiredLWS)
 	}
 	return err

--- a/test/e2e/fixtures/model_service_builder.go
+++ b/test/e2e/fixtures/model_service_builder.go
@@ -43,7 +43,11 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 	desiredDeployment := buildModelServiceDeployment(namespace, name, poolName, modelID, useSimulator, maxNumSeqs)
 
 	existingDeployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing deployment %s: %w", deploymentName, err)
+		}
+	} else {
 		if existingDeployment.Status.ReadyReplicas > 0 && modelServiceDeploymentMatchesDesired(*existingDeployment, *desiredDeployment) {
 			return nil
 		}
@@ -57,8 +61,6 @@ func EnsureModelService(ctx context.Context, k8sClient *kubernetes.Clientset, na
 		if err := WaitUntilDeploymentDeleted(ctx, k8sClient, namespace, deploymentName, 2*time.Minute); err != nil {
 			return fmt.Errorf("timeout waiting for deployment %s to be deleted: %w", deploymentName, err)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing deployment %s: %w", deploymentName, err)
 	}
 
 	_, err = k8sClient.AppsV1().Deployments(namespace).Create(ctx, desiredDeployment, metav1.CreateOptions{})

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -83,7 +83,11 @@ func EnsureScaledObject(
 	existing := scaledObjectRef(namespace, name)
 	key := client.ObjectKey{Namespace: namespace, Name: obj.GetName()}
 	err := crClient.Get(ctx, key, existing)
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing ScaledObject %s: %w", obj.GetName(), err)
+		}
+	} else {
 		deleteErr := crClient.Delete(ctx, existing)
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing ScaledObject %s: %w", obj.GetName(), deleteErr)
@@ -96,8 +100,6 @@ func EnsureScaledObject(
 		if waitErr != nil {
 			return fmt.Errorf("timeout waiting for ScaledObject %s deletion: %w", obj.GetName(), waitErr)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing ScaledObject %s: %w", obj.GetName(), err)
 	}
 	return crClient.Create(ctx, obj)
 }
@@ -141,7 +143,7 @@ func buildScaledObject(namespace, name, scaleTargetName, vaName string, minRepli
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objName,
 			Namespace: namespace,
-			Labels:    map[string]string{"test-resource": "true"},
+			Labels:    map[string]string{"test-resource": defaultTestResourceLabelValue},
 		},
 		Spec: spec,
 	}

--- a/test/e2e/fixtures/va_builder.go
+++ b/test/e2e/fixtures/va_builder.go
@@ -84,7 +84,11 @@ func EnsureVariantAutoscaling(
 ) error {
 	existingVA := &variantautoscalingv1alpha1.VariantAutoscaling{}
 	err := crClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, existingVA)
-	if err == nil {
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing VA %s: %w", name, err)
+		}
+	} else {
 		deleteErr := crClient.Delete(ctx, existingVA)
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing VA %s: %w", name, deleteErr)
@@ -92,8 +96,6 @@ func EnsureVariantAutoscaling(
 		if err := WaitUntilVariantAutoscalingDeleted(ctx, crClient, namespace, name, 1*time.Minute); err != nil {
 			return fmt.Errorf("timeout waiting for VA %s to be deleted: %w", name, err)
 		}
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing VA %s: %w", name, err)
 	}
 	va := buildVariantAutoscaling(namespace, name, deploymentName, modelID, accelerator, cost, controllerInstance, opts...)
 	return crClient.Create(ctx, va)
@@ -121,7 +123,7 @@ func EnsureVariantAutoscalingWithDefaults(
 
 func buildVariantAutoscaling(namespace, name, deploymentName, modelID, accelerator string, cost float64, controllerInstance string, opts ...VAOption) *variantautoscalingv1alpha1.VariantAutoscaling {
 	labels := map[string]string{
-		"test-resource":            "true",
+		"test-resource":            defaultTestResourceLabelValue,
 		utils.AcceleratorNameLabel: accelerator,
 	}
 	if controllerInstance != "" {

--- a/test/e2e/fixtures/workload_builder.go
+++ b/test/e2e/fixtures/workload_builder.go
@@ -68,7 +68,7 @@ func CreateLoadJob(
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":           name + "-load",
-				"test-resource": "true",
+				"test-resource": defaultTestResourceLabelValue,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -77,7 +77,7 @@ func CreateLoadJob(
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app":           name + "-load",
-						"test-resource": "true",
+						"test-resource": defaultTestResourceLabelValue,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -183,8 +183,12 @@ func EnsureBurstLoadJob(
 	loadCfg LoadConfig,
 ) error {
 	jobName := name + "-load"
-	existing, err := k8sClient.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
-	if err == nil && existing != nil {
+	_, err := k8sClient.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("check existing Job %s: %w", jobName, err)
+		}
+	} else {
 		deleteErr := k8sClient.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{})
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return fmt.Errorf("delete existing Job %s: %w", jobName, deleteErr)
@@ -196,8 +200,6 @@ func EnsureBurstLoadJob(
 		if waitErr != nil {
 			return fmt.Errorf("timeout waiting for Job %s deletion: %w", jobName, waitErr)
 		}
-	} else if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("check existing Job %s: %w", jobName, err)
 	}
 	job := buildBurstLoadJob(namespace, name, targetServiceURL, loadCfg)
 	_, err = k8sClient.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
@@ -212,7 +214,7 @@ func buildBurstLoadJob(namespace, name, targetServiceURL string, loadCfg LoadCon
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":           name + "-load",
-				"test-resource": "true",
+				"test-resource": defaultTestResourceLabelValue,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -221,7 +223,7 @@ func buildBurstLoadJob(namespace, name, targetServiceURL string, loadCfg LoadCon
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app":           name + "-load",
-						"test-resource": "true",
+						"test-resource": defaultTestResourceLabelValue,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -368,7 +370,7 @@ exit 0
 			Labels: map[string]string{
 				"experiment":    experimentLabel,
 				"worker":        strconv.Itoa(workerID),
-				"test-resource": "true",
+				"test-resource": defaultTestResourceLabelValue,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -378,7 +380,7 @@ exit 0
 					Labels: map[string]string{
 						"experiment":    experimentLabel,
 						"worker":        strconv.Itoa(workerID),
-						"test-resource": "true",
+						"test-resource": defaultTestResourceLabelValue,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
This tightens up the shared e2e fixture helpers without changing what e2e tests are trying to do.

Pulled scattered magic strings into named defaults where it helps, fixed a few misleading names (baseName where we append suffixes), and made the “ensure” paths easier to read by handling Get errors up front. HPA/LWS/service waits use the same kind of polling we use elsewhere, and we added a short package note plus links from the testing guide and e2e README so the next person knows where this stuff lives.

No intentional behavior change for existing tests, mostly readability and consistency.