### PR TITLE
Feat: Observability - Configuration State Metrics

### DIFF
--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -115,6 +115,19 @@ const (
 
 	// WVAModelsProcessed is a gauge that tracks the number of models processed in the last optimization cycle.
 	WVAModelsProcessed = "wva_models_processed"
+
+	// WVAConfigInfo is an info-style gauge that exposes WVA configuration as labels.
+	// Labels: analyzer_name, limiter_enabled, scale_to_zero_enabled
+	WVAConfigInfo = "wva_config_info"
+
+	// WVAConfigKvSpareThreshold is a gauge that tracks the KV cache spare threshold configuration.
+	WVAConfigKvSpareThreshold = "wva_config_kv_spare_threshold"
+
+	// WVAConfigQueueSpareThreshold is a gauge that tracks the queue spare threshold configuration.
+	WVAConfigQueueSpareThreshold = "wva_config_queue_spare_threshold"
+
+	// WVAConfigOptimizationIntervalSeconds is a gauge that tracks the optimization interval in seconds.
+	WVAConfigOptimizationIntervalSeconds = "wva_config_optimization_interval_seconds"
 )
 
 // Metric Label Names
@@ -128,4 +141,7 @@ const (
 	LabelAcceleratorType    = "accelerator_type"
 	LabelControllerInstance = "controller_instance"
 	LabelStatus             = "status"
+	LabelAnalyzerName       = "analyzer_name"
+	LabelLimiterEnabled     = "limiter_enabled"
+	LabelScaleToZeroEnabled = "scale_to_zero_enabled"
 )

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -177,6 +177,7 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 // StartOptimizeLoop starts the optimization loop for the saturation engine.
 // It runs until the context is cancelled.
 func (e *Engine) StartOptimizeLoop(ctx context.Context) {
+	metrics.SetConfigOptimizationInterval(float64(e.Config.OptimizationInterval().Seconds()))
 	e.executor.Start(ctx)
 }
 
@@ -325,6 +326,20 @@ func (e *Engine) optimize(ctx context.Context) (retErr error) {
 	return nil
 }
 
+// Resolve saturation config and record config metrics
+func (e *Engine) resolveSaturationConfig(
+	configMap map[string]config.SaturationScalingConfig,
+	modelID, namespace string,
+) config.SaturationScalingConfig {
+	config := resolveSaturationConfig(configMap, modelID, namespace)
+	// record config metric after resolution instead of where the configmaps are reconciled. Here we
+	// have the exact values being used by the optimize engine.
+	metrics.SetConfigKvSpareThreshold(config.KvSpareTrigger)
+	metrics.SetConfigQueueSpareThreshold(config.QueueSpareTrigger)
+	metrics.SetConfigInfo(config.AnalyzerName, config.EnableLimiter, e.Config.ScaleToZeroEnabled())
+	return config
+}
+
 // optimizeV1 runs the V1 percentage-based saturation analysis path (saturation-percentage-based).
 // Processes each model independently: analyze → enforce → convert → limiter.
 func (e *Engine) optimizeV1(
@@ -353,7 +368,7 @@ func (e *Engine) optimizeV1(
 			continue
 		}
 
-		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
+		saturationConfig := e.resolveSaturationConfig(saturationConfigMap, modelID, namespace)
 		saturationTargets, saturationAnalysis, data, err := e.RunSaturationAnalysis(ctx, modelID, modelVAs, saturationConfig, e.client)
 		if err != nil {
 			logger.Error(err, "Saturation analysis failed", "modelID", modelID)
@@ -461,8 +476,8 @@ func (e *Engine) optimizeV2(
 				"namespace", namespace, "modelID", modelID)
 			continue
 		}
-		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)
 
+		saturationConfig := e.resolveSaturationConfig(saturationConfigMap, modelID, namespace)
 		data, err := e.prepareModelData(ctx, modelID, modelVAs, e.client)
 		if err != nil {
 			logger.Error(err, "Model data preparation failed", "modelID", modelID)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -417,7 +417,7 @@ func (e *Engine) optimizeV1(
 		}
 
 		saturationConfig := e.resolveSaturationConfig(saturationConfigMap, modelID, namespace)
-    
+
 		// Prepare model data once per model (single metrics collection pass).
 		data, err := e.prepareModelData(ctx, modelID, modelVAs, e.client)
 

--- a/internal/metrics/config_state_metrics_test.go
+++ b/internal/metrics/config_state_metrics_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	trueStr  = "true"
+	falseStr = "false"
+)
+
+func TestSetConfigInfo(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set config info with different values
+	SetConfigInfo("saturation_analyzer_v2", true, false)
+
+	// Verify the gauge
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAConfigInfo {
+			found = true
+			if len(mf.GetMetric()) != 1 {
+				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
+			}
+			m := mf.GetMetric()[0]
+			g := m.GetGauge()
+			if g == nil {
+				t.Error("Expected gauge metric")
+			} else if g.GetValue() != 1 {
+				t.Errorf("Expected gauge value 1 (info-style metric), got %f", g.GetValue())
+			}
+
+			// Verify labels
+			analyzerName := getLabelValue(m, constants.LabelAnalyzerName)
+			if analyzerName != "saturation_analyzer_v2" {
+				t.Errorf("Expected analyzer_name 'saturation_analyzer_v2', got '%s'", analyzerName)
+			}
+
+			limiterEnabled := getLabelValue(m, constants.LabelLimiterEnabled)
+			if limiterEnabled != trueStr {
+				t.Errorf("Expected limiter_enabled 'true', got '%s'", limiterEnabled)
+			}
+
+			scaleToZeroEnabled := getLabelValue(m, constants.LabelScaleToZeroEnabled)
+			if scaleToZeroEnabled != falseStr {
+				t.Errorf("Expected scale_to_zero_enabled 'false', got '%s'", scaleToZeroEnabled)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAConfigInfo)
+	}
+}
+
+func TestSetConfigInfo_MultipleConfigurations(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set multiple different configurations to test label cardinality
+	SetConfigInfo("saturation_analyzer_v1", false, false)
+	SetConfigInfo("saturation_analyzer_v2", true, true)
+
+	// Verify the gauge
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAConfigInfo {
+			found = true
+			// Should have 2 metrics (one per configuration)
+			if len(mf.GetMetric()) != 2 {
+				t.Errorf("Expected 2 metric series, got %d", len(mf.GetMetric()))
+			}
+
+			for _, m := range mf.GetMetric() {
+				g := m.GetGauge()
+				if g == nil {
+					t.Error("Expected gauge metric")
+					continue
+				}
+				if g.GetValue() != 1 {
+					t.Errorf("Expected gauge value 1, got %f", g.GetValue())
+				}
+
+				analyzerName := getLabelValue(m, constants.LabelAnalyzerName)
+				switch analyzerName {
+				case "saturation_analyzer_v1":
+					if getLabelValue(m, constants.LabelLimiterEnabled) != falseStr {
+						t.Error("Expected limiter_enabled 'false' for v1")
+					}
+					if getLabelValue(m, constants.LabelScaleToZeroEnabled) != falseStr {
+						t.Error("Expected scale_to_zero_enabled 'false' for v1")
+					}
+				case "saturation_analyzer_v2":
+					if getLabelValue(m, constants.LabelLimiterEnabled) != trueStr {
+						t.Error("Expected limiter_enabled 'true' for v2")
+					}
+					if getLabelValue(m, constants.LabelScaleToZeroEnabled) != trueStr {
+						t.Error("Expected scale_to_zero_enabled 'true' for v2")
+					}
+				default:
+					t.Errorf("Unexpected analyzer_name: %s", analyzerName)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAConfigInfo)
+	}
+}
+
+func TestSetConfigKvSpareThreshold(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set KV spare threshold (gauge should reflect the last value)
+	SetConfigKvSpareThreshold(0.05)
+	SetConfigKvSpareThreshold(0.10)
+
+	// Verify the gauge
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAConfigKvSpareThreshold {
+			found = true
+			if len(mf.GetMetric()) != 1 {
+				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
+			}
+			g := mf.GetMetric()[0].GetGauge()
+			if g == nil {
+				t.Error("Expected gauge metric")
+			} else if g.GetValue() != 0.10 {
+				t.Errorf("Expected gauge value 0.10 (last set), got %f", g.GetValue())
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAConfigKvSpareThreshold)
+	}
+}
+
+func TestSetConfigQueueSpareThreshold(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set queue spare threshold (gauge should reflect the last value)
+	SetConfigQueueSpareThreshold(2.0)
+	SetConfigQueueSpareThreshold(5.0)
+
+	// Verify the gauge
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAConfigQueueSpareThreshold {
+			found = true
+			if len(mf.GetMetric()) != 1 {
+				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
+			}
+			g := mf.GetMetric()[0].GetGauge()
+			if g == nil {
+				t.Error("Expected gauge metric")
+			} else if g.GetValue() != 5.0 {
+				t.Errorf("Expected gauge value 5.0 (last set), got %f", g.GetValue())
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAConfigQueueSpareThreshold)
+	}
+}
+
+func TestSetConfigOptimizationInterval(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set optimization interval (gauge should reflect the last value)
+	SetConfigOptimizationInterval(30.0)
+	SetConfigOptimizationInterval(60.0)
+
+	// Verify the gauge
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range metrics {
+		if mf.GetName() == constants.WVAConfigOptimizationIntervalSeconds {
+			found = true
+			if len(mf.GetMetric()) != 1 {
+				t.Errorf("Expected 1 metric series, got %d", len(mf.GetMetric()))
+			}
+			g := mf.GetMetric()[0].GetGauge()
+			if g == nil {
+				t.Error("Expected gauge metric")
+			} else if g.GetValue() != 60.0 {
+				t.Errorf("Expected gauge value 60.0 (last set), got %f", g.GetValue())
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Metric %s not found in gathered metrics", constants.WVAConfigOptimizationIntervalSeconds)
+	}
+}
+
+func TestConfigStateMetrics_NilSafety(t *testing.T) {
+	// Save the package-level vars and set to nil to simulate uninitialized state
+	savedConfigInfo := configInfoGauge
+	savedKvThreshold := configKvSpareThresholdGauge
+	savedQueueThreshold := configQueueSpareThresholdGauge
+	savedInterval := configOptimizationIntervalSecsGauge
+
+	configInfoGauge = nil
+	configKvSpareThresholdGauge = nil
+	configQueueSpareThresholdGauge = nil
+	configOptimizationIntervalSecsGauge = nil
+
+	defer func() {
+		configInfoGauge = savedConfigInfo
+		configKvSpareThresholdGauge = savedKvThreshold
+		configQueueSpareThresholdGauge = savedQueueThreshold
+		configOptimizationIntervalSecsGauge = savedInterval
+	}()
+
+	// Should not panic when metrics are not initialized
+	SetConfigInfo("test_analyzer", true, false)
+	SetConfigKvSpareThreshold(0.05)
+	SetConfigQueueSpareThreshold(2.0)
+	SetConfigOptimizationInterval(30.0)
+}
+
+func TestConfigStateMetrics_AllMetricsRegistered(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics failed: %v", err)
+	}
+
+	// Set all config metrics
+	SetConfigInfo("saturation_analyzer_v2", true, true)
+	SetConfigKvSpareThreshold(0.10)
+	SetConfigQueueSpareThreshold(5.0)
+	SetConfigOptimizationInterval(60.0)
+
+	// Gather all metrics
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	// Check that all 4 config metrics are present
+	expectedMetrics := map[string]bool{
+		constants.WVAConfigInfo:                        false,
+		constants.WVAConfigKvSpareThreshold:            false,
+		constants.WVAConfigQueueSpareThreshold:         false,
+		constants.WVAConfigOptimizationIntervalSeconds: false,
+	}
+
+	for _, mf := range metrics {
+		if _, exists := expectedMetrics[mf.GetName()]; exists {
+			expectedMetrics[mf.GetName()] = true
+		}
+	}
+
+	for metricName, found := range expectedMetrics {
+		if !found {
+			t.Errorf("Expected metric %s to be registered and set, but it was not found", metricName)
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
@@ -22,6 +23,11 @@ var (
 
 	optimizationDuration *prometheus.HistogramVec
 	modelsProcessedGauge *prometheus.GaugeVec
+
+	configInfoGauge                     *prometheus.GaugeVec
+	configKvSpareThresholdGauge         *prometheus.GaugeVec
+	configQueueSpareThresholdGauge      *prometheus.GaugeVec
+	configOptimizationIntervalSecsGauge *prometheus.GaugeVec
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -104,6 +110,46 @@ func InitMetrics(registry prometheus.Registerer) error {
 		modelsProcessedLabels,
 	)
 
+	// Config info metric with labels
+	configInfoLabels := []string{constants.LabelAnalyzerName, constants.LabelLimiterEnabled, constants.LabelScaleToZeroEnabled}
+	if controllerInstance != "" {
+		configInfoLabels = append(configInfoLabels, constants.LabelControllerInstance)
+	}
+	configInfoGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAConfigInfo,
+			Help: "WVA configuration information (value is always 1)",
+		},
+		configInfoLabels,
+	)
+
+	// Config threshold and interval metrics
+	configLabels := []string{}
+	if controllerInstance != "" {
+		configLabels = append(configLabels, constants.LabelControllerInstance)
+	}
+	configKvSpareThresholdGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAConfigKvSpareThreshold,
+			Help: "KV cache spare threshold configuration value",
+		},
+		configLabels,
+	)
+	configQueueSpareThresholdGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAConfigQueueSpareThreshold,
+			Help: "Queue spare threshold configuration value",
+		},
+		configLabels,
+	)
+	configOptimizationIntervalSecsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVAConfigOptimizationIntervalSeconds,
+			Help: "Optimization interval in seconds",
+		},
+		configLabels,
+	)
+
 	// Register metrics with the registry
 	if err := registry.Register(replicaScalingTotal); err != nil {
 		return fmt.Errorf("failed to register replicaScalingTotal metric: %w", err)
@@ -122,6 +168,18 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(modelsProcessedGauge); err != nil {
 		return fmt.Errorf("failed to register modelsProcessedGauge metric: %w", err)
+	}
+	if err := registry.Register(configInfoGauge); err != nil {
+		return fmt.Errorf("failed to register configInfoGauge metric: %w", err)
+	}
+	if err := registry.Register(configKvSpareThresholdGauge); err != nil {
+		return fmt.Errorf("failed to register configKvSpareThresholdGauge metric: %w", err)
+	}
+	if err := registry.Register(configQueueSpareThresholdGauge); err != nil {
+		return fmt.Errorf("failed to register configQueueSpareThresholdGauge metric: %w", err)
+	}
+	if err := registry.Register(configOptimizationIntervalSecsGauge); err != nil {
+		return fmt.Errorf("failed to register configOptimizationIntervalSecsGauge metric: %w", err)
 	}
 
 	return nil
@@ -221,4 +279,57 @@ func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1al
 	}
 	desiredRatio.With(baseLabels).Set(float64(desired) / float64(current))
 	return nil
+}
+
+// SetConfigInfo sets the config info metric with the given analyzer name and feature flags.
+// The metric value is always set to 1 (info-style metric).
+func SetConfigInfo(analyzerName string, limiterEnabled, scaleToZeroEnabled bool) {
+	if configInfoGauge == nil {
+		return
+	}
+	labels := prometheus.Labels{
+		constants.LabelAnalyzerName:       analyzerName,
+		constants.LabelLimiterEnabled:     strconv.FormatBool(limiterEnabled),
+		constants.LabelScaleToZeroEnabled: strconv.FormatBool(scaleToZeroEnabled),
+	}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	configInfoGauge.With(labels).Set(1)
+}
+
+// SetConfigKvSpareThreshold sets the KV spare threshold configuration value.
+func SetConfigKvSpareThreshold(threshold float64) {
+	if configKvSpareThresholdGauge == nil {
+		return
+	}
+	labels := prometheus.Labels{}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	configKvSpareThresholdGauge.With(labels).Set(threshold)
+}
+
+// SetConfigQueueSpareThreshold sets the queue spare threshold configuration value.
+func SetConfigQueueSpareThreshold(threshold float64) {
+	if configQueueSpareThresholdGauge == nil {
+		return
+	}
+	labels := prometheus.Labels{}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	configQueueSpareThresholdGauge.With(labels).Set(threshold)
+}
+
+// SetConfigOptimizationInterval sets the optimization interval in seconds.
+func SetConfigOptimizationInterval(intervalSeconds float64) {
+	if configOptimizationIntervalSecsGauge == nil {
+		return
+	}
+	labels := prometheus.Labels{}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	configOptimizationIntervalSecsGauge.With(labels).Set(intervalSeconds)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -28,10 +28,10 @@ var (
 	configKvSpareThresholdGauge         *prometheus.GaugeVec
 	configQueueSpareThresholdGauge      *prometheus.GaugeVec
 	configOptimizationIntervalSecsGauge *prometheus.GaugeVec
-	metricsCollectionDuration *prometheus.HistogramVec
-	metricsCollectionErrors   *prometheus.CounterVec
-	metricsPodsDiscovered     *prometheus.GaugeVec
-	metricsFreshnessStatus    *prometheus.GaugeVec
+	metricsCollectionDuration           *prometheus.HistogramVec
+	metricsCollectionErrors             *prometheus.CounterVec
+	metricsPodsDiscovered               *prometheus.GaugeVec
+	metricsFreshnessStatus              *prometheus.GaugeVec
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -152,6 +152,8 @@ func InitMetrics(registry prometheus.Registerer) error {
 			Help: "Optimization interval in seconds",
 		},
 		configLabels,
+	)
+
 	metricsCollectionDurationLabels := []string{constants.LabelQueryType}
 	if controllerInstance != "" {
 		metricsCollectionDurationLabels = append(metricsCollectionDurationLabels, constants.LabelControllerInstance)
@@ -231,6 +233,7 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(configOptimizationIntervalSecsGauge); err != nil {
 		return fmt.Errorf("failed to register configOptimizationIntervalSecsGauge metric: %w", err)
+	}
 	if err := registry.Register(metricsCollectionDuration); err != nil {
 		return fmt.Errorf("failed to register metricsCollectionDuration metric: %w", err)
 	}
@@ -394,6 +397,8 @@ func SetConfigOptimizationInterval(intervalSeconds float64) {
 		labels[constants.LabelControllerInstance] = controllerInstance
 	}
 	configOptimizationIntervalSecsGauge.With(labels).Set(intervalSeconds)
+}
+
 // ObserveMetricsCollectionDuration records the duration of a metrics collection operation.
 func ObserveMetricsCollectionDuration(durationSeconds float64, queryType string) {
 	if metricsCollectionDuration == nil {


### PR DESCRIPTION
Close: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/917
# Configuration State Metrics
- [x] wva_config_info                     gauge   {analyzer_name, limiter_enabled, scale_to_zero_enabled}
  - Example from Kind cluster:
    ```
    {
    "key": "wva_config_info",
    "value": [
        {
        "type": "gauge",
        "unit": "",
        "help": "WVA configuration information (value is always 1)"
        }
    ]
    }

    [
    {
    "metric": {
      "__name__": "wva_config_info",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.19:8443",
      "job": "workload-variant-autoscaler-metrics",
      "limiter_enabled": "false",                     <=======
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
      "scale_to_zero_enabled": "true",                <=========
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
      1777928137.169,
      "1"  <========== always 1
    ]
    }
    ]
    ```
    - Update value by edit CM w/o restarting controller:
    ```
    {
        "metric": {
        "__name__": "wva_config_info",
        "analyzer_name": "saturation",            <==== updated value. Entry not there if empty.
        "container": "manager",
        "endpoint": "https",
        "instance": "10.244.2.19:8443",
        "job": "workload-variant-autoscaler-metrics",
        "limiter_enabled": "true",                   <==== updated value
        "namespace": "workload-variant-autoscaler-system",
        "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
        "scale_to_zero_enabled": "true",
        "service": "workload-variant-autoscaler-metrics"
        },
        "value": [
        1777929105.070,
        "1"
        ]
    }
    ```
  
- [x] wva_config_kv_spare_threshold       gauge   {}
    - Example from Kind cluster:
    ```
    {
    "key": "wva_config_kv_spare_threshold",
    "value": [
        {
        "type": "gauge",
        "unit": "",
        "help": "KV cache spare threshold configuration value"
        }
    ]
    }

     {
    "metric": {
      "__name__": "wva_config_kv_spare_threshold",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.19:8443",
      "job": "workload-variant-autoscaler-metrics",
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
      1777928212.666,
      "0.1"   <====== matching value
    ]
  }

    apiVersion: v1
    data:
    default: |
        kvCacheThreshold: 0.8
        queueLengthThreshold: 5
        kvSpareTrigger: 0.1         <===== matching value
        queueSpareTrigger: 3
    kind: ConfigMap
    metadata:
    annotations:
        meta.helm.sh/release-name: workload-variant-autoscaler
        meta.helm.sh/release-namespace: workload-variant-autoscaler-system

    ```
    - Update value by edit CM w/o restarting controller:
    ```
    {
    "metric": {
      "__name__": "wva_config_kv_spare_threshold",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.19:8443",
      "job": "workload-variant-autoscaler-metrics",
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
      1777928717.455,
      "0.5"    <==== updated from 0.1 to 0.5
    ]
    }
    ```

- [x] wva_config_queue_spare_threshold    gauge   {}
    - Example from Kind cluster:
    ```
    {
    "key": "wva_config_queue_spare_threshold",
    "value": [
        {
        "type": "gauge",
        "unit": "",
        "help": "Queue spare threshold configuration value"
        }
    ]
    }

    {
    "metric": {
      "__name__": "wva_config_queue_spare_threshold",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.19:8443",
      "job": "workload-variant-autoscaler-metrics",
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
      1777928390.027,
      "3"               <==== matching value
        ]
    }
    
    ```
    -  Update value by edit CM w/o restarting controller:
    ```
     {
    "metric": {
      "__name__": "wva_config_queue_spare_threshold",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.19:8443",
      "job": "workload-variant-autoscaler-metrics",
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-wn64f",
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
    1777928508.980,
    "7"  <=========== metric updated w/o restart controller
    ]
    }
  ```
- [x] wva_config_optimization_interval_seconds  gauge {}
  - This is recorded once when controller starts.
  - Example from Kind cluster::
    ```
    {
    "key": "wva_config_optimization_interval_seconds",
    "value": [
        {
        "type": "gauge",
        "unit": "",
        "help": "Optimization interval in seconds"
        }
    ]
    }

    {
    "metric": {
      "__name__": "wva_config_optimization_interval_seconds",
      "container": "manager",
      "endpoint": "https",
      "instance": "10.244.2.13:8443",
      "job": "workload-variant-autoscaler-metrics",
      "namespace": "workload-variant-autoscaler-system",
      "pod": "workload-variant-autoscaler-controller-manager-66dffdf499-gptxq",
      "service": "workload-variant-autoscaler-metrics"
    },
    "value": [
      1777927504.810,
      "30"   <===========  default value
    ]
   }

    ```
  
## Implementation:
- [x] Emit on each optimization cycle (values may change via ConfigMap hot-reload)
    - For wva_config_kv_spare_threshold, wva_config_queue_spare_threshold 
- [x] Use prometheus.NewGaugeVec with const labels pattern for wva_config_info

## Acceptance Criteria:
- [x] Config info gauge reflects current analyzer and feature flags
- [x] Threshold gauges update when ConfigMap changes
- [x] Unit tests verify metric values match config