### PR TITLE
Change VariantAutoscaling API group to llm-d.ai

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	cp config/crd/bases/llmd.ai_variantautoscalings.yaml charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml
+	cp config/crd/bases/llm-d.ai_variantautoscalings.yaml charts/workload-variant-autoscaler/crds/llm-d.ai_variantautoscalings.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,7 @@ resources:
     namespaced: true
   controller: true
   domain: ai
-  group: llmd
+  group: llm-d
   kind: VariantAutoscaling
   path: github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For detailed architecture information, see the [design documentation](docs/desig
 ## Example
 
 ```yaml
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-autoscaler
@@ -144,7 +144,7 @@ To check if your cluster has the latest CRD schema:
 
 ```bash
 # Check the CRD fields
-kubectl get crd variantautoscalings.llmd.ai -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}' | jq 'keys'
+kubectl get crd variantautoscalings.llm-d.ai -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}' | jq 'keys'
 ```
 
 ## Contributing

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the llmd v1alpha1 API group.
+// Package v1alpha1 contains API Schema definitions for the llm-d v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=llmd.ai
+// +groupName=llm-d.ai
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "llmd.ai", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "llm-d.ai", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/charts/workload-variant-autoscaler/crds/llm-d.ai_variantautoscalings.yaml
+++ b/charts/workload-variant-autoscaler/crds/llm-d.ai_variantautoscalings.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  name: variantautoscalings.llmd.ai
+  name: variantautoscalings.llm-d.ai
 spec:
-  group: llmd.ai
+  group: llm-d.ai
   names:
     kind: VariantAutoscaling
     listKind: VariantAutoscalingList

--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -121,7 +121,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
@@ -133,13 +133,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/finalizers
   verbs:
   - update
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_admin_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over llmd.llm-d.ai.
+# Grants full permissions ('*') over llm-d.ai.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -13,13 +13,13 @@ metadata:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
   - '*'
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_editor_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the llmd.llm-d.ai.
+# Grants permissions to create, update, and delete resources within the llm-d.ai.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -13,7 +13,7 @@ metadata:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
@@ -25,7 +25,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/variantautoscaling_viewer_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to llmd.llm-d.ai resources.
+# Grants read-only access to llm-d.ai resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -13,7 +13,7 @@ metadata:
     {{- include "workload-variant-autoscaler.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
@@ -21,7 +21,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/charts/workload-variant-autoscaler/templates/variantautoscaling.yaml
+++ b/charts/workload-variant-autoscaler/templates/variantautoscaling.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.va.enabled }}
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 # Optimizing a variant, create only when the model is deployed and serving traffic
 # this is for the collector the collect existing (previous) running metrics of the variant.
 kind: VariantAutoscaling

--- a/config/crd/bases/llm-d.ai_variantautoscalings.yaml
+++ b/config/crd/bases/llm-d.ai_variantautoscalings.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  name: variantautoscalings.llmd.ai
+  name: variantautoscalings.llm-d.ai
 spec:
-  group: llmd.ai
+  group: llm-d.ai
   names:
     kind: VariantAutoscaling
     listKind: VariantAutoscalingList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/llmd.ai_variantautoscalings.yaml
+- bases/llm-d.ai_variantautoscalings.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 #patches:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -101,7 +101,7 @@ rules:
   - get
   - update
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
@@ -113,13 +113,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/finalizers
   verbs:
   - update
 - apiGroups:
-  - llmd.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/config/rbac/variantautoscaling_admin_role.yaml
+++ b/config/rbac/variantautoscaling_admin_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over llmd.llm-d.ai.
+# Grants full permissions ('*') over llm-d.ai.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -14,13 +14,13 @@ metadata:
   name: variantautoscaling-admin-role
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
-  - VariantAutoscalingss
+  - variantautoscalings
   verbs:
   - '*'
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings/status
   verbs:

--- a/config/rbac/variantautoscaling_editor_role.yaml
+++ b/config/rbac/variantautoscaling_editor_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the llmd.llm-d.ai.
+# Grants permissions to create, update, and delete resources within the llm-d.ai.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -14,7 +14,7 @@ metadata:
   name: variantautoscaling-editor-role
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
   - variantautoscalings
   verbs:
@@ -26,8 +26,8 @@ rules:
   - update
   - watch
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
-  - VariantAutoscalingss/status
+  - variantautoscalings/status
   verbs:
   - get

--- a/config/rbac/variantautoscaling_viewer_role.yaml
+++ b/config/rbac/variantautoscaling_viewer_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project workload-variant-autoscaler itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to llmd.llm-d.ai resources.
+# Grants read-only access to llm-d.ai resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -11,19 +11,19 @@ metadata:
   labels:
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
-  name: VariantAutoscalings-viewer-role
+  name: variantautoscaling-viewer-role
 rules:
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
-  - VariantAutoscalingss
+  - variantautoscalings
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - llmd.llm-d.ai
+  - llm-d.ai
   resources:
-  - VariantAutoscalingss/status
+  - variantautoscalings/status
   verbs:
   - get

--- a/config/samples/hpa/va.yaml
+++ b/config/samples/hpa/va.yaml
@@ -1,6 +1,6 @@
 # Example VariantAutoscaling for HPA/KEDA integration.
 # Ensure a Deployment named sample-deployment exists in llm-d-sim (e.g. from kind-emulator or e2e).
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: sample-deployment

--- a/config/samples/keda/va.yaml
+++ b/config/samples/keda/va.yaml
@@ -1,6 +1,6 @@
 # Example VariantAutoscaling for HPA/KEDA integration.
 # Ensure a Deployment named sample-deployment exists in llm-d-sim (e.g. from kind-emulator or e2e).
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: sample-deployment

--- a/config/samples/variantautoscaling-integration.yaml
+++ b/config/samples/variantautoscaling-integration.yaml
@@ -1,6 +1,6 @@
 # Example VariantAutoscaling for HPA/KEDA integration.
 # Ensure a Deployment named sample-deployment exists in llm-d-sim (e.g. from kind-emulator or e2e).
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: sample-deployment

--- a/config/samples/variantautoscaling-with-cost.yaml
+++ b/config/samples/variantautoscaling-with-cost.yaml
@@ -14,7 +14,7 @@
 # CR itself only specifies the cost via the variantCost field.
 
 ---
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-70b-premium-h100
@@ -37,7 +37,7 @@ spec:
   variantCost: "80.0"  # Cost per replica (reflects H100 premium pricing)
 
 ---
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-70b-standard-a100
@@ -61,7 +61,7 @@ spec:
 
 ---
 # Example: Budget variant with lower cost for best-effort workloads
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-budget-t4
@@ -85,7 +85,7 @@ spec:
 ---
 # Example: Multi-tenant cost tracking
 # Assign different costs to the same accelerator for different tenants
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-tenant-gold
@@ -105,7 +105,7 @@ spec:
   variantCost: "25.0"  # Higher cost reflects priority/SLA
 
 ---
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-tenant-silver
@@ -127,7 +127,7 @@ spec:
 ---
 # Note: If variantCost is not specified, it defaults to 10.0
 # Example of default behavior:
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-default-cost

--- a/config/samples/variantautoscaling-with-lws.yaml
+++ b/config/samples/variantautoscaling-with-lws.yaml
@@ -1,7 +1,7 @@
 # Example: VariantAutoscaling with LeaderWorkerSet (LWS) as scale target
 # Ensure a LeaderWorkerSet named vllm-lws exists in llm-d-sim (e.g. from kind-emulator or e2e).
 # 
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: sample-deployment

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -546,7 +546,7 @@ If you don't create VariantAutoscaling via Helm, create it manually:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: my-vllm-deployment-decode

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -234,7 +234,7 @@ Tune load with `TOTAL_REQUESTS`, `BATCH_SIZE`, and optional `BATCH_SLEEP`, `MAX_
 watch kubectl get deploy -n llm-d-sim
 
 # Watch VariantAutoscaling status
-watch kubectl get variantautoscalings.llmd.ai -A
+watch kubectl get variantautoscalings.llm-d.ai -A
 
 # View controller logs
 kubectl logs -n workload-variant-autoscaler-system \
@@ -259,7 +259,7 @@ kubectl logs -n workload-variant-autoscaler-system \
   deployment/workload-variant-autoscaler-controller-manager
 
 # Verify CRDs installed
-kubectl get crd variantautoscalings.llmd.ai
+kubectl get crd variantautoscalings.llm-d.ai
 
 # Check RBAC
 kubectl get clusterrole,clusterrolebinding -l app=workload-variant-autoscaler

--- a/docs/developer-guide/release-process.md
+++ b/docs/developer-guide/release-process.md
@@ -114,7 +114,7 @@ The [llm-d](https://github.com/llm-d/llm-d) repo hosts a **workload-autoscaling 
    - In `guides/workload-autoscaling/README.md`, update the "Version Compatibility" callout to state the new WVA version (e.g. "tested and validated with **WVA vX.Y.Z**").
 
 2. **URLs that embed the version tag**  
-   - **CRD install (Step 4):** URLs like `.../workload-variant-autoscaler/vX.Y.Z/charts/.../crds/llmd.ai_variantautoscalings.yaml` — replace the version segment with the new release tag.
+   - **CRD install (Step 4):** URLs like `.../workload-variant-autoscaler/vX.Y.Z/charts/.../crds/llm-d.ai_variantautoscalings.yaml` — replace the version segment with the new release tag.
    - **Prometheus Adapter values (Step 6):** All `curl`/download URLs that point at `.../workload-variant-autoscaler/vX.Y.Z/config/samples/...` (e.g. `prometheus-adapter-values.yaml`, `prometheus-adapter-values-ocp.yaml`).
    - **Upgrading section:** Any CRD or sample URLs in the "Upgrading" section that include the version tag.
 

--- a/docs/user-guide/LeaderWorkerSet-support.md
+++ b/docs/user-guide/LeaderWorkerSet-support.md
@@ -160,7 +160,7 @@ Verify the sample variant. Here we include and high-light the important fields:
 ```
 kubectl get va lws-va-workload-variant-autoscaler-va -n llm-d-sim -o yaml
 
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   ...

--- a/docs/user-guide/crd-reference.md
+++ b/docs/user-guide/crd-reference.md
@@ -1,12 +1,12 @@
 # API Reference
 
 ## Packages
-- [llmd.ai/v1alpha1](#llmdaiv1alpha1)
+- [llm-d.ai/v1alpha1](#llm-daiv1alpha1)
 
 
-## llmd.ai/v1alpha1
+## llm-d.ai/v1alpha1
 
-Package v1alpha1 contains API Schema definitions for the llmd v1alpha1 API group.
+Package v1alpha1 contains API Schema definitions for the llm-d v1alpha1 API group.
 
 ### Resource Types
 - [VariantAutoscaling](#variantautoscaling)
@@ -62,7 +62,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | `llmd.ai/v1alpha1` | | |
+| `apiVersion` _string_ | `llm-d.ai/v1alpha1` | | |
 | `kind` _string_ | `VariantAutoscaling` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  | Optional: \{\} <br /> |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  | Optional: \{\} <br /> |
@@ -101,7 +101,7 @@ VariantAutoscalingList contains a list of VariantAutoscaling resources.
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | `llmd.ai/v1alpha1` | | |
+| `apiVersion` _string_ | `llm-d.ai/v1alpha1` | | |
 | `kind` _string_ | `VariantAutoscalingList` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  | Optional: \{\} <br /> |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  | Optional: \{\} <br /> |

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -54,7 +54,7 @@ See [KEDA Integration Guide](keda-integration.md)
 
 2. **Verify CRDs are installed:**
    ```bash
-   kubectl get crd variantautoscalings.llmd.ai
+   kubectl get crd variantautoscalings.llm-d.ai
    ```
 
 3. **Check controller logs:**

--- a/docs/user-guide/multi-controller-isolation.md
+++ b/docs/user-guide/multi-controller-isolation.md
@@ -158,7 +158,7 @@ spec:
 When `controllerInstance` is set, the Helm chart automatically adds the label to VA resources:
 
 ```yaml
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-autoscaler
@@ -265,7 +265,7 @@ controllerInstance: "test"
 For manually created VAs, ensure labels match the target controller:
 
 ```yaml
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   labels:

--- a/docs/user-guide/scale-from-zero.md
+++ b/docs/user-guide/scale-from-zero.md
@@ -77,7 +77,7 @@ spec:
 2. **Create a VariantAutoscaling resource**:
 
 ```yaml
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: llama-8b-autoscaler

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -51,7 +51,7 @@ kubectl get deployment -n <controller-namespace> workload-variant-autoscaler-con
 Add or update the label on your VariantAutoscaling resource:
 
 ```yaml
-apiVersion: llmd.ai/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: VariantAutoscaling
 metadata:
   name: my-va

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -75,9 +75,9 @@ func NewVariantAutoscalingReconciler(
 	}
 }
 
-// +kubebuilder:rbac:groups=llmd.ai,resources=variantautoscalings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=llmd.ai,resources=variantautoscalings/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=llmd.ai,resources=variantautoscalings/finalizers,verbs=update
+// +kubebuilder:rbac:groups=llm-d.ai,resources=variantautoscalings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=llm-d.ai,resources=variantautoscalings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=llm-d.ai,resources=variantautoscalings/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get;list;update;patch;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch


### PR DESCRIPTION
Fixes #1086 

## Summary
- rename the `VariantAutoscaling` API group from `llmd.ai` to `llm-d.ai`
- regenerate CRD and RBAC manifests and update Helm chart resources to use the new group
- update samples and user/developer docs to reference `llm-d.ai` and the renamed CRD manifest filenames

## Scope
This PR only updates the `VariantAutoscaling` API group from `llmd.ai` to `llm-d.ai`.

It intentionally does not rename WVA label and annotation prefixes such as `wva.llmd.ai/*`. Those keys are a separate compatibility surface, and changing them would introduce additional migration impact for existing manifests, selectors, and namespace configuration.

## Testing
- `GOTOOLCHAIN=go1.25.0 make test`

## Migration Notes
- update any manifests and automation that still reference `llmd.ai/v1alpha1` to `llm-d.ai/v1alpha1`
- apply the renamed CRD manifest before upgrading chart-managed installs

## Notes
- `docs/CHANGELOG-v0.5.0.md` is intentionally unchanged because it documents the historical v0.5.0 release and should continue to reflect the API group used at that time

## Open Question
I interpreted #1086 as applying only to the VA CRD/API group. If the alignment should also include WVA label and annotation prefixes such as `wva.llmd.ai/*`, I can follow up in a separate change since that has broader migration impact.