### PR TITLE
docs: add How to Run instructions and benchmark results

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -48,56 +48,92 @@ Summary of WVA benchmark runs with configuration details.
 | Scale-down policy | 10 Pods / 150s |
 | Metric source | External (`wva_desired_replicas`) |
 
+## How to Run
+
+> **Prerequisites:** Active `kubectl`/`oc` context pointing at your cluster.
+
+**Step 1 — Install the benchmark CLI** (once per workspace):
+
+```bash
+make benchmark-install
+```
+
+**Step 2 — Stand up the benchmark environment:**
+
+```bash
+make benchmark-standup BENCHMARK_NAMESPACE=<your-namespace>
+```
+
+**Step 3 — Run a scenario:**
+
+```bash
+make benchmark-run BENCHMARK_NAMESPACE=<your-namespace> BENCHMARK_WORKLOAD=prefill_heavy.yaml
+```
+
+Repeat with `decode_heavy.yaml` or `symmetrical.yaml` for the other scenarios.
+
+**Step 4 — Tear down when done:**
+
+```bash
+make benchmark-teardown BENCHMARK_NAMESPACE=<your-namespace>
+```
+
+Results are saved automatically in a timestamped directory at the repo root (e.g. `<username>-YYYYMMDD-HHMMSS/results/`).
+
+> **Tip:** To run all three scenarios in one command: `make benchmark-full BENCHMARK_NAMESPACE=<your-namespace>`
+
+---
+
 ## Prefill Heavy Scenario
 
 **llm-d Release:** v0.6.0
-**Model:** unsloth/Meta-Llama-3.1-8B
+**Model:** Qwen/Qwen3-32B
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
 | Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (prefill) |
-|--------|----------------|------------------------|
-| P99 TTFT (ms) | 64,968 | _TBD_ |
-| P99 ITL (ms) | 68.45 | _TBD_ |
-| Avg replicas | 1.91 | _TBD_ |
-| Max replicas | 2 | _TBD_ |
-| Avg KV cache utilization | 0.4307 | _TBD_ |
-| Avg queue depth (EPP) | 158.36 | _TBD_ |
-| Error count | 361 (510 incomplete) | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.91 | _TBD_ |
+|--------|------------------------|--------------------------------|
+| P99 TTFT (ms) | 98,810 | _TBD_ |
+| P99 ITL (ms/token) | 55.06 | _TBD_ |
+| Avg replicas | 1.68 | _TBD_ |
+| Max replicas | 3 | _TBD_ |
+| Avg KV cache utilization | 65.1% | _TBD_ |
+| Avg queue depth (EPP) | 236.8 | _TBD_ |
+| Error count | 4,186 / 4,882 | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
 
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
-**Model:** unsloth/Meta-Llama-3.1-8B
+**Model:** Qwen/Qwen3-32B
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1), Tuned(v1)
 
-| Metric |WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (decode) |
-|--------|----------------|------------------------|
-| P99 TTFT (ms) | 41,361 | _TBD_ |
-| P99 ITL (ms) | 38.03 | _TBD_ |
-| Avg replicas | 1.92 | _TBD_ |
-| Max replicas | 2 | _TBD_ |
-| Avg KV cache utilization | 0.5155 | _TBD_ |
-| Avg queue depth (EPP) | 34.25 | _TBD_ |
-| Error count | 192 (511 incomplete) | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.92 | _TBD_ |
+| Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (decode) |
+|--------|------------------------|-------------------------------|
+| P99 TTFT (ms) | 85,612 | _TBD_ |
+| P99 ITL (ms/token) | 47.09 | _TBD_ |
+| Avg replicas | 1.73 | _TBD_ |
+| Max replicas | 3 | _TBD_ |
+| Avg KV cache utilization | 88.8% | _TBD_ |
+| Avg queue depth (EPP) | 111.8 | _TBD_ |
+| Error count | 3,506 / 4,105 | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
 
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0
-**Model:** unsloth/Meta-Llama-3.1-8B
+**Model:** Qwen/Qwen3-32B
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1)
 
 | Metric | WVA v0.6.0 Default(v1) |
-|--------|----------------|
-| P99 TTFT (ms) | 2,188 |
-| P99 ITL (ms) | 35.09 |
-| Avg replicas | 1.92 |
-| Max replicas | 2 |
-| Avg KV cache utilization | 0.2110 |
-| Avg queue depth (EPP) | 4.38 |
-| Error count | 0 (343 incomplete) |
-| Cost (avg replicas × GPU/hr) | 1.92 |
+|--------|------------------------|
+| P99 TTFT (ms) | 101,083 |
+| P99 ITL (ms/token) | 67.61 |
+| Avg replicas | 1.70 |
+| Max replicas | 3 |
+| Avg KV cache utilization | 66.7% |
+| Avg queue depth (EPP) | 135.1 |
+| Error count | 3,773 / 4,839 |
+| Cost (avg replicas × GPU/hr) | _TBD_ |


### PR DESCRIPTION
## Summary

- Add a **How to Run** section documenting the `make benchmark-*` targets.
- Update model name to `Qwen/Qwen3-32B` across all scenarios.
- Populate Default(v1) results for all 3 scenarios (prefill_heavy, decode_heavy, symmetrical) from validated runs (2026-05-05).

## Test plan

- [x] All 3 scenarios tested end-to-end using PR #1080
- [x] WVA scaling confirmed in all runs (max 3 replicas)
- [ ] Tuned(v1) results to be filled in a follow-up