### PR TITLE
Phase 1 - refactor(deploy): install script simplification

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -287,17 +287,18 @@ jobs:
       - name: Deploy WVA and llm-d infrastructure
         env:
           ENVIRONMENT: openshift
+          # Cluster provides gateway — skip install-llmd gateway helmfile.
           INSTALL_GATEWAY_CTRLPLANE: "false"
-          E2E_TESTS_ENABLED: "true"
           NAMESPACE_SCOPED: "false"
           LLMD_NS: ${{ env.LLMD_NAMESPACE }}
           WVA_NS: ${{ env.WVA_NAMESPACE }}
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
-          DEPLOY_VA: "false"
-          DEPLOY_HPA: "false"
+          # Benchmark does not use chart VA/HPA from install — workloads and autoscalers come from the benchmark job.
           DECODE_REPLICAS: "1"
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
+          # See OpenShift e2e: user-workload Prometheus cannot bearer-auth to WVA /metrics.
           WVA_METRICS_SECURE: "false"
+          # Full capacity-scaling chart values (install.sh no longer passes these).
           KV_CACHE_THRESHOLD: "0.90"
           QUEUE_LENGTH_THRESHOLD: "10"
           KV_SPARE_TRIGGER: "0.05"
@@ -309,8 +310,19 @@ jobs:
           VLLM_BLOCK_SIZE: "64"
           VLLM_ENFORCE_EAGER: "true"
           INSTALL_GRAFANA: "true"
+          MODEL_ID: ${{ env.MODEL_ID }}
+          ACCELERATOR_TYPE: ${{ env.ACCELERATOR_TYPE }}
+          LLMD_PATCH_EPP_FLOW_CONTROL: "true"
+          LLMD_SKIP_INFERENCE_OBJECTIVE: "true"
         run: |
-          ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
+          # Split deploy: WVA base (install.sh) → llm-d (install-llmd-infra.sh) → chart capacity tuning (helm upgrade).
+          ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
+          ./deploy/install-llmd-infra.sh -e openshift
+          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
+            --set wva.capacityScaling.default.kvCacheThreshold="${KV_CACHE_THRESHOLD}" \
+            --set wva.capacityScaling.default.queueLengthThreshold="${QUEUE_LENGTH_THRESHOLD}" \
+            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
+            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
 
       - name: Label namespaces for OpenShift monitoring
         run: |

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -690,32 +690,25 @@ jobs:
         env:
           # HF_TOKEN is inherited from GITHUB_ENV (set in 'Get HF token from cluster secret' step)
           ENVIRONMENT: openshift
+          # Platform already provides a gateway — install-llmd-infra skips control-plane helmfile.
           INSTALL_GATEWAY_CTRLPLANE: "false"
-          E2E_TESTS_ENABLED: "true"
-          # OpenShift typically lacks HPAScaleToZero; e2e forces SCALE_TO_ZERO_ENABLED off for openshift
-          # (see test/e2e/config.go). KEDA ScaledObjects support minReplicas=0 for scale-from-zero tests.
+          # OpenShift usually lacks HPAScaleToZero (see test/e2e/config.go — e2e disables native scale-to-zero there).
+          # KEDA ScaledObjects support minReplicas=0 for scale-from-zero specs.
           SCALER_BACKEND: keda
           NAMESPACE_SCOPED: "false"
-          # Pass PR-specific namespaces to install script
+          # Isolate this PR's workloads from other runs.
           LLMD_NS: ${{ env.LLMD_NAMESPACE }}
           WVA_NS: ${{ env.WVA_NAMESPACE }}
-          # Controller instance label for multi-controller isolation in parallel e2e tests
+          # Labels metrics / selectors so multiple controllers can coexist in parallel jobs.
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
-          # Skip infra VA/HPA — the smoke test creates its own VA+HPA targeting
-          # its own deployment. The infra VA adds a second idle pod to the
-          # saturation analysis group, diluting KV cache metrics and preventing
-          # scale-up from triggering.
-          DEPLOY_VA: "false"
-          DEPLOY_HPA: "false"
-          # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
+          # Chart-managed VA/HPA are not enabled via install scripts — tests create their own VA+HPA.
+          # A second idle infra VA would dilute KV/queue metrics and block saturation scale-up.
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
-          # Decode replicas for e2e testing (start with 1 replica, let HPA scale)
+          # Start with one decode replica; specs scale via HPA / KEDA from there.
           DECODE_REPLICAS: "1"
-          # OpenShift uses built-in user-workload monitoring, not a separate namespace
+          # OpenShift user-workload Prometheus (not kube-prometheus-stack in a custom namespace).
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
-          # Disable bearer token auth on WVA /metrics endpoint — OpenShift's
-          # user-workload-monitoring cannot authenticate with the controller-manager
-          # SA token. The endpoint is still only accessible within the cluster network.
+          # User-workload Prometheus cannot use the controller-manager SA token for /metrics bearer auth.
           WVA_METRICS_SECURE: "false"
           # Lower saturation thresholds for simulator mode — the simulator's
           # KV-cache and queue metrics are modest, so default thresholds
@@ -724,9 +717,14 @@ jobs:
           # queueLength > 0.5, which the simulator produces under load.
           KV_SPARE_TRIGGER: "0.5"
           QUEUE_SPARE_TRIGGER: "4.5"
-          # inference-scheduling guide has routing proxy disabled, so vLLM
-          # serves directly on port 8000 (not 8200 behind proxy)
+          # inference-scheduling guide runs vLLM directly on 8000 (no 8200 routing proxy).
           VLLM_SVC_PORT: "8000"
+          MODEL_ID: ${{ env.MODEL_ID }}
+          ACCELERATOR_TYPE: ${{ env.ACCELERATOR_TYPE }}
+          LLMD_PATCH_EPP_FLOW_CONTROL: "true"
+          LLMD_SKIP_INFERENCE_OBJECTIVE: "true"
+          # Ensure helmfile installs default ModelService (decode workload); e2e waits on this Deployment below.
+          LLMD_SKIP_DEFAULT_MODELSERVICE: "false"
         run: |
           echo "Deploying WVA and llm-d infrastructure..."
           echo "  MODEL_ID: $MODEL_ID"
@@ -741,7 +739,14 @@ jobs:
           echo "  KV_SPARE_TRIGGER: ${KV_SPARE_TRIGGER:-<default>}"
           echo "  QUEUE_SPARE_TRIGGER: ${QUEUE_SPARE_TRIGGER:-<default>}"
           echo "  HF token configuration: ✓"
-          ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
+          # Base monitoring + WVA + scaler (install.sh does not deploy llm-d).
+          ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
+          # Gateway/EPP/ModelService + WVA poolGroup alignment (see deploy/install-llmd-infra.sh).
+          ./deploy/install-llmd-infra.sh -e openshift
+          # Capacity thresholds are not passed from install.sh — tune after install for CI simulators.
+          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
+            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
+            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
 
       - name: Create secondary namespace for Model B
         run: |
@@ -763,17 +768,42 @@ jobs:
           kubectl rollout status deployment -l app.kubernetes.io/name=workload-variant-autoscaler -n "$WVA_NAMESPACE" --timeout=300s || true
           kubectl get pods -n "$WVA_NAMESPACE"
 
+          # Wait for ModelService decode Deployment to exist (helmfile can lag; names can vary slightly by llm-d release).
+          CANONICAL_DECODE="ms-inference-scheduling-llm-d-modelservice-decode"
+          DECODE_DEPLOY=""
+          for i in $(seq 1 90); do
+            if kubectl get deployment "$CANONICAL_DECODE" -n "$LLMD_NAMESPACE" &>/dev/null; then
+              DECODE_DEPLOY="$CANONICAL_DECODE"
+              break
+            fi
+            DECODE_DEPLOY=$(kubectl get deploy -n "$LLMD_NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -E -- '-decode$' | grep -i modelservice | head -1 || true)
+            if [ -n "$DECODE_DEPLOY" ]; then
+              break
+            fi
+            echo "Waiting for ModelService decode Deployment in $LLMD_NAMESPACE ($i/90)..."
+            sleep 10
+          done
+          if [ -z "$DECODE_DEPLOY" ]; then
+            echo "::error::No decode Deployment found in $LLMD_NAMESPACE (check llm-d helmfile)"
+            kubectl get deploy -n "$LLMD_NAMESPACE" -o wide || true
+            exit 1
+          fi
+          echo "Using Model A1 decode Deployment: $DECODE_DEPLOY"
+
           # Ensure the vLLM deployment has the correct replica count.
           # A previous failed run's "Scale down GPU workloads" step may have set replicas=0
           # and helmfile doesn't override manually-changed replicas on re-deploy.
           # kubectl rollout status returns instantly on 0-replica deployments, so we must
           # ensure replicas > 0 before waiting.
           DESIRED_REPLICAS="${DECODE_REPLICAS:-1}"
-          CURRENT_REPLICAS=$(kubectl get deployment ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
-          if [ "$CURRENT_REPLICAS" -eq 0 ]; then
+          CURRENT_REPLICAS=$(kubectl get deployment "$DECODE_DEPLOY" -n "$LLMD_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+          if ! [[ "${CURRENT_REPLICAS:-}" =~ ^[0-9]+$ ]]; then
+            CURRENT_REPLICAS=0
+          fi
+          if [ "${CURRENT_REPLICAS}" -eq 0 ]; then
             echo "WARNING: Model A1 deployment has 0 replicas (likely from previous failed run cleanup)"
             echo "Scaling to $DESIRED_REPLICAS replica(s)..."
-            kubectl scale deployment/ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE" --replicas="$DESIRED_REPLICAS" || {
+            kubectl scale "deployment/$DECODE_DEPLOY" -n "$LLMD_NAMESPACE" --replicas="$DESIRED_REPLICAS" || {
               echo "ERROR: Failed to scale Model A1 deployment"
               exit 1
             }
@@ -783,12 +813,12 @@ jobs:
           # kubectl rollout status waits for all replicas to be Ready, unlike
           # --for=condition=available which is satisfied even at 0 ready replicas.
           # vLLM model loading takes 15-20 minutes, so we use a 25-minute timeout.
-          kubectl rollout status deployment/ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE" --timeout=1500s || {
+          kubectl rollout status "deployment/$DECODE_DEPLOY" -n "$LLMD_NAMESPACE" --timeout=1500s || {
             echo "WARNING: Model A1 deployment not ready after 25 minutes"
             echo "=== Pod status ==="
             kubectl get pods -n "$LLMD_NAMESPACE"
             echo "=== Deployment conditions ==="
-            kubectl get deployment ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE" -o jsonpath='{.status.conditions}' | jq . || true
+            kubectl get deployment "$DECODE_DEPLOY" -n "$LLMD_NAMESPACE" -o jsonpath='{.status.conditions}' | jq . || true
             echo "=== Recent events ==="
             kubectl get events -n "$LLMD_NAMESPACE" --sort-by='.lastTimestamp' | tail -20
           }
@@ -796,30 +826,25 @@ jobs:
 
       - name: Deploy Model B infrastructure in secondary namespace
         env:
-          # HF_TOKEN is inherited from GITHUB_ENV
+          # HF_TOKEN is inherited from GITHUB_ENV (same as Model A1).
           ENVIRONMENT: openshift
           INSTALL_GATEWAY_CTRLPLANE: "false"
-          E2E_TESTS_ENABLED: "true"
           SCALER_BACKEND: keda
           NAMESPACE_SCOPED: "false"
-          # Override namespaces for Model B stack
+          # Second llm-d stack — same WVA controller monitors both LLMD_NAMESPACE and LLMD_NAMESPACE_B.
           LLMD_NS: ${{ env.LLMD_NAMESPACE_B }}
           WVA_NS: ${{ env.WVA_NAMESPACE }}
-          # Skip WVA controller and prometheus (use existing)
+          # install-llmd-infra-only: reuse existing WVA + monitoring from Model A1 (no second controller).
           DEPLOY_WVA: "false"
-          DEPLOY_PROMETHEUS: "false"
-          DEPLOY_PROMETHEUS_ADAPTER: "false"
-          DEPLOY_VA: "false"
-          DEPLOY_HPA: "false"
-          # vLLM max-num-seqs for e2e testing (lower = easier to saturate)
+          MODEL_ID: ${{ env.MODEL_ID }}
+          ACCELERATOR_TYPE: ${{ env.ACCELERATOR_TYPE }}
           VLLM_MAX_NUM_SEQS: ${{ env.MAX_NUM_SEQS }}
-          # Decode replicas for e2e testing (start with 1 replica, let HPA scale)
           DECODE_REPLICAS: "1"
-          # OpenShift monitoring settings (same as Model A1 deploy)
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
           WVA_METRICS_SECURE: "false"
-          # Same port as Model A1 (inference-scheduling guide, proxy disabled)
+          # Match Model A1 (inference-scheduling guide, proxy disabled).
           VLLM_SVC_PORT: "8000"
+          LLMD_SKIP_DEFAULT_MODELSERVICE: "false"
         run: |
           echo "Deploying Model B infrastructure in $LLMD_NAMESPACE_B..."
           echo "  MODEL_ID: $MODEL_ID"
@@ -827,8 +852,8 @@ jobs:
           echo "  VLLM_MAX_NUM_SEQS: $VLLM_MAX_NUM_SEQS"
           echo "  DECODE_REPLICAS: $DECODE_REPLICAS"
 
-          # Deploy llm-d infrastructure only (no WVA controller, no VA/HPA)
-          ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --environment openshift
+          # llm-d only — no install.sh (would duplicate monitoring/scaler).
+          ./deploy/install-llmd-infra.sh -e openshift
 
           echo "Waiting for Model B deployment to start (initial rollout)..."
           # Wait briefly for deployments to be created by helm before checking rollout status
@@ -873,13 +898,37 @@ jobs:
 
       - name: Wait for Model B to be ready
         run: |
+          CANONICAL_DECODE="ms-inference-scheduling-llm-d-modelservice-decode"
+          DECODE_DEPLOY=""
+          for i in $(seq 1 90); do
+            if kubectl get deployment "$CANONICAL_DECODE" -n "$LLMD_NAMESPACE_B" &>/dev/null; then
+              DECODE_DEPLOY="$CANONICAL_DECODE"
+              break
+            fi
+            DECODE_DEPLOY=$(kubectl get deploy -n "$LLMD_NAMESPACE_B" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -E -- '-decode$' | grep -i modelservice | head -1 || true)
+            if [ -n "$DECODE_DEPLOY" ]; then
+              break
+            fi
+            echo "Waiting for Model B decode Deployment in $LLMD_NAMESPACE_B ($i/90)..."
+            sleep 10
+          done
+          if [ -z "$DECODE_DEPLOY" ]; then
+            echo "::error::No decode Deployment found in $LLMD_NAMESPACE_B"
+            kubectl get deploy -n "$LLMD_NAMESPACE_B" -o wide || true
+            exit 1
+          fi
+          echo "Using Model B decode Deployment: $DECODE_DEPLOY"
+
           # Same fix as Model A1: ensure replicas > 0 before waiting for rollout
           DESIRED_REPLICAS="${DECODE_REPLICAS:-1}"
-          CURRENT_REPLICAS=$(kubectl get deployment ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE_B" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
-          if [ "$CURRENT_REPLICAS" -eq 0 ]; then
+          CURRENT_REPLICAS=$(kubectl get deployment "$DECODE_DEPLOY" -n "$LLMD_NAMESPACE_B" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+          if ! [[ "${CURRENT_REPLICAS:-}" =~ ^[0-9]+$ ]]; then
+            CURRENT_REPLICAS=0
+          fi
+          if [ "${CURRENT_REPLICAS}" -eq 0 ]; then
             echo "WARNING: Model B deployment has 0 replicas (likely from previous failed run cleanup)"
             echo "Scaling to $DESIRED_REPLICAS replica(s)..."
-            kubectl scale deployment/ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE_B" --replicas="$DESIRED_REPLICAS" || {
+            kubectl scale "deployment/$DECODE_DEPLOY" -n "$LLMD_NAMESPACE_B" --replicas="$DESIRED_REPLICAS" || {
               echo "ERROR: Failed to scale Model B deployment"
               exit 1
             }
@@ -887,12 +936,12 @@ jobs:
 
           echo "Waiting for Model B vLLM deployment to be ready (up to 25 minutes for model loading)..."
           # Same as Model A1: use rollout status to wait for actual pod readiness.
-          kubectl rollout status deployment/ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE_B" --timeout=1500s || {
+          kubectl rollout status "deployment/$DECODE_DEPLOY" -n "$LLMD_NAMESPACE_B" --timeout=1500s || {
             echo "WARNING: Model B deployment not ready after 25 minutes"
             echo "=== Pod status ==="
             kubectl get pods -n "$LLMD_NAMESPACE_B"
             echo "=== Deployment conditions ==="
-            kubectl get deployment ms-inference-scheduling-llm-d-modelservice-decode -n "$LLMD_NAMESPACE_B" -o jsonpath='{.status.conditions}' | jq . || true
+            kubectl get deployment "$DECODE_DEPLOY" -n "$LLMD_NAMESPACE_B" -o jsonpath='{.status.conditions}' | jq . || true
             echo "=== Recent events ==="
             kubectl get events -n "$LLMD_NAMESPACE_B" --sort-by='.lastTimestamp' | tail -20
           }
@@ -1035,7 +1084,7 @@ jobs:
         env:
           # Consolidated e2e test environment variables
           ENVIRONMENT: openshift
-          USE_SIMULATOR: "true"
+          USE_SIMULATOR: "false"
           SCALE_TO_ZERO_ENABLED: "true"
           WVA_NAMESPACE: ${{ env.WVA_NAMESPACE }}
           MONITORING_NAMESPACE: openshift-user-workload-monitoring

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -323,7 +323,7 @@ jobs:
           SCALE_TO_ZERO_ENABLED: "false"
           CREATE_CLUSTER: "true"
           INSTALL_GATEWAY_CTRLPLANE: "true"
-          E2E_TESTS_ENABLED: "true"
+          # Emulated Kind: chart decode may be removed post-deploy (LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, default true).
           # Pin llm-d release for deterministic CI behavior
           LLM_D_RELEASE: "v0.6.0"
           # Dual-controller smoke installs a second Helm release; chart path must be explicit in CI.
@@ -437,12 +437,12 @@ jobs:
           SCALE_TO_ZERO_ENABLED: "true"
           CREATE_CLUSTER: "true"
           INSTALL_GATEWAY_CTRLPLANE: "true"
-          E2E_TESTS_ENABLED: "true"
           LLM_D_RELEASE: "v0.6.0"
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"
           PROMETHEUS_ADAPTER_WAIT: "false"
           DELETE_CLUSTER: "false"
+          # Same simulator saturation tuning as smoke — defaults are too high for reliable scale-up signals.
           KV_SPARE_TRIGGER: "0.5"
           QUEUE_SPARE_TRIGGER: "4.5"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ ENVIRONMENT                 ?= kind-emulator
 USE_SIMULATOR               ?= true
 SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
+LLM_D_RELEASE               ?= v0.6.0
+KV_SPARE_TRIGGER           ?=
+QUEUE_SPARE_TRIGGER         ?=
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
 E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
@@ -40,11 +43,8 @@ BENCHMARK_UV         ?= false
 BENCHMARK_SCENARIOS_DIR ?= $(CURDIR)/test/benchmark/scenarios
 BENCHMARK_MODEL_ID   ?= $(MODEL_ID)
 
-# Flags for deploy/install.sh installation script
-# Full e2e / CI-style cluster infra (WVA + llm-d, no chart VA/HPA): prefer `make deploy-e2e-infra`
-# (wraps ./deploy/install.sh with INFRA_ONLY=true; set ENVIRONMENT=kubernetes|openshift|kind-emulator).
+# Flags for deploy/install.sh + install-llmd-infra.sh (e2e / CI-style cluster infra; no chart VA/HPA).
 CREATE_CLUSTER ?= false
-DEPLOY_LLM_D ?= true
 DELETE_CLUSTER ?= false
 DELETE_NAMESPACES ?= false
 
@@ -131,15 +131,24 @@ destroy-kind-cluster:
 .PHONY: deploy-wva-emulated-on-kind
 deploy-wva-emulated-on-kind: ## Deploy WVA + llm-d on Kind (Prometheus Adapter as scaler backend)
 	@echo ">>> Deploying workload-variant-autoscaler (cluster args: $(KIND_ARGS), image: $(IMG))"
-	KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) DEPLOY_LLM_D=$(DEPLOY_LLM_D) ENVIRONMENT=kind-emulator CREATE_CLUSTER=$(CREATE_CLUSTER) CLUSTER_GPU_TYPE=$(CLUSTER_GPU_TYPE) CLUSTER_NODES=$(CLUSTER_NODES) CLUSTER_GPUS=$(CLUSTER_GPUS) NAMESPACE_SCOPED=false SCALER_BACKEND=$(SCALER_BACKEND) \
-		deploy/install.sh
+	KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) ENVIRONMENT=kind-emulator CREATE_CLUSTER=$(CREATE_CLUSTER) CLUSTER_GPU_TYPE=$(CLUSTER_GPU_TYPE) CLUSTER_NODES=$(CLUSTER_NODES) CLUSTER_GPUS=$(CLUSTER_GPUS) NAMESPACE_SCOPED=false SCALER_BACKEND=$(SCALER_BACKEND) \
+		deploy/install.sh && \
+	KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) ENVIRONMENT=kind-emulator NAMESPACE_SCOPED=false \
+		DEPLOY_LLM_D_INFERENCE_SIM=$${DEPLOY_LLM_D_INFERENCE_SIM:-true} \
+		LLM_D_RELEASE=$(LLM_D_RELEASE) DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		LLMD_PATCH_EPP_FLOW_CONTROL=true LLMD_SKIP_INFERENCE_OBJECTIVE=true \
+		LLMD_SKIP_DEFAULT_MODELSERVICE=true LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
+		INSTALL_GATEWAY_CTRLPLANE=true \
+		./deploy/install-llmd-infra.sh -e kind-emulator
 
 ## Undeploy WVA from the emulated environment on Kind.
 ## Undeploy WVA from Kind (set SCALER_BACKEND=keda if you deployed with KEDA)
 .PHONY: undeploy-wva-emulated-on-kind
 undeploy-wva-emulated-on-kind:
 	@echo ">>> Undeploying workload-variant-autoscaler from Kind"
-	KIND=$(KIND) KUBECTL=$(KUBECTL) ENVIRONMENT=kind-emulator DEPLOY_LLM_D=$(DEPLOY_LLM_D) DELETE_NAMESPACES=$(DELETE_NAMESPACES) DELETE_CLUSTER=$(DELETE_CLUSTER) SCALER_BACKEND=$(SCALER_BACKEND) \
+	KIND=$(KIND) KUBECTL=$(KUBECTL) ENVIRONMENT=kind-emulator DELETE_NAMESPACES=$(DELETE_NAMESPACES) DELETE_CLUSTER=$(DELETE_CLUSTER) SCALER_BACKEND=$(SCALER_BACKEND) \
+		./deploy/install-llmd-infra.sh --undeploy -e kind-emulator; \
+	KIND=$(KIND) KUBECTL=$(KUBECTL) ENVIRONMENT=kind-emulator DELETE_NAMESPACES=$(DELETE_NAMESPACES) DELETE_CLUSTER=$(DELETE_CLUSTER) SCALER_BACKEND=$(SCALER_BACKEND) \
 		deploy/install.sh --undeploy
 
 ## Deploy WVA to OpenShift cluster with specified image.
@@ -147,28 +156,32 @@ undeploy-wva-emulated-on-kind:
 deploy-wva-on-openshift: manifests kustomize ## Deploy WVA to OpenShift cluster with specified image.
 	@echo "Deploying WVA to OpenShift with image: $(IMG)"
 	@echo "Target namespace: $(or $(NAMESPACE),workload-variant-autoscaler-system)"
-	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=openshift DEPLOY_LLM_D=$(DEPLOY_LLM_D) ./deploy/install.sh
+	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=openshift ./deploy/install.sh && \
+	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=openshift LLM_D_RELEASE=$(LLM_D_RELEASE) ./deploy/install-llmd-infra.sh -e openshift
 
 ## Undeploy WVA from OpenShift.
 .PHONY: undeploy-wva-on-openshift
 undeploy-wva-on-openshift:
 	@echo ">>> Undeploying workload-variant-autoscaler from OpenShift"
 	export KIND=$(KIND) KUBECTL=$(KUBECTL) ENVIRONMENT=openshift && \
-		DEPLOY_LLM_D=$(DEPLOY_LLM_D) deploy/install.sh --undeploy
+		deploy/install-llmd-infra.sh --undeploy -e openshift; \
+		deploy/install.sh --undeploy
 
 ## Deploy WVA on Kubernetes with the specified image.
 .PHONY: deploy-wva-on-k8s
 deploy-wva-on-k8s: manifests kustomize ## Deploy WVA on Kubernetes with the specified image.
 	@echo "Deploying WVA on Kubernetes with image: $(IMG)"
 	@echo "Target namespace: $(or $(NAMESPACE),workload-variant-autoscaler-system)"
-	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=kubernetes DEPLOY_LLM_D=$(DEPLOY_LLM_D) ./deploy/install.sh
+	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=kubernetes ./deploy/install.sh && \
+	NAMESPACE=$(or $(NAMESPACE),workload-variant-autoscaler-system) IMG=$(IMG) ENVIRONMENT=kubernetes LLM_D_RELEASE=$(LLM_D_RELEASE) ./deploy/install-llmd-infra.sh -e kubernetes
 
 ## Undeploy WVA from Kubernetes.
 .PHONY: undeploy-wva-on-k8s
 undeploy-wva-on-k8s:
 	@echo ">>> Undeploying workload-variant-autoscaler from Kubernetes"
 	export KIND=$(KIND) KUBECTL=$(KUBECTL) ENVIRONMENT=kubernetes && \
-		ENVIRONMENT=kubernetes DEPLOY_LLM_D=$(DEPLOY_LLM_D)  deploy/install.sh --undeploy
+		deploy/install-llmd-infra.sh --undeploy -e kubernetes; \
+		deploy/install.sh --undeploy
 
 # E2E tests on Kind cluster for saturation-based autoscaling
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
@@ -183,11 +196,12 @@ undeploy-wva-on-k8s:
 # These targets use the test/e2e/ suite that works on any Kubernetes cluster
 # Supports FOCUS and SKIP variables for ginkgo test filtering.
 
-# Deploys only the infrastructure (WVA controller + llm-d) without VA/HPA resources.
+# Deploys WVA + monitoring + scaler (install.sh), then llm-d EPP/gateway (install-llmd-infra.sh). No chart VA/HPA.
 # If IMG is set, builds the image locally first (unless SKIP_BUILD=true).
+# Ordering: install.sh first, then install-llmd-infra.sh (WVA poolGroup upgrade runs after InferencePool exists).
 .PHONY: deploy-e2e-infra
-deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no VA/HPA). Uses Prometheus Adapter unless SCALER_BACKEND=keda.
-	@echo "Deploying e2e test infrastructure (infra-only mode)..."
+deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HPA). Uses Prometheus Adapter unless SCALER_BACKEND=keda.
+	@echo "Deploying e2e test infrastructure..."
 	@if [ -n "$(IMG)" ]; then \
 		echo "IMG is set to '$(IMG)'"; \
 		if [ "$(SKIP_BUILD)" != "true" ]; then \
@@ -206,31 +220,59 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (infra-only: WVA + llm-d, no
 		fi; \
 		echo "Using local image: $$IMAGE_REPO:$$IMAGE_TAG"; \
 		ENVIRONMENT=$(ENVIRONMENT) \
-		INFRA_ONLY=true \
-		USE_SIMULATOR=$(USE_SIMULATOR) \
-		SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
-		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
-		DECODE_REPLICAS=$(DECODE_REPLICAS) \
-		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \
-		./deploy/install.sh; \
+		./deploy/install.sh && \
+		KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) \
+		ENVIRONMENT=$(ENVIRONMENT) \
+		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
+		CREATE_CLUSTER=false \
+		WVA_IMAGE_REPO=$$IMAGE_REPO \
+		WVA_IMAGE_TAG=$$IMAGE_TAG \
+		WVA_IMAGE_PULL_POLICY=IfNotPresent \
+		LLM_D_RELEASE=$(LLM_D_RELEASE) \
+		DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		INSTALL_GATEWAY_CTRLPLANE=true \
+		LLMD_SKIP_DEFAULT_MODELSERVICE=true \
+		LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
+		LLMD_PATCH_EPP_FLOW_CONTROL=true \
+		LLMD_SKIP_INFERENCE_OBJECTIVE=true \
+		./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"; \
 	else \
 		echo "IMG not set - using default image from registry (latest)"; \
 		ENVIRONMENT=$(ENVIRONMENT) \
-		INFRA_ONLY=true \
-		USE_SIMULATOR=$(USE_SIMULATOR) \
-		SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
-		INSTALL_GATEWAY_CTRLPLANE=true \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
-		DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		./deploy/install.sh && \
+		KIND=$(KIND) KUBECTL=$(KUBECTL) \
+		ENVIRONMENT=$(ENVIRONMENT) \
+		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
+		CREATE_CLUSTER=false \
 		LLM_D_RELEASE=$(LLM_D_RELEASE) \
-		./deploy/install.sh; \
+		DECODE_REPLICAS=$(DECODE_REPLICAS) \
+		INSTALL_GATEWAY_CTRLPLANE=true \
+		LLMD_SKIP_DEFAULT_MODELSERVICE=true \
+		LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
+		LLMD_PATCH_EPP_FLOW_CONTROL=true \
+		LLMD_SKIP_INFERENCE_OBJECTIVE=true \
+		./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"; \
+	fi; \
+	REL=$${WVA_RELEASE_NAME:-workload-variant-autoscaler}; NS=$${WVA_NS:-workload-variant-autoscaler-system}; \
+	if [ -n "$(KV_SPARE_TRIGGER)" ] || [ -n "$(QUEUE_SPARE_TRIGGER)" ]; then \
+		echo "Applying optional WVA capacity threshold overrides (KV_SPARE_TRIGGER / QUEUE_SPARE_TRIGGER)..."; \
+		helm upgrade "$$REL" "$(CURDIR)/charts/workload-variant-autoscaler" -n "$$NS" --reuse-values \
+			$(if $(KV_SPARE_TRIGGER),--set wva.capacityScaling.default.kvSpareTrigger=$(KV_SPARE_TRIGGER)) \
+			$(if $(QUEUE_SPARE_TRIGGER),--set wva.capacityScaling.default.queueSpareTrigger=$(QUEUE_SPARE_TRIGGER)); \
 	fi
+
+## DEPRECATED: prefer ./deploy/install-llmd-infra.sh or upstream llm-d install tooling; kept for Makefile discoverability.
+.PHONY: deploy-e2e-llmd-infra
+deploy-e2e-llmd-infra: ## DEPRECATED — runs install-llmd-infra only (run after deploy/install.sh for full stack).
+	@echo "DEPRECATED target deploy-e2e-llmd-infra: invoking ./deploy/install-llmd-infra.sh"
+	@ENVIRONMENT=$(ENVIRONMENT) ./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"
 
 .PHONY: deploy-e2e-infra-multi-model
 deploy-e2e-infra-multi-model: ## Deploy e2e test infrastructure with two concurrent model services
@@ -499,6 +541,7 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-deploy-scripts: ## Run bash -n for deploy/install.sh, deploy/lib/*.sh, and deploy plugins
 	@echo "Syntax-checking deploy shell scripts..."
 	@bash -n deploy/install.sh
+	@bash -n deploy/install-llmd-infra.sh
 	@bash -n deploy/install-multi-model.sh
 	@for script in deploy/lib/*.sh; do bash -n "$$script"; done
 	@for script in deploy/*/install.sh; do if [ -f "$$script" ]; then bash -n "$$script"; fi; done
@@ -508,7 +551,8 @@ lint-deploy-scripts: ## Run bash -n for deploy/install.sh, deploy/lib/*.sh, and 
 .PHONY: smoke-deploy-scripts
 smoke-deploy-scripts: lint-deploy-scripts ## Non-interactive deploy script smoke check (source order + arg parsing)
 	@echo "Running deploy script smoke check..."
-	@SKIP_CHECKS=true E2E_TESTS_ENABLED=true INSTALL_GATEWAY_CTRLPLANE=true ENVIRONMENT=kubernetes ./deploy/install.sh --help >/dev/null
+	@SKIP_CHECKS=true ENVIRONMENT=kubernetes ./deploy/install.sh --help >/dev/null
+	@SKIP_CHECKS=true ENVIRONMENT=kubernetes ./deploy/install-llmd-infra.sh --help >/dev/null
 	@echo "deploy script smoke OK"
 
 .PHONY: lint-fix

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -115,7 +115,7 @@ helm install wva-model-b ./workload-variant-autoscaler \
 | hpa.maxReplicas | int | `10` |  |
 | hpa.targetAverageValue | string | `"1"` |  |
 | llmd.modelID | string | `"unsloth/Meta-Llama-3.1-8B"` |  |
-| llmd.modelName | string | `"ms-inference-scheduling-llm-d-modelservice"` |  |
+| llmd.modelName | string | `"ms-inference-scheduling-llm-d-modelservice"` | Example matches older llm-d guide basenames; llm-d main uses [guides/optimized-baseline](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) — align with your cluster’s ModelService name. |
 | llmd.namespace | string | `"llm-d-autoscaler"` |  |
 | va.accelerator | string | `"H100"` |  |
 | va.enabled | bool | `true` |  |
@@ -229,15 +229,6 @@ helm install workload-variant-autoscaler ./workload-variant-autoscaler \
   --set hpa.behavior.scaleDown.stabilizationWindowSeconds=30
 ```
 
-**Configuration via install.sh:**
-```bash
-# Set stabilization window via environment variable
-HPA_STABILIZATION_SECONDS=120 ./deploy/install.sh
-
-# Production default (240s)
-./deploy/install.sh
-```
-
 **Key Parameters:**
 - **stabilizationWindowSeconds**: Time to wait before applying scaling decisions (prevents flapping)
 - **selectPolicy**: How to choose from multiple policies (`Max`, `Min`, `Disabled`)
@@ -311,7 +302,7 @@ When running multiple WVA controllers in the same cluster (e.g., for parallel e2
 For parallel e2e tests, each test run can use a unique controller instance:
 ```bash
 # Each PR/run uses its namespace as the controller instance
-CONTROLLER_INSTANCE="llm-d-autoscaler-pr-123" ./deploy/install.sh
+CONTROLLER_INSTANCE="llm-d-autoscaler-pr-123" ./deploy/install.sh -e kubernetes
 ```
 
 This ensures that:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -111,184 +111,87 @@ bash install.sh
 
 The script accepts both command-line flags and environment variables:
 
-**Command-line flags**:
+**Command-line flags** (`deploy/install.sh`):
 
 ```bash
 bash install.sh [OPTIONS]
 
 Options:
   -i, --wva-image IMAGE    WVA container image (default: ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest)
-  -m, --model MODEL        Model ID (default: unsloth/Meta-Llama-3.1-8B)
-  -a, --accelerator TYPE   GPU type: A100, H100, L40S (auto-detected by default)
-  -u, --undeploy          Undeploy all components
-  -e, --environment ENV    Environment: kubernetes, openshift, kind-emulator
-  -h, --help              Show help
+  -r, --release-name NAME  Helm release name for WVA
+  -u, --undeploy           Undeploy WVA, monitoring, and scaler (not llm-d)
+  -e, --environment ENV    kubernetes | openshift | kind-emulator
+  -h, --help               Show help
 ```
 
-**Environment variables** (see [Configuration Reference](#configuration-reference) for complete list):
+**llm-d stack** (gateway, EPP, ModelService): use `deploy/install-llmd-infra.sh` **after** `install.sh` when you need inference infrastructure. That script is **deprecated** as a long-term shim; migrate to llm-d-owned install tooling when available.
+
+On **emulated** environments (`kind-emulator`), `deploy/lib/infra_llmd.sh` runs post-deploy ModelService cleanup at the end of `deploy_llm_d_infrastructure`: it removes the chart **prefill** deployment (until WVA supports prefill and decode together), and when **`LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=true`** (default) it also removes the chart **decode** deployment so e2e and local flows can apply their own model workloads. This logic is **not** in `deploy/kind-emulator/install.sh`.
+
+**Environment variables** (see [Configuration Reference](#configuration-reference); llm-d-specific vars are documented in the install-llmd-infra header comment):
 
 ```bash
-# Core Configuration
-export HF_TOKEN="hf_xxx"                    # HuggingFace token (required for llm-d)
-export MODEL_ID="unsloth/Meta-Llama-3.1-8B" # Model to deploy
-export ACCELERATOR_TYPE="A100"              # GPU type (auto-detected)
-export WVA_IMAGE_TAG="latest"               # WVA image version
+# Always set for install.sh
+export ENVIRONMENT="kubernetes"   # or openshift, kind-emulator
+export LLMD_NS="llm-d-inference-scheduler"  # namespace WVA watches
 
-# Deployment Flags
-export DEPLOY_PROMETHEUS=true               # Deploy Prometheus stack
-export DEPLOY_WVA=true                      # Deploy WVA controller
-export DEPLOY_LLM_D=true                    # Deploy llm-d infrastructure
-export DEPLOY_PROMETHEUS_ADAPTER=true       # Deploy Prometheus Adapter
-export DEPLOY_VA=true                       # Chart-managed VariantAutoscaling (default off; e2e often creates its own)
-export DEPLOY_HPA=true                      # Chart-managed HPA (default off; enable with DEPLOY_VA for demos)
-export DEPLOY_LWS=true                      # Deploy LeaderWorkerSet (set false if already installed)
+# When DEPLOY_WVA=true (default)
+export WVA_IMAGE_REPO="ghcr.io/llm-d/llm-d-workload-variant-autoscaler"
+export WVA_IMAGE_TAG="latest"
 
-# LeaderWorkerSet Configuration
-export LWS_NAMESPACE="lws-system"           # Namespace for LWS installation
-export LWS_CHART_VERSION="0.8.0"            # LWS Helm chart version
+# Optional
+export DEPLOY_WVA=false            # Monitoring + scaler only
+export DEPLOY_PROMETHEUS=false
+export DEPLOY_LWS=false           # Skip LeaderWorkerSet if already on cluster
 
-# HPA Configuration
-export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window (default: 240s)
-
-# Gateway Configuration
-export GATEWAY_PROVIDER="istio"             # Gateway provider: istio, kgateway
-export INSTALL_GATEWAY_CTRLPLANE="true"     # Install gateway control plane
-
-# SLO Targets
-export SLO_TPOT=10                         # Time per output token (ms) SLO
-export SLO_TTFT=1000                       # Time to first token (ms) SLO
+# llm-d (install-llmd-infra.sh) — examples
+export HF_TOKEN="hf_xxx"
+export MODEL_ID="unsloth/Meta-Llama-3.1-8B"
+export INSTALL_GATEWAY_CTRLPLANE=true
+# Guide basename under llm-d guides/ (llm-d README: GUIDE_NAME). Default inference-scheduling matches
+# LLM_D_RELEASE pins; llm-d main primary guide is optimized-baseline:
+# https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline
+# export GUIDE_NAME=optimized-baseline   # only when your LLM_D_RELEASE checkout includes that path + values layout
 ```
 
-#### Interactive Gateway Configuration
+#### Gateway control plane (`install-llmd-infra.sh`)
 
-When running the script, it will prompt you about Gateway control plane installation:
+`INSTALL_GATEWAY_CTRLPLANE` defaults to **true** (install the gateway control plane via helmfile). Set **`INSTALL_GATEWAY_CTRLPLANE=false`** if your cluster already has a suitable gateway.
 
-```bash
-Gateway Control Plane Configuration
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#### Script deployment examples
 
-The Gateway control plane (istio) is required to serve requests.
-You can either:
-  1. Install the Gateway control plane (recommended for new clusters or emulated clusters)
-  2. Use an existing Gateway control plane in your cluster (recommended for production clusters)
+Chart-managed **VariantAutoscaling** and **HPA** are no longer toggled from `install.sh`; use `helm upgrade` with `--set va.enabled=true` / `hpa.enabled=true` on the WVA chart, or let tests/operators create CRs.
 
-Do you want to install the Gateway control plane? (y/n):
-```
-
-To skip this prompt and automate the decision:
-
-```bash
-# Install gateway control plane automatically
-export INSTALL_GATEWAY_CTRLPLANE="true"
-bash install.sh
-
-# Use existing gateway (don't install)
-export INSTALL_GATEWAY_CTRLPLANE="false"
-bash install.sh
-```
-
-#### Script Deployment Examples
-
-##### Example 1: Full deployment with defaults
+##### Example 1: Base infra then llm-d
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
-# Optional: chart-managed VA + HPA for a single-variant demo (install.sh defaults skip these)
-export DEPLOY_VA=true
-export DEPLOY_HPA=true
-make deploy-wva-on-k8s
+./deploy/install.sh -e kubernetes
+./deploy/install-llmd-infra.sh -e kubernetes
 ```
 
-##### Example 2: Custom model and namespace
+##### Example 2: E2E-style stack (same as `make deploy-e2e-infra`)
+
+Runs `install.sh` then `install-llmd-infra.sh` with e2e-oriented llm-d flags (skip default ModelService, EPP flow-control patch, etc.).
 
 ```bash
-export HF_TOKEN="hf_xxxxx"
-export MODEL_ID="meta-llama/Llama-2-7b-hf"
-export SLO_TPOT=5
-export SLO_TTFT=500
-export DEPLOY_VA=true
-export DEPLOY_HPA=true
-make deploy-wva-on-k8s
+make deploy-e2e-infra ENVIRONMENT=kind-emulator IMG=localhost/llm-d-workload-variant-autoscaler:dev
 ```
 
-##### Example 3: Deploy only WVA (llm-d already running)
+##### Example 3: WVA + monitoring only (no llm-d)
 
 ```bash
 export DEPLOY_WVA=true
-export DEPLOY_LLM_D=false
-export DEPLOY_PROMETHEUS=true  # Prometheus is needed for metrics - disable if it is already installed in your cluster
-export DEPLOY_PROMETHEUS_ADAPTER=false
-export DEPLOY_VA=true          # Create a VariantAutoscaling CR for the existing model service
-export DEPLOY_HPA=false
-make deploy-wva-on-k8s
+export DEPLOY_PROMETHEUS=true
+export DEPLOY_PROMETHEUS_ADAPTER=true
+./deploy/install.sh -e kubernetes
 ```
 
-##### Example 4: Skip LeaderWorkerSet installation (LWS already on cluster)
+##### Example 4: Skip LeaderWorkerSet (already on cluster)
 
 ```bash
-export DEPLOY_LWS=false  # Skip LWS when it is already installed cluster-wide
-make deploy-wva-on-k8s
-```
-
-##### Example 5: Fast HPA scaling for development/testing
-
-```bash
-export HF_TOKEN="hf_xxxxx"
-export DEPLOY_VA=true
-export DEPLOY_HPA=true
-export HPA_STABILIZATION_SECONDS=30  # Fast scaling for dev/test (default: 240)
-make deploy-wva-on-k8s
-```
-
-##### Example 6: E2E testing with very fast scaling
-
-```bash
-export HF_TOKEN="hf_xxxxx"
-export E2E_TESTS_ENABLED=true
-export INFRA_ONLY=true               # Tests create VA/HPA; see also make deploy-e2e-infra
-export HPA_STABILIZATION_SECONDS=0   # Only applies if chart HPA is enabled
-export VLLM_MAX_NUM_SEQS=8           # Low batch size for easy saturation
-make deploy-wva-on-k8s
-```
-
-##### Example 7: Parameter estimation with specific batch size
-
-```bash
-export HF_TOKEN="hf_xxxxx"
-export VLLM_MAX_NUM_SEQS=64         # Match desired max batch size
-export MODEL_ID="unsloth/Meta-Llama-3.1-8B"
-export DEPLOY_VA=true
-export DEPLOY_HPA=true
-make deploy-wva-on-k8s
-```
-
-##### Example 8: Infra-only mode for e2e testing
-
-Deploy only the llm-d infrastructure and WVA controller without creating VariantAutoscaling or HPA resources. This is useful for e2e testing where tests dynamically create their own VA/HPA resources.
-
-```bash
-# Using command-line flag
-export HF_TOKEN="hf_xxxxx"
-./deploy/install.sh --infra-only
-
-# Using environment variable
-export HF_TOKEN="hf_xxxxx"
-export INFRA_ONLY=true
-make deploy-wva-emulated-on-kind
-
-# Verify: Only WVA controller + llm-d infrastructure should exist
-kubectl get variantautoscaling --all-namespaces  # Should be empty
-kubectl get hpa --all-namespaces | grep -v kube-system  # Should be empty (except system HPAs)
-```
-
-**What gets deployed in infra-only mode:**
-- ✅ Prometheus stack (metrics collection)
-- ✅ WVA controller
-- ✅ llm-d infrastructure (Gateway, CRDs, RBAC, EPP)
-- ✅ Prometheus Adapter (external metrics API)
-- ❌ VariantAutoscaling CRs (tests create these)
-- ❌ HPA resources (tests create these)
-- ❌ Model services (tests create these)
+export DEPLOY_LWS=false
+./deploy/install.sh -e kubernetes
 ```
 
 ### Method 2: Helm Chart
@@ -637,11 +540,7 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `ENVIRONMENT` | Deployment environment | `kubernetes` |
-| `WELL_LIT_PATH_NAME` | llm-d path name | `inference-scheduling` |
-| `MODEL_ID` | Model to deploy | `unsloth/Meta-Llama-3.1-8B` |
-| `ACCELERATOR_TYPE` | GPU type | Auto-detected |
-| `SLO_TPOT` | Time per output token SLO (ms) | `10` |
-| `SLO_TTFT` | Time to first token SLO (ms) | `1000` |
+| `WVA_BASE_NAME` | Controller base name in chart | `inference-scheduling` |
 
 #### Image Configuration
 
@@ -664,77 +563,36 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GATEWAY_PROVIDER` | Gateway implementation | `istio` |
-| `INSTALL_GATEWAY_CTRLPLANE` | Install gateway control plane | `false` (prompts user) |
+| `INSTALL_GATEWAY_CTRLPLANE` | Install gateway control plane via helmfile | `true` |
+| `LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS` | On emulated clusters, delete chart decode Deployment after deploy (e2e applies its own) | `true` |
 
-#### Deployment Flags
+#### Deployment Flags (`install.sh`)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DEPLOY_PROMETHEUS` | Deploy Prometheus stack | `true` |
 | `DEPLOY_WVA` | Deploy WVA controller | `true` |
-| `DEPLOY_LLM_D` | Deploy llm-d infrastructure | `true` |
-| `DEPLOY_PROMETHEUS_ADAPTER` | Deploy Prometheus Adapter | `true` |
-| `DEPLOY_VA` | Deploy VariantAutoscaling CR via WVA Helm chart | `false` |
-| `DEPLOY_HPA` | Deploy HPA via WVA Helm chart | `false` |
+| `DEPLOY_PROMETHEUS_ADAPTER` | Deploy Prometheus Adapter (when `SCALER_BACKEND=prometheus-adapter`) | `true` |
 | `DEPLOY_LWS` | Deploy LeaderWorkerSet (skip if already installed or not needed) | `true` |
-| `INFRA_ONLY` | Deploy only infrastructure (skip VA/HPA) | `false` |
 | `SKIP_CHECKS` | Skip prerequisite checks | `false` |
+| `SCALER_BACKEND` | `prometheus-adapter`, `keda`, or `none` | `prometheus-adapter` |
 
-#### HPA Configuration
+VariantAutoscaling, HPA stabilization, and vLLM ModelService tuning are not controlled by `install.sh`; use **Helm** (`va.enabled`, `hpa.*`, `wva.capacityScaling.*`) or **`install-llmd-infra.sh`** (`MODEL_ID`, `VLLM_MAX_NUM_SEQS`, `LLMD_*`, etc.).
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `HPA_STABILIZATION_SECONDS` | HPA stabilization window in seconds | `240` |
-
-**Best Practices:**
-- **Production**: 120-300 seconds (prevents flapping, ensures stability)
-- **Development**: 30-60 seconds (faster iteration)
-- **E2E Tests**: 0-30 seconds (rapid validation)
-
-**Examples:**
-```bash
-# Production deployment (default)
-HPA_STABILIZATION_SECONDS=240 ./deploy/install.sh
-
-# Development deployment
-HPA_STABILIZATION_SECONDS=60 ./deploy/install.sh
-
-# E2E testing
-HPA_STABILIZATION_SECONDS=30 ./deploy/install.sh
-```
-
-#### Advanced Configuration
+#### Advanced (`install.sh`)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SKIP_TLS_VERIFY` | Skip TLS verification | Auto-detected |
 | `WVA_LOG_LEVEL` | WVA logging level | `info` |
-| `VLLM_SVC_ENABLED` | Enable vLLM Service | `true` |
+| `VLLM_SVC_ENABLED` | Enable vLLM Service in chart | `true` |
 | `VLLM_SVC_NODEPORT` | vLLM NodePort | `30000` |
-| `LLM_D_RELEASE` | llm-d version | `v0.6.0` |
 | `LWS_NAMESPACE` | Namespace for LeaderWorkerSet installation | `lws-system` |
 | `LWS_CHART_VERSION` | LeaderWorkerSet Helm chart version | `0.8.0` |
-| `VLLM_MAX_NUM_SEQS` | vLLM max concurrent sequences per replica | (unset - uses vLLM default) |
 
-**vLLM Performance Tuning:**
+#### Optional: capacity thresholds after `make deploy-e2e-infra`
 
-The `VLLM_MAX_NUM_SEQS` variable controls the maximum number of concurrent sequences (batch size) that each vLLM replica can handle. Lower values make the server easier to saturate, which is useful for testing autoscaling behavior.
-
-**Use cases:**
-- **E2E Testing**: Set to low values (e.g., `8` or `16`) to quickly trigger saturation and test autoscaling
-- **Parameter Estimation**: Match this to your desired maximum batch size (see [Configuration Guide](../docs/user-guide/configuration.md))
-- **Production**: Leave unset to use vLLM's default based on available GPU memory
-
-**Example:**
-```bash
-# E2E testing with easy saturation
-export VLLM_MAX_NUM_SEQS=8
-make deploy-wva-on-k8s
-
-# Parameter estimation with batch size 64
-export VLLM_MAX_NUM_SEQS=64
-make deploy-wva-on-k8s
-```
+If `KV_SPARE_TRIGGER` and/or `QUEUE_SPARE_TRIGGER` are set in the environment, the Makefile runs a follow-up `helm upgrade --reuse-values` on the WVA release.
 
 ### Helm Values Reference
 
@@ -824,10 +682,10 @@ kubectl describe variantautoscaling <name> -n <namespace>
 For rapid testing of autoscaling behavior, configure vLLM with a low `max-num-seqs` value to make the server easy to saturate:
 
 ```bash
-# Deploy with testing-friendly configuration
-export VLLM_MAX_NUM_SEQS=8              # Low batch size triggers saturation quickly
-export HPA_STABILIZATION_SECONDS=30     # Fast scaling for testing
-make deploy-wva-on-k8s  # or -on-openshift, -emulated-on-kind
+# Deploy base infra + llm-d, then tune vLLM via install-llmd-infra env or chart values
+export VLLM_MAX_NUM_SEQS=8
+make deploy-wva-on-k8s   # runs install.sh + install-llmd-infra for kind-emulator
+# For HPA stabilization when using chart-managed HPA: helm upgrade --set hpa.behavior...
 ```
 
 This configuration helps you:

--- a/deploy/inference-objective-e2e.yaml
+++ b/deploy/inference-objective-e2e.yaml
@@ -1,6 +1,7 @@
 # InferenceObjective for GIE queuing (scale-from-zero flow control).
-# install.sh applies this when ENABLE_SCALE_TO_ZERO=true and not E2E (e2e applies e2e-default from Go).
-# poolRef.name is templated by install.sh to match the deployed InferencePool.
+# install-llmd-infra.sh applies this when ENABLE_SCALE_TO_ZERO=true and LLMD_SKIP_INFERENCE_OBJECTIVE is not true
+# (e2e applies e2e-default from Go when LLMD_SKIP_INFERENCE_OBJECTIVE=true).
+# poolRef.name is templated to match the deployed InferencePool.
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceObjective
 metadata:

--- a/deploy/install-llmd-infra.sh
+++ b/deploy/install-llmd-infra.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# DEPRECATED: Transitional shim for llm-d infrastructure (repo clone, HF secret, gateway
+# control plane, EPP, ModelService via helmfile, RBAC/EPP patches, WVA poolGroup upgrade).
+#
+# Prefer the llm-d project's own installation tooling (helmfile, llm-d CLI, or upstream
+# guides) once your environment can consume it directly. Track removal in a follow-up issue.
+#
+# Ordering: run deploy/install.sh first (WVA + monitoring + scaler backend), then this script
+# when you need llm-d. The poolGroup helm upgrade on WVA requires InferencePool objects created
+# by this deploy.
+#
+# Usage:
+#   ./deploy/install-llmd-infra.sh [-e kubernetes|openshift|kind-emulator] [--undeploy]
+#
+# Prerequisites: kubectl, helm, git. On kubernetes/openshift, GPU discovery uses jq — install it or run on kind-emulator to skip that path.
+
+set -e
+set -o pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+WVA_PROJECT=${WVA_PROJECT:-$PWD}
+# Basename under llm-d guides/ (llm-d calls this GUIDE_NAME). On llm-d main the former
+# inference-scheduling layout lives at guides/optimized-baseline:
+# https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline
+# Default stays inference-scheduling so pinned LLM_D_RELEASE (e.g. v0.6.0) still finds helmfile + values.
+if [ -n "${GUIDE_NAME:-}" ]; then
+    WELL_LIT_PATH_NAME="$GUIDE_NAME"
+fi
+: "${WELL_LIT_PATH_NAME:=inference-scheduling}"
+GUIDE_NAME="$WELL_LIT_PATH_NAME"
+NAMESPACE_SUFFIX=${NAMESPACE_SUFFIX:-"inference-scheduler"}
+LLMD_NS=${LLMD_NS:-"llm-d-$NAMESPACE_SUFFIX"}
+WVA_NS=${WVA_NS:-"workload-variant-autoscaler-system"}
+MONITORING_NAMESPACE=${MONITORING_NAMESPACE:-"workload-variant-autoscaler-monitoring"}
+
+LLM_D_OWNER=${LLM_D_OWNER:-"llm-d"}
+LLM_D_PROJECT=${LLM_D_PROJECT:-"llm-d"}
+LLM_D_RELEASE=${LLM_D_RELEASE:-"v0.6.0"}
+LLM_D_MODELSERVICE_NAME=${LLM_D_MODELSERVICE_NAME:-"ms-$GUIDE_NAME-llm-d-modelservice"}
+LLM_D_EPP_NAME=${LLM_D_EPP_NAME:-"gaie-$GUIDE_NAME-epp"}
+CLIENT_PREREQ_DIR=${CLIENT_PREREQ_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/prereq/client-setup"}
+GATEWAY_PREREQ_DIR=${GATEWAY_PREREQ_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/prereq/gateway-provider"}
+EXAMPLE_DIR=${EXAMPLE_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/$GUIDE_NAME"}
+LLM_D_MODELSERVICE_VALUES=${LLM_D_MODELSERVICE_VALUES:-"$EXAMPLE_DIR/ms-$GUIDE_NAME/values.yaml"}
+ITL_AVERAGE_LATENCY_MS=${ITL_AVERAGE_LATENCY_MS:-20}
+TTFT_AVERAGE_LATENCY_MS=${TTFT_AVERAGE_LATENCY_MS:-200}
+ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
+LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.0"}
+
+GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"}
+# Install Gateway control plane via helmfile when true (default). Set false if your cluster already has one.
+INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-true}"
+
+# Model identity and vLLM / ModelService chart tuning (wired into llm-d values or overrides).
+DEFAULT_MODEL_ID=${DEFAULT_MODEL_ID:-"Qwen/Qwen3-0.6B"}
+MODEL_ID=${MODEL_ID:-"unsloth/Meta-Llama-3.1-8B"}
+ACCELERATOR_TYPE=${ACCELERATOR_TYPE:-"H100"}
+
+VLLM_SVC_ENABLED=${VLLM_SVC_ENABLED:-true}
+VLLM_SVC_PORT=${VLLM_SVC_PORT:-8200}
+VLLM_MAX_NUM_SEQS=${VLLM_MAX_NUM_SEQS:-""}
+DECODE_REPLICAS=${DECODE_REPLICAS:-""}
+LLMD_IMAGE_TAG=${LLMD_IMAGE_TAG:-""}
+VLLM_GPU_MEM_UTIL=${VLLM_GPU_MEM_UTIL:-""}
+VLLM_MAX_MODEL_LEN=${VLLM_MAX_MODEL_LEN:-""}
+VLLM_BLOCK_SIZE=${VLLM_BLOCK_SIZE:-""}
+VLLM_ENFORCE_EAGER=${VLLM_ENFORCE_EAGER:-""}
+
+DEPLOY_WVA=${DEPLOY_WVA:-true}
+WVA_RELEASE_NAME=${WVA_RELEASE_NAME:-"workload-variant-autoscaler"}
+NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
+SKIP_CHECKS=${SKIP_CHECKS:-false}
+# When deploying on emulated clusters, delete chart decode Deployment after helmfile so tests can apply their own (default true).
+LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=${LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS:-true}
+
+# CI / e2e-oriented flags (Makefile sets most of these; defaults are conservative for ad-hoc demos).
+LLMD_SKIP_DEFAULT_MODELSERVICE=${LLMD_SKIP_DEFAULT_MODELSERVICE:-false}
+LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=${LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY:-false}
+LLMD_PATCH_EPP_FLOW_CONTROL=${LLMD_PATCH_EPP_FLOW_CONTROL:-false}
+LLMD_SKIP_INFERENCE_OBJECTIVE=${LLMD_SKIP_INFERENCE_OBJECTIVE:-false}
+
+DEPLOY_LLM_D_INFERENCE_SIM=${DEPLOY_LLM_D_INFERENCE_SIM:-false}
+LLM_D_INFERENCE_SIM_IMG_REPO=${LLM_D_INFERENCE_SIM_IMG_REPO:-"ghcr.io/llm-d/llm-d-inference-sim"}
+LLM_D_INFERENCE_SIM_IMG_TAG=${LLM_D_INFERENCE_SIM_IMG_TAG:-"latest"}
+
+ENVIRONMENT=${ENVIRONMENT:-"kubernetes"}
+COMPATIBLE_ENV_LIST=("kubernetes" "openshift" "kind-emulator")
+NON_EMULATED_ENV_LIST=("kubernetes" "openshift")
+REQUIRED_TOOLS=("kubectl" "helm" "git")
+
+UNDEPLOY=false
+
+# Minimal bootstrap so parse_llmd_args can call log_error / containsElement
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_LIB_DIR="$SCRIPT_DIR/lib"
+# shellcheck source=lib/common.sh
+source "$DEPLOY_LIB_DIR/common.sh"
+# shellcheck source=lib/constants.sh
+source "$DEPLOY_LIB_DIR/constants.sh"
+
+print_llmd_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Deploy llm-d inference stack (gateway, EPP, ModelService) after WVA base infra.
+
+Run deploy/install.sh first unless you only need to tear down llm-d (--undeploy).
+
+Options:
+  -e, --environment NAME   kubernetes | openshift | kind-emulator (default: $ENVIRONMENT)
+  --undeploy               Remove llm-d helm releases and optional gateway control plane
+  -h, --help               Show this help
+
+Environment: see deploy/README.md (llm-d / gateway variables). Key flags:
+  LLMD_SKIP_DEFAULT_MODELSERVICE, LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY,
+  LLMD_PATCH_EPP_FLOW_CONTROL, LLMD_SKIP_INFERENCE_OBJECTIVE, INSTALL_GATEWAY_CTRLPLANE,
+  LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, MODEL_ID, ACCELERATOR_TYPE, HF_TOKEN,
+  GUIDE_NAME (or legacy WELL_LIT_PATH_NAME), RELEASE_NAME_POSTFIX
+EOF
+}
+
+parse_llmd_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -e|--environment)
+                ENVIRONMENT="$2"
+                shift 2
+                ;;
+            --undeploy)
+                UNDEPLOY=true
+                shift
+                ;;
+            -h|--help)
+                print_llmd_help
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                print_llmd_help
+                exit 1
+                ;;
+        esac
+    done
+    if ! containsElement "$ENVIRONMENT" "${COMPATIBLE_ENV_LIST[@]}"; then
+        log_error "Invalid environment: $ENVIRONMENT. Valid: ${COMPATIBLE_ENV_LIST[*]}"
+    fi
+}
+
+# Entry flow: parse args → prerequisites → env plugin (kind/openshift/…) → GPU detect (non-emulated)
+# → deploy_llm_d_infrastructure (clone llm-d, helmfile, WVA poolGroup upgrade, emulated cleanup).
+main_llmd() {
+    parse_llmd_args "$@"
+
+    # shellcheck source=lib/verify.sh
+    source "$DEPLOY_LIB_DIR/verify.sh"
+    # shellcheck source=lib/wait_helpers.sh
+    source "$DEPLOY_LIB_DIR/wait_helpers.sh"
+    # shellcheck source=lib/prereqs.sh
+    source "$DEPLOY_LIB_DIR/prereqs.sh"
+    # shellcheck source=lib/discovery.sh
+    source "$DEPLOY_LIB_DIR/discovery.sh"
+    # shellcheck source=lib/cleanup.sh
+    source "$DEPLOY_LIB_DIR/cleanup.sh"
+    # shellcheck source=lib/infra_llmd.sh
+    source "$DEPLOY_LIB_DIR/infra_llmd.sh"
+
+    if [ "$UNDEPLOY" = "true" ]; then
+        log_info "Undeploying llm-d infrastructure on $ENVIRONMENT"
+        undeploy_llm_d_infrastructure
+        log_success "llm-d undeploy finished (run deploy/install.sh --undeploy separately for WVA/monitoring if needed)"
+        exit 0
+    fi
+
+    if [ "$SKIP_CHECKS" != "true" ]; then
+        check_prerequisites
+    fi
+
+    if [[ "${CLUSTER_TYPE:-}" == "kind" ]]; then
+        ENVIRONMENT="kind-emulator"
+    fi
+
+    if [ -f "$SCRIPT_DIR/$ENVIRONMENT/install.sh" ]; then
+        # shellcheck source=/dev/null
+        source "$SCRIPT_DIR/$ENVIRONMENT/install.sh"
+    else
+        log_error "Environment script not found: $SCRIPT_DIR/$ENVIRONMENT/install.sh"
+    fi
+    # Env plugins (e.g. kind-emulator) may override WELL_LIT_PATH_NAME / EXAMPLE_DIR / llm-d names.
+    GUIDE_NAME="$WELL_LIT_PATH_NAME"
+
+    if declare -f check_specific_prerequisites > /dev/null; then
+        if [ "$SKIP_CHECKS" != "true" ]; then
+            check_specific_prerequisites
+        fi
+    fi
+
+    log_info "INSTALL_GATEWAY_CTRLPLANE=$INSTALL_GATEWAY_CTRLPLANE (set false to skip gateway control plane install)"
+
+    kubectl create namespace "$LLMD_NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+    if containsElement "$ENVIRONMENT" "${NON_EMULATED_ENV_LIST[@]}"; then
+        detect_gpu_type
+    else
+        log_info "Skipping GPU type detection for emulated environment (ENVIRONMENT=$ENVIRONMENT)"
+    fi
+
+    deploy_llm_d_infrastructure
+
+    log_success "llm-d infrastructure deployment on $ENVIRONMENT complete!"
+}
+
+main_llmd "$@"

--- a/deploy/install-llmd-infra.sh
+++ b/deploy/install-llmd-infra.sh
@@ -13,7 +13,8 @@
 # Usage:
 #   ./deploy/install-llmd-infra.sh [-e kubernetes|openshift|kind-emulator] [--undeploy]
 #
-# Prerequisites: kubectl, helm, git. On kubernetes/openshift, GPU discovery uses jq — install it or run on kind-emulator to skip that path.
+# Prerequisites: kubectl, helm, git, yq, jq (yq edits values.yaml; jq builds JSON merge patches for
+# Service/ServiceMonitor label alignment; GPU discovery uses jq on kubernetes/openshift).
 
 set -e
 set -o pipefail
@@ -51,7 +52,6 @@ LLM_D_MODELSERVICE_VALUES=${LLM_D_MODELSERVICE_VALUES:-"$EXAMPLE_DIR/ms-$GUIDE_N
 ITL_AVERAGE_LATENCY_MS=${ITL_AVERAGE_LATENCY_MS:-20}
 TTFT_AVERAGE_LATENCY_MS=${TTFT_AVERAGE_LATENCY_MS:-200}
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
-LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.0"}
 
 GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"}
 # Install Gateway control plane via helmfile when true (default). Set false if your cluster already has one.
@@ -92,7 +92,7 @@ LLM_D_INFERENCE_SIM_IMG_TAG=${LLM_D_INFERENCE_SIM_IMG_TAG:-"latest"}
 ENVIRONMENT=${ENVIRONMENT:-"kubernetes"}
 COMPATIBLE_ENV_LIST=("kubernetes" "openshift" "kind-emulator")
 NON_EMULATED_ENV_LIST=("kubernetes" "openshift")
-REQUIRED_TOOLS=("kubectl" "helm" "git")
+REQUIRED_TOOLS=("kubectl" "helm" "git" "yq" "jq")
 
 UNDEPLOY=false
 

--- a/deploy/install-multi-model.sh
+++ b/deploy/install-multi-model.sh
@@ -2,18 +2,16 @@
 #
 # Multi-Model Deployment Orchestrator
 #
-# Thin wrapper around deploy/install.sh that deploys N models into the
-# same cluster, each with its own EPP and InferencePool, then creates a
-# shared HTTPRoute with URLRewrite rules so all models are reachable
-# through a single Gateway.
+# Orchestrates deploy/install.sh (WVA + monitoring + scaler) and deploy/install-llmd-infra.sh
+# per model into the same cluster, then creates a shared HTTPRoute with URLRewrite rules.
 #
 # Usage:
 #   MODELS="Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B" ./deploy/install-multi-model.sh
 #
 # Architecture:
-#   install.sh  (call 1) → full stack: control plane, WVA, monitoring, Model 1
-#   install.sh  (call N) → model-only: skip WVA/monitoring/gateway, deploy Model N
-#   This script          → multi-model-specific: InferencePools, HTTPRoute, verification
+#   install.sh + install-llmd-infra.sh (call 1) → WVA, monitoring, scaler, Model 1 + gateway
+#   install-llmd-infra.sh (call N) → additional Model N (no WVA / no monitoring)
+#   This script → multi-model HTTPRoute and verification
 #
 
 set -e
@@ -42,12 +40,14 @@ model_to_slug() {
 # ── Configuration ────────────────────────────────────────────────────
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
 DEPLOY_SCRIPT="$WVA_PROJECT/deploy/install.sh"
+LLMD_DEPLOY_SCRIPT="$WVA_PROJECT/deploy/install-llmd-infra.sh"
 LLMD_NS=${LLMD_NS:-"llm-d-inference-scheduler"}
 ENVIRONMENT=${ENVIRONMENT:-"kind-emulator"}
 DECODE_REPLICAS=${DECODE_REPLICAS:-1}
+LLM_D_RELEASE=${LLM_D_RELEASE:-v0.6.0}
 MODELS=${MODELS:-"Qwen/Qwen3-0.6B,unsloth/Meta-Llama-3.1-8B"}
 
-chmod +x "$DEPLOY_SCRIPT"
+chmod +x "$DEPLOY_SCRIPT" "$LLMD_DEPLOY_SCRIPT"
 
 # ── Parse model list ─────────────────────────────────────────────────
 IFS=',' read -ra MODEL_LIST <<< "$MODELS"
@@ -107,13 +107,12 @@ if [ "$UNDEPLOY" = true ]; then
 
     # 4. Call install.sh --undeploy for the full stack (WVA, monitoring, scaler backend, namespaces).
     #    Only need to call once for the first model since it deployed the control plane.
-    log_info "Undeploying control plane (WVA, monitoring, scaler backend)..."
+    log_info "Undeploying llm-d (gateway) then WVA/monitoring/scaler..."
     ENVIRONMENT="$ENVIRONMENT" \
-    RELEASE_NAME_POSTFIX="${SLUG_LIST[0]}" \
     INSTALL_GATEWAY_CTRLPLANE=true \
-    DEPLOY_WVA=true \
-    DEPLOY_PROMETHEUS=true \
-    DEPLOY_LLM_D=false \
+    DELETE_NAMESPACES="${DELETE_NAMESPACES:-false}" \
+    "$LLMD_DEPLOY_SCRIPT" --undeploy -e "$ENVIRONMENT" || true
+    ENVIRONMENT="$ENVIRONMENT" \
     DELETE_NAMESPACES="${DELETE_NAMESPACES:-false}" \
     "$DEPLOY_SCRIPT" --undeploy
 
@@ -138,18 +137,18 @@ for i in "${!MODEL_LIST[@]}"; do
         log_info "Step ${step}/${TOTAL_STEPS}: Full stack + ${slug}"
         log_info "═══════════════════════════════════════════════════════════"
 
-        # First model: deploy the full control plane, WVA, monitoring, and model
+        # First model: WVA + monitoring + scaler, then llm-d for this model
+        ENVIRONMENT="$ENVIRONMENT" \
+        DEPLOY_WVA=true \
+        DEPLOY_PROMETHEUS=true \
+        "$DEPLOY_SCRIPT"
         ENVIRONMENT="$ENVIRONMENT" \
         MODEL_ID="$model" \
         RELEASE_NAME_POSTFIX="$slug" \
-        INFRA_ONLY=false \
         INSTALL_GATEWAY_CTRLPLANE=true \
-        DEPLOY_WVA=true \
-        DEPLOY_PROMETHEUS=true \
-        DEPLOY_LLM_D=true \
+        LLM_D_RELEASE="$LLM_D_RELEASE" \
         DECODE_REPLICAS="$DECODE_REPLICAS" \
-        E2E_TESTS_ENABLED=false \
-        "$DEPLOY_SCRIPT"
+        "$LLMD_DEPLOY_SCRIPT" -e "$ENVIRONMENT"
 
         # Replace the model-specific Gateway with a shared, model-agnostic one.
         # install.sh created infra-<slug>-inference-gateway; we replace it with
@@ -185,13 +184,8 @@ GWEOF
         log_info "Step ${step}/${TOTAL_STEPS}: Model-only ${slug}"
         log_info "═══════════════════════════════════════════════════════════"
 
-        # Subsequent models: reuse existing control plane, deploy model only.
-        # Inherits WVA_NS, NAMESPACE_SCOPED, LLM_D_RELEASE, WVA_IMAGE_*
-        # from the process environment (set by Makefile or caller).
-        #
-        # E2E_TESTS_ENABLED=true suppresses the interactive Gateway prompt
-        # (safe here because INFRA_ONLY=false, so the modelservice-skip
-        # side effect does not activate).
+        # Subsequent models: reuse existing control plane; install-llmd-infra only.
+        # Inherits WVA_NS, NAMESPACE_SCOPED, LLM_D_RELEASE from the environment (Makefile or caller).
 
         # The gaie-* (inference-scheduler) chart creates a shared Secret with a
         # fixed name that causes Helm ownership conflicts across releases.
@@ -203,16 +197,11 @@ GWEOF
         ENVIRONMENT="$ENVIRONMENT" \
         MODEL_ID="$model" \
         RELEASE_NAME_POSTFIX="$slug" \
-        INFRA_ONLY=false \
         INSTALL_GATEWAY_CTRLPLANE=false \
         DEPLOY_WVA=false \
-        DEPLOY_PROMETHEUS=false \
-        DEPLOY_PROMETHEUS_ADAPTER=false \
-        SCALER_BACKEND=none \
-        DEPLOY_LLM_D=true \
+        LLM_D_RELEASE="$LLM_D_RELEASE" \
         DECODE_REPLICAS="$DECODE_REPLICAS" \
-        E2E_TESTS_ENABLED=true \
-        "$DEPLOY_SCRIPT"
+        "$LLMD_DEPLOY_SCRIPT" -e "$ENVIRONMENT"
 
         # The helmfile creates an infra-<slug> release per model which includes
         # a redundant Gateway resource. Delete only the Gateway resource (not the

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 #
-# Workload-Variant-Autoscaler Deployment Script
-# Automated deployment of WVA, llm-d infrastructure, Prometheus, and HPA
+# Workload-Variant-Autoscaler infrastructure bootstrap: optional WVA controller,
+# Prometheus monitoring stack, and scaler backend (KEDA or Prometheus Adapter).
+#
+# For llm-d (gateway, EPP, ModelService, HF secret, WVA poolGroup alignment), run
+# deploy/install-llmd-infra.sh after this script when you need that stack.
 #
 # Prerequisites:
-# - Access to a Kubernetes/OpenShift cluster or Kind cluster with emulated GPUs
-# - HuggingFace token (for llm-d deployment)
+# - kubectl and helm installed
+# - Cluster credentials configured
 #
 
 set -e  # Exit on error
@@ -20,16 +23,14 @@ NC='\033[0m' # No Color
 
 # Configuration
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
-WELL_LIT_PATH_NAME=${WELL_LIT_PATH_NAME:-"inference-scheduling"}
-NAMESPACE_SUFFIX=${NAMESPACE_SUFFIX:-"inference-scheduler"}
 
 # Namespaces
-LLMD_NS=${LLMD_NS:-"llm-d-$NAMESPACE_SUFFIX"}
+LLMD_NS=${LLMD_NS:-"llm-d-inference-scheduler"}
 MONITORING_NAMESPACE=${MONITORING_NAMESPACE:-"workload-variant-autoscaler-monitoring"}
 WVA_NS=${WVA_NS:-"workload-variant-autoscaler-system"}
 PROMETHEUS_SECRET_NS=${PROMETHEUS_SECRET_NS:-$MONITORING_NAMESPACE}
 
-# WVA Configuration
+# WVA Configuration (required when DEPLOY_WVA=true)
 WVA_IMAGE_REPO=${WVA_IMAGE_REPO:-"ghcr.io/llm-d/llm-d-workload-variant-autoscaler"}
 WVA_IMAGE_TAG=${WVA_IMAGE_TAG:-"latest"}
 WVA_IMAGE_PULL_POLICY=${WVA_IMAGE_PULL_POLICY:-"Always"}
@@ -40,38 +41,12 @@ VLLM_SVC_NODEPORT=${VLLM_SVC_NODEPORT:-30000}
 SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-"false"}
 WVA_LOG_LEVEL=${WVA_LOG_LEVEL:-"info"}
 VALUES_FILE=${VALUES_FILE:-"$WVA_PROJECT/charts/workload-variant-autoscaler/values.yaml"}
-# Controller instance identifier for multi-controller isolation (optional)
-# When set, adds controller_instance label to metrics and HPA selectors
+# Optional: multi-controller isolation (sets controller_instance on metrics / selectors when non-empty).
 CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
+WVA_BASE_NAME=${WVA_BASE_NAME:-"inference-scheduling"}
+NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
 
-# llm-d Configuration
-LLM_D_OWNER=${LLM_D_OWNER:-"llm-d"}
-LLM_D_PROJECT=${LLM_D_PROJECT:-"llm-d"}
-LLM_D_RELEASE=${LLM_D_RELEASE:-"v0.6.0"}
-LLM_D_MODELSERVICE_NAME=${LLM_D_MODELSERVICE_NAME:-"ms-$WELL_LIT_PATH_NAME-llm-d-modelservice"}
-LLM_D_EPP_NAME=${LLM_D_EPP_NAME:-"gaie-$WELL_LIT_PATH_NAME-epp"}
-CLIENT_PREREQ_DIR=${CLIENT_PREREQ_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/prereq/client-setup"}
-GATEWAY_PREREQ_DIR=${GATEWAY_PREREQ_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/prereq/gateway-provider"}
-EXAMPLE_DIR=${EXAMPLE_DIR:-"$WVA_PROJECT/$LLM_D_PROJECT/guides/$WELL_LIT_PATH_NAME"}
-LLM_D_MODELSERVICE_VALUES=${LLM_D_MODELSERVICE_VALUES:-"$EXAMPLE_DIR/ms-$WELL_LIT_PATH_NAME/values.yaml"}
-ITL_AVERAGE_LATENCY_MS=${ITL_AVERAGE_LATENCY_MS:-20}
-TTFT_AVERAGE_LATENCY_MS=${TTFT_AVERAGE_LATENCY_MS:-200}
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
-# llm-d-inference scheduler with image with flowcontrol support
-LLM_D_INFERENCE_SCHEDULER_IMG=${LLM_D_INFERENCE_SCHEDULER_IMG:-"ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.0"}
-
-# Gateway Configuration
-GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"} # Options: kgateway, istio
-# Save original value to detect if explicitly set via environment variable
-INSTALL_GATEWAY_CTRLPLANE_ORIGINAL="${INSTALL_GATEWAY_CTRLPLANE:-}"
-INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-false}"
-
-# Model and SLO Configuration
-DEFAULT_MODEL_ID=${DEFAULT_MODEL_ID:-"Qwen/Qwen3-0.6B"}
-MODEL_ID=${MODEL_ID:-"unsloth/Meta-Llama-3.1-8B"}
-ACCELERATOR_TYPE=${ACCELERATOR_TYPE:-"H100"}
-SLO_TPOT=${SLO_TPOT:-10}  # Target time-per-output-token SLO (in ms)
-SLO_TTFT=${SLO_TTFT:-1000}  # Target time-to-first-token SLO (in ms)
 
 # Prometheus Configuration
 PROM_CA_CERT_PATH=${PROM_CA_CERT_PATH:-"/tmp/prometheus-ca.crt"}
@@ -80,52 +55,22 @@ PROMETHEUS_SECRET_NAME=${PROMETHEUS_SECRET_NAME:-"prometheus-web-tls"}
 # Flags for deployment steps
 DEPLOY_PROMETHEUS=${DEPLOY_PROMETHEUS:-true}
 DEPLOY_WVA=${DEPLOY_WVA:-true}
-DEPLOY_LLM_D=${DEPLOY_LLM_D:-true}
 DEPLOY_PROMETHEUS_ADAPTER=${DEPLOY_PROMETHEUS_ADAPTER:-true}
-# Infra-first: chart-managed VariantAutoscaling / HPA are opt-in (e2e and operators
-# typically create their own CRs). Set DEPLOY_VA=true and DEPLOY_HPA=true for a demo stack.
-DEPLOY_VA=${DEPLOY_VA:-false}
-DEPLOY_HPA=${DEPLOY_HPA:-false}
-HPA_STABILIZATION_SECONDS=${HPA_STABILIZATION_SECONDS:-240}
-# HPA minReplicas: 0 enables scale-to-zero (requires HPAScaleToZero feature gate)
-# Default to 1 for safety; set to 0 for scale-to-zero testing
-HPA_MIN_REPLICAS=${HPA_MIN_REPLICAS:-1}
 SKIP_CHECKS=${SKIP_CHECKS:-false}
-E2E_TESTS_ENABLED=${E2E_TESTS_ENABLED:-false}
-# WVA metrics endpoint security (set false to disable bearer token auth on /metrics)
 WVA_METRICS_SECURE=${WVA_METRICS_SECURE:-true}
-# vLLM max-num-seqs (max concurrent sequences per replica, lower = easier to saturate for testing)
-VLLM_MAX_NUM_SEQS=${VLLM_MAX_NUM_SEQS:-""}
-# Decode replicas override (useful for e2e testing with limited GPUs)
-DECODE_REPLICAS=${DECODE_REPLICAS:-""}
 
-# Infra-only mode: Deploy only llm-d infrastructure and WVA controller (skip VA/HPA)
-# Useful for e2e testing where tests create their own VA/HPA resources
-INFRA_ONLY=${INFRA_ONLY:-false}
-
-# Saturation threshold overrides (V1 analyzer)
-# kvSpareTrigger: scale-up fires when (kvCacheThreshold - avgKvUsage) < this value
-# queueSpareTrigger: scale-up fires when (queueLengthThreshold - avgQueueLength) < this value
-# Leave empty to use chart defaults (kvSpareTrigger=0.1, queueSpareTrigger=3)
-KV_SPARE_TRIGGER=${KV_SPARE_TRIGGER:-""}
-QUEUE_SPARE_TRIGGER=${QUEUE_SPARE_TRIGGER:-""}
-
-# Scaler backend: "prometheus-adapter" (default), "keda", or "none"
-# prometheus-adapter: deploy Prometheus Adapter + patch external metrics APIService
-# keda:              on kubernetes assume cluster-managed KEDA (no Helm; set KEDA_HELM_INSTALL=true to install);
-#                    on kind-emulator install via Helm when needed; OpenShift is always platform-managed (no Helm)
-# none:              skip all scaler backend deployment; use when KEDA or another metrics API
-#                    is already installed on the cluster (e.g. llmd benchmark clusters)
+# Scaler backend: prometheus-adapter | keda | none.
+# - keda on kubernetes: expects cluster CRD unless KEDA_HELM_INSTALL=true (then this script installs Helm KEDA).
+# - keda on openshift: platform-managed KEDA only (no Helm install from this script).
+# - none: skip scaler install (cluster already provides external metrics).
 SCALER_BACKEND=${SCALER_BACKEND:-prometheus-adapter}
 KEDA_NAMESPACE=${KEDA_NAMESPACE:-keda-system}
-# Pin KEDA chart version for reproducible installs (only used when deploy_keda installs from helm)
+# Pinned for reproducible Helm installs (used when deploy_keda actually runs helm upgrade).
 KEDA_CHART_VERSION=${KEDA_CHART_VERSION:-2.19.0}
-# kubernetes: default false (cluster-managed KEDA); set true to let this script install/upgrade KEDA via Helm
+# On kubernetes: default false (cluster-managed KEDA); kind-emulator flows often set true or use cluster path.
 KEDA_HELM_INSTALL=${KEDA_HELM_INSTALL:-false}
 
-# LeaderWorkerSet (LWS) configuration
-# Set DEPLOY_LWS=false to skip LWS installation (e.g., when running benchmarks
-# locally or when LWS is already installed cluster-wide)
+# LeaderWorkerSet (WVA dependency). Set false when LWS is pre-installed or not needed (e.g. some benchmarks).
 DEPLOY_LWS=${DEPLOY_LWS:-true}
 LWS_NAMESPACE=${LWS_NAMESPACE:-"lws-system"}
 LWS_CHART_VERSION=${LWS_CHART_VERSION:-"0.8.0"}
@@ -138,7 +83,6 @@ NON_EMULATED_ENV_LIST=("kubernetes" "openshift")
 REQUIRED_TOOLS=("kubectl" "helm" "git")
 DEPLOY_LIB_DIR="$SCRIPT_DIR/lib"
 
-# TODO: add kubernetes to these defaults to enable TLS verification when deploying to production clusters
 PRODUCTION_ENV_LIST=("openshift")
 
 # Shared deploy helpers
@@ -154,14 +98,10 @@ source "$DEPLOY_LIB_DIR/wait_helpers.sh"
 source "$DEPLOY_LIB_DIR/cli.sh"
 # shellcheck source=lib/prereqs.sh
 source "$DEPLOY_LIB_DIR/prereqs.sh"
-# shellcheck source=lib/discovery.sh
-source "$DEPLOY_LIB_DIR/discovery.sh"
 # shellcheck source=lib/infra_scaler_backend.sh
 source "$DEPLOY_LIB_DIR/infra_scaler_backend.sh"
 # shellcheck source=lib/scaler_runtime.sh
 source "$DEPLOY_LIB_DIR/scaler_runtime.sh"
-# shellcheck source=lib/infra_llmd.sh
-source "$DEPLOY_LIB_DIR/infra_llmd.sh"
 # shellcheck source=lib/infra_wva.sh
 source "$DEPLOY_LIB_DIR/infra_wva.sh"
 # shellcheck source=lib/infra_monitoring.sh
@@ -171,12 +111,8 @@ source "$DEPLOY_LIB_DIR/cleanup.sh"
 # shellcheck source=lib/install_core.sh
 source "$DEPLOY_LIB_DIR/install_core.sh"
 
-# Undeployment flags
 UNDEPLOY=${UNDEPLOY:-false}
 DELETE_NAMESPACES=${DELETE_NAMESPACES:-false}
 
-# Main deployment flow
-# Core orchestration moved to deploy/lib/install_core.sh
-
-# Run main function
+# Orchestration lives in deploy/lib/install_core.sh (keeps this entrypoint to variable defaults + sourcing only).
 main "$@"

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -70,10 +70,8 @@ export KIND_IMAGE_PLATFORM=linux/amd64      # Single platform for kind load (avo
 ```bash
 export DEPLOY_PROMETHEUS=true         # Deploy Prometheus stack
 export DEPLOY_WVA=true                # Deploy WVA controller
-export DEPLOY_LLM_D=true              # Deploy llm-d infrastructure (emulated)
 export DEPLOY_PROMETHEUS_ADAPTER=true # Deploy Prometheus Adapter
-export DEPLOY_VA=true                 # Opt in: chart VariantAutoscaling (default in script: false)
-export DEPLOY_HPA=true                # Opt in: chart HPA (default in script: false)
+# llm-d: `make deploy-wva-emulated-on-kind` runs install.sh then install-llmd-infra.sh
 ```
 
 ### Step-by-Step Setup
@@ -90,20 +88,15 @@ make create-kind-cluster KIND_ARGS="-t mix -n 4 -g 2"
 # -g: GPUs per node
 ```
 
-**2. Deploy WVA only:**
+**2. Deploy WVA + monitoring only (no llm-d):**
 
 ```bash
-export DEPLOY_WVA=true
-export DEPLOY_LLM_D=false
-export DEPLOY_PROMETHEUS=true # Prometheus is needed for WVA to scrape metrics
-export VLLM_SVC_ENABLED=true
-export DEPLOY_PROMETHEUS_ADAPTER=false
-export DEPLOY_VA=false
-export DEPLOY_HPA=false
-make deploy-wva-emulated-on-kind
+cd /path/to/repo
+export ENVIRONMENT=kind-emulator
+./deploy/install.sh
 ```
 
-**3. Deploy with llm-d (by default):**
+**3. Full stack (WVA + llm-d emulated):**
 
 ```bash
 make deploy-wva-emulated-on-kind
@@ -142,6 +135,10 @@ Destroys the Kind cluster.
 ```bash
 ./teardown.sh
 ```
+
+### install.sh (Kind environment plugin)
+
+`deploy/kind-emulator/install.sh` is **sourced** by `deploy/install-llmd-infra.sh` when `ENVIRONMENT=kind-emulator`. It handles Kind-specific setup (namespaces, image load, monitoring wiring, and related helpers). **llm-d ModelService post-deploy cleanup** for emulated clusters (remove chart prefill; optionally remove chart decode when `LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=true`, the default) runs from **`deploy/lib/infra_llmd.sh`** inside `deploy_llm_d_infrastructure`, not from this `install.sh`.
 
 ## Cluster Configuration
 
@@ -290,17 +287,17 @@ This can happen when loading a multi-platform image into Kind: the image manifes
 
 ```bash
 # Force linux/amd64 (e.g. for Intel or emulated nodes)
-KIND_IMAGE_PLATFORM=linux/amd64 make deploy-wva-emulated-on-kind CREATE_CLUSTER=true DEPLOY_LLM_D=true
+KIND_IMAGE_PLATFORM=linux/amd64 make deploy-wva-emulated-on-kind CREATE_CLUSTER=true
 
 # Force linux/arm64 (e.g. for Apple Silicon with native arm64 nodes)
-KIND_IMAGE_PLATFORM=linux/arm64 make deploy-wva-emulated-on-kind CREATE_CLUSTER=true DEPLOY_LLM_D=true
+KIND_IMAGE_PLATFORM=linux/arm64 make deploy-wva-emulated-on-kind CREATE_CLUSTER=true
 ```
 
 Alternatively, build the image locally and deploy with `IfNotPresent` so the script skips the registry pull and loads your local single-platform image:
 
 ```bash
 make docker-build IMG=ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest
-WVA_IMAGE_PULL_POLICY=IfNotPresent make deploy-wva-emulated-on-kind CREATE_CLUSTER=true DEPLOY_LLM_D=true
+WVA_IMAGE_PULL_POLICY=IfNotPresent make deploy-wva-emulated-on-kind CREATE_CLUSTER=true
 ```
 
 ## Development Workflow

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -20,12 +20,12 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Configuration
+# Configuration (Kind emulator). llm-d deploy is via deploy/install-llmd-infra.sh — set MODEL_ID / gateway vars there or in Makefile.
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
+LLM_D_PROJECT=${LLM_D_PROJECT:-llm-d}
 WELL_LIT_PATH_NAME="simulated-accelerators"
 NAMESPACE_SUFFIX="sim"
 EXAMPLE_DIR="$WVA_PROJECT/$LLM_D_PROJECT/guides/$WELL_LIT_PATH_NAME"
-DEPLOY_LLM_D_INFERENCE_SIM=true
 
 # Namespaces
 LLMD_NS="llm-d-$NAMESPACE_SUFFIX"
@@ -36,26 +36,15 @@ WVA_NS=${WVA_NS:-"workload-variant-autoscaler-system"}
 WVA_RECONCILE_INTERVAL=${WVA_RECONCILE_INTERVAL:-"60s"} # WVA controller reconcile interval - tests set 30s interval
 SKIP_TLS_VERIFY=true  # Skip TLS verification in emulated environments
 WVA_LOG_LEVEL="debug" # WVA log level set to debug for emulated environments
-# Initial WVA pool group; install.sh auto-detects the actual InferencePool API group after llm-d deploy and upgrades WVA (scale-from-zero).
 POOL_GROUP=${POOL_GROUP:-"inference.networking.k8s.io"}
 
-# llm-d Configuration
+# llm-d naming (used by WVA ServiceMonitor / install-llmd-infra; kind uses guides/simulated-accelerators, not optimized-baseline)
 LLM_D_INFERENCE_SIM_IMG_REPO=${LLM_D_INFERENCE_SIM_IMG_REPO:-"ghcr.io/llm-d/llm-d-inference-sim"}
 LLM_D_INFERENCE_SIM_IMG_TAG=${LLM_D_INFERENCE_SIM_IMG_TAG:-"latest"}
 
 LLM_D_MODELSERVICE_NAME="ms-$NAMESPACE_SUFFIX-llm-d-modelservice"
 LLM_D_MODELSERVICE_VALUES="ms-$NAMESPACE_SUFFIX/values.yaml"
 LLM_D_EPP_NAME="gaie-$NAMESPACE_SUFFIX-epp"
-
-# Model and SLO Configuration
-MODEL_ID=${MODEL_ID:-"unsloth/Meta-Llama-3.1-8B"}
-DEFAULT_MODEL_ID="random"
-ACCELERATOR_TYPE="A100"
-SLO_TPOT=24     # Target time-per-output-token SLO (in ms)
-SLO_TTFT=500  # Target time-to-first-token SLO (in ms)
-
-# Gateway Configuration
-INSTALL_GATEWAY_CTRLPLANE="true" # if true, installs gateway control plane providers - defaults to true for emulated clusters
 
 # Prometheus Configuration
 PROMETHEUS_SVC_NAME="kube-prometheus-stack-prometheus"
@@ -72,8 +61,6 @@ CLUSTER_GPU_TYPE=${CLUSTER_GPU_TYPE:-"mix"}
 
 # Flags for deployment steps
 CREATE_CLUSTER=${CREATE_CLUSTER:-false}
-DEPLOY_LLM_D_INFERENCE_SIM=${DEPLOY_LLM_D_INFERENCE_SIM:-true}
-E2E_TESTS_ENABLED=${E2E_TESTS_ENABLED:-false}
 
 # Undeployment flags
 DELETE_CLUSTER=${DELETE_CLUSTER:-false}
@@ -301,32 +288,6 @@ _wva_deploy_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib"
 source "${_wva_deploy_lib}/deploy_prometheus_kube_stack.sh"
 # shellcheck source=kube_like_adapter.sh
 source "${_wva_deploy_lib}/kube_like_adapter.sh"
-
-# REQUIRED FUNCTION - only for emulated environments ####
-# Apply llm-d infrastructure fixes for Kind emulated clusters - e.g., remove prefill deployments, remove decode deployments if tests are enabled
-apply_llm_d_infrastructure_fixes() {
-    log_info "Applying llm-d infrastructure fixes for KIND emulator..."
-    # Skip cleanup when modelservice release is not installed (e.g., e2e infra-only
-    # path now excludes it via helmfile selector).
-    if ! helm list -n "$LLMD_NS" --short 2>/dev/null | grep -q '^ms-'; then
-        log_info "No llm-d modelservice release detected in $LLMD_NS; skipping prefill/decode cleanup"
-        return
-    fi
-
-    # Delete prefill deployment
-    # TODO: remove once WVA supports both prefill and decode
-    log_info "Deleting prefill deployments..."
-    kubectl delete deployments.apps \
-        $LLM_D_MODELSERVICE_NAME-prefill \
-        --ignore-not-found -n "$LLMD_NS"
-        
-    if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-        log_info "Deleting decode deployments for tests..."
-        kubectl delete deployments.apps \
-            $LLM_D_MODELSERVICE_NAME-decode \
-            --ignore-not-found -n "$LLMD_NS"
-    fi
-}
 
 #### REQUIRED FUNCTION used by deploy/install.sh ####
 delete_namespaces() {

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -61,8 +61,8 @@ This script automates the complete deployment process on kubernetes cluster incl
 # Required: Set your HuggingFace token
 export HF_TOKEN="your-hf-token-here"
 
-# Optional: Customize deployment
-export WELL_LIT_PATH_NAME="inference-scheduler"                           # Default
+# Optional: Customize deployment (basename under llm-d guides/; llm-d main uses optimized-baseline)
+export GUIDE_NAME="inference-scheduling"                                  # Default for pinned LLM_D_RELEASE (e.g. v0.6.0)
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"                               # Default
 export WVA_IMAGE_REPO="ghcr.io/llm-d/llm-d-workload-variant-autoscaler"         # Default
 export WVA_IMAGE_TAG="latest"                                             # Default
@@ -100,26 +100,20 @@ export HF_TOKEN="hf_xxxxx"                  # Required: HuggingFace token
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B" # Model to deploy
 export ACCELERATOR_TYPE="H100"              # GPU type
 export WVA_IMAGE_TAG="latest"               # WVA version
-export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window
+# HPA stabilization: set on Helm chart (`hpa.behavior.*`), not install.sh
 
-# Performance tuning (optional)
+# Performance tuning (optional; passed to install-llmd-infra / ModelService)
 export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)
-```
-
-For a complete list of all configuration options, see the [Configuration Reference](../README.md#configuration-reference) in the main deployment guide.
 export ACCELERATOR_TYPE="A100"              # GPU type (auto-detected)
-export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway
+export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway (for install-llmd-infra.sh)
 ```
 
-**Deployment flags** - Control which components to deploy:
+**Deployment flags** (`deploy/install.sh`) — use Helm for chart VA/HPA; llm-d is **`deploy/install-llmd-infra.sh`**:
 
 ```bash
 export DEPLOY_PROMETHEUS=true         # Deploy kube-prometheus-stack
 export DEPLOY_WVA=true                # Deploy WVA controller
-export DEPLOY_LLM_D=true              # Deploy llm-d infrastructure
 export DEPLOY_PROMETHEUS_ADAPTER=true # Deploy Prometheus Adapter
-export DEPLOY_VA=true                 # Opt in: chart VariantAutoscaling (install.sh default: false)
-export DEPLOY_HPA=true                # Opt in: chart HPA (install.sh default: false)
 ```
 
 ## Usage Examples
@@ -144,27 +138,20 @@ export DEPLOY_HPA=true
 make deploy-wva-on-k8s
 ```
 
-### Example 3: E2E Testing Configuration
+### Example 3: CI-style stack (WVA + llm-d)
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
-export E2E_TESTS_ENABLED=true
-export INFRA_ONLY=true
-export HPA_STABILIZATION_SECONDS=30  # Only if chart HPA enabled
-export VLLM_MAX_NUM_SEQS=8          # Low batch size for easy saturation
-make deploy-wva-on-k8s
+make deploy-wva-on-k8s   # install.sh + install-llmd-infra.sh
 ```
 
-### Example 4: Deploy Only WVA (llm-d Already Deployed)
+### Example 4: Deploy only WVA + Prometheus (llm-d already deployed)
 
 ```bash
 export DEPLOY_WVA=true
-export DEPLOY_LLM_D=false
-export DEPLOY_PROMETHEUS=true # Prometheus is needed for WVA to scrape metrics
+export DEPLOY_PROMETHEUS=true
 export VLLM_SVC_ENABLED=true
 export DEPLOY_PROMETHEUS_ADAPTER=false
-export DEPLOY_VA=true
-export DEPLOY_HPA=false
 make deploy-wva-on-k8s
 ```
 
@@ -663,10 +650,9 @@ kubectl set env deployment/workload-variant-autoscaler-controller-manager \
 ### Update WVA Image
 
 ```bash
-export WVA_IMAGE="ghcr.io/yourorg/llm-d-workload-variant-autoscaler:custom-tag"
-export DEPLOY_LLM_D=false  # Don't redeploy llm-d
-export DEPLOY_PROMETHEUS=false  # Don't redeploy Prometheus
-make deploy-wva-on-k8s
+export IMG="ghcr.io/yourorg/llm-d-workload-variant-autoscaler:custom-tag"
+export DEPLOY_PROMETHEUS=false
+make deploy-wva-on-k8s   # base infra only; skip install-llmd-infra if you manage llm-d separately
 ```
 
 ## Performance Tuning

--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -120,9 +120,7 @@ cleanup() {
         undeploy_prometheus_adapter
     fi
 
-    if [ "$DEPLOY_LLM_D" = "true" ]; then
-        undeploy_llm_d_infrastructure
-    fi
+    # llm-d is not torn down here: use deploy/install-llmd-infra.sh --undeploy (releases + optional gateway helmfile).
 
     if [ "$DEPLOY_WVA" = "true" ]; then
         undeploy_wva_controller
@@ -150,7 +148,6 @@ cleanup() {
     echo "Removed components:"
     [ "$SCALER_BACKEND" = "keda" ] && echo "✓ KEDA"
     [ "$DEPLOY_PROMETHEUS_ADAPTER" = "true" ] && echo "✓ Prometheus Adapter"
-    [ "$DEPLOY_LLM_D" = "true" ] && echo "✓ llm-d Infrastructure"
     [ "$DEPLOY_WVA" = "true" ] && echo "✓ WVA Controller"
     [ "$DEPLOY_PROMETHEUS" = "true" ] && echo "✓ Prometheus Stack"
 

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 #
 # CLI help and argument parsing for deploy/install.sh.
-# Requires vars: WVA_IMAGE_REPO, WVA_IMAGE_TAG, MODEL_ID, ACCELERATOR_TYPE,
-# WVA_RELEASE_NAME, COMPATIBLE_ENV_LIST.
+# Requires vars: WVA_IMAGE_REPO, WVA_IMAGE_TAG, WVA_RELEASE_NAME, COMPATIBLE_ENV_LIST.
 # Requires funcs: log_info/log_warning/log_error, containsElement().
 #
 
@@ -10,69 +9,48 @@ print_help() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-This script deploys the complete Workload-Variant-Autoscaler stack on a cluster with real GPUs.
+Bootstrap WVA (optional), monitoring, and scaler backend on a Kubernetes or OpenShift cluster.
+For llm-d (gateway, EPP, ModelService), run deploy/install-llmd-infra.sh after this script.
 
 Options:
-  -i, --wva-image IMAGE        Container image to use for the WVA (default: $WVA_IMAGE_REPO:$WVA_IMAGE_TAG)
-  -m, --model MODEL            Model ID to use (default: $MODEL_ID)
-  -a, --accelerator TYPE       Accelerator type: A100, H100, L40S, etc. (default: $ACCELERATOR_TYPE)
+  -i, --wva-image IMAGE        Container image for WVA (default: $WVA_IMAGE_REPO:$WVA_IMAGE_TAG)
   -r, --release-name NAME      Helm release name for WVA (default: $WVA_RELEASE_NAME)
-  --infra-only                 Deploy only llm-d infrastructure and WVA controller (skip VA/HPA, for e2e testing)
-  -u, --undeploy               Undeploy all components
-  -e, --environment            Specify deployment environment: kubernetes, openshift, kind-emulated (default: kubernetes)
+  -u, --undeploy               Undeploy WVA, monitoring, and scaler backend (not llm-d; use install-llmd-infra.sh --undeploy)
+  -e, --environment            kubernetes | openshift | kind-emulator (default: kubernetes)
   -h, --help                   Show this help and exit
 
+Deprecated (ignored by install.sh for chart deploy; passed through for CI/scripts calling install-llmd-infra next):
+  --model MODEL_ID             Same as MODEL_ID env (llm-d / chart overrides use install-llmd-infra.sh)
+  --accelerator TYPE           Same as ACCELERATOR_TYPE env
+
 Environment Variables:
-  IMG                          Container image to use for the WVA (alternative to -i flag)
-  HF_TOKEN                     HuggingFace token for model access (required for llm-d deployment)
-  WVA_RELEASE_NAME             Helm release name for WVA (alternative to -r flag)
-  INSTALL_GATEWAY_CTRLPLANE    Install Gateway control plane (default: prompt user, can be set to "true"/"false")
+  IMG                          WVA image as repo:tag (alternative to -i)
+  WVA_RELEASE_NAME             Helm release name (alternative to -r)
+  SKIP_CHECKS                  Skip kubectl/helm/git prerequisite check (default: false). Install scripts are non-interactive and fail fast on errors.
   DEPLOY_PROMETHEUS            Deploy Prometheus stack (default: true)
   DEPLOY_WVA                   Deploy WVA controller (default: true)
-  DEPLOY_LLM_D                 Deploy llm-d infrastructure (default: true)
-  DEPLOY_PROMETHEUS_ADAPTER    Deploy Prometheus Adapter (default: true)
-  DEPLOY_VA                    Deploy VariantAutoscaling via chart (default: false)
-  DEPLOY_HPA                   Deploy HPA via chart (default: false)
-  HPA_STABILIZATION_SECONDS    HPA stabilization window in seconds (default: 240)
-  HPA_MIN_REPLICAS             HPA minReplicas (default: 1, set to 0 for scale-to-zero)
-  INFRA_ONLY                   Deploy only infrastructure (default: false, same as --infra-only flag)
-  SCALER_BACKEND               Scaler backend: "prometheus-adapter" (default), "keda", or "none".
-                               prometheus-adapter: installs Prometheus Adapter and patches the external metrics APIService.
-                               keda: skips Prometheus Adapter; on kubernetes assumes cluster-managed KEDA (KEDA_HELM_INSTALL=true for Helm);
-                                     kind-emulator installs KEDA via Helm when needed; OpenShift is platform-managed only.
-                               none: skips all scaler backend deployment. Use this on clusters that already have
-                                     KEDA or another external metrics API installed (e.g. llmd benchmark clusters).
-  KEDA_HELM_INSTALL            When true with ENVIRONMENT=kubernetes, install/upgrade KEDA via Helm (default: false)
+  DEPLOY_PROMETHEUS_ADAPTER    Deploy Prometheus Adapter when SCALER_BACKEND=prometheus-adapter (default: true)
+  SCALER_BACKEND               prometheus-adapter (default), keda, or none
+  KEDA_HELM_INSTALL            Install KEDA via Helm on kubernetes when true (default: false)
   KEDA_NAMESPACE               Namespace for KEDA (default: keda-system)
   UNDEPLOY                     Undeploy mode (default: false)
   DELETE_NAMESPACES            Delete namespaces after undeploy (default: false)
-  CONTROLLER_INSTANCE          Controller instance label for multi-controller isolation (optional)
+  LLMD_NS                      Namespace WVA watches for workloads (default: llm-d-inference-scheduler)
+                               Optional overrides (not set by install.sh): LLM_D_MODELSERVICE_NAME, MODEL_ID
+                               for chart llmd.modelName / llmd.modelID when you export them before running.
 
 Examples:
-  # Deploy with default values
   $(basename "$0")
 
-  # Deploy with custom WVA image
-  IMG=<your_registry>/llm-d-workload-variant-autoscaler:tag $(basename "$0")
+  IMG=registry.example.com/wva:dev $(basename "$0") -e kind-emulator
 
-  # Deploy with custom model and accelerator
-  $(basename "$0") -m unsloth/Meta-Llama-3.1-8B -a A100
-
-  # Deploy with custom release name (for multi-install support)
-  $(basename "$0") -r my-wva-release
-
-  # Deploy infra-only mode (for e2e testing)
-  $(basename "$0") --infra-only
-  # Or with environment variable
-  INFRA_ONLY=true $(basename "$0")
+  $(basename "$0") -r my-wva-release -e openshift
 EOF
 }
 
 parse_args() {
-  # Check for IMG environment variable (used by Make)
   if [[ -n "$IMG" ]]; then
     log_info "Detected IMG environment variable: $IMG"
-    # Split image into repo and tag
     if [[ "$IMG" == *":"* ]]; then
       IFS=':' read -r WVA_IMAGE_REPO WVA_IMAGE_TAG <<< "$IMG"
     else
@@ -80,11 +58,9 @@ parse_args() {
     fi
   fi
 
-  # Parse command-line arguments
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -i|--wva-image)
-        # Split image into repo and tag - overrides IMG env var
         if [[ "$2" == *":"* ]]; then
           IFS=':' read -r WVA_IMAGE_REPO WVA_IMAGE_TAG <<< "$2"
         else
@@ -92,16 +68,22 @@ parse_args() {
         fi
         shift 2
         ;;
-      -m|--model)             MODEL_ID="$2"; shift 2 ;;
-      -a|--accelerator)       ACCELERATOR_TYPE="$2"; shift 2 ;;
       -r|--release-name)      WVA_RELEASE_NAME="$2"; shift 2 ;;
-      --infra-only)           INFRA_ONLY=true; shift ;;
       -u|--undeploy)          UNDEPLOY=true; shift ;;
       -e|--environment)
         ENVIRONMENT="$2" ; shift 2
         if ! containsElement "$ENVIRONMENT" "${COMPATIBLE_ENV_LIST[@]}"; then
           log_error "Invalid environment: $ENVIRONMENT. Valid options are: ${COMPATIBLE_ENV_LIST[*]}"
         fi
+        ;;
+      --model)
+        # Legacy CI/scripts — install.sh does not consume MODEL_ID; install-llmd-infra.sh does.
+        export MODEL_ID="$2"
+        shift 2
+        ;;
+      --accelerator)
+        export ACCELERATOR_TYPE="$2"
+        shift 2
         ;;
       -h|--help)              print_help; exit 0 ;;
       *)

--- a/deploy/lib/discovery.sh
+++ b/deploy/lib/discovery.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Runtime environment discovery helpers for deploy/install.sh.
+# Runtime environment discovery helpers for deploy/install-llmd-infra.sh (GPU / InferencePool group).
 # Requires vars: LLMD_NS, POOL_DETECT_RETRIES, DEFAULT_MODEL_ID.
 # Requires funcs: log_info/log_warning/log_success.
-# Sets/exports: ACCELERATOR_TYPE, DEPLOY_LLM_D_INFERENCE_SIM, DETECTED_POOL_GROUP.
+# Sets: ACCELERATOR_TYPE, DEPLOY_LLM_D_INFERENCE_SIM (when no cluster GPUs); DETECTED_POOL_GROUP (detect_inference_pool_api_group).
 #
 
 detect_gpu_type() {
@@ -24,7 +24,7 @@ detect_gpu_type() {
             log_warning "Install NVIDIA GPU Operator"
         else
             log_warning "No GPUs detected on host either"
-            log_info "Setting DEPLOY_LLM_D_INFERENCE_SIM=true for demo mode"
+            log_info "Setting DEPLOY_LLM_D_INFERENCE_SIM=true for demo mode (no cluster GPUs visible)"
             DEPLOY_LLM_D_INFERENCE_SIM=true
         fi
     else
@@ -56,7 +56,6 @@ detect_gpu_type() {
     fi
 
     export ACCELERATOR_TYPE
-    export DEPLOY_LLM_D_INFERENCE_SIM
     log_info "Using detected accelerator type: $ACCELERATOR_TYPE"
 }
 

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -118,10 +118,14 @@ deploy_llm_d_infrastructure() {
         ACTUAL_DEFAULT_MODEL="$DEFAULT_MODEL_ID"
     fi
 
-    # Update model ID if different from the guide's actual default
+    # Update model ID if different from the guide's actual default.
+    # Use strenv() so MODEL_ID / ACTUAL_DEFAULT_MODEL are never interpolated into yq
+    # expression text (avoids breakage on quotes, pipes, etc. in HuggingFace IDs).
     if [ "$MODEL_ID" != "$ACTUAL_DEFAULT_MODEL" ] ; then
         log_info "Updating deployment to use model: $MODEL_ID (replacing guide default: $ACTUAL_DEFAULT_MODEL)"
-        yq eval "(.. | select(. == \"$ACTUAL_DEFAULT_MODEL\")) = \"$MODEL_ID\" | (.. | select(. == \"hf://$ACTUAL_DEFAULT_MODEL\")) = \"hf://$MODEL_ID\"" -i "$LLM_D_MODELSERVICE_VALUES"
+        MODEL_ID="$MODEL_ID" ACTUAL_DEFAULT_MODEL="$ACTUAL_DEFAULT_MODEL" yq eval -i \
+            '(.. | select(. == strenv(ACTUAL_DEFAULT_MODEL))) = strenv(MODEL_ID) | (.. | select(. == ("hf://" + strenv(ACTUAL_DEFAULT_MODEL)))) = ("hf://" + strenv(MODEL_ID))' \
+            "$LLM_D_MODELSERVICE_VALUES"
 
         # Increase model-storage volume size
         log_info "Increasing model-storage volume size for model: $MODEL_ID"
@@ -285,18 +289,16 @@ deploy_llm_d_infrastructure() {
       local svc_name="${wva_fullname}-vllm"
       local svcmon_name="${wva_fullname}-vllm-mon"
       log_info "Aligning WVA Service/ServiceMonitor selectors: llm-d.ai/model=$CURRENT_MODEL_LABEL"
-      # Patch Service selector
-      kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "{
-        \"spec\": {\"selector\": {\"llm-d.ai/model\": \"$CURRENT_MODEL_LABEL\"}}
-      }" && log_success "Patched Service $svc_name selector" \
+      # Build merge patches with jq so label values cannot break JSON (e.g. quotes, backslashes).
+      local svc_patch svcmon_patch svc_label_patch
+      svc_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"llm-d.ai/model":$label}}}')
+      kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_patch" && log_success "Patched Service $svc_name selector" \
          || log_warning "Failed to patch Service $svc_name selector"
-      # Patch ServiceMonitor matchLabels
-      kubectl patch servicemonitor "$svcmon_name" -n "$LLMD_NS" --type=merge -p "{
-        \"spec\": {\"selector\": {\"matchLabels\": {\"llm-d.ai/model\": \"$CURRENT_MODEL_LABEL\"}}}
-      }" && log_success "Patched ServiceMonitor $svcmon_name selector" \
+      svcmon_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"matchLabels":{"llm-d.ai/model":$label}}}}')
+      kubectl patch servicemonitor "$svcmon_name" -n "$LLMD_NS" --type=merge -p "$svcmon_patch" && log_success "Patched ServiceMonitor $svcmon_name selector" \
          || log_warning "Failed to patch ServiceMonitor $svcmon_name selector"
-      # Also patch the Service labels so the ServiceMonitor can find it
-      kubectl label service "$svc_name" -n "$LLMD_NS" "llm-d.ai/model=$CURRENT_MODEL_LABEL" --overwrite \
+      svc_label_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"metadata":{"labels":{"llm-d.ai/model":$label}}}')
+      kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_label_patch" \
         && log_success "Patched Service $svc_name label" \
         || log_warning "Failed to patch Service $svc_name label"
     fi
@@ -329,8 +331,8 @@ deploy_llm_d_infrastructure() {
         fi
     fi
 
-    # Patch llm-d-inference-scheduler deployment image and enable flowControl when scale-to-zero or e2e tests are enabled
-    # (required for scale-from-zero: the image must support flow control for queue metrics).
+    # EPP (inference scheduler) image comes from the llm-d guide helmfile at LLM_D_RELEASE — not overridden here.
+    # Enable flowControl in the EPP ConfigMap when scale-to-zero or e2e tests require it (queue metrics path).
     if [ "$ENABLE_SCALE_TO_ZERO" == "true" ] || [ "${LLMD_PATCH_EPP_FLOW_CONTROL:-false}" == "true" ]; then
         if kubectl get deployment "$LLM_D_EPP_NAME" -n "$LLMD_NS" &> /dev/null; then
         

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -1,11 +1,35 @@
 #!/usr/bin/env bash
 #
-# Shared llm-d infrastructure deployment helpers for deploy/install.sh.
+# Shared llm-d infrastructure deployment helpers for deploy/install-llmd-infra.sh.
 # Requires vars: LLMD_NS, WVA_NS, EXAMPLE_DIR, WVA_PROJECT, GATEWAY_PROVIDER,
-# LLM_D_* values, model/latency knobs.
+# LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, LLM_D_* values, model/latency knobs.
 # Requires funcs: log_info/log_warning/log_success/log_error,
 # containsElement(), wait_deployment_available_nonfatal(), detect_inference_pool_api_group().
 #
+
+# Post-deploy cleanup for emulated clusters (e.g. Kind): chart ModelService ships both prefill and decode;
+# current WVA flows expect a single user-owned decode workload. Always remove prefill; decode removal is gated
+# by LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS (default true for e2e / local emulated flows).
+apply_llm_d_infrastructure_fixes() {
+    log_info "Applying llm-d infrastructure fixes for emulated cluster..."
+    # Skip cleanup when modelservice release is not installed (e.g. e2e infra-only path excludes it).
+    if ! helm list -n "$LLMD_NS" --short 2>/dev/null | grep -q '^ms-'; then
+        log_info "No llm-d modelservice release detected in $LLMD_NS; skipping prefill/decode cleanup"
+        return
+    fi
+
+    log_info "Deleting prefill deployments..."
+    kubectl delete deployments.apps \
+        "$LLM_D_MODELSERVICE_NAME-prefill" \
+        --ignore-not-found -n "$LLMD_NS"
+
+    if [ "${LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS:-true}" = "true" ]; then
+        log_info "Deleting decode deployments (LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=true; tests deploy their own workloads)..."
+        kubectl delete deployments.apps \
+            "$LLM_D_MODELSERVICE_NAME-decode" \
+            --ignore-not-found -n "$LLMD_NS"
+    fi
+}
 
 deploy_llm_d_infrastructure() {
     log_info "Deploying llm-d infrastructure..."
@@ -210,12 +234,11 @@ deploy_llm_d_infrastructure() {
       helmfile_selector_exprs+=("kind!=autoscaling")
       log_info "Skipping WVA in helmfile (will be deployed separately from local chart)"
     fi
-    if [ "$E2E_TESTS_ENABLED" = "true" ] && [ "$INFRA_ONLY" = "true" ]; then
-      # E2E infra-only tests create scenario-specific modelservice workloads
-      # themselves. Skip the default llm-d-modelservice release so baseline
-      # infrastructure is clean and we avoid create-then-delete churn.
+    if [ "${LLMD_SKIP_DEFAULT_MODELSERVICE:-false}" = "true" ]; then
+      # E2E and similar flows create scenario-specific ModelService workloads;
+      # skip the default llm-d-modelservice release so baseline infra is clean.
       helmfile_selector_exprs+=("chart!=llm-d-modelservice")
-      log_info "E2E infra-only mode: skipping llm-d-modelservice release in helmfile"
+      log_info "Skipping llm-d-modelservice release in helmfile (LLMD_SKIP_DEFAULT_MODELSERVICE=true)"
     fi
     local selector_csv=""
     if [ "${#helmfile_selector_exprs[@]}" -gt 0 ]; then
@@ -237,16 +260,16 @@ deploy_llm_d_infrastructure() {
         log_warning "Role $LLM_D_EPP_NAME not found, skipping RBAC patch"
     fi
 
-    if [ "$E2E_TESTS_ENABLED" = "true" ] && [ "$INFRA_ONLY" = "true" ]; then
+    if [ "${LLMD_SKIP_DEFAULT_MODELSERVICE:-false}" = "true" ]; then
       if helm list -n "$LLMD_NS" --short 2>/dev/null | grep -q '^ms-'; then
-        log_warning "Modelservice release still present in $LLMD_NS despite e2e selector; tests may need extra cleanup"
+        log_warning "Modelservice release still present in $LLMD_NS despite selector; tests may need extra cleanup"
       fi
     fi
 
     # Post-deploy: align the WVA vllm-service selector and ServiceMonitor to match
     # the actual pod labels. The llm-d-modelservice chart sets pod labels from
     # modelArtifacts.labels (e.g. "Qwen3-32B"), but the WVA chart's Service selector
-    # uses llmd.modelName (e.g. "ms-inference-scheduling-llm-d-modelservice").
+    # uses llmd.modelName (e.g. "ms-<GUIDE_NAME>-llm-d-modelservice" from the active llm-d guide).
     # We patch the Service/ServiceMonitor selectors (which ARE mutable) rather than
     # the deployment labels (which have immutable selectors).
     if [ "$NEEDS_LABEL_ALIGNMENT" == "true" ]; then
@@ -308,7 +331,7 @@ deploy_llm_d_infrastructure() {
 
     # Patch llm-d-inference-scheduler deployment image and enable flowControl when scale-to-zero or e2e tests are enabled
     # (required for scale-from-zero: the image must support flow control for queue metrics).
-    if [ "$ENABLE_SCALE_TO_ZERO" == "true" ] || [ "$E2E_TESTS_ENABLED" == "true" ]; then
+    if [ "$ENABLE_SCALE_TO_ZERO" == "true" ] || [ "${LLMD_PATCH_EPP_FLOW_CONTROL:-false}" == "true" ]; then
         if kubectl get deployment "$LLM_D_EPP_NAME" -n "$LLMD_NS" &> /dev/null; then
         
             # Enable flowControl feature gate in the EPP ConfigMap
@@ -354,7 +377,7 @@ deploy_llm_d_infrastructure() {
 
     # Deploy InferenceObjective for GIE queuing when flow control is enabled (scale-from-zero).
     # E2E applies e2e-default from Go (test/e2e/fixtures) so tests do not depend on install.sh for this CR.
-    if [ "$E2E_TESTS_ENABLED" != "true" ] && [ "$ENABLE_SCALE_TO_ZERO" == "true" ]; then
+    if [ "${LLMD_SKIP_INFERENCE_OBJECTIVE:-false}" != "true" ] && [ "$ENABLE_SCALE_TO_ZERO" == "true" ]; then
         if kubectl get crd inferenceobjectives.inference.networking.x-k8s.io &>/dev/null; then
             local infobj_file="${WVA_PROJECT}/deploy/inference-objective-e2e.yaml"
             if [ -f "$infobj_file" ]; then
@@ -402,9 +425,9 @@ deploy_llm_d_infrastructure() {
     # For deterministic e2e infra-only runs, avoid waiting on all llm-d deployments.
     # The full wait often blocks on modelservice decode/prefill readiness, which is
     # unnecessary for the e2e suite because tests create/manage their own workloads.
-    if [ "$E2E_TESTS_ENABLED" = "true" ] && [ "$INFRA_ONLY" = "true" ]; then
+    if [ "${LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY:-false}" = "true" ]; then
         local E2E_DEPLOY_WAIT_TIMEOUT="${E2E_DEPLOY_WAIT_TIMEOUT:-120s}"
-        log_info "E2E infra-only mode: waiting for essential llm-d components (timeout=${E2E_DEPLOY_WAIT_TIMEOUT})..."
+        log_info "Waiting for essential llm-d components only (timeout=${E2E_DEPLOY_WAIT_TIMEOUT}, LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true)..."
 
         if kubectl get deployment "$LLM_D_EPP_NAME" -n "$LLMD_NS" &>/dev/null; then
             kubectl wait --for=condition=Available "deployment/$LLM_D_EPP_NAME" -n "$LLMD_NS" --timeout="$E2E_DEPLOY_WAIT_TIMEOUT" || \
@@ -473,6 +496,10 @@ deploy_llm_d_infrastructure() {
     # List all pods in llm-d namespace
     log_info "Listing all pods in $LLMD_NS namespace:"
     kubectl get pods -n "$LLMD_NS" -o wide || log_warning "Failed to list pods in $LLMD_NS"
+
+    if ! containsElement "$ENVIRONMENT" "${NON_EMULATED_ENV_LIST[@]}"; then
+        apply_llm_d_infrastructure_fixes
+    fi
 
     cd "$WVA_PROJECT"
     

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -68,6 +68,11 @@ deploy_wva_controller() {
     # But allow override via env var (e.g. for E2E tests)
     NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
 
+    # Chart baseName is the controller's logical pool name (InferencePool prefix), not necessarily the llm-d guide folder.
+    WVA_BASE_NAME="${WVA_BASE_NAME:-inference-scheduling}"
+
+    # VA / HPA / capacity thresholds are chart defaults unless changed via helm --set separately (see deploy README).
+    # llmd.modelName / llmd.modelID are optional Helm overrides here when the vars are exported (often unset for infra-only installs).
     helm upgrade -i "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
         -n "$WVA_NS" \
         --values $VALUES_FILE \
@@ -75,17 +80,9 @@ deploy_wva_controller() {
         --set wva.image.repository="$WVA_IMAGE_REPO" \
         --set wva.image.tag="$WVA_IMAGE_TAG" \
         --set wva.imagePullPolicy="$WVA_IMAGE_PULL_POLICY" \
-        --set wva.baseName="$WELL_LIT_PATH_NAME" \
-        --set llmd.modelName="$LLM_D_MODELSERVICE_NAME" \
-        --set va.enabled="$DEPLOY_VA" \
-        --set va.accelerator="$ACCELERATOR_TYPE" \
-        --set llmd.modelID="$MODEL_ID" \
-        --set va.sloTpot="$SLO_TPOT" \
-        --set va.sloTtft="$SLO_TTFT" \
-        --set hpa.enabled="$DEPLOY_HPA" \
-        --set hpa.minReplicas="$HPA_MIN_REPLICAS" \
-        --set hpa.behavior.scaleUp.stabilizationWindowSeconds="$HPA_STABILIZATION_SECONDS" \
-        --set hpa.behavior.scaleDown.stabilizationWindowSeconds="$HPA_STABILIZATION_SECONDS" \
+        --set wva.baseName="$WVA_BASE_NAME" \
+        ${LLM_D_MODELSERVICE_NAME:+--set llmd.modelName="$LLM_D_MODELSERVICE_NAME"} \
+        ${MODEL_ID:+--set llmd.modelID="$MODEL_ID"} \
         --set llmd.namespace="$LLMD_NS" \
         --set wva.prometheus.baseURL="$PROMETHEUS_URL" \
         --set wva.prometheus.monitoringNamespace="$MONITORING_NAMESPACE" \
@@ -99,11 +96,7 @@ deploy_wva_controller() {
         --set wva.metrics.secure="$WVA_METRICS_SECURE" \
         --set wva.scaleToZero="$ENABLE_SCALE_TO_ZERO" \
         ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE} \
-        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP} \
-        ${KV_CACHE_THRESHOLD:+--set wva.capacityScaling.default.kvCacheThreshold=$KV_CACHE_THRESHOLD} \
-        ${QUEUE_LENGTH_THRESHOLD:+--set wva.capacityScaling.default.queueLengthThreshold=$QUEUE_LENGTH_THRESHOLD} \
-        ${KV_SPARE_TRIGGER:+--set wva.capacityScaling.default.kvSpareTrigger=$KV_SPARE_TRIGGER} \
-        ${QUEUE_SPARE_TRIGGER:+--set wva.capacityScaling.default.queueSpareTrigger=$QUEUE_SPARE_TRIGGER}
+        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP}
 
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."
@@ -155,7 +148,7 @@ delete_namespaces_kube_like() {
 
     for ns in $LLMD_NS $WVA_NS $MONITORING_NAMESPACE; do
         if kubectl get namespace $ns &> /dev/null; then
-            if [[ "$ns" == "$LLMD_NS" && "$DEPLOY_LLM_D" == "false" ]] || [[ "$ns" == "$WVA_NS" && "$DEPLOY_WVA" == "false" ]] || [[ "$ns" == "$MONITORING_NAMESPACE" && "$DEPLOY_PROMETHEUS" == "false" ]]; then
+            if [[ "$ns" == "$WVA_NS" && "$DEPLOY_WVA" == "false" ]] || [[ "$ns" == "$MONITORING_NAMESPACE" && "$DEPLOY_PROMETHEUS" == "false" ]]; then
                 log_info "Skipping deletion of namespace $ns as it was not deployed"
             else
                 log_info "Deleting namespace $ns..."

--- a/deploy/lib/install_core.sh
+++ b/deploy/lib/install_core.sh
@@ -4,18 +4,11 @@
 # Requires vars: ENVIRONMENT, SCRIPT_DIR, SKIP_CHECKS, deployment toggles.
 # Requires funcs sourced by install.sh: parse_args(), check_prerequisites(),
 # set_tls_verification(), set_wva_logging_level(), create_namespaces(), deploy_*(), verify_deployment(), print_summary().
+# llm-d install is deploy/install-llmd-infra.sh (not sourced here).
 #
 
 main() {
-    # Parse command line arguments first
     parse_args "$@"
-
-    # Handle infra-only mode: skip VA and HPA deployment
-    if [ "$INFRA_ONLY" = "true" ]; then
-        log_info "Infra-only mode enabled: Skipping VA and HPA deployment"
-        DEPLOY_VA=false
-        DEPLOY_HPA=false
-    fi
 
     # When using KEDA as scaler backend: skip Prometheus Adapter and deploy KEDA instead
     if [ "$SCALER_BACKEND" = "keda" ]; then
@@ -29,8 +22,8 @@ main() {
         log_info "============================================================="
         echo ""
 
-        # Source environment-specific script to make functions available
         if [ -f "$SCRIPT_DIR/$ENVIRONMENT/install.sh" ]; then
+            # shellcheck source=/dev/null
             source "$SCRIPT_DIR/$ENVIRONMENT/install.sh"
         else
             log_error "Environment-specific script not found: $SCRIPT_DIR/$ENVIRONMENT/install.sh"
@@ -40,17 +33,14 @@ main() {
         exit 0
     fi
 
-    # Normal deployment flow
     log_info "Starting Workload-Variant-Autoscaler Deployment on $ENVIRONMENT"
     log_info "==========================================================="
     echo ""
 
-    # Check prerequisites
     if [ "$SKIP_CHECKS" != "true" ]; then
         check_prerequisites
     fi
 
-    # Set TLS verification and logging level based on environment
     set_tls_verification
     set_wva_logging_level
 
@@ -59,12 +49,11 @@ main() {
         ENVIRONMENT="kind-emulator"
     fi
 
-    # Source environment-specific script to make functions available
     log_info "Loading environment-specific functions for $ENVIRONMENT..."
     if [ -f "$SCRIPT_DIR/$ENVIRONMENT/install.sh" ]; then
+        # shellcheck source=/dev/null
         source "$SCRIPT_DIR/$ENVIRONMENT/install.sh"
 
-        # Run environment-specific prerequisite checks if function exists
         if declare -f check_specific_prerequisites > /dev/null; then
             if [ "$SKIP_CHECKS" != "true" ]; then
                 check_specific_prerequisites
@@ -74,14 +63,6 @@ main() {
         log_error "Environment script not found: $SCRIPT_DIR/$ENVIRONMENT/install.sh"
     fi
 
-    # Detect GPU type for non-emulated environments
-    if containsElement "$ENVIRONMENT" "${NON_EMULATED_ENV_LIST[@]}"; then
-        detect_gpu_type
-    else
-        log_info "Skipping GPU type detection for emulated environment (ENVIRONMENT=$ENVIRONMENT)"
-    fi
-
-    # Display configuration
     log_info "Using configuration:"
     echo "    Deployed on:          $ENVIRONMENT"
     echo "    WVA Image:            $WVA_IMAGE_REPO:$WVA_IMAGE_TAG"
@@ -89,58 +70,33 @@ main() {
     echo "    llm-d Namespace:      $LLMD_NS"
     echo "    Monitoring Namespace: $MONITORING_NAMESPACE"
     echo "    Scaler Backend:       $SCALER_BACKEND"
-    echo "    Model:                $MODEL_ID"
-    echo "    Accelerator:          $ACCELERATOR_TYPE"
     echo ""
 
-    # Prompt for Gateway control plane installation
-    if [[ "$E2E_TESTS_ENABLED" == "false" ]]; then
-        prompt_gateway_installation
-    elif [[ -n "$INSTALL_GATEWAY_CTRLPLANE_ORIGINAL" ]]; then
-        log_info "Using explicitly set INSTALL_GATEWAY_CTRLPLANE=$INSTALL_GATEWAY_CTRLPLANE"
-    else
-        log_info "Enabling Gateway control plane installation for tests"
-        export INSTALL_GATEWAY_CTRLPLANE="true"
-    fi
-
-    # Create namespaces
     create_namespaces
 
     deploy_monitoring_stack
     deploy_optional_benchmark_grafana
 
-    # Deploy WVA prerequisites first (environment-specific)
+    # llm-d (gateway, EPP, ModelService, clone/helmfile, emulated ModelService cleanup) is not part of
+    # install.sh — run deploy/install-llmd-infra.sh after this script when you need that stack; see
+    # deploy/install.sh header and deploy/README.md. GPU discovery for llm-d lives there too.
+
+    # Deploy WVA prerequisites first (environment-specific).
     if [ "$DEPLOY_WVA" = "true" ]; then
         deploy_wva_prerequisites
     fi
 
-    # Deploy WVA controller before llm-d infrastructure
+    # Deploy WVA controller (autoscaler + chart); InferencePool CRDs and llm-d workloads follow install-llmd-infra.sh.
     if [ "$DEPLOY_WVA" = "true" ]; then
         deploy_wva_controller
     else
         log_info "Skipping WVA deployment (DEPLOY_WVA=false)"
     fi
 
-    # Deploy llm-d infrastructure after WVA (includes InferencePool CRD)
-    if [ "$DEPLOY_LLM_D" = "true" ]; then
-        deploy_llm_d_infrastructure
-
-        # For emulated environments, apply specific fixes
-        if ! containsElement "$ENVIRONMENT" "${NON_EMULATED_ENV_LIST[@]}"; then
-            apply_llm_d_infrastructure_fixes
-        else
-            log_info "Skipping llm-d related fixes for non-emulated environment (ENVIRONMENT=$ENVIRONMENT)"
-        fi
-    else
-        log_info "Skipping llm-d deployment (DEPLOY_LLM_D=false)"
-    fi
-
     deploy_scaler_backend
 
-    # Verify deployment
     verify_deployment
 
-    # Print summary
     print_summary
 
     log_success "Deployment on $ENVIRONMENT complete!"

--- a/deploy/lib/llm_d_nightly_install.sh
+++ b/deploy/lib/llm_d_nightly_install.sh
@@ -28,36 +28,33 @@ fi
 
 export INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-false}"
 export BENCHMARK_MODE="${BENCHMARK_MODE:-false}"
-export E2E_TESTS_ENABLED="${E2E_TESTS_ENABLED:-true}"
 export NAMESPACE_SCOPED="${NAMESPACE_SCOPED:-false}"
 export DEPLOY_WVA="${DEPLOY_WVA:-true}"
 export DEPLOY_PROMETHEUS="${DEPLOY_PROMETHEUS:-true}"
 export DEPLOY_PROMETHEUS_ADAPTER="${DEPLOY_PROMETHEUS_ADAPTER:-true}"
-export DEPLOY_VA="${DEPLOY_VA:-false}"
-export DEPLOY_HPA="${DEPLOY_HPA:-false}"
 export SCALER_BACKEND="${SCALER_BACKEND:-keda}"
 export ENABLE_SCALE_TO_ZERO="${ENABLE_SCALE_TO_ZERO:-true}"
 export POOL_GROUP="${POOL_GROUP:-inference.networking.k8s.io}"
-# Nightly CI should validate WVA against llm-d main by default.
+# Nightly path defaults to llm-d main unless the workflow pins LLM_D_RELEASE.
 export LLM_D_RELEASE="${LLM_D_RELEASE:-main}"
 export LLM_D_PROJECT="${LLM_D_PROJECT:-llm-d}"
 export WVA_PROJECT="${WVA_PROJECT:-$ROOT}"
 export CLIENT_PREREQ_DIR="${CLIENT_PREREQ_DIR:-$WVA_PROJECT/$LLM_D_PROJECT/helpers/client-setup}"
 export GATEWAY_PREREQ_DIR="${GATEWAY_PREREQ_DIR:-$WVA_PROJECT/$LLM_D_PROJECT/helpers/gateway-provider}"
+export LLMD_PATCH_EPP_FLOW_CONTROL="${LLMD_PATCH_EPP_FLOW_CONTROL:-true}"
+export LLMD_SKIP_INFERENCE_OBJECTIVE="${LLMD_SKIP_INFERENCE_OBJECTIVE:-true}"
 
 if [[ "$PLATFORM" == openshift ]]; then
 	export MONITORING_NAMESPACE="${MONITORING_NAMESPACE:-openshift-user-workload-monitoring}"
 	export WVA_METRICS_SECURE="${WVA_METRICS_SECURE:-false}"
 	export ENVIRONMENT=openshift
 	./deploy/install.sh \
-		--model "${MODEL_ID:-unsloth/Meta-Llama-3.1-8B}" \
-		--accelerator "${ACCELERATOR_TYPE:-H100}" \
 		--release-name "${WVA_RELEASE_NAME:-workload-variant-autoscaler}" \
 		--environment openshift
+	./deploy/install-llmd-infra.sh -e openshift
 else
 	export ENVIRONMENT=kubernetes
 	./deploy/install.sh \
-		--model "${MODEL_ID:-unsloth/Meta-Llama-3.1-8B}" \
-		--accelerator "${ACCELERATOR_TYPE:-H100}" \
 		--release-name "${WVA_RELEASE_NAME:-workload-variant-autoscaler}"
+	./deploy/install-llmd-infra.sh -e kubernetes
 fi

--- a/deploy/lib/prereqs.sh
+++ b/deploy/lib/prereqs.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 #
-# Prerequisite checks and interactive prompts for deploy/install.sh.
-# Requires vars: REQUIRED_TOOLS, E2E_TESTS_ENABLED, ENVIRONMENT, GATEWAY_PROVIDER.
-# Requires funcs: log_info/log_warning/log_success.
-# Sets/exports: INSTALL_CLIENT_TOOLS, INSTALL_GATEWAY_CTRLPLANE.
+# Prerequisite checks for deploy/install.sh and deploy/install-llmd-infra.sh.
+# Requires vars: REQUIRED_TOOLS.
+# Requires funcs: log_info/log_success/log_error.
 #
 
 check_prerequisites() {
@@ -11,83 +10,16 @@ check_prerequisites() {
 
     local missing_tools=()
 
-    # Check for required tools
     for tool in "${REQUIRED_TOOLS[@]}"; do
         if ! command -v "$tool" &> /dev/null; then
-            missing_tools+=($tool)
+            missing_tools+=("$tool")
         fi
     done
 
+    # Keep deploy paths deterministic: fail fast instead of prompting for installs.
     if [ ${#missing_tools[@]} -ne 0 ]; then
-        log_warning "Missing required tools: ${missing_tools[*]}"
-        if [ "$E2E_TESTS_ENABLED" == "false" ]; then
-            prompt_install_missing_tools
-        else
-            log_info "E2E tests enabled - will install missing tools by default"
-        fi
+        log_error "Missing required tools: ${missing_tools[*]}. Install them on PATH, or set SKIP_CHECKS=true to bypass this check (not recommended)."
     fi
 
     log_success "All generic prerequisites tools met"
-}
-
-prompt_install_missing_tools() {
-    echo ""
-    log_info "The client tools are required to install and manage the infrastructure."
-    echo "  You can either:"
-    echo "      1. Install them manually."
-    echo "      2. Let the script attempt to install them for you."
-    echo "The environment is currently set to: ${ENVIRONMENT}"
-
-    while true; do
-        read -p "Do you want to install the required client tools? (y/n): " -r answer
-        case $answer in
-            [Yy]* )
-                INSTALL_CLIENT_TOOLS="true"
-                log_success "Will install client tools when deploying llm-d"
-                break
-                ;;
-            [Nn]* )
-                INSTALL_CLIENT_TOOLS="false"
-                log_warning "Will not install the required client tools. Please install them manually."
-                break
-                ;;
-            * )
-                echo "Please answer y (yes) or n (no)."
-                ;;
-        esac
-    done
-}
-
-prompt_gateway_installation() {
-    echo ""
-    log_info "Gateway Control Plane Configuration"
-    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo ""
-    echo "The Gateway control plane (${GATEWAY_PROVIDER}) is required to serve requests."
-    echo "You can either:"
-    echo "  1. Install the Gateway control plane (recommended for new clusters or emulated clusters)"
-    echo "  2. Use an existing Gateway control plane in your cluster (recommended for production clusters)"
-    echo "The environment is currently set to: ${ENVIRONMENT}"
-
-    while true; do
-        read -p "Do you want to install the Gateway control plane? (y/n): " -r answer
-        case $answer in
-            [Yy]* )
-                INSTALL_GATEWAY_CTRLPLANE="true"
-                log_success "Will install Gateway control plane ($GATEWAY_PROVIDER) when deploying llm-d"
-                break
-                ;;
-            [Nn]* )
-                INSTALL_GATEWAY_CTRLPLANE="false"
-                log_info "Will attempt to use existing Gateway control plane when deploying llm-d"
-                break
-                ;;
-            * )
-                echo "Please answer y (yes) or n (no)."
-                ;;
-        esac
-    done
-
-    export INSTALL_GATEWAY_CTRLPLANE
-    echo ""
 }

--- a/deploy/lib/scaler_runtime.sh
+++ b/deploy/lib/scaler_runtime.sh
@@ -2,7 +2,7 @@
 #
 # Scaler backend deployment/runtime helpers for deploy/install.sh.
 # Requires vars: MONITORING_NAMESPACE, KEDA_NAMESPACE, KEDA_CHART_VERSION,
-# PROM_CA_CERT_PATH, PROMETHEUS_BASE_URL, PROMETHEUS_PORT, E2E_TESTS_ENABLED.
+# PROM_CA_CERT_PATH, PROMETHEUS_BASE_URL, PROMETHEUS_PORT.
 # Requires funcs: log_info/log_warning/log_success/log_error,
 # should_skip_helm_repo_update(), retry_until_success().
 #
@@ -67,6 +67,7 @@ stop_apiservice_guard() {
 
 deploy_keda() {
     log_info "Deploying KEDA (scaler backend)..."
+    # Deploy flow is non-interactive: missing/failed scaler backend is a hard failure.
 
     # OpenShift: KEDA is cluster-managed (OLM/operator); never Helm-install — avoids
     # ClusterRole/release conflicts with an existing platform KEDA.
@@ -75,11 +76,7 @@ deploy_keda() {
         if kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
             log_success "KEDA ScaledObject CRD is available on the cluster"
         else
-            if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-                log_error "OpenShift: scaledobjects.keda.sh CRD not found — install cluster KEDA before E2E (SCALER_BACKEND=keda)"
-                exit 1
-            fi
-            log_warning "KEDA ScaledObject CRD not found — ScaledObject-based scaling will not work"
+            log_error "OpenShift: scaledobjects.keda.sh CRD not found — install cluster KEDA before E2E (SCALER_BACKEND=keda)"
         fi
         return
     fi
@@ -90,11 +87,7 @@ deploy_keda() {
         if kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
             log_success "KEDA ScaledObject CRD is available on the cluster"
         else
-            if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-                log_error "Kubernetes: scaledobjects.keda.sh CRD not found — install KEDA on the cluster or set KEDA_HELM_INSTALL=true"
-                exit 1
-            fi
-            log_warning "KEDA ScaledObject CRD not found — ScaledObject-based scaling will not work"
+            log_error "Kubernetes: scaledobjects.keda.sh CRD not found — install KEDA on the cluster or set KEDA_HELM_INSTALL=true"
         fi
         return
     fi
@@ -138,11 +131,7 @@ deploy_keda() {
         --set prometheus.operator.enabled=true \
         --wait \
         --timeout=5m; then
-        if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-            log_error "KEDA Helm installation failed - required for E2E tests with SCALER_BACKEND=keda"
-        else
-            log_warning "KEDA Helm installation failed, but continuing..."
-        fi
+        log_error "KEDA Helm installation failed (SCALER_BACKEND=keda)"
     else
         log_success "KEDA deployed in $KEDA_NAMESPACE"
     fi
@@ -150,6 +139,7 @@ deploy_keda() {
 
 deploy_prometheus_adapter() {
     log_info "Deploying Prometheus Adapter..."
+    # Deploy flow is non-interactive: adapter install/readiness failures are hard failures.
 
     # Add Prometheus community helm repo
     log_info "Adding Prometheus community helm repo"
@@ -211,14 +201,7 @@ deploy_prometheus_adapter() {
         --set prometheus.port="$PROMETHEUS_PORT" \
         --timeout=3m \
         $wait_flag; then
-        if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-            log_error "Prometheus Adapter Helm installation failed - required for E2E tests"
-        else
-            log_warning "Prometheus Adapter Helm installation failed, but continuing..."
-            log_warning "HPA may not work until adapter is healthy"
-            log_info "Check adapter status: kubectl get pods -n \"$MONITORING_NAMESPACE\" | grep prometheus-adapter"
-            log_info "Check adapter logs: kubectl logs -n \"$MONITORING_NAMESPACE\" deployment/prometheus-adapter"
-        fi
+        log_error "Prometheus Adapter Helm installation failed"
     fi
 
     # If we skipped --wait (e.g., in CI), verify Prometheus Adapter is actually running
@@ -234,12 +217,7 @@ deploy_prometheus_adapter() {
         if [ "$adapter_ready" = "true" ]; then
             log_success "Prometheus Adapter is running"
         else
-            if [ "$E2E_TESTS_ENABLED" = "true" ]; then
-                log_error "Prometheus Adapter failed to become ready after ${max_attempts} attempts - required for E2E tests"
-            else
-                log_warning "Prometheus Adapter may still be starting (not ready after ${max_attempts} attempts)"
-                log_info "Check adapter status: kubectl get pods -n \"$MONITORING_NAMESPACE\" | grep prometheus-adapter"
-            fi
+            log_error "Prometheus Adapter failed to become ready after ${max_attempts} attempts"
         fi
     else
         log_success "Prometheus Adapter deployment completed"

--- a/deploy/lib/verify.sh
+++ b/deploy/lib/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Shared verification and deployment summary helpers for deploy/install.sh.
-# Requires vars: namespaces, model/accelerator values, deploy toggles.
+# Covers WVA / Prometheus / scaler backend only — llm-d is installed separately (install-llmd-infra.sh).
 # Requires funcs: log_info/log_warning/log_success, containsElement().
 # Uses constants: DEFAULT_VERIFY_STARTUP_SLEEP_SECONDS and shared selectors.
 #
@@ -11,7 +11,7 @@ verify_deployment() {
 
     local all_good=true
 
-    # Check WVA pods
+    # --- WVA
     log_info "Checking WVA controller pods..."
     sleep "$DEFAULT_VERIFY_STARTUP_SLEEP_SECONDS"
     if kubectl get pods -n "$WVA_NS" -l "$WVA_CONTROLLER_LABEL_SELECTOR" 2>/dev/null | grep -q Running; then
@@ -21,7 +21,7 @@ verify_deployment() {
         all_good=false
     fi
 
-    # Check Prometheus
+    # --- Monitoring
     if [ "$DEPLOY_PROMETHEUS" = "true" ]; then
         log_info "Checking Prometheus..."
         if kubectl get pods -n "$MONITORING_NAMESPACE" -l app.kubernetes.io/name=prometheus 2>/dev/null | grep -q Running; then
@@ -31,31 +31,7 @@ verify_deployment() {
         fi
     fi
 
-    # Check llm-d infrastructure
-    if [ "$DEPLOY_LLM_D" = "true" ]; then
-        log_info "Checking llm-d infrastructure..."
-        if kubectl get deployment -n "$LLMD_NS" 2>/dev/null | grep -q gaie; then
-            log_success "llm-d infrastructure deployed"
-        else
-            log_warning "llm-d infrastructure may still be deploying"
-        fi
-    fi
-
-    # Check VariantAutoscaling deployed by WVA Helm chart
-    if [ "$DEPLOY_VA" = "true" ]; then
-        log_info "Checking VariantAutoscaling resource..."
-        if kubectl get variantautoscaling -n "$LLMD_NS" &> /dev/null; then
-            local va_count=$(kubectl get variantautoscaling -n "$LLMD_NS" --no-headers 2>/dev/null | wc -l)
-            if [ "$va_count" -gt 0 ]; then
-                log_success "VariantAutoscaling resource(s) found"
-                kubectl get variantautoscaling -n "$LLMD_NS" -o wide
-            fi
-        else
-            log_info "No VariantAutoscaling resources deployed yet (will be created by Helm chart)"
-        fi
-    fi
-
-    # Check scaler backend (KEDA, Prometheus Adapter, or none)
+    # --- Scaler backend
     if [ "$SCALER_BACKEND" = "keda" ]; then
         log_info "Checking KEDA..."
         if kubectl get pods -n "$KEDA_NAMESPACE" -l "$KEDA_OPERATOR_LABEL_SELECTOR" 2>/dev/null | grep -q Running; then
@@ -88,14 +64,10 @@ print_summary() {
     echo "=========================================="
     echo ""
     echo "Deployment Environment: $ENVIRONMENT"
-    echo "WVA Namespace:          $WVA_NS"
-    echo "LLMD Namespace:         $LLMD_NS"
-    echo "Monitoring Namespace:   $MONITORING_NAMESPACE"
-    echo "Model:                  $MODEL_ID"
-    echo "Accelerator:            $ACCELERATOR_TYPE"
+    echo "WVA Namespace:           $WVA_NS"
+    echo "LLMD Namespace:          $LLMD_NS"
+    echo "Monitoring Namespace:    $MONITORING_NAMESPACE"
     echo "WVA Image:              $WVA_IMAGE_REPO:$WVA_IMAGE_TAG"
-    echo "SLO (TPOT):             $SLO_TPOT ms"
-    echo "SLO (TTFT):             $SLO_TTFT ms"
     echo ""
     echo "Deployed Components:"
     echo "===================="
@@ -105,9 +77,6 @@ print_summary() {
     if [ "$DEPLOY_WVA" = "true" ]; then
         echo "✓ WVA Controller (via Helm chart)"
     fi
-    if [ "$DEPLOY_LLM_D" = "true" ]; then
-        echo "✓ llm-d Infrastructure (Gateway, GAIE, ModelService)"
-    fi
     if [ "$SCALER_BACKEND" = "keda" ]; then
         echo "✓ KEDA (scaler backend, external metrics API)"
     elif [ "$SCALER_BACKEND" = "none" ]; then
@@ -115,61 +84,23 @@ print_summary() {
     elif [ "$DEPLOY_PROMETHEUS_ADAPTER" = "true" ]; then
         echo "✓ Prometheus Adapter (external metrics API)"
     fi
-    if [ "$DEPLOY_VA" = "true" ]; then
-        echo "✓ VariantAutoscaling CR (via Helm chart)"
-    fi
-    if [ "$DEPLOY_HPA" = "true" ]; then
-        echo "✓ HPA (via Helm chart)"
-    fi
     echo ""
     echo "Next Steps:"
     echo "==========="
     echo ""
-    echo "1. Check VariantAutoscaling status:"
-    echo "   kubectl get variantautoscaling -n $LLMD_NS"
+    echo "1. Deploy llm-d (EPP, gateway, ModelService) when needed:"
+    echo "     ./deploy/install-llmd-infra.sh -e $ENVIRONMENT"
     echo ""
-    echo "2. View detailed status with conditions:"
-    echo "   kubectl describe variantautoscaling $LLM_D_MODELSERVICE_NAME-decode -n $LLMD_NS"
+    echo "2. Create VariantAutoscaling / HPA via tests, operators, or helm with chart toggles."
     echo ""
     echo "3. View WVA logs:"
     echo "   kubectl logs -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler -f"
     echo ""
-    echo "4. Check external metrics API:"
+    echo "4. Check external metrics API (when Prometheus Adapter is used):"
     echo "   kubectl get --raw \"/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NS/wva_desired_replicas\" | jq"
     echo ""
     echo "5. Port-forward Prometheus to view metrics:"
     echo "   kubectl port-forward -n $MONITORING_NAMESPACE svc/${PROMETHEUS_SVC_NAME} ${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
-    echo "   # Then visit https://localhost:${PROMETHEUS_PORT}"
-    echo ""
-    echo "Important Notes:"
-    echo "================"
-    echo ""
-    if  ! containsElement "$ENVIRONMENT" "${NON_EMULATED_ENV_LIST[@]}"; then
-        echo "• This deployment uses the llm-d inference simulator without real GPUs"
-        echo "• The llm-d inference simulator generates synthetic metrics for testing"
-    else
-        echo "• Model Loading:"
-        echo "  - Using $MODEL_ID"
-        echo "  - Model loading takes 2-3 minutes on $ACCELERATOR_TYPE GPUs"
-        echo "  - Metrics will appear once model is fully loaded"
-        echo "  - WVA will automatically detect metrics and start optimization"
-    fi
-    echo ""
-    echo "Troubleshooting:"
-    echo "================"
-    echo ""
-    echo "• Check WVA controller logs:"
-    echo "  kubectl logs -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler"
-    echo ""
-    echo "• Check all pods in llm-d namespace:"
-    echo "  kubectl get pods -n $LLMD_NS"
-    echo ""
-    echo "• Check if metrics are being scraped by Prometheus:"
-    echo "  kubectl port-forward -n $MONITORING_NAMESPACE svc/${PROMETHEUS_SVC_NAME} ${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
-    echo "  # Then visit https://localhost:${PROMETHEUS_PORT} and query: vllm:num_requests_running"
-    echo ""
-    echo "• Check Prometheus Adapter logs:"
-    echo "  kubectl logs -n $MONITORING_NAMESPACE deployment/prometheus-adapter"
     echo ""
     echo "=========================================="
 }

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -103,12 +103,11 @@ export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (bat
 export HPA_STABILIZATION_SECONDS=240        # HPA stabilization window
 ```
 
-**Deployment flags** - Control which components to deploy:
+**Deployment flags** (`deploy/install.sh`) — llm-d is **`deploy/install-llmd-infra.sh`** after base infra:
 
 ```bash
 export DEPLOY_WVA=true                    # Deploy WVA controller
-export DEPLOY_LLM_D=true                  # Deploy llm-d infrastructure
-export DEPLOY_PROMETHEUS_ADAPTER=true     # Deploy Prometheus Adapter
+export DEPLOY_PROMETHEUS_ADAPTER=true     # Deploy Prometheus Adapter (unless SCALER_BACKEND=keda)
 ```
 
 **Note**: OpenShift uses the built-in User Workload Monitoring (Thanos) instead of deploying a separate Prometheus stack.
@@ -131,21 +130,17 @@ export MODEL_ID="meta-llama/Llama-2-7b-hf"
 make deploy-wva-on-openshift
 ```
 
-### Example 3: E2E Testing Configuration
+### Example 3: CI-style stack (WVA + llm-d)
 
 ```bash
 export HF_TOKEN="hf_xxxxx"
-export HPA_STABILIZATION_SECONDS=30  # Fast scaling for testing
-export VLLM_MAX_NUM_SEQS=8          # Low batch size for easy saturation
-export E2E_TESTS_ENABLED=true
-make deploy-wva-on-openshift
+make deploy-wva-on-openshift   # install.sh + install-llmd-infra.sh
 ```
 
-### Example 4: Deploy Only WVA (llm-d Already Deployed)
+### Example 4: Deploy Only WVA (llm-d already deployed)
 
 ```bash
 export DEPLOY_WVA=true
-export DEPLOY_LLM_D=false
 export DEPLOY_PROMETHEUS_ADAPTER=false
 make deploy-wva-on-openshift
 ```

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -160,29 +160,21 @@ go test ./test/e2e/... -run TestDoesNotExist
 
 ### Infra-Only Setup (Required Before Running Tests)
 
-Tests expect **only** the WVA controller and llm-d infrastructure to be deployed; they create VariantAutoscaling resources, HPAs, and model services themselves. Use the install script in **infra-only** mode:
-
-```bash
-# From repository root: deploy only WVA + llm-d infrastructure (no VA/HPA/model services)
-cd deploy
-export ENVIRONMENT="kind-emulator"   # or "openshift", "kubernetes"
-export INFRA_ONLY=true
-./install.sh
-# Or: ./install.sh --infra-only
-```
+Tests expect **WVA + monitoring + scaler + llm-d EPP/gateway** to be deployed; they create VariantAutoscaling resources, HPAs, and model workloads themselves. Use **`make deploy-e2e-infra`** (runs `deploy/install.sh` then `deploy/install-llmd-infra.sh`) or invoke those scripts with the same environment variables the Makefile sets.
 
 This deploys:
 - WVA controller
-- llm-d infrastructure (Gateway, CRDs, RBAC, EPP)
+- llm-d gateway/EPP (and related infra); `make deploy-e2e-infra` skips the default chart ModelService release (`LLMD_SKIP_DEFAULT_MODELSERVICE=true`)
 - Prometheus stack and Prometheus Adapter (or KEDA when `SCALER_BACKEND=keda`)
-- **No** VariantAutoscaling, HPA, or model services (tests create these)
+- **No** chart VariantAutoscaling or HPA (tests create these)
+- On **emulated** clusters, **`deploy/lib/infra_llmd.sh`** applies ModelService post-deploy cleanup (drop prefill; drop decode when **`LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=true`**, the default) after helmfile deploy — not from **`deploy/kind-emulator/install.sh`**.
 
-When `E2E_TESTS_ENABLED=true` (or `ENABLE_SCALE_TO_ZERO=true`), the deploy script enables **GIE queuing** by adding the `flowControl` feature gate to the EPP ConfigMap and updating the EPP image to a version that supports flow control. For **e2e**, the **InferenceObjective** `e2e-default` is created by the scale-from-zero tests (`test/e2e/fixtures`), not by `install.sh`. For non-e2e scale-to-zero (`ENABLE_SCALE_TO_ZERO=true` without e2e), `install.sh` still applies `deploy/inference-objective-e2e.yaml`. Queuing helps populate `inference_extension_flow_control_queue_size` when requests hit the gateway.
+When `LLMD_PATCH_EPP_FLOW_CONTROL=true` (set by `make deploy-e2e-infra`) or `ENABLE_SCALE_TO_ZERO=true`, **`install-llmd-infra.sh`** enables **GIE queuing** on the EPP (flowControl feature gate + image). For **e2e**, the **InferenceObjective** `e2e-default` is created by the scale-from-zero tests (`test/e2e/fixtures`), not by the install scripts. For non-e2e scale-to-zero (`ENABLE_SCALE_TO_ZERO=true` without `LLMD_SKIP_INFERENCE_OBJECTIVE`), `install-llmd-infra.sh` can still apply `deploy/inference-objective-e2e.yaml`. Queuing helps populate `inference_extension_flow_control_queue_size` when requests hit the gateway.
 
 **Install script tuning (optional, same variables as `deploy/install.sh`):**
 
 - **`SKIP_HELM_REPO_UPDATE`**: When set to **`true`**, `helm repo update` is skipped during installs (faster, less network churn). Default runs `helm repo update` to refresh repo indexes.
-- **`E2E_DEPLOY_WAIT_TIMEOUT`**: For infra-only e2e deploys (`INFRA_ONLY=true` with `E2E_TESTS_ENABLED=true`), caps the `kubectl wait` for the EPP and inference-gateway deployments (default **`120s`**). Raise it if image pulls rollouts routinely exceed that window.
+- **`E2E_DEPLOY_WAIT_TIMEOUT`**: When `LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true` (as in `make deploy-e2e-infra`), caps the `kubectl wait` for the EPP and inference-gateway deployments (default **`120s`**). Raise it if image pulls rollouts routinely exceed that window.
 
 Alternatively, use the Makefile to deploy infra and run tests in one go:
 
@@ -235,7 +227,7 @@ Key environment variables (see [E2E Test Suite README](../../test/e2e/README.md)
 | `E2E_EVENTUALLY_STANDARD`, etc. | see README | Optional `Eventually` timeouts and poll intervals (`E2E_EVENTUALLY_*`, `E2E_EVENTUALLY_POLL*`) |
 | `RESTART_PROMETHEUS_ADAPTER` | `auto` | kind-emulator: `auto` probes adapter + API before restarting pods; `true`/`false` force always/never |
 
-Deploy-time knobs (passed through when you run `./deploy/install.sh` or `make deploy-e2e-infra`): `SKIP_HELM_REPO_UPDATE`, `E2E_DEPLOY_WAIT_TIMEOUT` — see **Install script tuning** above.
+Deploy-time knobs: `SKIP_HELM_REPO_UPDATE`, `E2E_DEPLOY_WAIT_TIMEOUT`, optional `KV_SPARE_TRIGGER` / `QUEUE_SPARE_TRIGGER` (Makefile applies a follow-up `helm upgrade` when set) — see **Install script tuning** above.
 
 For running multiple test runs in parallel, use [multi-controller isolation](../user-guide/multi-controller-isolation.md) (`CONTROLLER_INSTANCE`).
 

--- a/docs/developer-guide/troubleshooting.md
+++ b/docs/developer-guide/troubleshooting.md
@@ -15,7 +15,7 @@
    
    WVA watches a single InferencePool API group (`inference.networking.k8s.io` or `inference.networking.x-k8s.io`). If the cluster's pools use the other group, the datastore stays empty and scale-from-zero never gets a recommendation.
    
-   **Solution**: Ensure InferencePool is created and reconciled before creating VariantAutoscaling. When using `deploy/install.sh` with llm-d (e.g. kind-emulator or CI), the script auto-detects the pool API group after llm-d deploy and upgrades WVA with the correct `wva.poolGroup` so both local and CI work regardless of llm-d version.
+   **Solution**: Ensure InferencePool is created and reconciled before creating VariantAutoscaling. When using **`deploy/install-llmd-infra.sh`** after `deploy/install.sh` (e.g. `make deploy-e2e-infra`), the llm-d script detects the pool API group after deploy and upgrades WVA with the correct `wva.poolGroup` so both local and CI work regardless of llm-d version.
 
 2. **Labels mismatch**:
    ```bash
@@ -58,7 +58,7 @@
 
 ### E2E and infra-only deploys
 
-For e2e and infra-only deploys, the install script enables EPP flow control when `E2E_TESTS_ENABLED=true` or `ENABLE_SCALE_TO_ZERO=true`. The **InferenceObjective** `e2e-default` is applied by scale-from-zero e2e code when the API exists; non-e2e scale-to-zero still uses `install.sh` with [deploy/inference-objective-e2e.yaml](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/deploy/inference-objective-e2e.yaml). See [deploy/install.sh](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/deploy/install.sh).
+For e2e-style deploys, **`install-llmd-infra.sh`** enables EPP flow control when `LLMD_PATCH_EPP_FLOW_CONTROL=true` or `ENABLE_SCALE_TO_ZERO=true`. The **InferenceObjective** `e2e-default` is applied by scale-from-zero e2e code when the API exists; non-e2e scale-to-zero can still use **`install-llmd-infra.sh`** with [deploy/inference-objective-e2e.yaml](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/deploy/inference-objective-e2e.yaml). See [deploy/install-llmd-infra.sh](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/deploy/install-llmd-infra.sh).
 
 ## Slow Scale-Up Response
 

--- a/docs/user-guide/hpa-integration.md
+++ b/docs/user-guide/hpa-integration.md
@@ -318,11 +318,9 @@ oc get featuregate cluster -o jsonpath='{.spec.customNoUpgrade.enabled}'
 5. Deploy HPA with `minReplicas: 0`:
 
 ```sh
-# Using install script
-HPA_MIN_REPLICAS=0 ./deploy/install.sh -e openshift
-
-# Or via Helm
+# Via Helm
 helm upgrade workload-variant-autoscaler ./charts/workload-variant-autoscaler \
+  --set hpa.enabled=true \
   --set hpa.minReplicas=0
 ```
 
@@ -377,21 +375,6 @@ helm install workload-variant-autoscaler ./charts/workload-variant-autoscaler \
 helm install workload-variant-autoscaler ./charts/workload-variant-autoscaler \
   --set hpa.behavior.scaleUp.stabilizationWindowSeconds=0 \
   --set hpa.behavior.scaleDown.stabilizationWindowSeconds=0
-```
-
-#### Via Deployment Script
-
-The `deploy/install.sh` script supports the `HPA_STABILIZATION_SECONDS` environment variable:
-
-```bash
-# Custom stabilization window
-HPA_STABILIZATION_SECONDS=120 ./deploy/install.sh
-
-# Production default (240 seconds)
-./deploy/install.sh
-
-# E2E testing (30 seconds)
-HPA_STABILIZATION_SECONDS=30 ./deploy/install.sh
 ```
 
 #### Via values.yaml

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,14 +28,12 @@ Cluster object builders and ensure/delete helpers live in [`fixtures/`](./fixtur
 
 ### Infrastructure Setup
 
-Before running tests, deploy the infrastructure in "infra-only" mode:
+Before running tests, deploy **WVA + monitoring + scaler + llm-d EPP/gateway** (no chart VA/HPA; tests create those):
 
 ```bash
-# Deploy only WVA controller + llm-d infrastructure (no VA/HPA resources)
-cd deploy
-export ENVIRONMENT="kind-emulator"  # or "openshift", "kubernetes"
-export INFRA_ONLY=true
-./install.sh
+# From repository root (recommended)
+export ENVIRONMENT=kind-emulator   # or openshift, kubernetes
+make deploy-e2e-infra IMG=localhost/llm-d-workload-variant-autoscaler:dev
 ```
 
 This deploys:
@@ -45,7 +43,7 @@ This deploys:
 - ✅ Prometheus Adapter (external metrics API)
 - ❌ **NO** VariantAutoscaling resources (tests create these)
 - ❌ **NO** HPA resources (tests create these)
-- ❌ **NO** Model services (tests create these)
+- ❌ **NO** default chart ModelService (`make deploy-e2e-infra` skips it; tests create workloads)
 
 ### Verify Infrastructure
 
@@ -125,7 +123,9 @@ export E2E_PROM_ADAPTER_PROBE_SEC=90
 
 `deploy/install.sh` runs **`helm repo update`** by default. To skip (faster but requires existing repo indexes), set **`SKIP_HELM_REPO_UPDATE=true`**.
 
-For infra-only e2e deploys, **`E2E_DEPLOY_WAIT_TIMEOUT`** (default **`120s`**) bounds how long `install.sh` waits for the EPP deployment and inference-gateway deployment to become Available after llm-d Helm apply. Increase if your cluster is slow to pull images.
+When using **`LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true`** (as in `make deploy-e2e-infra`), **`E2E_DEPLOY_WAIT_TIMEOUT`** (default **`120s`**) bounds how long `install-llmd-infra.sh` waits for the EPP and inference-gateway deployments to become Available. Increase if your cluster is slow to pull images.
+
+Emulated Kind post-deploy ModelService cleanup (prefill removal; decode removal when **`LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS=true`**, the default) lives in **`deploy/lib/infra_llmd.sh`**, not in `deploy/kind-emulator/install.sh`.
 
 ### Example: Run on Kind with Emulated GPUs
 
@@ -182,7 +182,6 @@ USE_SIMULATOR=true \
 SCALE_TO_ZERO_ENABLED=false \
 CREATE_CLUSTER=true \
 INSTALL_GATEWAY_CTRLPLANE=true \
-E2E_TESTS_ENABLED=true \
 IMG=ghcr.io/llm-d/llm-d-workload-variant-autoscaler:0.0.1-test \
 DELETE_CLUSTER=false \
 SCALER_BACKEND=keda \
@@ -232,7 +231,7 @@ ginkgo -v --label-filter="smoke" ./test/e2e/
 
 **Tests:**
 1. **Scale-From-Zero** (~7 min)
-   - Requires EPP flow control (`E2E_TESTS_ENABLED=true` or `ENABLE_SCALE_TO_ZERO=true` patches EPP). The scale-from-zero spec applies **InferenceObjective** `e2e-default` via `test/e2e/fixtures` when the CRD exists (install.sh no longer applies it for e2e).
+   - Requires EPP flow control (`LLMD_PATCH_EPP_FLOW_CONTROL=true` / `ENABLE_SCALE_TO_ZERO=true` on `install-llmd-infra.sh`, or `make deploy-e2e-infra`). The scale-from-zero spec applies **InferenceObjective** `e2e-default` via `test/e2e/fixtures` when the CRD exists.
    - Create HPA (or KEDA ScaledObject) with minReplicas=0
    - Verify deployment scales to 0 when idle
    - Generate first request, verify scale-up from 0 → 1
@@ -405,7 +404,7 @@ Use this when smoke/full tests fail on **VA reconciliation**, **HPA / desired re
 **Things to verify:**
 1. **Prometheus** is scraping model/EPP targets; **`MetricsAvailable`** on the VA in `kubectl describe`.
 2. **`external.metrics.k8s.io`** works when using **`SCALER_BACKEND=prometheus-adapter`**; on kind-emulator, the default `auto` mode already probes adapter pod Ready + `external.metrics.k8s.io/v1beta1` discovery. If the API is still empty after install, set **`RESTART_PROMETHEUS_ADAPTER=true`** to force a restart.
-3. **Scale-from-zero:** infra deployed with **`E2E_TESTS_ENABLED=true`** (or **`ENABLE_SCALE_TO_ZERO=true`**) so EPP flow control is on; raise **`E2E_EVENTUALLY_*`** / **`SCALE_UP_TIMEOUT`** if cold start is slow; see **Tier 2** trigger job tunables.
+3. **Scale-from-zero:** infra deployed with **`make deploy-e2e-infra`** (or **`LLMD_PATCH_EPP_FLOW_CONTROL=true`** / **`ENABLE_SCALE_TO_ZERO=true`** on `install-llmd-infra.sh`) so EPP flow control is on; raise **`E2E_EVENTUALLY_*`** / **`SCALE_UP_TIMEOUT`** if cold start is slow; see **Tier 2** trigger job tunables.
 
 **Debug commands** (adjust `-n` to your llm-d namespace, e.g. `LLMD_NAMESPACE`):
 ```bash
@@ -474,4 +473,4 @@ var _ = Describe("My New Test", Label("full"), Ordered, func() {
 
 - [Developer Testing Guide](../../docs/developer-guide/testing.md)
 - [Deployment Guide](../../deploy/README.md)
-- [INFRA_ONLY Mode Documentation](../../deploy/README.md#example-7-infra-only-mode-for-e2e-testing)
+- [Deploy README — e2e-style stack](../../deploy/README.md#example-2-e2e-style-stack-same-as-make-deploy-e2e-infra)

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -136,7 +136,7 @@ func cleanupScaleFromZeroResources() {
 
 // Scale-from-zero test validates that the WVA controller correctly detects pending requests
 // and scales up scale targets from zero replicas. Requires GIE queuing (flowControl feature gate
-// enabled on EPP from install when E2E_TESTS_ENABLED=true) and an InferenceObjective (applied below in BeforeAll).
+// enabled on EPP from install when LLMD_PATCH_EPP_FLOW_CONTROL=true) and an InferenceObjective (applied below in BeforeAll).
 // This suite needs a scaler that allows minReplicas=0 on the scaled workload: either
 // SCALE_TO_ZERO_ENABLED=true where native HPA supports it (HPAScaleToZero), or SCALER_BACKEND=keda
 // (ScaledObject). OpenShift usually lacks HPAScaleToZero; e2e config ignores SCALE_TO_ZERO_ENABLED there,

--- a/test/testconfig/config.go
+++ b/test/testconfig/config.go
@@ -31,7 +31,7 @@ type SharedConfig struct {
 	EPPMode          string            // "poolName" or "endpointSelector"
 	PoolName         string            // InferencePool name (if using poolName mode)
 	EndpointSelector map[string]string // Pod selector (if using endpointSelector)
-	EPPServiceName   string            // EPP service name (e.g., "gaie-inference-scheduling-epp")
+	EPPServiceName   string            // EPP service name (e.g. gaie-<guide>-epp; guide basename matches llm-d guides/)
 
 	// Model configuration
 	ModelID         string // e.g., "unsloth/Meta-Llama-3.1-8B"

--- a/test/utils/e2eutils.go
+++ b/test/utils/e2eutils.go
@@ -1312,19 +1312,17 @@ func SetupTestEnvironment(image string, numNodes, gpusPerNode int, gpuTypes stri
 	gom.Expect(os.Setenv("WVA_IMAGE_PULL_POLICY", "IfNotPresent")).To(gom.Succeed()) // The image is built locally by the tests
 	gom.Expect(os.Setenv("CREATE_CLUSTER", "true")).To(gom.Succeed())                // Always create a new cluster for E2E tests
 
-	// Enable components needed for the tests
-	gom.Expect(os.Setenv("DEPLOY_LLM_D", "true")).To(gom.Succeed())
+	// llm-d stack is deployed by ./deploy/install-llmd-infra.sh (fixtures / Makefile); install.sh does not own it.
+	// Chart-managed VariantAutoscaling / HPA are opt-in Helm values — tests typically apply their own CRs instead.
+	// Enable components needed for the tests (Makefile deploy-e2e-infra runs install.sh + install-llmd-infra.sh)
 	gom.Expect(os.Setenv("DEPLOY_WVA", "true")).To(gom.Succeed())
 	gom.Expect(os.Setenv("DEPLOY_PROMETHEUS", "true")).To(gom.Succeed())
 	gom.Expect(os.Setenv("DEPLOY_PROMETHEUS_ADAPTER", "true")).To(gom.Succeed())
-	gom.Expect(os.Setenv("E2E_TESTS_ENABLED", "true")).To(gom.Succeed())
 	gom.Expect(os.Setenv("WVA_RECONCILE_INTERVAL", "30s")).To(gom.Succeed())
 
-	// Disable components not needed to be deployed by the script
-	gom.Expect(os.Setenv("DEPLOY_LLM_D_INFERENCE_SIM", "false")).To(gom.Succeed()) // tests deploy their own llm-d-sim deployments
-	gom.Expect(os.Setenv("DEPLOY_VA", "false")).To(gom.Succeed())                  // tests create their own VariantAutoscaling resources
-	gom.Expect(os.Setenv("DEPLOY_HPA", "false")).To(gom.Succeed())                 // tests create their own HPAs if needed
-	gom.Expect(os.Setenv("VLLM_SVC_ENABLED", "false")).To(gom.Succeed())           // tests deploy their own Service
+	// install-llmd-infra: skip default ModelService; tests deploy their own workloads
+	gom.Expect(os.Setenv("DEPLOY_LLM_D_INFERENCE_SIM", "false")).To(gom.Succeed())
+	gom.Expect(os.Setenv("VLLM_SVC_ENABLED", "false")).To(gom.Succeed()) // tests deploy their own Service
 }
 
 // DeleteAllVariantAutoscalings deletes all VariantAutoscaling objects in a namespace


### PR DESCRIPTION
Addresses - https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/872
This pr is focused on simplifying the install script and extracting the llm-d infra installation only (moving into deprecation soon, to use upstream installation). Specifically follows the proposed plan [here](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/872#issuecomment-4299924320)
Consecutive PRs will also deprecate the Helm installation, moving to Kustomize (matching upstream)

Main changes in this pr
- WVA install is slimmer: chart VA/HPA and capacity knobs aren’t crammed through install.sh
- llm-d installation is extracted out, not part of the install script, which now focuses on wva + monitoring
- No more interactive prompts in deploy scripts: missing tools fail unless bypassed

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)