### PR TITLE
docs: fix per-model override semantics for saturation scaling

### DIFF
--- a/docs/saturation-scaling-config.md
+++ b/docs/saturation-scaling-config.md
@@ -316,12 +316,10 @@ data:
     queueSpareTrigger: 3
 
   # Override for granite model in production namespace
-  # All fields must be specified — no inheritance from default
+  # Only fields specified here are overridden; the rest inherit from `default`
   "ibm/granite-13b#production": |
     kvCacheThreshold: 0.85
-    queueLengthThreshold: 5
     kvSpareTrigger: 0.15
-    queueSpareTrigger: 3
 
   # Override for llama model in lab namespace
   "meta/llama-70b#lab": |
@@ -334,22 +332,30 @@ data:
 **Key points:**
 - Override keys **must** use the format `{modelID}#{namespace}` to match the engine's lookup
 - The `model_id` and `namespace` YAML fields inside the entry are parsed but **not used for lookup**
-- Overrides **replace** the `default` config entirely — there is no field-level inheritance. If an override omits a field (e.g., `queueLengthThreshold`), that field will be zero, not inherited from `default`. Always specify all required fields in each override entry.
+- Overrides use **field-level merge**: only non-zero fields in the override replace the corresponding values from `default`; any field you omit (or set to its zero value) inherits from `default`. See `Merge()` in `internal/config/saturation_scaling.go`.
 - Multiple overrides can exist for different model/namespace combinations
 
-### 4. Per-Model Overrides — No Field Inheritance
+### 4. Per-Model Overrides — Field-Level Inheritance
 
-Overrides **fully replace** the `default` config. There is no field-level merging — omitted
-fields will be zero, not inherited from `default`. Always specify all required threshold
-fields in each override entry:
+Overrides are merged onto `default` field by field: only non-zero fields in the override
+replace values from `default`, and any field you omit inherits from `default`. To change
+just one threshold, specify only that field:
 
 ```yaml
+  # Inherits queueLengthThreshold, kvSpareTrigger, queueSpareTrigger from `default`
   "my-org/my-model#my-namespace": |
     kvCacheThreshold: 0.90
-    queueLengthThreshold: 5
-    kvSpareTrigger: 0.1
-    queueSpareTrigger: 3
 ```
+
+> **Gotcha:** Because `Merge()` only overlays non-zero values, an override cannot force
+> a field to its zero value — the override is treated as "unset" and inherits from
+> `default` instead. This affects every field type, not just numeric thresholds:
+>
+> - `kvSpareTrigger: 0` → inherits from `default` (cannot zero out a numeric threshold)
+> - `enableLimiter: false` → inherits from `default` (cannot disable a limiter that's enabled by default)
+> - `analyzers: []` → inherits from `default` (cannot clear a non-empty analyzer list)
+>
+> See `Merge()` in `internal/config/saturation_scaling.go`.
 
 ## Validation
 

--- a/docs/user-guide/saturation-analyzer.md
+++ b/docs/user-guide/saturation-analyzer.md
@@ -291,11 +291,16 @@ Lookup order: `modelID#namespace` → `default` → zero-value with defaults app
     queueSpareTrigger: 3
 ```
 
-> **Note:** Overrides **fully replace** the `default` config — there is no field-level
-> inheritance. Always specify all required threshold fields. The `model_id` and `namespace`
-> YAML fields inside the entry are parsed into the config struct but are **not used for
-> lookup**. The ConfigMap data key itself determines which model/namespace the override
-> applies to.
+> **Note:** Overrides use **field-level merge**: only non-zero fields in the override
+> replace the corresponding values from `default`; omitted fields inherit from `default`.
+> The `model_id` and `namespace` YAML fields inside the entry are parsed into the config
+> struct but are **not used for lookup** — the ConfigMap data key itself determines which
+> model/namespace the override applies to.
+>
+> **Gotcha:** Because `Merge()` only overlays non-zero values, an override cannot force
+> a field to its zero value — `kvSpareTrigger: 0`, `enableLimiter: false`, or an empty
+> `analyzers: []` are all treated as "unset" and inherit from `default`. See
+> [Saturation Scaling Configuration](../saturation-scaling-config.md) for the full list.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

While setting up the project locally on kind to play with the saturation scaling logic, I noticed the docs about per-model overrides don't match what the code actually does.

Both `docs/saturation-scaling-config.md` and `docs/user-guide/saturation-analyzer.md` claim per-model overrides "fully replace" the `default` config, with omitted fields ending up as zero. But `Merge()` in `internal/config/saturation_scaling.go` only overlays non-zero fields onto the base, and `resolveSaturationConfig()` uses it exactly that way. There's already a spec in `engine_v2_test.go` ("should allow partial override with only one field changed") that asserts the merge behavior the docs deny.

Looks like partial-override support landed in #994 but the docs weren't updated alongside it.

### Changes

- Reword both files to say overrides do field-level merge — only non-zero fields in the override replace values from `default`, omitted fields inherit.
- Simplify one of the `ibm/granite-13b` examples to demonstrate partial override (one field changed, others inherited). Easier to copy-paste and makes the merge behavior obvious.
- Call out the zero-value gotcha: explicitly setting `field: 0` in an override is treated as "unset" because `Merge()` only overlays non-zero values. This is a real surprise if you're trying to set something to zero on purpose.

No code changes.

## Test plan

- [x] Re-read `Merge()` and `resolveSaturationConfig()` to confirm partial-merge semantics.
- [x] `go test ./internal/config/...` — passes (covers `Merge()` field-level behavior).
- [x] `go test ./internal/engines/saturation/... -ginkgo.focus="partial override"` — the existing partial-override spec at `engine_v2_test.go:249` passes, confirming the new wording matches reality.