### PR TITLE
ci: fix llm-d-infra reusable workflow references (.yml → .yaml)

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   gatekeeper:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yaml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   prow:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yaml@main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   auto-merge:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yaml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -3,4 +3,4 @@ on: pull_request
 
 jobs:
   remove-lgtm:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yaml@main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   unstale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yaml@main
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

All seven workflows in this repo that call reusable workflows from `llm-d/llm-d-infra` started failing on/around May 6, 2026 with:

```
error parsing called workflow ".github/workflows/ci-signed-commits.yaml"
-> "llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main"
: failed to fetch workflow: workflow was not found.
```

Root cause: the upstream reusable workflow files in `llm-d/llm-d-infra/.github/workflows/` are named `reusable-*.yaml` (verified via the directory listing on `main`), but every caller in this repo references them as `reusable-*.yml`. The files appear to have been renamed from `.yml` to `.yaml` around May 6, breaking every caller simultaneously. The "Check Signed Commits" check is the most visible failure since it gates merges on every PR; the other six workflows fail silently on their own schedules/triggers.

## Files changed

| File | Reference (before → after) |
|---|---|
| `.github/workflows/ci-signed-commits.yaml` | `reusable-signed-commits.yml` → `.yaml` |
| `.github/workflows/non-main-gatekeeper.yml` | `reusable-non-main-gatekeeper.yml` → `.yaml` |
| `.github/workflows/prow-github.yml` | `reusable-prow-commands.yml` → `.yaml` |
| `.github/workflows/prow-pr-automerge.yml` | `reusable-prow-automerge.yml` → `.yaml` |
| `.github/workflows/prow-pr-remove-lgtm.yml` | `reusable-prow-remove-lgtm.yml` → `.yaml` |
| `.github/workflows/stale.yaml` | `reusable-stale.yml` → `.yaml` |
| `.github/workflows/unstale.yaml` | `reusable-unstale.yml` → `.yaml` |

7 files changed, 7 insertions, 7 deletions.

## Test plan

- [ ] Verify the "Check Signed Commits" job runs successfully on this PR (it's gated on every PR; if the reference resolves, it should report a pass/fail rather than the "Invalid workflow file" parse error).
- [ ] Verify the `Non-Main Gatekeeper` check fires correctly on PRs targeting non-main branches.
- [ ] Spot-check: the `Prow Commands` (`/lgtm`, `/approve`, etc.) workflow responds to a comment on this PR.
- [ ] Confirm no remaining `.yml@main` references to `llm-d/llm-d-infra` workflows:
  ```
  grep -rn "llm-d/llm-d-infra/.github/workflows/.*\.yml@" .github/workflows/
  ```
  (should return nothing)

## Notes

This is purely a caller-side path fix. No logic changes; no upstream coordination required. The fix is consistent with other consumer repos that have presumably already migrated to the `.yaml` extension.