### PR TITLE
feat: support multiple saturation scaling stacks per namespace via VA annotation

### DIFF
--- a/api/v1alpha1/variantautoscaling_types.go
+++ b/api/v1alpha1/variantautoscaling_types.go
@@ -190,3 +190,20 @@ func (va *VariantAutoscaling) GetScaleTargetName() string {
 func (va *VariantAutoscaling) GetScaleTargetKind() string {
 	return va.Spec.ScaleTargetRef.Kind
 }
+
+// SaturationConfigAnnotationKey is the annotation key on VariantAutoscaling resources
+// that specifies which saturation scaling ConfigMap to use. When set, the VA uses
+// the named ConfigMap instead of the default well-known ConfigMap.
+// The referenced ConfigMap must exist in the same namespace as the VA and have
+// the label app.kubernetes.io/name: workload-variant-autoscaler.
+const SaturationConfigAnnotationKey = "wva.llmd.ai/saturation-config"
+
+// SaturationConfigRef returns the name of the saturation scaling ConfigMap
+// this VA should use, as specified by the wva.llmd.ai/saturation-config annotation.
+// Returns empty string if not set, meaning the default well-known ConfigMap should be used.
+func (va *VariantAutoscaling) SaturationConfigRef() string {
+	if va.Annotations != nil {
+		return va.Annotations[SaturationConfigAnnotationKey]
+	}
+	return ""
+}

--- a/api/v1alpha1/variantautoscaling_types_test.go
+++ b/api/v1alpha1/variantautoscaling_types_test.go
@@ -222,6 +222,55 @@ func jsonContainsKey(b []byte, key string) bool {
 	return ok
 }
 
+func TestSaturationConfigRef(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "no annotations returns empty",
+			annotations: nil,
+			expected:    "",
+		},
+		{
+			name:        "empty annotations returns empty",
+			annotations: map[string]string{},
+			expected:    "",
+		},
+		{
+			name: "annotation present returns value",
+			annotations: map[string]string{
+				"wva.llmd.ai/saturation-config": "my-custom-config",
+			},
+			expected: "my-custom-config",
+		},
+		{
+			name: "other annotations present but not saturation config",
+			annotations: map[string]string{
+				"some-other-annotation": "value",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			va := &VariantAutoscaling{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-va",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+			result := va.SaturationConfigRef()
+			if result != tt.expected {
+				t.Errorf("SaturationConfigRef() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestMinMaxReplicasJSON(t *testing.T) {
 	minVal := int32(2)
 	va := &VariantAutoscaling{

--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -14,23 +14,29 @@ rules:
   verbs:
   - list
   - watch
-  # Note: This broad permission is required for namespace-local ConfigMap overrides.
-  # The controller filters by well-known names (wva-saturation-scaling-config, wva-model-scale-to-zero-config)
-  # in its predicate logic, providing effective access control.
+  # Note: This broad list/watch/get permission is required for namespace-local ConfigMap overrides
+  # and custom saturation ConfigMaps (multi-stack). The controller filters by the
+  # app.kubernetes.io/name label (cache) and well-known names (predicate), providing
+  # effective access control. The cache only watches labelled ConfigMaps.
 - apiGroups:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
   {{- if not .Values.wva.namespaceScoped }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   resourceNames:
   - {{ include "workload-variant-autoscaler.fullname" . }}-variantautoscaling-config
   - {{ include "workload-variant-autoscaler.fullname" . }}-wva-saturation-scaling-config
   - wva-model-scale-to-zero-config
   - wva-queueing-model-config
-{{- end }}
   verbs:
-  - get
   - update
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,13 +82,16 @@ type SaturationScalingConfigPerModel map[string]SaturationScalingConfig
 // for all models. Maps model ID (or "default" key) to its configuration.
 type QMAnalyzerConfigPerModel map[string]interfaces.QueueingModelScalingConfig
 
-// saturationConfig holds saturation scaling configuration (namespace-aware)
+// saturationConfig holds saturation scaling configuration (namespace-aware, multi-stack).
+// Scoped configs are keyed by "namespace/configMapName" to support multiple saturation
+// ConfigMaps per namespace. Each VA can reference a specific ConfigMap via annotation.
 type saturationConfig struct {
-	// Global default configuration
+	// Global default configuration (from system namespace)
 	global SaturationScalingConfigPerModel
 
-	// Namespace-local configuration overrides (keyed by namespace name)
-	namespaceConfigs map[string]SaturationScalingConfigPerModel
+	// Scoped configuration overrides keyed by "namespace/configMapName".
+	// Supports multiple ConfigMaps per namespace for multi-stack deployments.
+	scopedConfigs map[string]SaturationScalingConfigPerModel
 }
 
 // qmAnalyzerConfig holds queueing model scaling configuration (namespace-aware)
@@ -317,11 +321,30 @@ func (c *Config) SaturationConfig() map[string]SaturationScalingConfig {
 // resolveSaturationConfig resolves saturation config for a namespace (namespace-local > global).
 // Must be called while holding at least a read lock.
 func (c *Config) resolveSaturationConfig(namespace string) map[string]SaturationScalingConfig {
-	// Check namespace-local first (if namespace is provided)
+	return c.resolveSaturationConfigForRef(namespace, SaturationConfigMapName())
+}
+
+// resolveSaturationConfigForRef resolves saturation config for a specific namespace and ConfigMap name.
+// Resolution order: scoped(namespace/cmName) > scoped(namespace/defaultName) > global.
+// Must be called while holding at least a read lock.
+func (c *Config) resolveSaturationConfigForRef(namespace, cmName string) map[string]SaturationScalingConfig {
 	if namespace != "" {
-		if nsConfig, exists := c.saturation.namespaceConfigs[namespace]; exists {
-			if len(nsConfig) > 0 {
-				return nsConfig
+		// Check exact scoped config first
+		scopedKey := namespace + "/" + cmName
+		if cfg, exists := c.saturation.scopedConfigs[scopedKey]; exists {
+			if len(cfg) > 0 {
+				return cfg
+			}
+		}
+
+		// If cmName is not the default, also try the default name as fallback
+		defaultName := SaturationConfigMapName()
+		if cmName != defaultName {
+			defaultKey := namespace + "/" + defaultName
+			if cfg, exists := c.saturation.scopedConfigs[defaultKey]; exists {
+				if len(cfg) > 0 {
+					return cfg
+				}
 			}
 		}
 	}
@@ -363,6 +386,33 @@ func (c *Config) SaturationConfigForNamespace(namespace string) map[string]Satur
 	defer c.mu.RUnlock()
 	sourceConfig := c.resolveSaturationConfig(namespace)
 	return copySaturationConfig(sourceConfig)
+}
+
+// SaturationConfigForRef returns the saturation scaling configuration for a specific
+// namespace and ConfigMap name. Used for multi-stack support where VAs can reference
+// different saturation ConfigMaps via the wva.llmd.ai/saturation-config annotation.
+// Resolution order: scoped(namespace/cmName) > scoped(namespace/defaultName) > global
+// Thread-safe. Returns a copy to prevent external modifications.
+func (c *Config) SaturationConfigForRef(namespace, cmName string) map[string]SaturationScalingConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	sourceConfig := c.resolveSaturationConfigForRef(namespace, cmName)
+	return copySaturationConfig(sourceConfig)
+}
+
+// HasScopedSaturationConfig returns true if a scoped saturation config exists for
+// the given namespace and ConfigMap name. Used to verify that an explicitly referenced
+// ConfigMap has been loaded before using it for scaling decisions.
+// Thread-safe.
+func (c *Config) HasScopedSaturationConfig(namespace, cmName string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.saturation.scopedConfigs == nil {
+		return false
+	}
+	scopedKey := namespace + "/" + cmName
+	cfg, exists := c.saturation.scopedConfigs[scopedKey]
+	return exists && len(cfg) > 0
 }
 
 // copySaturationConfig creates a deep copy of the saturation config map.
@@ -418,35 +468,44 @@ func (c *Config) UpdateSaturationConfig(config map[string]SaturationScalingConfi
 // If namespace is empty, updates global config.
 // Thread-safe. Takes a copy of the provided map to prevent external modifications.
 func (c *Config) UpdateSaturationConfigForNamespace(namespace string, config map[string]SaturationScalingConfig) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Make a copy to prevent external modifications
-	newConfig := make(map[string]SaturationScalingConfig, len(config))
-	maps.Copy(newConfig, config)
-
-	var oldCount int
 	if namespace == "" {
-		// Update global
-		oldCount = len(c.saturation.global)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		newConfig := make(map[string]SaturationScalingConfig, len(config))
+		maps.Copy(newConfig, config)
+		oldCount := len(c.saturation.global)
 		c.saturation.global = newConfig
 		newCount := len(c.saturation.global)
 		if oldCount != newCount {
 			ctrl.Log.Info("Updated global saturation config", "oldEntries", oldCount, "newEntries", newCount)
 		}
-	} else {
-		// Update namespace-local
-		if c.saturation.namespaceConfigs == nil {
-			c.saturation.namespaceConfigs = make(map[string]SaturationScalingConfigPerModel)
-		}
-		oldCount = len(c.saturation.namespaceConfigs[namespace])
-		c.saturation.namespaceConfigs[namespace] = newConfig
-		newCount := len(c.saturation.namespaceConfigs[namespace])
-		if oldCount != newCount {
-			ctrl.Log.Info("Updated namespace-local saturation config", "namespace", namespace, "oldEntries", oldCount, "newEntries", newCount)
-		}
+		return
+	}
+	c.UpdateSaturationConfigScoped(namespace, SaturationConfigMapName(), config)
+}
+
+// UpdateSaturationConfigScoped updates the saturation scaling configuration for a specific
+// namespace and ConfigMap name. Used for multi-stack support where different ConfigMaps
+// in the same namespace store different saturation configs.
+// Thread-safe. Takes a copy of the provided map to prevent external modifications.
+func (c *Config) UpdateSaturationConfigScoped(namespace, cmName string, config map[string]SaturationScalingConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	newConfig := make(map[string]SaturationScalingConfig, len(config))
+	maps.Copy(newConfig, config)
+
+	if c.saturation.scopedConfigs == nil {
+		c.saturation.scopedConfigs = make(map[string]SaturationScalingConfigPerModel)
 	}
 
+	scopedKey := namespace + "/" + cmName
+	oldCount := len(c.saturation.scopedConfigs[scopedKey])
+	c.saturation.scopedConfigs[scopedKey] = newConfig
+	newCount := len(c.saturation.scopedConfigs[scopedKey])
+	if oldCount != newCount {
+		ctrl.Log.Info("Updated scoped saturation config", "namespace", namespace, "configMap", cmName, "oldEntries", oldCount, "newEntries", newCount)
+	}
 }
 
 // UpdateScaleToZeroConfig updates the global scale-to-zero configuration.
@@ -594,10 +653,14 @@ func (c *Config) RemoveNamespaceConfig(namespace string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	removed := false
-	if c.saturation.namespaceConfigs != nil {
-		if _, exists := c.saturation.namespaceConfigs[namespace]; exists {
-			delete(c.saturation.namespaceConfigs, namespace)
-			removed = true
+	// Remove all scoped saturation configs for this namespace
+	if c.saturation.scopedConfigs != nil {
+		prefix := namespace + "/"
+		for key := range c.saturation.scopedConfigs {
+			if strings.HasPrefix(key, prefix) {
+				delete(c.saturation.scopedConfigs, key)
+				removed = true
+			}
 		}
 	}
 	if c.qmAnalyzer.namespaceConfigs != nil {
@@ -614,6 +677,24 @@ func (c *Config) RemoveNamespaceConfig(namespace string) {
 	}
 	if removed {
 		ctrl.Log.Info("Removed namespace-local config", "namespace", namespace)
+	}
+}
+
+// RemoveScopedSaturationConfig removes the saturation configuration for a specific
+// namespace and ConfigMap name. Used when a labelled saturation ConfigMap is deleted.
+// Thread-safe.
+func (c *Config) RemoveScopedSaturationConfig(namespace, cmName string) {
+	if namespace == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.saturation.scopedConfigs != nil {
+		scopedKey := namespace + "/" + cmName
+		if _, exists := c.saturation.scopedConfigs[scopedKey]; exists {
+			delete(c.saturation.scopedConfigs, scopedKey)
+			ctrl.Log.Info("Removed scoped saturation config", "namespace", namespace, "configMap", cmName)
+		}
 	}
 }
 
@@ -665,8 +746,8 @@ func NewTestConfig() *Config {
 			scaleFromZeroMaxConcurrency: 10,
 		},
 		saturation: saturationConfig{
-			global:           make(SaturationScalingConfigPerModel),
-			namespaceConfigs: make(map[string]SaturationScalingConfigPerModel),
+			global:        make(SaturationScalingConfigPerModel),
+			scopedConfigs: make(map[string]SaturationScalingConfigPerModel),
 		},
 		qmAnalyzer: qmAnalyzerConfig{
 			global:           make(QMAnalyzerConfigPerModel),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -492,6 +492,186 @@ func TestConfig_MultipleNamespaces(t *testing.T) {
 	assert.Equal(t, 0.80, globalSatConfig2["default"].KvCacheThreshold, "Global config should be unchanged")
 }
 
+func TestConfig_ScopedSaturationConfig(t *testing.T) {
+	cfg := NewTestConfig()
+
+	defaultName := SaturationConfigMapName()
+
+	globalSat := map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.80,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	}
+	cfg.UpdateSaturationConfig(globalSat)
+
+	cfg.UpdateSaturationConfigScoped("prod", "custom-sat-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.60,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", defaultName, map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.70,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+
+	assert.Equal(t, 0.60, cfg.SaturationConfigForRef("prod", "custom-sat-config")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.70, cfg.SaturationConfigForRef("prod", defaultName)["default"].KvCacheThreshold)
+	assert.Equal(t, 0.70, cfg.SaturationConfigForRef("prod", "unknown-config")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.80, cfg.SaturationConfigForRef("staging", "custom-sat-config")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.70, cfg.SaturationConfigForNamespace("prod")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.80, cfg.SaturationConfigForNamespace("")["default"].KvCacheThreshold)
+}
+
+func TestConfig_RemoveScopedSaturationConfig(t *testing.T) {
+	cfg := NewTestConfig()
+
+	defaultName := SaturationConfigMapName()
+
+	cfg.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.80,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", "custom-sat-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.60,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", defaultName, map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.70,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+
+	cfg.RemoveScopedSaturationConfig("prod", "custom-sat-config")
+	assert.Equal(t, 0.70, cfg.SaturationConfigForRef("prod", "custom-sat-config")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.70, cfg.SaturationConfigForRef("prod", defaultName)["default"].KvCacheThreshold)
+
+	cfg.RemoveScopedSaturationConfig("prod", defaultName)
+	assert.Equal(t, 0.80, cfg.SaturationConfigForNamespace("prod")["default"].KvCacheThreshold)
+}
+
+func TestConfig_RemoveNamespaceConfig_RemovesAllScoped(t *testing.T) {
+	cfg := NewTestConfig()
+
+	defaultName := SaturationConfigMapName()
+
+	cfg.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.80,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", "custom-sat-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.60,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", defaultName, map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.70,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+
+	cfg.RemoveNamespaceConfig("prod")
+	assert.Equal(t, 0.80, cfg.SaturationConfigForNamespace("prod")["default"].KvCacheThreshold)
+}
+
+func TestConfig_MultiStackSameNamespace(t *testing.T) {
+	cfg := NewTestConfig()
+
+	cfg.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.80,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", "stack-a-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.55,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", "stack-b-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.65,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+
+	require.Equal(t, 0.55, cfg.SaturationConfigForRef("prod", "stack-a-config")["default"].KvCacheThreshold)
+	require.Equal(t, 0.65, cfg.SaturationConfigForRef("prod", "stack-b-config")["default"].KvCacheThreshold)
+
+	cfg.UpdateSaturationConfigScoped("prod", "stack-a-config", map[string]SaturationScalingConfig{
+		"default": {
+			KvCacheThreshold:     0.50,
+			QueueLengthThreshold: 5,
+			KvSpareTrigger:       0.10,
+			QueueSpareTrigger:    3,
+		},
+	})
+
+	assert.Equal(t, 0.50, cfg.SaturationConfigForRef("prod", "stack-a-config")["default"].KvCacheThreshold)
+	assert.Equal(t, 0.65, cfg.SaturationConfigForRef("prod", "stack-b-config")["default"].KvCacheThreshold)
+}
+
+func TestConfig_HasScopedSaturationConfig(t *testing.T) {
+	cfg := NewTestConfig()
+
+	cfg.UpdateSaturationConfig(map[string]SaturationScalingConfig{
+		"default": {KvCacheThreshold: 0.80},
+	})
+	cfg.UpdateSaturationConfigScoped("prod", "custom-config", map[string]SaturationScalingConfig{
+		"default": {KvCacheThreshold: 0.60},
+	})
+
+	assert.True(t, cfg.HasScopedSaturationConfig("prod", "custom-config"),
+		"Should find existing scoped config")
+	assert.False(t, cfg.HasScopedSaturationConfig("prod", "missing-config"),
+		"Should not find non-existent scoped config")
+	assert.False(t, cfg.HasScopedSaturationConfig("staging", "custom-config"),
+		"Should not find config in wrong namespace")
+	assert.False(t, cfg.HasScopedSaturationConfig("", "custom-config"),
+		"Should not find config with empty namespace")
+
+	cfg.RemoveScopedSaturationConfig("prod", "custom-config")
+	assert.False(t, cfg.HasScopedSaturationConfig("prod", "custom-config"),
+		"Should not find removed scoped config")
+}
+
 func TestQMAnalyzerConfig_GlobalGetSet(t *testing.T) {
 	cfg := NewTestConfig()
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -140,8 +140,8 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	}
 
 	cfg.saturation = saturationConfig{
-		global:           make(SaturationScalingConfigPerModel),
-		namespaceConfigs: make(map[string]SaturationScalingConfigPerModel),
+		global:        make(SaturationScalingConfigPerModel),
+		scopedConfigs: make(map[string]SaturationScalingConfigPerModel),
 	}
 
 	cfg.scaleToZero = scaleToZeroConfig{

--- a/internal/constants/labels.go
+++ b/internal/constants/labels.go
@@ -2,6 +2,10 @@
 // This file contains Kubernetes label keys used for filtering and identification.
 package constants
 
+import (
+	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+)
+
 // Kubernetes Label Keys
 // Label keys used on Kubernetes resources for filtering and identification.
 const (
@@ -25,6 +29,10 @@ const (
 	// even if the namespace has VAs or opt-in labels.
 	// This provides explicit control to exclude namespaces from WVA management.
 	NamespaceExcludeAnnotationKey = "wva.llmd.ai/exclude"
+
+	// SaturationConfigAnnotationKey is re-exported from the API package for internal use.
+	// The canonical definition lives in api/v1alpha1.SaturationConfigAnnotationKey.
+	SaturationConfigAnnotationKey = wvav1alpha1.SaturationConfigAnnotationKey
 )
 
 // AnnotationValueTrue is the canonical string value for boolean annotations and labels.

--- a/internal/controller/configmap_bootstrap.go
+++ b/internal/controller/configmap_bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -108,9 +109,61 @@ func (r *ConfigMapReconciler) BootstrapInitialConfigMaps(ctx context.Context) er
 		}
 	}
 
+	// Bootstrap custom saturation ConfigMaps for each scanned namespace.
+	// These are non-well-known ConfigMaps with the app.kubernetes.io/name: workload-variant-autoscaler label,
+	// enabling multi-stack support where different VAs reference different saturation configs.
+	labelledCount := 0
+	for _, ns := range namespacesToScan {
+		count, err := r.bootstrapLabelledSaturationConfigMaps(ctx, ns)
+		if err != nil {
+			r.Config.MarkConfigMapsBootstrapFailed(err)
+			return err
+		}
+		labelledCount += count
+	}
+
 	r.Config.MarkConfigMapsBootstrapComplete()
-	logger.Info("Initial ConfigMap bootstrap completed", "targets", len(targets))
+	logger.Info("Initial ConfigMap bootstrap completed", "targets", len(targets), "labelledSaturationConfigs", labelledCount)
 	return nil
+}
+
+// bootstrapLabelledSaturationConfigMaps discovers and loads custom saturation ConfigMaps
+// with the app.kubernetes.io/name: workload-variant-autoscaler label in a namespace
+// (excluding well-known names which are already handled by bootstrapConfigMap).
+func (r *ConfigMapReconciler) bootstrapLabelledSaturationConfigMaps(ctx context.Context, namespace string) (int, error) {
+	logger := log.FromContext(ctx)
+
+	cmList := &corev1.ConfigMapList{}
+	labelSelector := labels.SelectorFromSet(labels.Set{
+		"app.kubernetes.io/name": "workload-variant-autoscaler",
+	})
+	if err := r.List(ctx, cmList, &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	}); err != nil {
+		return 0, fmt.Errorf("failed to list labelled saturation ConfigMaps in namespace %s: %w", namespace, err)
+	}
+
+	count := 0
+	wellKnownNames := map[string]bool{
+		config.ConfigMapName():                 true,
+		config.SaturationConfigMapName():       true,
+		config.DefaultScaleToZeroConfigMapName: true,
+		config.QMAnalyzerConfigMapName():       true,
+	}
+	for i := range cmList.Items {
+		cm := &cmList.Items[i]
+		if wellKnownNames[cm.Name] {
+			continue // Already handled by well-known name bootstrap
+		}
+		r.handleSaturationConfigMap(ctx, cm, namespace, false)
+		count++
+	}
+
+	if count > 0 {
+		logger.Info("Bootstrapped labelled saturation ConfigMaps", "namespace", namespace, "count", count)
+	}
+	return count, nil
 }
 
 func (r *ConfigMapReconciler) bootstrapConfigMap(ctx context.Context, name, namespace string, isGlobal bool) error {

--- a/internal/controller/configmap_reconciler.go
+++ b/internal/controller/configmap_reconciler.go
@@ -85,7 +85,9 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	case config.QMAnalyzerConfigMapName():
 		r.handleQMAnalyzerConfigMap(ctx, cm, namespace, isGlobal)
 	default:
-		logger.V(1).Info("Ignoring unrecognized ConfigMap", "name", name, "namespace", namespace)
+		// Non-well-known ConfigMaps that reach here have passed the cache label
+		// filter and predicate, so they are WVA-owned custom saturation configs.
+		r.handleSaturationConfigMap(ctx, cm, namespace, isGlobal)
 	}
 
 	return ctrl.Result{}, nil
@@ -117,14 +119,18 @@ func (r *ConfigMapReconciler) handleConfigMapDeletion(ctx context.Context, name,
 	// Remove namespace-local config on deletion
 	switch name {
 	case config.SaturationConfigMapName():
-		r.Config.RemoveNamespaceConfig(namespace)
-		logger.Info("Removed namespace-local saturation config on ConfigMap deletion", "namespace", namespace)
+		r.Config.RemoveScopedSaturationConfig(namespace, name)
+		logger.Info("Removed namespace-local saturation config on ConfigMap deletion", "namespace", namespace, "configMap", name)
 	case config.DefaultScaleToZeroConfigMapName:
 		r.Config.RemoveNamespaceConfig(namespace)
 		logger.Info("Removed namespace-local scale-to-zero config on ConfigMap deletion", "namespace", namespace)
 	case config.QMAnalyzerConfigMapName():
 		r.Config.RemoveNamespaceConfig(namespace)
 		logger.Info("Removed namespace-local queueing model config on ConfigMap deletion", "namespace", namespace)
+	default:
+		// Custom-named saturation ConfigMaps — remove only the specific scoped entry.
+		r.Config.RemoveScopedSaturationConfig(namespace, name)
+		logger.Info("Removed scoped saturation config on ConfigMap deletion", "namespace", namespace, "configMap", name)
 	}
 }
 
@@ -168,8 +174,8 @@ func (r *ConfigMapReconciler) handleSaturationConfigMap(ctx context.Context, cm 
 		r.Config.UpdateSaturationConfig(configs)
 		logger.Info("Updated global saturation config from ConfigMap", "entries", count)
 	} else {
-		r.Config.UpdateSaturationConfigForNamespace(namespace, configs)
-		logger.Info("Updated namespace-local saturation config from ConfigMap", "namespace", namespace, "entries", count)
+		r.Config.UpdateSaturationConfigScoped(namespace, cm.Name, configs)
+		logger.Info("Updated scoped saturation config from ConfigMap", "namespace", namespace, "configMap", cm.Name, "entries", count)
 	}
 }
 

--- a/internal/controller/configmap_reconciler_test.go
+++ b/internal/controller/configmap_reconciler_test.go
@@ -453,6 +453,146 @@ var _ = Describe("ConfigMapReconciler", func() {
 		})
 	})
 
+	Context("Reconcile - Custom Saturation ConfigMaps (Multi-Stack)", func() {
+		BeforeEach(func() {
+			By("Tracking the test namespace in datastore")
+			ds.NamespaceTrack("VariantAutoscaling", "test-va", testNamespace)
+		})
+
+		It("should reconcile a custom saturation ConfigMap with WVA label", func() {
+			By("Creating a custom saturation ConfigMap with WVA ownership label")
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stack-a-saturation-config",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "workload-variant-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"default": "kvCacheThreshold: 0.55\nqueueLengthThreshold: 8\nkvSpareTrigger: 0.12\nqueueSpareTrigger: 4",
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			By("Reconciling the ConfigMap")
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cm.Name,
+					Namespace: cm.Namespace,
+				},
+			}
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			By("Verifying the scoped config was stored under the custom ConfigMap name")
+			satConfigMap := cfg.SaturationConfigForRef(testNamespace, "stack-a-saturation-config")
+			Expect(satConfigMap).NotTo(BeNil())
+			satConfig, exists := satConfigMap["default"]
+			Expect(exists).To(BeTrue())
+			Expect(satConfig.KvCacheThreshold).To(BeNumerically("~", 0.55, 0.01))
+		})
+
+		It("should handle deletion of a custom saturation ConfigMap", func() {
+			By("Creating and reconciling a custom saturation ConfigMap")
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stack-b-saturation-config",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "workload-variant-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"default": "kvCacheThreshold: 0.65\nqueueLengthThreshold: 12",
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cm.Name,
+					Namespace: cm.Namespace,
+				},
+			}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying config was stored")
+			satConfigMap := cfg.SaturationConfigForRef(testNamespace, "stack-b-saturation-config")
+			Expect(satConfigMap).NotTo(BeNil())
+			_, exists := satConfigMap["default"]
+			Expect(exists).To(BeTrue())
+
+			By("Deleting the ConfigMap")
+			Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+
+			By("Reconciling the deletion")
+			Eventually(func() bool {
+				_, err := reconciler.Reconcile(ctx, req)
+				return err == nil
+			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			By("Verifying scoped config was cleaned up, fallback to global")
+			satConfigMap = cfg.SaturationConfigForRef(testNamespace, "stack-b-saturation-config")
+			if satConfig, exists := satConfigMap["default"]; exists {
+				Expect(satConfig.KvCacheThreshold).NotTo(BeNumerically("~", 0.65, 0.01))
+			}
+		})
+
+		It("should support multiple custom ConfigMaps in the same namespace independently", func() {
+			By("Creating first custom saturation ConfigMap")
+			cm1 := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stack-x-config",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "workload-variant-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"default": "kvCacheThreshold: 0.50\nqueueLengthThreshold: 6",
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm1)).To(Succeed())
+
+			By("Creating second custom saturation ConfigMap")
+			cm2 := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stack-y-config",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "workload-variant-autoscaler",
+					},
+				},
+				Data: map[string]string{
+					"default": "kvCacheThreshold: 0.90\nqueueLengthThreshold: 20",
+				},
+			}
+			Expect(k8sClient.Create(ctx, cm2)).To(Succeed())
+
+			By("Reconciling both ConfigMaps")
+			for _, cm := range []*corev1.ConfigMap{cm1, cm2} {
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      cm.Name,
+						Namespace: cm.Namespace,
+					},
+				}
+				_, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying independent resolution")
+			configX := cfg.SaturationConfigForRef(testNamespace, "stack-x-config")
+			Expect(configX["default"].KvCacheThreshold).To(BeNumerically("~", 0.50, 0.01))
+
+			configY := cfg.SaturationConfigForRef(testNamespace, "stack-y-config")
+			Expect(configY["default"].KvCacheThreshold).To(BeNumerically("~", 0.90, 0.01))
+		})
+	})
+
 	Context("Error Handling", func() {
 		It("should handle invalid saturation config gracefully", func() {
 			By("Creating a ConfigMap with invalid YAML")

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -42,9 +42,15 @@ func ConfigMapPredicate(ds datastore.Datastore, cfg *config.Config) predicate.Pr
 			config.QMAnalyzerConfigMapName():       true,
 		}
 
-		// Check if this is a well-known ConfigMap name
+		// For non-well-known names, check the WVA ownership label.
+		// In multi-namespace mode the cache already filters by this label,
+		// but in single-namespace mode there is no cache label filter,
+		// so the predicate must enforce it.
 		if !wellKnownNames[name] {
-			return false
+			lbls := obj.GetLabels()
+			if lbls == nil || lbls["app.kubernetes.io/name"] != "workload-variant-autoscaler" {
+				return false
+			}
 		}
 
 		// Global ConfigMaps: must be in controller namespace

--- a/internal/controller/predicates_test.go
+++ b/internal/controller/predicates_test.go
@@ -33,9 +33,96 @@ import (
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 )
+
+var _ = Describe("ConfigMapPredicate - Custom Saturation ConfigMaps", func() {
+	var (
+		cfg *config.Config
+		ds  datastore.Datastore
+	)
+
+	BeforeEach(func() {
+		logging.NewTestLogger()
+		cfg = config.NewTestConfig()
+		ds = datastore.NewDatastore(cfg)
+	})
+
+	It("should allow a ConfigMap with the WVA ownership label in system namespace", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-saturation-config",
+				Namespace: config.SystemNamespace(),
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "workload-variant-autoscaler",
+				},
+			},
+		}
+		predicateFn := ConfigMapPredicate(ds, cfg)
+		result := predicateFn.Generic(event.GenericEvent{Object: cm})
+		Expect(result).To(BeTrue(), "Predicate should allow WVA-labelled ConfigMap in system namespace")
+	})
+
+	It("should reject a ConfigMap without label and non-well-known name", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-random-configmap",
+				Namespace: config.SystemNamespace(),
+			},
+		}
+		predicateFn := ConfigMapPredicate(ds, cfg)
+		result := predicateFn.Generic(event.GenericEvent{Object: cm})
+		Expect(result).To(BeFalse(), "Predicate should reject ConfigMap without label and non-well-known name")
+	})
+
+	It("should reject a ConfigMap with wrong label value", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-config",
+				Namespace: config.SystemNamespace(),
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "some-other-app",
+				},
+			},
+		}
+		predicateFn := ConfigMapPredicate(ds, cfg)
+		result := predicateFn.Generic(event.GenericEvent{Object: cm})
+		Expect(result).To(BeFalse(), "Predicate should reject ConfigMap with wrong label value")
+	})
+
+	It("should allow a WVA-labelled ConfigMap in a tracked namespace", func() {
+		ds.NamespaceTrack("VariantAutoscaling", "test-va", "my-namespace")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stack-a-saturation",
+				Namespace: "my-namespace",
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "workload-variant-autoscaler",
+				},
+			},
+		}
+		predicateFn := ConfigMapPredicate(ds, cfg)
+		result := predicateFn.Generic(event.GenericEvent{Object: cm})
+		Expect(result).To(BeTrue(), "Predicate should allow WVA-labelled ConfigMap in tracked namespace")
+	})
+
+	It("should reject a WVA-labelled ConfigMap in an untracked namespace", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stack-a-saturation",
+				Namespace: "untracked-namespace",
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "workload-variant-autoscaler",
+				},
+			},
+		}
+		predicateFn := ConfigMapPredicate(ds, cfg)
+		result := predicateFn.Generic(event.GenericEvent{Object: cm})
+		Expect(result).To(BeFalse(), "Predicate should reject WVA-labelled ConfigMap in untracked namespace")
+	})
+})
 
 var _ = Describe("VariantAutoscalingPredicate", func() {
 	var (

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -386,18 +387,38 @@ func (e *Engine) optimizeV1(
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
 		namespace := modelVAs[0].Namespace
+		configRef := modelVAs[0].SaturationConfigRef()
 		logger.Info("Processing model (V1)",
 			"modelID", modelID,
 			"namespace", namespace,
 			"variantCount", len(modelVAs),
-			"groupKey", groupKey)
+			"groupKey", groupKey,
+			"configRef", configRef)
 
 		// Get namespace-aware saturation config (namespace-local > global)
-		saturationConfigMap := e.Config.SaturationConfigForNamespace(namespace)
+		var saturationConfigMap map[string]config.SaturationScalingConfig
+		if configRef != "" {
+			if !e.Config.HasScopedSaturationConfig(namespace, configRef) {
+				logger.Info("Referenced saturation ConfigMap not found, skipping model to avoid wrong config",
+					"namespace", namespace,
+					"modelID", modelID,
+					"configRef", configRef)
+				if e.Recorder != nil {
+					e.Recorder.Eventf(&modelVAs[0], corev1.EventTypeWarning, "SaturationConfigNotFound",
+						"Referenced saturation ConfigMap %q not found in namespace %q; model %q skipped",
+						configRef, namespace, modelID)
+				}
+				continue
+			}
+			saturationConfigMap = e.Config.SaturationConfigForRef(namespace, configRef)
+		} else {
+			saturationConfigMap = e.Config.SaturationConfigForNamespace(namespace)
+		}
 		if len(saturationConfigMap) == 0 {
 			logger.Info("Saturation scaling config not loaded yet for namespace, skipping model",
 				"namespace", namespace,
-				"modelID", modelID)
+				"modelID", modelID,
+				"configRef", configRef)
 			continue
 		}
 
@@ -587,17 +608,36 @@ func (e *Engine) optimizeV2(
 	for groupKey, modelVAs := range modelGroups {
 		modelID := modelVAs[0].Spec.ModelID
 		namespace := modelVAs[0].Namespace
+		configRef := modelVAs[0].SaturationConfigRef()
 		logger.Info("Processing model (V2)",
 			"modelID", modelID,
 			"namespace", namespace,
 			"variantCount", len(modelVAs),
-			"groupKey", groupKey)
+			"groupKey", groupKey,
+			"configRef", configRef)
 
 		// Get namespace-aware saturation config
-		saturationConfigMap := e.Config.SaturationConfigForNamespace(namespace)
+		var saturationConfigMap map[string]config.SaturationScalingConfig
+		if configRef != "" {
+			if !e.Config.HasScopedSaturationConfig(namespace, configRef) {
+				logger.Info("Referenced saturation ConfigMap not found, skipping model to avoid wrong config",
+					"namespace", namespace,
+					"modelID", modelID,
+					"configRef", configRef)
+				if e.Recorder != nil {
+					e.Recorder.Eventf(&modelVAs[0], corev1.EventTypeWarning, "SaturationConfigNotFound",
+						"Referenced saturation ConfigMap %q not found in namespace %q; model %q skipped",
+						configRef, namespace, modelID)
+				}
+				continue
+			}
+			saturationConfigMap = e.Config.SaturationConfigForRef(namespace, configRef)
+		} else {
+			saturationConfigMap = e.Config.SaturationConfigForNamespace(namespace)
+		}
 		if len(saturationConfigMap) == 0 {
 			logger.Info("Saturation scaling config not loaded yet for namespace, skipping model",
-				"namespace", namespace, "modelID", modelID)
+				"namespace", namespace, "modelID", modelID, "configRef", configRef)
 			continue
 		}
 		saturationConfig := resolveSaturationConfig(saturationConfigMap, modelID, namespace)

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -58,17 +58,19 @@ func InactiveVariantAutoscalingByModel(ctx context.Context, client client.Client
 // AcceleratorNameLabel is the label key used to specify the accelerator name for a VA.
 const AcceleratorNameLabel = "inference.optimization/acceleratorName"
 
-// GroupVariantAutoscalingByModel groups VariantAutoscalings by model ID and namespace.
-// Variants of the same model on different accelerators are grouped together to enable
-// cost-based optimization (scale up cheaper variants, scale down expensive variants).
-// The key format is "modelID|namespace".
+// GroupVariantAutoscalingByModel groups VariantAutoscalings by model ID, namespace,
+// and saturation config reference. Variants of the same model on different accelerators
+// are grouped together to enable cost-based optimization (scale up cheaper variants,
+// scale down expensive variants).
+// The key format is "modelID|namespace|configRef".
 func GroupVariantAutoscalingByModel(
 	vas []wvav1alpha1.VariantAutoscaling,
 ) map[string][]wvav1alpha1.VariantAutoscaling {
 	groups := make(map[string][]wvav1alpha1.VariantAutoscaling)
 	for _, va := range vas {
-		// Use modelID + namespace as key to group all variants of same model
-		key := va.Spec.ModelID + "|" + va.Namespace
+		// Use modelID + namespace + configRef as key to group all variants of same model
+		configRef := va.SaturationConfigRef()
+		key := va.Spec.ModelID + "|" + va.Namespace + "|" + configRef
 		groups[key] = append(groups[key], va)
 	}
 	return groups

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -60,7 +60,7 @@ func TestGroupVariantAutoscalingByModel(t *testing.T) {
 				},
 			},
 			expectedGroups: 1,
-			expectedKeys:   []string{"llama-8b|default"},
+			expectedKeys:   []string{"llama-8b|default|"},
 		},
 		{
 			name: "same model same namespace groups together",
@@ -85,7 +85,7 @@ func TestGroupVariantAutoscalingByModel(t *testing.T) {
 				},
 			},
 			expectedGroups: 1,
-			expectedKeys:   []string{"llama-8b|default"},
+			expectedKeys:   []string{"llama-8b|default|"},
 		},
 		{
 			name: "different namespaces creates separate groups",
@@ -110,7 +110,97 @@ func TestGroupVariantAutoscalingByModel(t *testing.T) {
 				},
 			},
 			expectedGroups: 2,
-			expectedKeys:   []string{"llama-8b|ns1", "llama-8b|ns2"},
+			expectedKeys:   []string{"llama-8b|ns1|", "llama-8b|ns2|"},
+		},
+		{
+			name: "same model same namespace different config refs creates separate groups",
+			vas: []wvav1alpha1.VariantAutoscaling{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-stack-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"wva.llmd.ai/saturation-config": "stack-a-config",
+						},
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-stack-b",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"wva.llmd.ai/saturation-config": "stack-b-config",
+						},
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+			},
+			expectedGroups: 2,
+			expectedKeys:   []string{"llama-8b|default|stack-a-config", "llama-8b|default|stack-b-config"},
+		},
+		{
+			name: "same model same namespace one with config ref one without",
+			vas: []wvav1alpha1.VariantAutoscaling{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-custom",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"wva.llmd.ai/saturation-config": "custom-config",
+						},
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-default",
+						Namespace: "default",
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+			},
+			expectedGroups: 2,
+			expectedKeys:   []string{"llama-8b|default|custom-config", "llama-8b|default|"},
+		},
+		{
+			name: "same model same namespace same config ref groups together",
+			vas: []wvav1alpha1.VariantAutoscaling{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"wva.llmd.ai/saturation-config": "shared-config",
+						},
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "va-2",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"wva.llmd.ai/saturation-config": "shared-config",
+						},
+					},
+					Spec: wvav1alpha1.VariantAutoscalingSpec{
+						ModelID: "llama-8b",
+					},
+				},
+			},
+			expectedGroups: 1,
+			expectedKeys:   []string{"llama-8b|default|shared-config"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes #880

Enable a single WVA controller instance to manage multiple independent saturation scaling configurations (VA + saturation scaling ConfigMap) within the same Kubernetes namespace. Previously, all VAs in a namespace shared a single `wva-saturation-scaling-config` ConfigMap, making it impossible to run independent autoscaling configurations for different deployments of the same model side by side.

### Motivation

In distributed inference workloads it is common to have multiple deployments of the same model in one namespace — for example, a production stack alongside an experimental stack, or separate prefill and decode pipelines each requiring
distinct saturation thresholds. Without per-stack saturation config, operators were forced to split workloads across namespaces solely to get different thresholds, adding operational overhead.

### Approach

This implementation uses an **annotation on the VA resource** (`wva.llmd.ai/saturation-config`) to reference a specific saturation ConfigMap, rather than modifying the VA CRD spec. This was a deliberate choice informed by
the [VA deprecation proposal](https://github.com/lionelvillard/llm-d-workload-variant-autoscaler/blob/a18bca72/docs/proposals/deprecate-va-crd.md) — since the VA CRD may be deprecated in favor of HPA/ScaledObject annotations, adding new CRD fields would create unnecessary migration burden. Annotations are portable: when the team moves forward with HPA/ScaledObject-based config, the same annotation key can be adopted with minimal change.

### Key changes

- **VA annotation**: `wva.llmd.ai/saturation-config` specifies which saturation ConfigMap a VA should use (defaults to the well-known name if unset)
- **3-tier config resolution**: VA annotation-referenced ConfigMap →namespace-local default ConfigMap → global ConfigMap. Within a ConfigMap, `modelID#namespace` key → `default` key
- **Independent grouping**: VAs are now grouped by `modelID|namespace|configRef`, so two VAs for the same model with different annotations are optimized independently
- **Custom ConfigMap discovery**: Custom saturation ConfigMaps only need the standard `app.kubernetes.io/name: workload-variant-autoscaler` label — no additional labels required
- **Error handling**: If a VA references a ConfigMap that doesn't exist, the controller logs a warning, emits a Kubernetes `Warning` Event (`SaturationConfigNotFound`), and skips the model — no silent fallback to an
  unintended config
- **RBAC**: Broadened `get` permissions for ConfigMaps to allow reading custom-named ConfigMaps; `update` remains restricted to well-known names

### Files changed (15 files, +830 / -65)

| Area | Files | What changed |
|------|-------|--------------|
| API | `variantautoscaling_types.go`, `_test.go` | New annotation constant and `SaturationConfigRef()` getter |
| Config | `config.go`, `loader.go` | Scoped config storage (`namespace/cmName`), `resolveSaturationConfigForRef`, `HasScopedSaturationConfig` |
| Controller | `configmap_reconciler.go`, `configmap_bootstrap.go`, `predicates.go`, tests | Custom ConfigMap reconciliation, bootstrap discovery, single-label predicate filtering |
| Engine | `engine.go` | configRef-aware config resolution in both V1 and V2 optimizers, Warning Event emission |
| Utils | `variant.go`, `_test.go` | Extended grouping key to include `configRef` |
| Constants | `labels.go` | Re-export annotation key from API package |
| Helm | `rbac/role.yaml` | Unrestricted `get` for ConfigMaps |