### PR TITLE
feat: add scale-from-zero benchmark scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,26 @@ benchmark-run-bursty: ## Run bursty traffic benchmark using inference-perf multi
 		-U http://infra-llmdbench-inference-gateway-istio.$(BENCHMARK_NAMESPACE).svc.cluster.local:80 \
 		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
 
+SCALE_FROM_ZERO_WORKLOAD ?= scale-from-zero.yaml
+
+.PHONY: benchmark-run-scale-from-zero
+benchmark-run-scale-from-zero: ## Run scale-from-zero benchmark (set BENCHMARK_NAMESPACE=<namespace>)
+	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \
+		echo "ERROR: BENCHMARK_NAMESPACE is required. Usage: make benchmark-run-scale-from-zero BENCHMARK_NAMESPACE=<namespace>"; \
+		exit 1; \
+	fi
+	@if [ -f "$(BENCHMARK_SCENARIOS_DIR)/$(SCALE_FROM_ZERO_WORKLOAD)" ]; then \
+		cp "$(BENCHMARK_SCENARIOS_DIR)/$(SCALE_FROM_ZERO_WORKLOAD)" \
+		   "$(BENCHMARK_REPO_DIR)/workload/profiles/inference-perf/$(SCALE_FROM_ZERO_WORKLOAD)"; \
+	fi
+	$(LLMDBENCHMARK) $(BENCHMARK_CLI_FLAGS) run \
+		-p $(BENCHMARK_NAMESPACE) \
+		-l inference-perf \
+		-w $(SCALE_FROM_ZERO_WORKLOAD) \
+		-U http://infra-llmdbench-inference-gateway-istio.$(BENCHMARK_NAMESPACE).svc.cluster.local:80 \
+		$(if $(BENCHMARK_MODEL_ID),-m $(BENCHMARK_MODEL_ID),) \
+		$(if $(filter true,$(BENCHMARK_MONITORING)),--monitoring,)
+
 .PHONY: benchmark-run-all
 benchmark-run-all: ## Run all scenarios: teardown → standup → run per scenario (set BENCHMARK_NAMESPACE=<namespace>)
 	@if [ -z "$(BENCHMARK_NAMESPACE)" ]; then \

--- a/test/benchmark/scenarios/scale-from-zero.yaml
+++ b/test/benchmark/scenarios/scale-from-zero.yaml
@@ -1,0 +1,46 @@
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 60
+  - rate: 5
+    duration: 120
+  - rate: 10
+    duration: 180
+  - rate: 15
+    duration: 180
+  - rate: 2
+    duration: 120
+  request_timeout: 300
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: random
+  input_distribution:
+    min: 500
+    max: 1500
+    mean: 1000
+    std_dev: 200
+    total_count: 5000
+  output_distribution:
+    min: 500
+    max: 1500
+    mean: 1000
+    std_dev: 200
+    total_count: 5000
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace


### PR DESCRIPTION
## Summary

Adds a **Scale-from-Zero** benchmark scenario to test WVA cold start behavior under gradually increasing traffic.

## Workload Profile

- **Traffic pattern:** Gradual ramp-up — 1 → 5 → 10 → 15 → 2 RPS
- **Total duration:** ~660s nominal
- **Input/Output tokens:** ~1000 prompt, ~1000 output

## Usage

\`\`\`bash
make benchmark-standup BENCHMARK_NAMESPACE=<namespace>
make benchmark-run-scale-from-zero BENCHMARK_NAMESPACE=<namespace>
make benchmark-teardown BENCHMARK_NAMESPACE=<namespace>
\`\`\`

## Results

| Metric | Run 1 | Run 2 | Run 3 | Avg |
|--------|-------|-------|-------|-----|
| P99 TTFT (ms) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| P99 ITL (ms/token) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Avg replicas | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Max replicas | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Avg KV cache utilization | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Avg queue depth (EPP) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Error count | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |

> Results will be populated before marking ready for review.

Made with [Cursor](https://cursor.com)