### PR TITLE
Identify vLLM metrics using instance label in the Prometheus metrics

### DIFF
--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -26,7 +26,7 @@ const (
 func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	registry := sourceRegistry.Get("prometheus").QueryList()
 
-	// Scheduler dispatch rate per endpoint (per-pod arrival rate)
+	// Scheduler dispatch rate per endpoint (per-instance arrival rate)
 	// Records successful scheduling attempts with endpoint and model information.
 	// Metric labels: status, pod_name, namespace, port, model_name, target_model_name
 	// We filter by status="success" and match model identity using target_model_name
@@ -34,38 +34,41 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// model_name (original request model) when target_model_name is not set.
 	// This follows the same pattern as scheduler flow control queries.
 	// Uses sum (not max) because dispatch rate is an additive counter — multiple
-	// series per pod should be summed. Uses rate() over 1m window for requests/sec.
+	// series per instance should be summed. Uses rate() over 1m window for requests/sec.
+	// Groups by pod_name and port to uniquely identify each vLLM instance.
 	registry.MustRegister(source.QueryTemplate{
 		Name: QuerySchedulerDispatchRate,
 		Type: source.QueryTypePromQL,
-		Template: `sum by (pod_name, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",target_model_name="{{.modelID}}"}[1m]))` +
-			` or sum by (pod_name, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",model_name="{{.modelID}}",target_model_name=""}[1m]))`,
+		Template: `sum by (pod_name, port, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",target_model_name="{{.modelID}}"}[1m]))` +
+			` or sum by (pod_name, port, namespace) (rate(inference_extension_scheduler_attempts_total{status="success",namespace="{{.namespace}}",model_name="{{.modelID}}",target_model_name=""}[1m]))`,
 		Params: []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Request dispatch rate per endpoint (requests/sec) from scheduler, " +
-			"representing the arrival rate to each replica for a specific model",
+			"representing the arrival rate to each replica for a specific model, grouped by pod_name and port",
 	})
 
-	// Average time-to-first-token per pod (seconds).
+	// Average time-to-first-token per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed TTFT for Kalman filter updates.
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgTTFT,
 		Type:     source.QueryTypePromQL,
-		Template: `max by (pod) (rate(vllm:time_to_first_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:time_to_first_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template: `max by (instance, pod) (rate(vllm:time_to_first_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:time_to_first_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:   []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Average time-to-first-token per pod (seconds), " +
+		Description: "Average time-to-first-token per instance (seconds), " +
 			"used by queueing model tuner for parameter learning",
 	})
 
-	// Average inter-token latency per pod (seconds).
+	// Average inter-token latency per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed ITL for Kalman filter updates.
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgITL,
 		Type:     source.QueryTypePromQL,
-		Template: `max by (pod) (rate(vllm:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template: `max by (instance, pod) (rate(vllm:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:   []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Average inter-token latency per pod (seconds), " +
+		Description: "Average inter-token latency per instance (seconds), " +
 			"used by queueing model tuner for parameter learning",
 	})
 

--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -25,68 +25,74 @@ const (
 func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	registry := sourceRegistry.Get("prometheus").QueryList()
 
-	// KV cache usage per pod (peak over last minute)
+	// KV cache usage per instance (peak over last minute)
 	// Uses max_over_time to catch saturation events between scrapes
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryKvCacheUsage,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod) (max_over_time(vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `max by (instance, pod) (max_over_time(vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Peak KV cache utilization per pod (0.0-1.0) over last minute",
+		Description: "Peak KV cache utilization per instance (0.0-1.0) over last minute",
 	})
 
-	// Queue length per pod (peak over last minute)
+	// Queue length per instance (peak over last minute)
 	// Uses max_over_time to catch burst traffic
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryQueueLength,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod) (max_over_time(vllm:num_requests_waiting{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `max by (instance, pod) (max_over_time(vllm:num_requests_waiting{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Peak queue length per pod over last minute",
+		Description: "Peak queue length per instance over last minute",
 	})
 
 	// --- V2 queries for token-based capacity analysis ---
 
-	// Cache config info per pod (static labels with block size and GPU blocks count)
-	// Uses max to deduplicate when multiple series exist per pod with different label combinations
+	// Cache config info per instance (static labels with block size and GPU blocks count)
+	// Uses max to deduplicate when multiple series exist per instance with different label combinations
 	// Used by Saturation Analyzer V2 for token capacity computation
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryCacheConfigInfo,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Template:    `max by (instance, pod, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "KV cache configuration info per pod (num_gpu_blocks and block_size as labels)",
+		Description: "KV cache configuration info per instance (num_gpu_blocks and block_size as labels)",
 	})
 
 	// Average output (generation) tokens per completed request
 	// Used for output-length-dependent k2 estimation
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgOutputTokens,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average output tokens per completed request (5m rate)",
 	})
 
 	// Average input (prompt) tokens per completed request
 	// Used in k2 derivation formula: k2 = N_max × (I + O/2)
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgInputTokens,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod) (rate(vllm:request_prompt_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_prompt_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:request_prompt_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_prompt_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average input tokens per completed request (5m rate)",
 	})
 
-	// Prefix cache hit rate per pod (5m rate)
+	// Prefix cache hit rate per instance (5m rate)
 	// Used to reduce estimated input token demand for scheduler-queued requests.
 	// Returns 0..1 where 1 means all prefix lookups were cache hits.
+	// Preserves both instance (IP:port for multi-vLLM pods) and pod (for pod lookup)
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryPrefixCacheHitRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod) (rate(vllm:prefix_cache_hits{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:prefix_cache_hits{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
-		Description: "Prefix cache hit rate per pod (0.0-1.0, 5m rate)",
+		Description: "Prefix cache hit rate per instance (0.0-1.0, 5m rate)",
 	})
 
 	// --- Scheduler flow control queries (model-level) ---

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,6 +157,7 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 
 	// podMetricData holds per-pod metric values and timestamps
 	type podMetricData struct {
+		podName        string // Actual pod name for K8s API lookups
 		kvUsage        float64
 		kvTimestamp    time.Time
 		hasKv          bool
@@ -226,6 +228,43 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 		trackTimestamp(data.avgITLTimestamp)
 	}
 
+	// Helper function to build consistent instance key from labels
+	// Prefers pod_name:port format for consistency with scheduler metrics
+	// Falls back to instance (IP:port) if pod_name is not available
+	buildInstanceKey := func(labels map[string]string) (string, string) {
+		podName := labels["pod"]
+		if podName == "" {
+			podName = labels["pod_name"]
+		}
+
+		// Try to extract port from instance label (IP:port format)
+		instance := labels["instance"]
+		port := ""
+		if instance != "" && podName != "" {
+			// Extract port from instance (format: IP:port)
+			if idx := strings.LastIndex(instance, ":"); idx != -1 {
+				port = instance[idx+1:]
+			}
+		}
+
+		// Build composite key: pod_name:port (consistent with scheduler metrics)
+		var instanceKey string
+		switch {
+		case podName != "" && port != "":
+			instanceKey = podName + ":" + port
+		case instance != "":
+			// Fallback to instance if we can't build pod_name:port
+			instanceKey = instance
+		case podName != "":
+			// Fallback to just pod name if no port available
+			instanceKey = podName
+		default:
+			return "", ""
+		}
+
+		return instanceKey, podName
+	}
+
 	// Extract per-pod metrics from results
 	podData := make(map[string]*podMetricData)
 
@@ -235,22 +274,22 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 			return nil, fmt.Errorf("KV cache query failed: %w", result.Error)
 		}
 		for _, value := range result.Values {
-			podName := value.Labels["pod"]
-			if podName == "" {
-				podName = value.Labels["pod_name"]
-			}
-			if podName == "" {
+			instanceKey, podName := buildInstanceKey(value.Labels)
+			if instanceKey == "" {
 				continue
 			}
 
-			if podData[podName] == nil {
-				podData[podName] = &podMetricData{}
+			if podData[instanceKey] == nil {
+				podData[instanceKey] = &podMetricData{
+					podName: podName,
+				}
 			}
-			podData[podName].kvUsage = value.Value
-			podData[podName].kvTimestamp = value.Timestamp
-			podData[podName].hasKv = true
+			podData[instanceKey].kvUsage = value.Value
+			podData[instanceKey].kvTimestamp = value.Timestamp
+			podData[instanceKey].hasKv = true
 
 			logger.V(logging.DEBUG).Info("KV cache metric",
+				"instanceKey", instanceKey,
 				"pod", podName,
 				"usage", value.Value,
 				"usagePercent", value.Value*100)
@@ -263,22 +302,22 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 			return nil, fmt.Errorf("queue length query failed: %w", result.Error)
 		}
 		for _, value := range result.Values {
-			podName := value.Labels["pod"]
-			if podName == "" {
-				podName = value.Labels["pod_name"]
-			}
-			if podName == "" {
+			instanceKey, podName := buildInstanceKey(value.Labels)
+			if instanceKey == "" {
 				continue
 			}
 
-			if podData[podName] == nil {
-				podData[podName] = &podMetricData{}
+			if podData[instanceKey] == nil {
+				podData[instanceKey] = &podMetricData{
+					podName: podName,
+				}
 			}
-			podData[podName].queueLen = int(value.Value)
-			podData[podName].queueTimestamp = value.Timestamp
-			podData[podName].hasQueue = true
+			podData[instanceKey].queueLen = int(value.Value)
+			podData[instanceKey].queueTimestamp = value.Timestamp
+			podData[instanceKey].hasQueue = true
 
 			logger.V(logging.DEBUG).Info("Queue metric",
+				"instanceKey", instanceKey,
 				"pod", podName,
 				"queueLength", int(value.Value))
 		}
@@ -288,38 +327,38 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryCacheConfigInfo]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 
 				// Parse num_gpu_blocks and block_size from string labels
 				if blocksStr, ok := value.Labels["num_gpu_blocks"]; ok && blocksStr != "" {
 					if blocks, err := strconv.ParseInt(blocksStr, 10, 64); err == nil {
-						podData[podName].numGpuBlocks = blocks
+						podData[instanceKey].numGpuBlocks = blocks
 					}
 				}
 				if sizeStr, ok := value.Labels["block_size"]; ok && sizeStr != "" {
 					if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
-						podData[podName].blockSize = size
+						podData[instanceKey].blockSize = size
 					}
 				}
-				if podData[podName].numGpuBlocks > 0 && podData[podName].blockSize > 0 {
-					podData[podName].hasCacheConfig = true
-					podData[podName].cacheConfigTimestamp = value.Timestamp
+				if podData[instanceKey].numGpuBlocks > 0 && podData[instanceKey].blockSize > 0 {
+					podData[instanceKey].hasCacheConfig = true
+					podData[instanceKey].cacheConfigTimestamp = value.Timestamp
 				}
 
 				logger.V(logging.DEBUG).Info("Cache config info metric",
+					"instanceKey", instanceKey,
 					"pod", podName,
-					"numGpuBlocks", podData[podName].numGpuBlocks,
-					"blockSize", podData[podName].blockSize)
+					"numGpuBlocks", podData[instanceKey].numGpuBlocks,
+					"blockSize", podData[instanceKey].blockSize)
 			}
 		}
 	}
@@ -328,21 +367,20 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryAvgOutputTokens]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				// NaN check: rate division by zero produces NaN
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) {
-					podData[podName].avgOutputTokens = value.Value
-					podData[podName].avgOutputTokensTimestamp = value.Timestamp
+					podData[instanceKey].avgOutputTokens = value.Value
+					podData[instanceKey].avgOutputTokensTimestamp = value.Timestamp
 				}
 			}
 		}
@@ -352,21 +390,20 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryAvgInputTokens]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				// NaN check: rate division by zero produces NaN
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) {
-					podData[podName].avgInputTokens = value.Value
-					podData[podName].avgInputTokensTimestamp = value.Timestamp
+					podData[instanceKey].avgInputTokens = value.Value
+					podData[instanceKey].avgInputTokensTimestamp = value.Timestamp
 				}
 			}
 		}
@@ -376,33 +413,34 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryPrefixCacheHitRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				// NaN check: rate division by zero produces NaN when no prefix cache queries
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 && value.Value <= 1 {
-					podData[podName].prefixCacheHitRate = value.Value
-					podData[podName].prefixCacheHitRateTimestamp = value.Timestamp
+					podData[instanceKey].prefixCacheHitRate = value.Value
+					podData[instanceKey].prefixCacheHitRateTimestamp = value.Timestamp
 				}
 			}
 		}
 	}
 
-	// Process scheduler dispatch rate results (arrival rate per pod)
+	// Process scheduler dispatch rate results (arrival rate per instance)
 	if result := results[registration.QuerySchedulerDispatchRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				// The scheduler metric has both "pod" (EPP scrape target) and "pod_name"
-				// (the vLLM endpoint pod). Prefer pod_name so we join with vLLM metrics.
+				// The scheduler metric has pod_name and port labels to identify the vLLM instance.
+				// Build a composite key: pod_name:port to support multiple instances per pod.
 				podName := value.Labels["pod_name"]
+				port := value.Labels["port"]
+
 				if podName == "" {
 					podName = value.Labels["pod"]
 				}
@@ -414,17 +452,27 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				// Create composite key: pod_name:port for unique instance identification
+				instanceKey := podName
+				if port != "" {
+					instanceKey = podName + ":" + port
+				}
+
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				// NaN check: rate can produce NaN if no successful attempts
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
-					podData[podName].arrivalRate = value.Value
-					podData[podName].hasArrivalRate = true
-					podData[podName].arrivalRateTimestamp = value.Timestamp
+					podData[instanceKey].arrivalRate = value.Value
+					podData[instanceKey].hasArrivalRate = true
+					podData[instanceKey].arrivalRateTimestamp = value.Timestamp
 
 					logger.V(logging.DEBUG).Info("Scheduler dispatch rate metric",
+						"instance", instanceKey,
 						"pod", podName,
+						"port", port,
 						"arrivalRate", value.Value)
 				}
 			}
@@ -435,22 +483,22 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryAvgTTFT]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value > 0 {
-					podData[podName].avgTTFT = value.Value
-					podData[podName].avgTTFTTimestamp = value.Timestamp
+					podData[instanceKey].avgTTFT = value.Value
+					podData[instanceKey].avgTTFTTimestamp = value.Timestamp
 
 					logger.V(logging.DEBUG).Info("Avg TTFT metric",
+						"instanceKey", instanceKey,
 						"pod", podName,
 						"avgTTFTSeconds", value.Value)
 				}
@@ -462,22 +510,22 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	if result := results[registration.QueryAvgITL]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
 
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{
+						podName: podName,
+					}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value > 0 {
-					podData[podName].avgITL = value.Value
-					podData[podName].avgITLTimestamp = value.Timestamp
+					podData[instanceKey].avgITL = value.Value
+					podData[instanceKey].avgITLTimestamp = value.Timestamp
 
 					logger.V(logging.DEBUG).Info("Avg ITL metric",
+						"instanceKey", instanceKey,
 						"pod", podName,
 						"avgITLSeconds", value.Value)
 				}
@@ -566,7 +614,15 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	metrics.SetMetricsPodsDiscovered(namespace, len(podData))
 	collectedAt := time.Now()
 
-	for podName, data := range podData {
+	for instanceKey, data := range podData {
+		// Use the actual pod name (not instance IP:port) for K8s API lookup
+		podName := data.podName
+		if podName == "" {
+			// Fallback: if pod name wasn't extracted from labels, use instanceKey
+			// This handles cases where the metric doesn't have pod label
+			podName = instanceKey
+		}
+
 		// Match Pod to VariantAutoscaling using indexed lookup
 		vaName := c.podVAMapper.FindVAForPod(ctx, podName, namespace, scaleTargets)
 
@@ -584,6 +640,7 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 		if !data.hasKv {
 			logger.Info("Pod missing KV cache metrics, using 0",
 				"pod", podName,
+				"instance", instanceKey,
 				"model", modelID,
 				"namespace", namespace)
 			kvUsage = 0
@@ -591,6 +648,7 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 		if !data.hasQueue {
 			logger.Info("Pod missing queue metrics, using 0",
 				"pod", podName,
+				"instance", instanceKey,
 				"model", modelID,
 				"namespace", namespace)
 			queueLen = 0
@@ -599,6 +657,7 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 		if vaName == "" {
 			logger.Info("Skipping pod that doesn't match any scale target",
 				"pod", podName,
+				"instance", instanceKey,
 				"scale targets", getScaleTargetNames(scaleTargets))
 			continue
 		}


### PR DESCRIPTION
This PR updates Prometheus queries to use better labels for identifying unique vLLM instances. This will help WVA integration with other components such as [FMA](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/tree/main). 


**Related Issue**: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1072
### Changes
#### 1. Updated PromQL Queries (saturation.go & queueing_model.go)
Modified all queries to preserve both `instance` (for multi-vLLM support) AND `pod` labels:
- `QueryKvCacheUsage`: `max by (instance, pod)`
- `QueryQueueLength`: `max by (instance, pod)`
- `QueryCacheConfigInfo`: `max by (instance, pod, num_gpu_blocks, block_size)`
- `QueryAvgOutputTokens`: `max by (instance, pod)`
- `QueryAvgInputTokens`: `max by (instance, pod)`
- `QueryPrefixCacheHitRate`: `max by (instance, pod)`
- `QueryAvgTTFT`: `max by (instance, pod)`
- `QueryAvgITL`: `max by (instance, pod)`

#### 2. Updated Metrics Collection (replica_metrics.go)
- Added `podName` field to `podMetricData` struct to store the actual pod name separately from the instance key
- Updated all metric processing sections to extract and store the pod name from labels (`pod` or `pod_name`)
- Modified the main loop to use the stored `podName` for K8s API lookups instead of the `instanceKey`
- Enhanced logging to include both `instance` and `pod` for better debugging

### Key Benefits
1. **Preserves multi-vLLM support**: The `instance` label (IP:port) is still used as the map key, allowing multiple vLLM instances per pod
2. **Enables proper pod lookup**: The actual pod name is extracted and used for Kubernetes API calls
3. **Better observability**: Logs now show both instance identifier and pod name
4. **Backward compatible**: Falls back to instanceKey if pod name isn't available

### Summary
- vLLM metrics use the standard Prometheus `instance` and `pod` labels for scrape targets
- Scheduler metrics use `pod_name` + `port` to identify target vLLM instances receiving requests 

### Example: 
Prometheus label `instance` provides a better identifier for vLLM instances than using the label `pod`, and it support more general use-cases such as: multiple vLLM instances running inside the same pod. 

```
curl -k 'https://localhost:9090/api/v1/query?query=vllm:num_requests_waiting' | jq
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "vllm:num_requests_waiting",
          "container": "vllm",
          "endpoint": "metrics",
          "instance": "10.244.1.33:8200",
          "job": "llm-d-sim/ms-sim-llm-d-modelservice-decode-podmonitor",
          "model_name": "unsloth/Meta-Llama-3.1-8B",
          "namespace": "llm-d-sim",
          "pod": "ms-sim-llm-d-modelservice-decode-cdd6d9669-9569r"
        },
        "value": [
          1776347939.229,
          "0"
        ]
      }
    ]
  }
}
```