### PR TITLE
feat: Phase 1 — dual-mode annotation-based variant discovery

### DIFF
--- a/charts/workload-variant-autoscaler/templates/rbac/role.yaml
+++ b/charts/workload-variant-autoscaler/templates/rbac/role.yaml
@@ -177,6 +177,22 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - list
+  - watch
 - nonResourceURLs:
   - /metrics
   - /debug/pprof/*

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,14 +31,11 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -55,7 +52,6 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller/indexers"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
@@ -93,70 +89,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// checkKEDACRD checks if the KEDA ScaledObject CRD is installed in the cluster.
-// TODO: this is checked once at start up for now. We should handle KEDA installed after controller starts.
-func checkKEDACRD(restConfig *rest.Config, logger logr.Logger) bool {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		logger.Error(err, "failed to create discovery client for CRD detection - assuming KEDA not installed")
-		return false
-	}
-
-	_, apiLists, err := discoveryClient.ServerGroupsAndResources()
-	if err != nil {
-		if apiLists == nil {
-			logger.Error(err, "failed to discover API resources - assuming KEDA not installed")
-			return false
-		}
-		logger.V(1).Info("partial error discovering API resources (this is usually fine)", "error", err)
-	}
-
-	for _, apiList := range apiLists {
-		if apiList.GroupVersion == "keda.sh/v1alpha1" {
-			for _, resource := range apiList.APIResources {
-				if resource.Kind == "ScaledObject" {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
-}
-
-// checkLeaderWorkerSetCRD checks if the LeaderWorkerSet CRD is installed in the cluster
-// TODO: this is checked once at start up for now. We should handle LWS installed after controller starts.
-func checkLeaderWorkerSetCRD(restConfig *rest.Config, logger logr.Logger) bool {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		logger.Error(err, "failed to create discovery client for CRD detection - assuming LWS not installed")
-		return false
-	}
-
-	// Check if leaderworkersets.leaderworkerset.x-k8s.io CRD exists
-	_, apiLists, err := discoveryClient.ServerGroupsAndResources()
-	if err != nil {
-		// Partial errors are common (e.g., unavailable API services), so check if we got any results
-		if apiLists == nil {
-			logger.Error(err, "failed to discover API resources - assuming LWS not installed")
-			return false
-		}
-		// Log but continue with partial results
-		logger.V(1).Info("partial error discovering API resources (this is usually fine)", "error", err)
-	}
-
-	for _, apiList := range apiLists {
-		if apiList.GroupVersion == constants.LeaderWorkerSetAPIVersion {
-			for _, resource := range apiList.APIResources {
-				if resource.Kind == constants.LeaderWorkerSetKind {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
-}
 
 // nolint:gocyclo
 func main() {
@@ -234,7 +166,7 @@ func main() {
 	setupLog.Info("Configuration loaded successfully")
 
 	// Conditionally add LeaderWorkerSet scheme if CRD exists
-	lwsEnabled := checkLeaderWorkerSetCRD(restConfig, setupLog)
+	lwsEnabled := utils.CheckLeaderWorkerSetCRD(restConfig, setupLog)
 	if lwsEnabled {
 		if err := lwsv1.AddToScheme(scheme); err != nil {
 			setupLog.Error(err, "failed to add LeaderWorkerSet scheme")
@@ -246,7 +178,7 @@ func main() {
 	}
 
 	// Detect KEDA for annotation-based ScaledObject discovery (dual-mode, Phase 1)
-	kedaEnabled := checkKEDACRD(restConfig, setupLog)
+	kedaEnabled := utils.CheckKEDACRD(restConfig, setupLog)
 	if kedaEnabled {
 		setupLog.Info("KEDA ScaledObject CRD detected - annotation-based ScaledObject discovery enabled")
 	} else {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -485,13 +485,32 @@ func main() {
 		cfg,
 		ds,
 		lwsEnabled,
-		kedaEnabled,
 	)
 
 	// Setup the controller with the manager
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller")
 		os.Exit(1)
+	}
+
+	// HPAReconciler: tracks namespaces for annotation-based discovery (always registered).
+	if err = (&controller.HPAReconciler{
+		Client:    mgr.GetClient(),
+		Datastore: ds,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create HPA controller")
+		os.Exit(1)
+	}
+
+	// ScaledObjectReconciler: registered only when KEDA CRD is present.
+	if kedaEnabled {
+		if err = (&controller.ScaledObjectReconciler{
+			Client:    mgr.GetClient(),
+			Datastore: ds,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create ScaledObject controller")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
@@ -85,8 +86,42 @@ func init() {
 	utilruntime.Must(promoperator.AddToScheme(scheme))
 	utilruntime.Must(inferencePoolV1.Install(scheme))
 	utilruntime.Must(inferencePoolV1alpha2.Install(scheme))
+	// KEDA scheme is registered unconditionally so the client can list ScaledObjects
+	// when the CRD is present. Listing fails gracefully (NoMatchError) when not installed.
+	utilruntime.Must(kedav1alpha1.AddToScheme(scheme))
 	// Note: LeaderWorkerSet scheme is added conditionally in main() after checking if CRD exists
 	// +kubebuilder:scaffold:scheme
+}
+
+// checkKEDACRD checks if the KEDA ScaledObject CRD is installed in the cluster.
+// TODO: this is checked once at start up for now. We should handle KEDA installed after controller starts.
+func checkKEDACRD(restConfig *rest.Config, logger logr.Logger) bool {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		logger.Error(err, "failed to create discovery client for CRD detection - assuming KEDA not installed")
+		return false
+	}
+
+	_, apiLists, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		if apiLists == nil {
+			logger.Error(err, "failed to discover API resources - assuming KEDA not installed")
+			return false
+		}
+		logger.V(1).Info("partial error discovering API resources (this is usually fine)", "error", err)
+	}
+
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == "keda.sh/v1alpha1" {
+			for _, resource := range apiList.APIResources {
+				if resource.Kind == "ScaledObject" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // checkLeaderWorkerSetCRD checks if the LeaderWorkerSet CRD is installed in the cluster
@@ -208,6 +243,14 @@ func main() {
 		setupLog.Info("LeaderWorkerSet CRD detected - support enabled")
 	} else {
 		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode)")
+	}
+
+	// Detect KEDA for annotation-based ScaledObject discovery (dual-mode, Phase 1)
+	kedaEnabled := checkKEDACRD(restConfig, setupLog)
+	if kedaEnabled {
+		setupLog.Info("KEDA ScaledObject CRD detected - annotation-based ScaledObject discovery enabled")
+	} else {
+		setupLog.Info("KEDA ScaledObject CRD not found - annotation-based discovery limited to HPAs")
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
@@ -510,6 +553,7 @@ func main() {
 		cfg,
 		ds,
 		lwsEnabled,
+		kedaEnabled,
 	)
 
 	// Setup the controller with the manager

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/crd"
 	poolutil "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/pool"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/client_golang/api"
@@ -88,7 +89,6 @@ func init() {
 	// Note: LeaderWorkerSet scheme is added conditionally in main() after checking if CRD exists
 	// +kubebuilder:scaffold:scheme
 }
-
 
 // nolint:gocyclo
 func main() {
@@ -166,7 +166,7 @@ func main() {
 	setupLog.Info("Configuration loaded successfully")
 
 	// Conditionally add LeaderWorkerSet scheme if CRD exists
-	lwsEnabled := utils.CheckLeaderWorkerSetCRD(restConfig, setupLog)
+	lwsEnabled := crd.CheckLeaderWorkerSetCRD(restConfig, setupLog)
 	if lwsEnabled {
 		if err := lwsv1.AddToScheme(scheme); err != nil {
 			setupLog.Error(err, "failed to add LeaderWorkerSet scheme")
@@ -178,7 +178,7 @@ func main() {
 	}
 
 	// Detect KEDA for annotation-based ScaledObject discovery (dual-mode, Phase 1)
-	kedaEnabled := utils.CheckKEDACRD(restConfig, setupLog)
+	kedaEnabled := crd.CheckKEDACRD(restConfig, setupLog)
 	if kedaEnabled {
 		setupLog.Info("KEDA ScaledObject CRD detected - annotation-based ScaledObject discovery enabled")
 	} else {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -75,10 +75,26 @@ rules:
   - list
   - watch
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - inference.networking.k8s.io
   - inference.networking.x-k8s.io
   resources:
   - inferencepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
   verbs:
   - get
   - list

--- a/config/samples/hpa/annotations/hpa.yaml
+++ b/config/samples/hpa/annotations/hpa.yaml
@@ -1,0 +1,46 @@
+# Annotation-based WVA discovery — no VariantAutoscaling CRD required.
+# WVA discovers this HPA via the llm-d.ai/managed annotation and exposes
+# wva_desired_replicas{variant_name="sample-deployment",namespace="llm-d-sim"}.
+# The Prometheus Adapter makes that metric available as an External metric so
+# this HPA can consume it directly.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sample-deployment-hpa
+  namespace: llm-d-sim
+  annotations:
+    llm-d.ai/managed: "true"
+    llm-d.ai/model-id: "default/default"
+    llm-d.ai/variant-cost: "10.0"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sample-deployment
+  minReplicas: 1
+  maxReplicas: 10
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 10
+        periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 10
+        periodSeconds: 15
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: wva_desired_replicas
+        selector:
+          matchLabels:
+            variant_name: sample-deployment
+            exported_namespace: llm-d-sim
+      target:
+        type: AverageValue
+        averageValue: "1"

--- a/config/samples/hpa/annotations/kustomization.yaml
+++ b/config/samples/hpa/annotations/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: hpa-annotations-sample
+# Annotation-based WVA discovery: no VariantAutoscaling CRD needed.
+# Apply with: kubectl kustomize config/samples/hpa/annotations | kubectl apply -f -
+resources:
+- hpa.yaml

--- a/config/samples/hpa/kustomization.yaml
+++ b/config/samples/hpa/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
   name: hpa-sample
+# Legacy (deprecated): requires a VariantAutoscaling CRD.
+# For the annotation-based approach (no CRD) use the annotations/ overlay instead.
 resources:
 - va.yaml
 - hpa.yaml

--- a/config/samples/keda/annotations/kustomization.yaml
+++ b/config/samples/keda/annotations/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: keda-annotations-sample
+# Annotation-based WVA discovery: no VariantAutoscaling CRD needed.
+# Apply with: kubectl kustomize config/samples/keda/annotations | kubectl apply -f -
+resources:
+- scaledobject.yaml

--- a/config/samples/keda/annotations/scaledobject.yaml
+++ b/config/samples/keda/annotations/scaledobject.yaml
@@ -64,4 +64,4 @@ spec:
       threshold: '1'
       activationThreshold: '0'
       metricType: "Value"
-      unsafeSsl: "true"
+      unsafeSsl: "true"  # WARNING: set to "false" in production and provide a CA bundle via authenticationRef

--- a/config/samples/keda/annotations/scaledobject.yaml
+++ b/config/samples/keda/annotations/scaledobject.yaml
@@ -1,0 +1,67 @@
+# Annotation-based WVA discovery — no VariantAutoscaling CRD required.
+# WVA discovers this ScaledObject via the llm-d.ai/managed annotation and
+# exposes wva_desired_replicas{variant_name="sample-deployment",namespace="llm-d-sim"}.
+# KEDA then reads that metric and drives the HPA it manages.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: sample-deployment-scaler
+  namespace: llm-d-sim
+  annotations:
+    llm-d.ai/managed: "true"
+    llm-d.ai/model-id: "default/default"
+    llm-d.ai/variant-cost: "10.0"
+  labels:
+    app: sample-deployment
+    scaler: keda-workload-variant-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sample-deployment
+  pollingInterval: 5
+  cooldownPeriod: 30
+  initialCooldownPeriod: 30
+  maxReplicaCount: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 2
+    behavior: "currentReplicasIfHigher"
+  advanced:
+    restoreToOriginalReplicaCount: false
+    horizontalPodAutoscalerConfig:
+      name: wva-keda-hpa-sample-deployment
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 30
+          - type: Pods
+            value: 5
+            periodSeconds: 15
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 30
+          - type: Pods
+            value: 5
+            periodSeconds: 15
+  triggers:
+  - type: prometheus
+    name: wva-desired-replicas
+    metadata:
+      serverAddress: https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090
+      # WVA emits with label "namespace"; exported_namespace is added by Prometheus Adapter.
+      query: |
+        wva_desired_replicas{
+          variant_name="sample-deployment",
+          namespace="llm-d-sim"
+        }
+      threshold: '1'
+      activationThreshold: '0'
+      metricType: "Value"
+      unsafeSsl: "true"

--- a/config/samples/keda/kustomization.yaml
+++ b/config/samples/keda/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:
   name: keda-sample
+# Legacy (deprecated): requires a VariantAutoscaling CRD.
+# For the annotation-based approach (no CRD) use the annotations/ overlay instead.
 resources:
 - va.yaml
 - scaledobject.yaml

--- a/docs/plans/va-deprecation.md
+++ b/docs/plans/va-deprecation.md
@@ -150,6 +150,24 @@ These overlays are the templates Phase 2 will promote to be the default and Phas
 - **Integration**: extend `internal/controller/variantautoscaling_controller_test.go` with a case that creates only an annotated ScaledObject (no VA) and asserts the engine produces `wva_desired_replicas` with correct labels.
 - **E2E**: add one new test (e.g. `test/e2e/annotation_discovery_test.go`) mirroring `smoke_test.go` but driven by annotations and backed by the kustomize overlays from 1.7. Keep existing VA-based e2e tests green.
 
+### 1.9 Documentation update
+
+Add annotation-based discovery coverage to the existing user-facing docs without removing any CRD content (that is Phase 2's job).
+
+- `docs/user-guide/keda-integration.md` — add a new "Annotation-based setup (recommended)" section before the existing CRD-based section. Show the minimal ScaledObject YAML with the three annotations, the Prometheus trigger, and the expected `wva_desired_replicas` output. Note that no VariantAutoscaling object is needed.
+- `docs/user-guide/hpa-integration.md` — same treatment for the HPA path: add an annotation-based section covering the three required annotations and the External metrics entry.
+- `docs/user-guide/configuration.md` — add an "Annotation schema" table documenting each `llm-d.ai/*` key (name, required/optional, default, description) so users have a single reference.
+- Both integration docs: add a one-line note at the top of the existing CRD section flagging it as the legacy path (`> **Note:** The VariantAutoscaling CRD path is being deprecated. Prefer the annotation-based setup above.`).
+
+### 1.10 Well-lit path update
+
+Ensure a new operator can adopt WVA annotation-based scaling from the project entry points without ever encountering the VA CRD.
+
+- `README.md` — replace or supplement the quick-start snippet (currently VA-centric) with an annotation-based ScaledObject or HPA example as the primary example. Keep a "Legacy CRD path" collapsible or footnote for existing users.
+- `docs/user-guide/configuration.md` (getting-started flow) — reorder the introduction so annotation-based usage is presented first; move CRD-based usage to a "Legacy" subsection.
+- `docs/integrations/prometheus.md` (or equivalent integration doc) — confirm the `wva_desired_replicas` metric label documentation reflects that the metric is emitted identically for both annotation-sourced and CRD-sourced variants, so the Prometheus/KEDA query examples work for both.
+- Verify that following only the well-lit path docs (annotation-based) from a clean clone produces a working WVA deployment on a kind cluster without touching any VA CRD YAML.
+
 ---
 
 ## Phase 2 — Deprecation

--- a/docs/plans/va-deprecation.md
+++ b/docs/plans/va-deprecation.md
@@ -154,19 +154,9 @@ These overlays are the templates Phase 2 will promote to be the default and Phas
 
 Add annotation-based discovery coverage to the existing user-facing docs without removing any CRD content (that is Phase 2's job).
 
-- `docs/user-guide/keda-integration.md` — add a new "Annotation-based setup (recommended)" section before the existing CRD-based section. Show the minimal ScaledObject YAML with the three annotations, the Prometheus trigger, and the expected `wva_desired_replicas` output. Note that no VariantAutoscaling object is needed.
-- `docs/user-guide/hpa-integration.md` — same treatment for the HPA path: add an annotation-based section covering the three required annotations and the External metrics entry.
-- `docs/user-guide/configuration.md` — add an "Annotation schema" table documenting each `llm-d.ai/*` key (name, required/optional, default, description) so users have a single reference.
-- Both integration docs: add a one-line note at the top of the existing CRD section flagging it as the legacy path (`> **Note:** The VariantAutoscaling CRD path is being deprecated. Prefer the annotation-based setup above.`).
-
 ### 1.10 Well-lit path update
 
-Ensure a new operator can adopt WVA annotation-based scaling from the project entry points without ever encountering the VA CRD.
-
-- `README.md` — replace or supplement the quick-start snippet (currently VA-centric) with an annotation-based ScaledObject or HPA example as the primary example. Keep a "Legacy CRD path" collapsible or footnote for existing users.
-- `docs/user-guide/configuration.md` (getting-started flow) — reorder the introduction so annotation-based usage is presented first; move CRD-based usage to a "Legacy" subsection.
-- `docs/integrations/prometheus.md` (or equivalent integration doc) — confirm the `wva_desired_replicas` metric label documentation reflects that the metric is emitted identically for both annotation-sourced and CRD-sourced variants, so the Prometheus/KEDA query examples work for both.
-- Verify that following only the well-lit path docs (annotation-based) from a clean clone produces a working WVA deployment on a kind cluster without touching any VA CRD YAML.
+Update WVA well-lit path to use the annotation-based samples instead of the VA CRD samples. This ensures new users see the new path first and start migrating.
 
 ---
 

--- a/docs/plans/va-deprecation.md
+++ b/docs/plans/va-deprecation.md
@@ -148,7 +148,8 @@ These overlays are the templates Phase 2 will promote to be the default and Phas
 
 - **Unit**: `internal/annotations/annotations_test.go` (parsing/defaulting/validation), `internal/utils/variant_fromannotations_test.go` (synthesis from fake ScaledObject/HPA).
 - **Integration**: extend `internal/controller/variantautoscaling_controller_test.go` with a case that creates only an annotated ScaledObject (no VA) and asserts the engine produces `wva_desired_replicas` with correct labels.
-- **E2E**: add one new test (e.g. `test/e2e/annotation_discovery_test.go`) mirroring `smoke_test.go` but driven by annotations and backed by the kustomize overlays from 1.7. Keep existing VA-based e2e tests green.
+- **E2E (new annotation path)**: add `test/e2e/annotation_discovery_test.go` mirroring `smoke_test.go` but driven by annotations and backed by the kustomize overlays from 1.7. Uses the existing `test/e2e/fixtures/hpa_builder.go` and `test/e2e/fixtures/scaled_object_builder.go` (with annotation helpers added) instead of `va_builder.go`. Keep existing VA-based e2e tests green.
+- **E2E (extend existing tests)**: update the existing e2e tests (`smoke_test.go`, `limiter_test.go`, `saturation_analyzer_path_test.go`, `scale_from_zero_test.go`) to exercise both VA-based and annotation-based (HPA / KEDA ScaledObject) setup paths for the same scenarios, so dual-mode is validated end-to-end across all test suites and not only in the new annotation-discovery test.
 
 ### 1.9 Documentation update
 

--- a/docs/plans/va-deprecation.md
+++ b/docs/plans/va-deprecation.md
@@ -10,7 +10,7 @@ This plan implements the proposal end-to-end across the three phases it defines:
 
 - **Phase 1** — Dual-mode: add annotation-based discovery without breaking existing VA CRD users.
 - **Phase 2** — Deprecation: mark the VA CRD deprecated, point users at annotations (docs-only migration; no CLI).
-- **Phase 3** — Removal: delete CRD manifests, reconciler, RBAC, and public API types. Keep `VariantAutoscaling` as an **internal struct** to minimize churn in the collector/analyzer/optimizer.
+- **Phase 3** — Removal: delete CRD manifests, VA reconciler, RBAC, and public API types. Keep `VariantAutoscaling` as an **internal struct** to minimize churn in the collector/analyzer/optimizer. The `HPAReconciler` and `ScaledObjectReconciler` from Phase 1 remain.
 
 Watch surfaces in Phase 1: both **KEDA ScaledObject** and **HPA** (any object bearing `llm-d.ai/managed: "true"` with a `scaleTargetRef`).
 
@@ -25,7 +25,9 @@ Watch surfaces in Phase 1: both **KEDA ScaledObject** and **HPA** (any object be
 - `charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml`
 
 **Controller**
-- `internal/controller/variantautoscaling_controller.go` — reconciler, RBAC markers, watch wiring
+- `internal/controller/variantautoscaling_controller.go` — existing VA reconciler (untouched in Phase 1)
+- `internal/controller/hpa_reconciler.go` — new HPAReconciler (created in 1.5)
+- `internal/controller/scaledobject_reconciler.go` — new ScaledObjectReconciler (created in 1.5)
 - `internal/controller/indexers/indexers.go`
 - `cmd/main.go` (scheme registration L83-84, reconciler wiring L506-516)
 
@@ -59,7 +61,7 @@ Watch surfaces in Phase 1: both **KEDA ScaledObject** and **HPA** (any object be
 
 ## Phase 1 — Dual-Mode Discovery
 
-Add annotation-based discovery that runs alongside the existing CRD reconciler. Both paths feed the same internal pipeline.
+Add annotation-based discovery that runs alongside the existing VA CRD reconciler. Two new dedicated reconcilers (`HPAReconciler`, `ScaledObjectReconciler`) handle namespace tracking; both paths feed the same internal pipeline.
 
 ### 1.1 Annotation schema package
 
@@ -101,34 +103,34 @@ The single engine entry point at `internal/engines/saturation/engine.go:259` con
 
 ### 1.4 Status writeback handles both sources
 
-Today the reconciler patches `va.status.desiredOptimizedAlloc` after the engine runs. Synthetic (annotation-sourced) variants have no VA object to patch.
+Today the VA reconciler patches `va.status.desiredOptimizedAlloc` after the engine runs. Synthetic (annotation-sourced) variants have no VA object to patch.
 
 - In `applySaturationDecisions` (and equivalent paths), check the synthetic tag from 1.2.
   - Synthetic → skip the status patch; the `wva_desired_replicas` metric emission is the sole output (matches the proposal's "Actuation: None — KEDA/HPA reads the metric").
   - CRD-sourced → unchanged behavior.
 - Verify the metric labels (`variant_name`, `exported_namespace`) match for both sources so KEDA triggers don't need to know which mode produced the metric.
 
-### 1.5 Watch ScaledObjects / HPAs
+### 1.5 New reconcilers for HPA and ScaledObject
 
-Add a lightweight controller (or extend the existing `VariantAutoscalingReconciler.SetupWithManager`) to watch:
+Following the project convention of one reconciler per Kubernetes object kind, create two new dedicated reconcilers:
 
-- `kedav1alpha1.ScaledObject` with predicate `annotations[llm-d.ai/managed] == "true"`
-- `autoscalingv2.HorizontalPodAutoscaler` with the same predicate
+**`internal/controller/hpa_reconciler.go`** — `HPAReconciler`
+- Watches `autoscalingv2.HorizontalPodAutoscaler` with `AnnotatedScalerPredicate()`.
+- `Reconcile` body: if object is being deleted or no longer managed (`!annotations.IsManaged`), call `datastore.NamespaceUntrack`; otherwise call `datastore.NamespaceTrack`. Return `ctrl.Result{}` with no requeue — namespace tracking is the sole side-effect.
+- `+kubebuilder:rbac` markers for `autoscaling/horizontalpodautoscalers` (get;list;watch) live in this file.
+- Registered unconditionally in `cmd/main.go` alongside the other reconcilers.
 
-The handler's only job is to call `datastore.NamespaceTrack("AnnotatedScaler", name, namespace)` on add/update and `Untrack` on delete, so namespace-local ConfigMap discovery keeps working. The engine's polling tick will pick up changes on the next cycle — no per-object Reconcile needed.
+**`internal/controller/scaledobject_reconciler.go`** — `ScaledObjectReconciler`
+- Watches `kedav1alpha1.ScaledObject` with `AnnotatedScalerPredicate()`.
+- Same `Reconcile` body as `HPAReconciler` (track/untrack).
+- `+kubebuilder:rbac` markers for `keda.sh/scaledobjects` (get;list;watch) live in this file.
+- Registered in `cmd/main.go` **only when** `kedaEnabled == true` (KEDA CRD detected at startup), mirroring the existing `lwsEnabled` pattern.
 
-Add a KEDA detection step in `cmd/main.go` (mirroring the existing `lwsEnabled` check). If KEDA CRDs aren't present, skip the ScaledObject watch but still install the HPA watch.
+Add a KEDA detection step in `cmd/main.go` (mirroring the existing `lwsEnabled` check) if not already present. If KEDA CRDs aren't present, skip `ScaledObjectReconciler` registration but still register `HPAReconciler`.
 
 ### 1.6 RBAC for watching
 
-Extend `+kubebuilder:rbac` markers (in the file created in 1.5) and `config/rbac/role.yaml`:
-
-```
-+kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
-+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
-```
-
-Regenerate role.yaml via `make manifests`.
+The `+kubebuilder:rbac` markers live in the new reconciler files created in 1.5 (`hpa_reconciler.go` and `scaledobject_reconciler.go`) rather than in `variantautoscaling_controller.go`. Remove the existing markers from `variantautoscaling_controller.go` if they were added there, regenerate `config/rbac/role.yaml` via `make manifests`, and update the Helm chart template (`charts/workload-variant-autoscaler/templates/rbac/role.yaml`) to mirror the change.
 
 ### 1.7 Kustomization samples for annotation-based scaling
 
@@ -147,7 +149,7 @@ These overlays are the templates Phase 2 will promote to be the default and Phas
 ### 1.8 Tests
 
 - **Unit**: `internal/annotations/annotations_test.go` (parsing/defaulting/validation), `internal/utils/variant_fromannotations_test.go` (synthesis from fake ScaledObject/HPA).
-- **Integration**: extend `internal/controller/variantautoscaling_controller_test.go` with a case that creates only an annotated ScaledObject (no VA) and asserts the engine produces `wva_desired_replicas` with correct labels.
+- **Integration**: add `internal/controller/hpa_reconciler_test.go` and `internal/controller/scaledobject_reconciler_test.go` covering the track/untrack logic; extend `internal/controller/variantautoscaling_controller_test.go` with a case that creates only an annotated ScaledObject (no VA) and asserts the engine produces `wva_desired_replicas` with correct labels.
 - **E2E (new annotation path)**: add `test/e2e/annotation_discovery_test.go` mirroring `smoke_test.go` but driven by annotations and backed by the kustomize overlays from 1.7. Uses the existing `test/e2e/fixtures/hpa_builder.go` and `test/e2e/fixtures/scaled_object_builder.go` (with annotation helpers added) instead of `va_builder.go`. Keep existing VA-based e2e tests green.
 - **E2E (extend existing tests)**: update the existing e2e tests (`smoke_test.go`, `limiter_test.go`, `saturation_analyzer_path_test.go`, `scale_from_zero_test.go`) to exercise both VA-based and annotation-based (HPA / KEDA ScaledObject) setup paths for the same scenarios, so dual-mode is validated end-to-end across all test suites and not only in the new annotation-discovery test.
 
@@ -231,11 +233,11 @@ Keep the type as the in-memory representation for the pipeline, but stop publish
 - Delete `charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml`.
 - Remove `llmdVariantAutoscalingV1alpha1.AddToScheme(scheme)` from `cmd/main.go` (and the import).
 
-### 3.3 Delete the reconciler
+### 3.3 Delete the VA reconciler
 
 - Remove `internal/controller/variantautoscaling_controller.go` and its test.
 - Remove `internal/controller/indexers/indexers.go` if it only indexed VAs.
-- Keep the annotation-watcher controller from Phase 1.5 (now the only discovery controller).
+- Keep `internal/controller/hpa_reconciler.go` and `internal/controller/scaledobject_reconciler.go` from Phase 1.5 (now the only discovery controllers).
 - Remove `controller.NewVariantAutoscalingReconciler(...)` wiring from `cmd/main.go`.
 
 ### 3.4 Delete RBAC

--- a/docs/plans/va-deprecation.md
+++ b/docs/plans/va-deprecation.md
@@ -1,0 +1,275 @@
+# Deprecate & Remove the VariantAutoscaling CRD
+
+## Context
+
+WVA currently requires operators to create a `VariantAutoscaling` (VA) CRD per model variant. The CRD duplicates information already present on the scaling target (Deployment, ScaledObject, HPA) and makes WVA a mandatory integration point. The proposal at `docs/proposals/deprecate-va-crd.md` argues the CRD is unnecessary: WVA can discover work by watching KEDA ScaledObjects / HPAs with the `llm-d.ai/managed: "true"` annotation, and variant metadata (model ID, cost, etc.) can live as annotations on those same objects.
+
+The internal pipeline — Prometheus collection, saturation/queueing analyzers, cost-aware optimization, exposure of `wva_desired_replicas` — does **not** change. Only discovery changes.
+
+This plan implements the proposal end-to-end across the three phases it defines:
+
+- **Phase 1** — Dual-mode: add annotation-based discovery without breaking existing VA CRD users.
+- **Phase 2** — Deprecation: mark the VA CRD deprecated, point users at annotations (docs-only migration; no CLI).
+- **Phase 3** — Removal: delete CRD manifests, reconciler, RBAC, and public API types. Keep `VariantAutoscaling` as an **internal struct** to minimize churn in the collector/analyzer/optimizer.
+
+Watch surfaces in Phase 1: both **KEDA ScaledObject** and **HPA** (any object bearing `llm-d.ai/managed: "true"` with a `scaleTargetRef`).
+
+---
+
+## Critical files
+
+**API / CRD**
+- `api/v1alpha1/variantautoscaling_types.go` — spec/status types
+- `api/v1alpha1/conditions.go`, `api/v1alpha1/groupversion_info.go`, `api/v1alpha1/zz_generated.deepcopy.go`
+- `config/crd/bases/llmd.ai_variantautoscalings.yaml`
+- `charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml`
+
+**Controller**
+- `internal/controller/variantautoscaling_controller.go` — reconciler, RBAC markers, watch wiring
+- `internal/controller/indexers/indexers.go`
+- `cmd/main.go` (scheme registration L83-84, reconciler wiring L506-516)
+
+**Discovery entry points (the key refactor surface)**
+- `internal/utils/variant.go` L77-91 — `ActiveVariantAutoscaling` / `InactiveVariantAutoscaling`
+- `internal/utils/variant.go` L93+ — `filterVariantsByScaleTargetAccessor`, `readyVariantAutoscalings`, `GroupVariantAutoscalingByModel`
+- `internal/engines/saturation/engine.go` L259 — single call site of `ActiveVariantAutoscaling`
+- `internal/datastore/datastore.go` — `NamespaceTrack("VariantAutoscaling", …)` for ConfigMap discovery
+
+**RBAC**
+- `config/rbac/role.yaml` L104-128
+- `config/rbac/variantautoscaling_{admin,editor,viewer}_role.yaml`
+- Matching chart templates under `charts/workload-variant-autoscaler/templates/rbac/`
+
+**Samples / Chart**
+- `config/samples/variantautoscaling-*.yaml`, `config/samples/{keda,hpa}/va.yaml`
+- `charts/workload-variant-autoscaler/templates/variantautoscaling.yaml`
+- `charts/workload-variant-autoscaler/values.yaml` (`va.*`, `llmd.modelID`, `llmd.scaleTargetKind`)
+
+**Tests**
+- `test/e2e/fixtures/va_builder.go`, `test/e2e/fixtures/wait.go`, `test/utils/e2eutils.go`
+- `test/e2e/{smoke,limiter,saturation_analyzer_path,scale_from_zero}_test.go`
+- `internal/controller/variantautoscaling_controller_test.go`
+
+**Docs**
+- `docs/user-guide/{crd-reference,hpa-integration,keda-integration,configuration,LeaderWorkerSet-support}.md`
+- `docs/design/controller-behavior.md`
+- `docs/proposals/deprecate-va-crd.md` (the proposal itself)
+
+---
+
+## Phase 1 — Dual-Mode Discovery
+
+Add annotation-based discovery that runs alongside the existing CRD reconciler. Both paths feed the same internal pipeline.
+
+### 1.1 Annotation schema package
+
+Create `internal/annotations/annotations.go` with the constants the proposal calls out:
+
+```go
+const (
+    Managed         = "llm-d.ai/managed"          // required, "true"
+    ModelID         = "llm-d.ai/model-id"         // required
+    VariantCost     = "llm-d.ai/variant-cost"     // optional, default "1.0"
+    // forward-compat: gpus-per-replica, scale-to-zero-retention, role — not needed
+    // until the corresponding features are wired; declare as constants now to lock the names.
+)
+```
+
+Also a small `Parse(obj metav1.Object) (*SyntheticVA, error)` helper that validates `Managed == "true"` and `ModelID != ""`, parses `VariantCost` (defaulting to `"1.0"`), and returns a struct mirroring the fields needed downstream.
+
+### 1.2 Synthesize `VariantAutoscaling` from annotations
+
+Add `internal/utils/variant_fromannotations.go` with a function that builds an in-memory `*wvav1alpha1.VariantAutoscaling` from a `ScaledObject` or `HPA`:
+
+- `metadata.namespace` / `metadata.name` — from the ScaledObject/HPA
+- `spec.scaleTargetRef` — copied from ScaledObject `.spec.scaleTargetRef` or HPA `.spec.scaleTargetRef`
+- `spec.modelID`, `spec.variantCost` — from annotations
+- `spec.{min,max}Replicas` — from ScaledObject `{minReplicaCount, maxReplicaCount}` or HPA `{minReplicas, maxReplicas}`
+- Status conditions — synthesized as `OptimizationReady=true` so `readyVariantAutoscalings` filtering continues to work
+
+Tag the synthesized object (e.g. an annotation on the in-memory copy, or a sibling map) so downstream code can tell "synthetic" from "real VA" — needed by the status-writeback logic in 1.4.
+
+### 1.3 Extend discovery functions
+
+Modify `internal/utils/variant.go`:
+
+- Add `ActiveVariantsFromAnnotations(ctx, client)` that lists `ScaledObjectList` (kedav1alpha1) **and** `HorizontalPodAutoscalerList` (autoscalingv2), filters by `Managed == "true"`, and runs each through the synthesizer from 1.2.
+- Extend `ActiveVariantAutoscaling` (and `Inactive…`) to concatenate CRD-sourced + annotation-sourced results, deduplicating by `(namespace, scaleTargetRef)` with CRD winning a tie (explicit beats implicit during dual-mode).
+- Keep `GroupVariantAutoscalingByModel` unchanged — it already works on any `VariantAutoscaling` slice.
+
+The single engine entry point at `internal/engines/saturation/engine.go:259` continues to call `ActiveVariantAutoscaling` — no change there.
+
+### 1.4 Status writeback handles both sources
+
+Today the reconciler patches `va.status.desiredOptimizedAlloc` after the engine runs. Synthetic (annotation-sourced) variants have no VA object to patch.
+
+- In `applySaturationDecisions` (and equivalent paths), check the synthetic tag from 1.2.
+  - Synthetic → skip the status patch; the `wva_desired_replicas` metric emission is the sole output (matches the proposal's "Actuation: None — KEDA/HPA reads the metric").
+  - CRD-sourced → unchanged behavior.
+- Verify the metric labels (`variant_name`, `exported_namespace`) match for both sources so KEDA triggers don't need to know which mode produced the metric.
+
+### 1.5 Watch ScaledObjects / HPAs
+
+Add a lightweight controller (or extend the existing `VariantAutoscalingReconciler.SetupWithManager`) to watch:
+
+- `kedav1alpha1.ScaledObject` with predicate `annotations[llm-d.ai/managed] == "true"`
+- `autoscalingv2.HorizontalPodAutoscaler` with the same predicate
+
+The handler's only job is to call `datastore.NamespaceTrack("AnnotatedScaler", name, namespace)` on add/update and `Untrack` on delete, so namespace-local ConfigMap discovery keeps working. The engine's polling tick will pick up changes on the next cycle — no per-object Reconcile needed.
+
+Add a KEDA detection step in `cmd/main.go` (mirroring the existing `lwsEnabled` check). If KEDA CRDs aren't present, skip the ScaledObject watch but still install the HPA watch.
+
+### 1.6 RBAC for watching
+
+Extend `+kubebuilder:rbac` markers (in the file created in 1.5) and `config/rbac/role.yaml`:
+
+```
++kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
++kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+```
+
+Regenerate role.yaml via `make manifests`.
+
+### 1.7 Kustomization samples for annotation-based scaling
+
+Add side-by-side kustomize overlays that consume `wva_desired_replicas` without a VA CRD. These are the user-facing artifacts Phase 1 produces — they prove both integration points work and become the starting point for migration docs in Phase 2.
+
+- `config/samples/keda/annotations/` — a new overlay containing:
+  - `scaledobject.yaml`: KEDA `ScaledObject` with `llm-d.ai/managed: "true"`, `llm-d.ai/model-id`, `llm-d.ai/variant-cost` annotations; `spec.triggers[0]` a Prometheus trigger querying `wva_desired_replicas{variant_name=…,exported_namespace=…}` (matches the example in `docs/proposals/deprecate-va-crd.md`).
+  - `deployment.yaml`: sample target Deployment.
+  - `kustomization.yaml`: bases + common labels.
+- `config/samples/hpa/annotations/` — equivalent overlay with an `HorizontalPodAutoscaler` carrying the same annotations and an external-metric source reading `wva_desired_replicas` via prometheus-adapter (reuse `prometheus-adapter-values.yaml`).
+- Update the existing `config/samples/keda/kustomization.yaml` and `config/samples/hpa/kustomization.yaml` to offer both the legacy (VA-based) and the new (annotation-based) overlays as selectable components.
+- Verify both overlays render (`kubectl kustomize config/samples/keda/annotations`) and apply cleanly on a kind cluster running the Phase 1 WVA build.
+
+These overlays are the templates Phase 2 will promote to be the default and Phase 3 will leave as the only sample.
+
+### 1.8 Tests
+
+- **Unit**: `internal/annotations/annotations_test.go` (parsing/defaulting/validation), `internal/utils/variant_fromannotations_test.go` (synthesis from fake ScaledObject/HPA).
+- **Integration**: extend `internal/controller/variantautoscaling_controller_test.go` with a case that creates only an annotated ScaledObject (no VA) and asserts the engine produces `wva_desired_replicas` with correct labels.
+- **E2E**: add one new test (e.g. `test/e2e/annotation_discovery_test.go`) mirroring `smoke_test.go` but driven by annotations and backed by the kustomize overlays from 1.7. Keep existing VA-based e2e tests green.
+
+---
+
+## Phase 2 — Deprecation
+
+Phase 1 must be fully merged before Phase 2 starts.
+
+### 2.1 Mark CRD deprecated
+
+In `api/v1alpha1/variantautoscaling_types.go`, add the kubebuilder deprecation marker:
+
+```go
+// +kubebuilder:deprecatedversion:warning="llmd.ai/v1alpha1 VariantAutoscaling is deprecated; migrate to annotations on ScaledObject/HPA. See docs/user-guide/migrating-from-va-crd.md"
+```
+
+Regenerate CRD manifests (`make manifests`) and the chart copy at `charts/workload-variant-autoscaler/crds/…`. kube-apiserver will then emit a warning on every operation against the CRD.
+
+### 2.2 Log deprecation warning in the reconciler
+
+In `VariantAutoscalingReconciler.Reconcile`, log a once-per-VA `logger.Info("VariantAutoscaling CRD is deprecated, migrate to annotations")` (guarded by a cache so it doesn't spam every reconcile). Emit a Kubernetes Event of type `Warning` reason `Deprecated` on the VA the first time it's seen.
+
+### 2.3 Migration documentation (docs only)
+
+Create `docs/user-guide/migrating-from-va-crd.md` covering:
+
+- Before/after side-by-side (from the proposal's table)
+- A `kubectl` / jq recipe for patching annotations onto an existing ScaledObject:
+  ```
+  kubectl annotate scaledobject <name> \
+    llm-d.ai/managed=true \
+    llm-d.ai/model-id=<id> \
+    llm-d.ai/variant-cost=<cost>
+  kubectl delete variantautoscaling <name>
+  ```
+- HPA equivalent
+- Validation steps (check `wva_desired_replicas` metric still present, check deprecation warning appears on VA).
+
+Update `docs/user-guide/{hpa-integration,keda-integration}.md` to lead with annotations, keep CRD usage as an "(deprecated)" subsection.
+
+### 2.4 Switch samples to annotations
+
+- Update `config/samples/keda/scaledobject.yaml` to carry the full annotation set; delete `config/samples/keda/va.yaml`.
+- Update `config/samples/hpa/hpa.yaml` similarly; delete `config/samples/hpa/va.yaml`.
+- Replace `config/samples/variantautoscaling-*.yaml` with annotation-based equivalents. Keep one `variantautoscaling-legacy.yaml` sample showing the deprecated path for reference until Phase 3.
+
+### 2.5 Chart default flip
+
+In `charts/workload-variant-autoscaler/values.yaml`, mark `va.enabled` as deprecated and default it to `false`. The `charts/workload-variant-autoscaler/templates/variantautoscaling.yaml` template should be gated and emit a `helm.sh/hook` notice when rendered. Add chart values for annotation-based samples (or document them in the chart README).
+
+### 2.6 Release notes
+
+Add a `CHANGELOG.md` / release-notes entry announcing the deprecation and linking to the migration doc.
+
+---
+
+## Phase 3 — Removal
+
+Phase 2 must have shipped in at least one release (supplying users a deprecation window) before Phase 3 starts.
+
+### 3.1 Move `VariantAutoscaling` types to an internal package
+
+Keep the type as the in-memory representation for the pipeline, but stop publishing it as a CRD API:
+
+- Move `api/v1alpha1/variantautoscaling_types.go`, `conditions.go`, `zz_generated.deepcopy.go` to `internal/variant/types.go` (drop `groupversion_info.go`; remove kubebuilder markers and `runtime.Object` boilerplate not needed internally).
+- Drop the `TypeMeta` / `ObjectMeta` embedding if unused, or keep a trimmed struct that exposes only the fields the pipeline reads (`Namespace`, `Name`, `Spec.ModelID`, `Spec.VariantCost`, `Spec.ScaleTargetRef`, `Spec.Min/MaxReplicas`, `Status.DesiredOptimizedAlloc`).
+- Update all callers (`s/wvav1alpha1.VariantAutoscaling/variant.Instance/`).
+
+### 3.2 Delete CRD manifests and scheme wiring
+
+- Delete `config/crd/bases/llmd.ai_variantautoscalings.yaml` and any kustomization references.
+- Delete `charts/workload-variant-autoscaler/crds/llmd.ai_variantautoscalings.yaml`.
+- Remove `llmdVariantAutoscalingV1alpha1.AddToScheme(scheme)` from `cmd/main.go` (and the import).
+
+### 3.3 Delete the reconciler
+
+- Remove `internal/controller/variantautoscaling_controller.go` and its test.
+- Remove `internal/controller/indexers/indexers.go` if it only indexed VAs.
+- Keep the annotation-watcher controller from Phase 1.5 (now the only discovery controller).
+- Remove `controller.NewVariantAutoscalingReconciler(...)` wiring from `cmd/main.go`.
+
+### 3.4 Delete RBAC
+
+- Drop the VA blocks from `config/rbac/role.yaml` (L104-128 and corresponding subresource rules).
+- Delete `config/rbac/variantautoscaling_{admin,editor,viewer}_role.yaml` and their chart templates.
+
+### 3.5 Delete samples and chart template
+
+- Delete `config/samples/variantautoscaling-legacy.yaml` (the reference sample kept during Phase 2).
+- Delete `charts/workload-variant-autoscaler/templates/variantautoscaling.yaml`.
+- Remove `va.*` keys from `values.yaml`; annotation examples stay as the default deployment path.
+
+### 3.6 Delete CRD-specific tests and fixtures
+
+- Remove `test/e2e/fixtures/va_builder.go` (replace usages with a `ScaledObjectBuilder` / `HPABuilder` in the same directory).
+- Update every e2e test that still builds VAs to build annotated ScaledObjects/HPAs instead; delete any test case that was purely validating CRD behavior.
+
+### 3.7 Docs cleanup
+
+- Delete `docs/user-guide/crd-reference.md` (and the `hack/crd-doc-gen` configuration entry that generates it).
+- Remove the "(deprecated)" CRD subsections added in Phase 2 from the integration docs.
+- Update `docs/design/controller-behavior.md` to describe the annotation-based discovery as the only path.
+- Update `docs/proposals/deprecate-va-crd.md` status from Draft to Implemented.
+
+---
+
+## Verification
+
+**Per phase**
+
+- Phase 1: `make test` green; new unit + integration tests pass; e2e `annotation_discovery_test.go` produces `wva_desired_replicas` with matching labels to the VA-driven `smoke_test.go`; existing VA-driven e2e remains green.
+- Phase 2: `kubectl apply -f <legacy-va.yaml>` prints the `deprecated version` warning; reconciler logs / Events show the deprecation notice; migration doc recipe works end-to-end on a kind cluster.
+- Phase 3: `make build` succeeds with no `api/v1alpha1` package; `kubectl get crds | grep variantautoscalings` returns empty after `helm upgrade`; all e2e tests pass using annotated ScaledObjects/HPAs.
+
+**End-to-end smoke (across phases)**
+
+1. Deploy WVA + KEDA + vLLM simulator via `make test-e2e-smoke`.
+2. Apply an annotated ScaledObject (no VA).
+3. Confirm: `kubectl get --raw /metrics | grep wva_desired_replicas` shows a series for the variant, and the KEDA trigger reads it and scales the Deployment.
+
+**Regression surface to watch**
+
+- Namespace tracking in `datastore` — both paths must register their namespaces for namespace-local `wva-saturation-scaling-config` lookups to keep working.
+- Metric label cardinality — `variant_name` / `exported_namespace` values must be identical across modes so existing Prometheus queries and KEDA triggers don't break.
+- LeaderWorkerSet scale targets — annotation discovery must treat `scaleTargetRef.kind == LeaderWorkerSet` the same as VA did (uses `lwsEnabled` flag).

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -75,8 +75,12 @@ func Parse(obj metav1.Object) (*Parsed, error) {
 	if cost == "" {
 		cost = defaultVariantCost
 	}
-	if _, err := strconv.ParseFloat(cost, 64); err != nil {
+	costVal, err := strconv.ParseFloat(cost, 64)
+	if err != nil {
 		return nil, fmt.Errorf("annotation %s must be a numeric string, got %q: %w", VariantCost, cost, err)
+	}
+	if costVal < 0 {
+		return nil, fmt.Errorf("annotation %q must be non-negative, got %v", VariantCost, costVal)
 	}
 	return &Parsed{
 		ModelID:     modelID,

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package annotations defines the WVA annotation schema used for annotation-based
+// discovery on KEDA ScaledObjects and Kubernetes HPAs. Placing this schema in a
+// dedicated package gives a single source of truth for annotation key names and
+// parsing logic across the controller, engine, and test fixtures.
+package annotations
+
+import (
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Managed is the annotation that opts a ScaledObject or HPA into WVA management.
+	// Value must be "true".
+	Managed = "llm-d.ai/managed"
+
+	// ModelID is the required annotation identifying the model served by the variant.
+	// It maps to VariantAutoscalingSpec.ModelID and is used for multi-variant grouping.
+	ModelID = "llm-d.ai/model-id"
+
+	// VariantCost is the optional annotation specifying cost per replica for
+	// cost-aware optimization. Must be a non-negative decimal string. Defaults to "10.0".
+	VariantCost = "llm-d.ai/variant-cost"
+
+	// Synthetic marks an in-memory VariantAutoscaling as annotation-sourced.
+	// Objects carrying this annotation are never written to the Kubernetes API server;
+	// they exist only within the WVA optimization pipeline.
+	Synthetic = "llm-d.ai/synthetic"
+
+	// defaultVariantCost matches the kubebuilder default on VariantAutoscalingConfigSpec.
+	defaultVariantCost = "10.0"
+)
+
+// Parsed holds the validated WVA annotation values extracted from a Kubernetes object.
+type Parsed struct {
+	ModelID     string
+	VariantCost string
+}
+
+// IsManaged returns true if obj bears llm-d.ai/managed: "true".
+func IsManaged(obj metav1.Object) bool {
+	return obj.GetAnnotations()[Managed] == "true"
+}
+
+// Parse extracts and validates WVA annotations from obj.
+// Returns an error if required annotations are missing or have invalid values.
+func Parse(obj metav1.Object) (*Parsed, error) {
+	ann := obj.GetAnnotations()
+	if ann[Managed] != "true" {
+		return nil, fmt.Errorf("annotation %s must be \"true\"", Managed)
+	}
+	modelID := ann[ModelID]
+	if modelID == "" {
+		return nil, fmt.Errorf("required annotation %s is missing or empty", ModelID)
+	}
+	cost := ann[VariantCost]
+	if cost == "" {
+		cost = defaultVariantCost
+	}
+	if _, err := strconv.ParseFloat(cost, 64); err != nil {
+		return nil, fmt.Errorf("annotation %s must be a numeric string, got %q: %w", VariantCost, cost, err)
+	}
+	return &Parsed{
+		ModelID:     modelID,
+		VariantCost: cost,
+	}, nil
+}

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -94,6 +94,11 @@ func TestParse(t *testing.T) {
 			wantModelID: "m",
 			wantCost:    "5",
 		},
+		{
+			name:    "negative cost rejected",
+			ann:     map[string]string{annotations.Managed: "true", annotations.ModelID: "m", annotations.VariantCost: "-5.0"},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+)
+
+func obj(ann map[string]string) metav1.Object {
+	return &metav1.ObjectMeta{Annotations: ann}
+}
+
+func TestIsManaged(t *testing.T) {
+	tests := []struct {
+		name string
+		ann  map[string]string
+		want bool
+	}{
+		{"managed true", map[string]string{annotations.Managed: "true"}, true},
+		{"managed false", map[string]string{annotations.Managed: "false"}, false},
+		{"missing", map[string]string{}, false},
+		{"nil annotations", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := annotations.IsManaged(obj(tc.ann)); got != tc.want {
+				t.Errorf("IsManaged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		ann         map[string]string
+		wantModelID string
+		wantCost    string
+		wantErr     bool
+	}{
+		{
+			name:        "all fields",
+			ann:         map[string]string{annotations.Managed: "true", annotations.ModelID: "ibm/granite-13b", annotations.VariantCost: "40.0"},
+			wantModelID: "ibm/granite-13b",
+			wantCost:    "40.0",
+		},
+		{
+			name:        "cost defaults to 10.0",
+			ann:         map[string]string{annotations.Managed: "true", annotations.ModelID: "ibm/granite-13b"},
+			wantModelID: "ibm/granite-13b",
+			wantCost:    "10.0",
+		},
+		{
+			name:    "missing managed",
+			ann:     map[string]string{annotations.ModelID: "ibm/granite-13b"},
+			wantErr: true,
+		},
+		{
+			name:    "managed false",
+			ann:     map[string]string{annotations.Managed: "false", annotations.ModelID: "ibm/granite-13b"},
+			wantErr: true,
+		},
+		{
+			name:    "missing model-id",
+			ann:     map[string]string{annotations.Managed: "true"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid cost",
+			ann:     map[string]string{annotations.Managed: "true", annotations.ModelID: "ibm/granite-13b", annotations.VariantCost: "not-a-number"},
+			wantErr: true,
+		},
+		{
+			name:        "integer cost",
+			ann:         map[string]string{annotations.Managed: "true", annotations.ModelID: "m", annotations.VariantCost: "5"},
+			wantModelID: "m",
+			wantCost:    "5",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := annotations.Parse(obj(tc.ann))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Parse() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got.ModelID != tc.wantModelID {
+				t.Errorf("ModelID = %q, want %q", got.ModelID, tc.wantModelID)
+			}
+			if got.VariantCost != tc.wantCost {
+				t.Errorf("VariantCost = %q, want %q", got.VariantCost, tc.wantCost)
+			}
+		})
+	}
+}

--- a/internal/controller/handler_test.go
+++ b/internal/controller/handler_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+)
+
+func newHandlerReconciler() *VariantAutoscalingReconciler {
+	return &VariantAutoscalingReconciler{
+		Datastore: datastore.NewDatastore(config.NewTestConfig()),
+	}
+}
+
+func TestHandleAnnotatedScalerEvent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("managed object tracks namespace", func(t *testing.T) {
+		r := newHandlerReconciler()
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "hpa-a",
+				Namespace:   "ns1",
+				Annotations: map[string]string{annotations.Managed: "true"},
+			},
+		}
+		r.handleAnnotatedScalerEvent(ctx, hpa)
+		if !r.Datastore.IsNamespaceTracked("ns1") {
+			t.Error("want ns1 tracked after managed object event")
+		}
+	})
+
+	t.Run("deleted object untracks namespace", func(t *testing.T) {
+		r := newHandlerReconciler()
+		r.Datastore.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
+
+		now := metav1.NewTime(time.Now())
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "hpa-a",
+				Namespace:         "ns1",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"test"}, // required for DeletionTimestamp to be set
+				Annotations:       map[string]string{annotations.Managed: "true"},
+			},
+		}
+		r.handleAnnotatedScalerEvent(ctx, hpa)
+		if r.Datastore.IsNamespaceTracked("ns1") {
+			t.Error("want ns1 untracked after deletion event")
+		}
+	})
+
+	t.Run("annotation removed untracks namespace", func(t *testing.T) {
+		r := newHandlerReconciler()
+		r.Datastore.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
+
+		// send update event with annotation removed
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hpa-a",
+				Namespace: "ns1",
+				// no llm-d.ai/managed annotation
+			},
+		}
+		r.handleAnnotatedScalerEvent(ctx, hpa)
+		if r.Datastore.IsNamespaceTracked("ns1") {
+			t.Error("want ns1 untracked after annotation removal")
+		}
+	})
+}

--- a/internal/controller/handler_test.go
+++ b/internal/controller/handler_test.go
@@ -21,73 +21,175 @@ import (
 	"testing"
 	"time"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 )
 
-func newHandlerReconciler() *VariantAutoscalingReconciler {
-	return &VariantAutoscalingReconciler{
-		Datastore: datastore.NewDatastore(config.NewTestConfig()),
+func scalerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add clientgoscheme: %v", err)
+	}
+	if err := kedav1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add kedav1alpha1: %v", err)
+	}
+	return s
+}
+
+// --- HPAReconciler tests ---
+
+func TestHPAReconciler_TracksNamespace(t *testing.T) {
+	s := scalerTestScheme(t)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "hpa-a",
+			Namespace:   "ns1",
+			Annotations: map[string]string{annotations.Managed: "true"},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 5},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(hpa).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+
+	r := &HPAReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "hpa-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 tracked after managed HPA reconcile")
 	}
 }
 
-func TestHandleAnnotatedScalerEvent(t *testing.T) {
-	ctx := context.Background()
+func TestHPAReconciler_UntracksOnNotFound(t *testing.T) {
+	s := scalerTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+	ds.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
 
-	t.Run("managed object tracks namespace", func(t *testing.T) {
-		r := newHandlerReconciler()
-		hpa := &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "hpa-a",
-				Namespace:   "ns1",
-				Annotations: map[string]string{annotations.Managed: "true"},
-			},
-		}
-		r.handleAnnotatedScalerEvent(ctx, hpa)
-		if !r.Datastore.IsNamespaceTracked("ns1") {
-			t.Error("want ns1 tracked after managed object event")
-		}
-	})
+	r := &HPAReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "hpa-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 untracked when HPA is not found (deleted)")
+	}
+}
 
-	t.Run("deleted object untracks namespace", func(t *testing.T) {
-		r := newHandlerReconciler()
-		r.Datastore.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
+func TestHPAReconciler_UntracksOnDeletion(t *testing.T) {
+	s := scalerTestScheme(t)
+	now := metav1.NewTime(time.Now())
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "hpa-a",
+			Namespace:         "ns1",
+			Finalizers:        []string{"test"},
+			DeletionTimestamp: &now,
+			Annotations:       map[string]string{annotations.Managed: "true"},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 5},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(hpa).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+	ds.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
 
-		now := metav1.NewTime(time.Now())
-		hpa := &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "hpa-a",
-				Namespace:         "ns1",
-				DeletionTimestamp: &now,
-				Finalizers:        []string{"test"}, // required for DeletionTimestamp to be set
-				Annotations:       map[string]string{annotations.Managed: "true"},
-			},
-		}
-		r.handleAnnotatedScalerEvent(ctx, hpa)
-		if r.Datastore.IsNamespaceTracked("ns1") {
-			t.Error("want ns1 untracked after deletion event")
-		}
-	})
+	r := &HPAReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "hpa-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 untracked when HPA has deletion timestamp")
+	}
+}
 
-	t.Run("annotation removed untracks namespace", func(t *testing.T) {
-		r := newHandlerReconciler()
-		r.Datastore.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
+func TestHPAReconciler_UntracksOnAnnotationRemoval(t *testing.T) {
+	s := scalerTestScheme(t)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "hpa-a", Namespace: "ns1"},
+		Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 5},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(hpa).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+	ds.NamespaceTrack("AnnotatedScaler", "hpa-a", "ns1")
 
-		// send update event with annotation removed
-		hpa := &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hpa-a",
-				Namespace: "ns1",
-				// no llm-d.ai/managed annotation
-			},
-		}
-		r.handleAnnotatedScalerEvent(ctx, hpa)
-		if r.Datastore.IsNamespaceTracked("ns1") {
-			t.Error("want ns1 untracked after annotation removal")
-		}
-	})
+	r := &HPAReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "hpa-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 untracked when llm-d.ai/managed annotation is removed")
+	}
+}
+
+// --- ScaledObjectReconciler tests ---
+
+func TestScaledObjectReconciler_TracksNamespace(t *testing.T) {
+	s := scalerTestScheme(t)
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "so-a",
+			Namespace:   "ns1",
+			Annotations: map[string]string{annotations.Managed: "true"},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(so).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+
+	r := &ScaledObjectReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "so-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 tracked after managed ScaledObject reconcile")
+	}
+}
+
+func TestScaledObjectReconciler_UntracksOnNotFound(t *testing.T) {
+	s := scalerTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+	ds.NamespaceTrack("AnnotatedScaler", "so-a", "ns1")
+
+	r := &ScaledObjectReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "so-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 untracked when ScaledObject is not found (deleted)")
+	}
+}
+
+func TestScaledObjectReconciler_UntracksOnAnnotationRemoval(t *testing.T) {
+	s := scalerTestScheme(t)
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "so-a", Namespace: "ns1"},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(so).Build()
+	ds := datastore.NewDatastore(config.NewTestConfig())
+	ds.NamespaceTrack("AnnotatedScaler", "so-a", "ns1")
+
+	r := &ScaledObjectReconciler{Client: cl, Datastore: ds}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "so-a", Namespace: "ns1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.IsNamespaceTracked("ns1") {
+		t.Error("want ns1 untracked when llm-d.ai/managed annotation is removed")
+	}
 }

--- a/internal/controller/hpa_reconciler.go
+++ b/internal/controller/hpa_reconciler.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+)
+
+// HPAReconciler tracks namespaces for annotation-based WVA discovery via HPA objects.
+// Its sole job is to call NamespaceTrack / NamespaceUntrack so the engine's polling
+// loop can scope its List calls to namespaces that contain managed scalers.
+type HPAReconciler struct {
+	client.Client
+	Datastore datastore.Datastore
+}
+
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+// Note: Kubernetes RBAC does not support annotation-based selectors, so this grant is
+// necessarily cluster-wide. Access is read-only (get;list;watch). AnnotatedScalerPredicate
+// limits event processing to managed objects (see TODO #1134 for scoped List calls).
+
+// Reconcile tracks or untracks the namespace of an HPA bearing llm-d.ai/managed: "true".
+func (r *HPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := r.Get(ctx, req.NamespacedName, hpa); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !hpa.DeletionTimestamp.IsZero() || !annotations.IsManaged(hpa) {
+		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+	} else {
+		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers HPAReconciler with the controller manager.
+func (r *HPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&autoscalingv2.HorizontalPodAutoscaler{},
+			builder.WithPredicates(AnnotatedScalerPredicate()),
+		).
+		Named("hpa").
+		Complete(r)
+}

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -149,9 +149,11 @@ func EventFilter() predicate.Funcs {
 // reaches handleAnnotatedScalerEvent and triggers the untrack path.
 func AnnotatedScalerPredicate() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return annotations.IsManaged(e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return annotations.IsManaged(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return annotations.IsManaged(e.ObjectOld) || annotations.IsManaged(e.ObjectNew) },
+		CreateFunc: func(e event.CreateEvent) bool { return annotations.IsManaged(e.Object) },
+		DeleteFunc: func(e event.DeleteEvent) bool { return annotations.IsManaged(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return annotations.IsManaged(e.ObjectOld) || annotations.IsManaged(e.ObjectNew)
+		},
 		GenericFunc: func(e event.GenericEvent) bool { return annotations.IsManaged(e.Object) },
 	}
 }

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
@@ -140,6 +141,18 @@ func EventFilter() predicate.Funcs {
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
 		},
+	}
+}
+
+// AnnotatedScalerPredicate passes events only for objects bearing llm-d.ai/managed: "true".
+// For Update events, either old or new object must be managed so that annotation removal
+// reaches handleAnnotatedScalerEvent and triggers the untrack path.
+func AnnotatedScalerPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return annotations.IsManaged(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return annotations.IsManaged(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return annotations.IsManaged(e.ObjectOld) || annotations.IsManaged(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return annotations.IsManaged(e.Object) },
 	}
 }
 

--- a/internal/controller/scaledobject_reconciler.go
+++ b/internal/controller/scaledobject_reconciler.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
+)
+
+// ScaledObjectReconciler tracks namespaces for annotation-based WVA discovery via KEDA
+// ScaledObject objects. Its sole job is to call NamespaceTrack / NamespaceUntrack so
+// the engine's polling loop can scope its List calls to namespaces that contain managed
+// scalers. Registered only when the KEDA CRD is detected at startup.
+type ScaledObjectReconciler struct {
+	client.Client
+	Datastore datastore.Datastore
+}
+
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
+// Note: Kubernetes RBAC does not support annotation-based selectors, so this grant is
+// necessarily cluster-wide. Access is read-only (get;list;watch). AnnotatedScalerPredicate
+// limits event processing to managed objects (see TODO #1134 for scoped List calls).
+
+// Reconcile tracks or untracks the namespace of a ScaledObject bearing llm-d.ai/managed: "true".
+func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	so := &kedav1alpha1.ScaledObject{}
+	if err := r.Get(ctx, req.NamespacedName, so); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !so.DeletionTimestamp.IsZero() || !annotations.IsManaged(so) {
+		r.Datastore.NamespaceUntrack("AnnotatedScaler", req.Name, req.Namespace)
+	} else {
+		r.Datastore.NamespaceTrack("AnnotatedScaler", req.Name, req.Namespace)
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers ScaledObjectReconciler with the controller manager.
+func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kedav1alpha1.ScaledObject{},
+			builder.WithPredicates(AnnotatedScalerPredicate()),
+		).
+		Named("scaledobject").
+		Complete(r)
+}

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller/indexers"
@@ -57,9 +54,8 @@ type VariantAutoscalingReconciler struct {
 
 	Recorder    record.EventRecorder
 	Config      *config.Config      // Unified configuration (injected from main.go)
-	Datastore   datastore.Datastore // Datastore for namespace tracking and InferencePool data
-	lwsEnabled  bool                // Whether LeaderWorkerSet support is enabled (CRD detected at startup)
-	kedaEnabled bool                // Whether KEDA ScaledObject CRD is installed (detected at startup)
+	Datastore  datastore.Datastore // Datastore for namespace tracking and InferencePool data
+	lwsEnabled bool                // Whether LeaderWorkerSet support is enabled (CRD detected at startup)
 }
 
 // NewVariantAutoscalingReconciler creates a new VariantAutoscalingReconciler
@@ -70,16 +66,14 @@ func NewVariantAutoscalingReconciler(
 	cfg *config.Config,
 	ds datastore.Datastore,
 	lwsEnabled bool,
-	kedaEnabled bool,
 ) *VariantAutoscalingReconciler {
 	return &VariantAutoscalingReconciler{
-		Client:      client,
-		Scheme:      scheme,
-		Recorder:    recorder,
-		Config:      cfg,
-		Datastore:   ds,
-		lwsEnabled:  lwsEnabled,
-		kedaEnabled: kedaEnabled,
+		Client:     client,
+		Scheme:     scheme,
+		Recorder:   recorder,
+		Config:     cfg,
+		Datastore:  ds,
+		lwsEnabled: lwsEnabled,
 	}
 }
 
@@ -106,11 +100,6 @@ func NewVariantAutoscalingReconciler(
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=inference.networking.x-k8s.io;inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update
-// Note: Kubernetes RBAC does not support annotation-based selectors, so these grants are
-// necessarily cluster-wide. Access is read-only (get;list;watch). The AnnotatedScalerPredicate
-// and per-namespace filtering (see TODO #1134) limit actual processing to managed objects.
-// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
-// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 
 const (
 	// ServiceMonitor constants for watching controller's own metrics ServiceMonitor
@@ -383,18 +372,6 @@ func (r *VariantAutoscalingReconciler) handleLeaderWorkerSetEvent(ctx context.Co
 	}}
 }
 
-// handleAnnotatedScalerEvent tracks or untracks the namespace of an annotated ScaledObject or HPA.
-// It returns no reconcile requests — namespace tracking is the sole side-effect.
-// The engine's polling loop discovers these objects via List on every tick.
-func (r *VariantAutoscalingReconciler) handleAnnotatedScalerEvent(ctx context.Context, obj client.Object) []reconcile.Request {
-	if !obj.GetDeletionTimestamp().IsZero() || !annotations.IsManaged(obj) {
-		r.Datastore.NamespaceUntrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
-	} else {
-		r.Datastore.NamespaceTrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
-	}
-	return nil
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
@@ -415,13 +392,6 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			&appsv1.Deployment{},
 			handler.EnqueueRequestsFromMapFunc(r.handleDeploymentEvent),
 			builder.WithPredicates(ScaleTargetPredicate()),
-		).
-		// Watch annotated HPAs for namespace tracking (annotation-based discovery, Phase 1).
-		// HPAs are core Kubernetes objects, always available.
-		Watches(
-			&autoscalingv2.HorizontalPodAutoscaler{},
-			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
-			builder.WithPredicates(AnnotatedScalerPredicate()),
 		)
 
 	// Only watch LeaderWorkerSet if LWS support is enabled (CRD detected at startup)
@@ -430,15 +400,6 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			&lwsv1.LeaderWorkerSet{},
 			handler.EnqueueRequestsFromMapFunc(r.handleLeaderWorkerSetEvent),
 			builder.WithPredicates(ScaleTargetPredicate()),
-		)
-	}
-
-	// Only watch KEDA ScaledObjects if the KEDA CRD is installed (detected at startup)
-	if r.kedaEnabled {
-		controllerBuilder = controllerBuilder.Watches(
-			&kedav1alpha1.ScaledObject{},
-			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
-			builder.WithPredicates(AnnotatedScalerPredicate()),
 		)
 	}
 

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller/indexers"
@@ -50,11 +53,13 @@ import (
 // VariantAutoscalingReconciler reconciles a variantAutoscaling object
 type VariantAutoscalingReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Recorder   record.EventRecorder
-	Config     *config.Config      // Unified configuration (injected from main.go)
-	Datastore  datastore.Datastore // Datastore for namespace tracking and InferencePool data
-	lwsEnabled bool                // Whether LeaderWorkerSet support is enabled (CRD detected at startup)
+	Scheme *runtime.Scheme
+
+	Recorder    record.EventRecorder
+	Config      *config.Config      // Unified configuration (injected from main.go)
+	Datastore   datastore.Datastore // Datastore for namespace tracking and InferencePool data
+	lwsEnabled  bool                // Whether LeaderWorkerSet support is enabled (CRD detected at startup)
+	kedaEnabled bool                // Whether KEDA ScaledObject CRD is installed (detected at startup)
 }
 
 // NewVariantAutoscalingReconciler creates a new VariantAutoscalingReconciler
@@ -65,14 +70,16 @@ func NewVariantAutoscalingReconciler(
 	cfg *config.Config,
 	ds datastore.Datastore,
 	lwsEnabled bool,
+	kedaEnabled bool,
 ) *VariantAutoscalingReconciler {
 	return &VariantAutoscalingReconciler{
-		Client:     client,
-		Scheme:     scheme,
-		Recorder:   recorder,
-		Config:     cfg,
-		Datastore:  ds,
-		lwsEnabled: lwsEnabled,
+		Client:      client,
+		Scheme:      scheme,
+		Recorder:    recorder,
+		Config:      cfg,
+		Datastore:   ds,
+		lwsEnabled:  lwsEnabled,
+		kedaEnabled: kedaEnabled,
 	}
 }
 
@@ -99,6 +106,8 @@ func NewVariantAutoscalingReconciler(
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=inference.networking.x-k8s.io;inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 
 const (
 	// ServiceMonitor constants for watching controller's own metrics ServiceMonitor
@@ -371,6 +380,18 @@ func (r *VariantAutoscalingReconciler) handleLeaderWorkerSetEvent(ctx context.Co
 	}}
 }
 
+// handleAnnotatedScalerEvent tracks or untracks the namespace of an annotated ScaledObject or HPA.
+// It returns no reconcile requests — namespace tracking is the sole side-effect.
+// The engine's polling loop discovers these objects via List on every tick.
+func (r *VariantAutoscalingReconciler) handleAnnotatedScalerEvent(ctx context.Context, obj client.Object) []reconcile.Request {
+	if !obj.GetDeletionTimestamp().IsZero() {
+		r.Datastore.NamespaceUntrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
+	} else if annotations.IsManaged(obj) {
+		r.Datastore.NamespaceTrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
@@ -391,6 +412,12 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			&appsv1.Deployment{},
 			handler.EnqueueRequestsFromMapFunc(r.handleDeploymentEvent),
 			builder.WithPredicates(ScaleTargetPredicate()),
+		).
+		// Watch annotated HPAs for namespace tracking (annotation-based discovery, Phase 1).
+		// HPAs are core Kubernetes objects, always available.
+		Watches(
+			&autoscalingv2.HorizontalPodAutoscaler{},
+			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
 		)
 
 	// Only watch LeaderWorkerSet if LWS support is enabled (CRD detected at startup)
@@ -399,6 +426,14 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			&lwsv1.LeaderWorkerSet{},
 			handler.EnqueueRequestsFromMapFunc(r.handleLeaderWorkerSetEvent),
 			builder.WithPredicates(ScaleTargetPredicate()),
+		)
+	}
+
+	// Only watch KEDA ScaledObjects if the KEDA CRD is installed (detected at startup)
+	if r.kedaEnabled {
+		controllerBuilder = controllerBuilder.Watches(
+			&kedav1alpha1.ScaledObject{},
+			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
 		)
 	}
 

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -106,6 +106,9 @@ func NewVariantAutoscalingReconciler(
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=inference.networking.x-k8s.io;inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update
+// Note: Kubernetes RBAC does not support annotation-based selectors, so these grants are
+// necessarily cluster-wide. Access is read-only (get;list;watch). The AnnotatedScalerPredicate
+// and per-namespace filtering (see TODO #1134) limit actual processing to managed objects.
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 
@@ -384,9 +387,9 @@ func (r *VariantAutoscalingReconciler) handleLeaderWorkerSetEvent(ctx context.Co
 // It returns no reconcile requests — namespace tracking is the sole side-effect.
 // The engine's polling loop discovers these objects via List on every tick.
 func (r *VariantAutoscalingReconciler) handleAnnotatedScalerEvent(ctx context.Context, obj client.Object) []reconcile.Request {
-	if !obj.GetDeletionTimestamp().IsZero() {
+	if !obj.GetDeletionTimestamp().IsZero() || !annotations.IsManaged(obj) {
 		r.Datastore.NamespaceUntrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
-	} else if annotations.IsManaged(obj) {
+	} else {
 		r.Datastore.NamespaceTrack("AnnotatedScaler", obj.GetName(), obj.GetNamespace())
 	}
 	return nil
@@ -418,6 +421,7 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(
 			&autoscalingv2.HorizontalPodAutoscaler{},
 			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
+			builder.WithPredicates(AnnotatedScalerPredicate()),
 		)
 
 	// Only watch LeaderWorkerSet if LWS support is enabled (CRD detected at startup)
@@ -434,6 +438,7 @@ func (r *VariantAutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		controllerBuilder = controllerBuilder.Watches(
 			&kedav1alpha1.ScaledObject{},
 			handler.EnqueueRequestsFromMapFunc(r.handleAnnotatedScalerEvent),
+			builder.WithPredicates(AnnotatedScalerPredicate()),
 		)
 	}
 

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -52,8 +52,8 @@ type VariantAutoscalingReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	Recorder    record.EventRecorder
-	Config      *config.Config      // Unified configuration (injected from main.go)
+	Recorder   record.EventRecorder
+	Config     *config.Config      // Unified configuration (injected from main.go)
 	Datastore  datastore.Datastore // Datastore for namespace tracking and InferencePool data
 	lwsEnabled bool                // Whether LeaderWorkerSet support is enabled (CRD detected at startup)
 }

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1151,12 +1151,17 @@ func (e *Engine) applySaturationDecisions(
 				"variant", vaName)
 		}
 
-		// Fetch latest version from API server to avoid conflicts
+		// Fetch latest version from API server to avoid conflicts.
+		// Synthetic (annotation-sourced) variants have no CRD instance; use the in-memory copy.
 		var updateVa llmdVariantAutoscalingV1alpha1.VariantAutoscaling
-		if err := utils.GetVariantAutoscalingWithBackoff(ctx, e.client, va.Name, va.Namespace, &updateVa); err != nil {
-			logger.Error(err, "Failed to get latest VA from API server",
-				"name", va.Name)
-			continue
+		if utils.IsSynthetic(va) {
+			updateVa = *va.DeepCopy()
+		} else {
+			if err := utils.GetVariantAutoscalingWithBackoff(ctx, e.client, va.Name, va.Namespace, &updateVa); err != nil {
+				logger.Error(err, "Failed to get latest VA from API server",
+					"name", va.Name)
+				continue
+			}
 		}
 
 		// Update CurrentAlloc from local analysis (which has the latest metrics)
@@ -1225,20 +1230,23 @@ func (e *Engine) applySaturationDecisions(
 		if acceleratorName == "" {
 			logger.Info("Skipping status update for VA without accelerator info, but setting MetricsAvailable=False",
 				"variant", vaName, "cacheKey.name", va.Name, "cacheKey.namespace", va.Namespace)
-			// Still set the cache entry so the controller can set MetricsAvailable=False.
-			// This is a partial decision for metrics status only - other fields like
-			// TargetReplicas and AcceleratorName are left at zero values since we don't
-			// have enough information to set them.
-			common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
-				VariantName:      vaName,
-				Namespace:        va.Namespace,
-				MetricsAvailable: false,
-				MetricsReason:    llmdVariantAutoscalingV1alpha1.ReasonMetricsMissing,
-				MetricsMessage:   llmdVariantAutoscalingV1alpha1.MessageMetricsUnavailable,
-			})
-			// Trigger reconciler to apply the condition
-			common.DecisionTrigger <- event.GenericEvent{
-				Object: &updateVa,
+			// Synthetic variants have no CRD status to patch; skip cache/trigger.
+			if !utils.IsSynthetic(va) {
+				// Still set the cache entry so the controller can set MetricsAvailable=False.
+				// This is a partial decision for metrics status only - other fields like
+				// TargetReplicas and AcceleratorName are left at zero values since we don't
+				// have enough information to set them.
+				common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
+					VariantName:      vaName,
+					Namespace:        va.Namespace,
+					MetricsAvailable: false,
+					MetricsReason:    llmdVariantAutoscalingV1alpha1.ReasonMetricsMissing,
+					MetricsMessage:   llmdVariantAutoscalingV1alpha1.MessageMetricsUnavailable,
+				})
+				// Trigger reconciler to apply the condition
+				common.DecisionTrigger <- event.GenericEvent{
+					Object: &updateVa,
+				}
 			}
 			continue
 		}
@@ -1324,39 +1332,41 @@ func (e *Engine) applySaturationDecisions(
 			act.RecordSaturationMetrics(ctx, decision)
 		}
 
-		// Update Shared State and Trigger Reconcile via Channel
-		// This avoids any API server interaction from the Engine.
+		// Update Shared State and Trigger Reconcile via Channel.
+		// Synthetic (annotation-sourced) variants have no CRD status to patch;
+		// metric emission above is their sole output, so skip cache/trigger.
+		if !utils.IsSynthetic(va) {
+			// 1. Update Cache
+			// Determine MetricsAvailable status for the cache.
+			// - hasAllocation is true when we successfully collected current replica metrics
+			//   for this variant during this loop (metrics pipeline is working).
+			// - hasDecision is true when the optimizer produced a scaling decision based on
+			//   saturation metrics in this run.
+			// Either condition implies saturation metrics were available and usable.
+			metricsAvailable := hasAllocation || hasDecision
+			metricsReason := llmdVariantAutoscalingV1alpha1.ReasonMetricsMissing
+			metricsMessage := llmdVariantAutoscalingV1alpha1.MessageMetricsUnavailable
+			if metricsAvailable {
+				metricsReason = llmdVariantAutoscalingV1alpha1.ReasonMetricsFound
+				metricsMessage = llmdVariantAutoscalingV1alpha1.MessageMetricsAvailable
+			}
 
-		// 1. Update Cache
-		// Determine MetricsAvailable status for the cache.
-		// - hasAllocation is true when we successfully collected current replica metrics
-		//   for this variant during this loop (metrics pipeline is working).
-		// - hasDecision is true when the optimizer produced a scaling decision based on
-		//   saturation metrics in this run.
-		// Either condition implies saturation metrics were available and usable.
-		metricsAvailable := hasAllocation || hasDecision
-		metricsReason := llmdVariantAutoscalingV1alpha1.ReasonMetricsMissing
-		metricsMessage := llmdVariantAutoscalingV1alpha1.MessageMetricsUnavailable
-		if metricsAvailable {
-			metricsReason = llmdVariantAutoscalingV1alpha1.ReasonMetricsFound
-			metricsMessage = llmdVariantAutoscalingV1alpha1.MessageMetricsAvailable
-		}
+			common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
+				VariantName:       vaName,
+				Namespace:         va.Namespace,
+				TargetReplicas:    targetReplicas,
+				AcceleratorName:   acceleratorName,
+				LastRunTime:       metav1.Now(),
+				CurrentAllocation: currentAllocations[vaName],
+				MetricsAvailable:  metricsAvailable,
+				MetricsReason:     metricsReason,
+				MetricsMessage:    metricsMessage,
+			})
 
-		common.DecisionCache.Set(va.Name, va.Namespace, interfaces.VariantDecision{
-			VariantName:       vaName,
-			Namespace:         va.Namespace,
-			TargetReplicas:    targetReplicas,
-			AcceleratorName:   acceleratorName,
-			LastRunTime:       metav1.Now(),
-			CurrentAllocation: currentAllocations[vaName],
-			MetricsAvailable:  metricsAvailable,
-			MetricsReason:     metricsReason,
-			MetricsMessage:    metricsMessage,
-		})
-
-		// 2. Trigger Reconciler
-		common.DecisionTrigger <- event.GenericEvent{
-			Object: &updateVa,
+			// 2. Trigger Reconciler
+			common.DecisionTrigger <- event.GenericEvent{
+				Object: &updateVa,
+			}
 		}
 
 		if hasDecision {

--- a/internal/utils/crd.go
+++ b/internal/utils/crd.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// CheckCRDInstalled reports whether a CRD with the given groupVersion and kind is
+// registered in the cluster. It is called once at startup; dynamic CRD installation
+// after the controller starts is not yet handled.
+func CheckCRDInstalled(restConfig *rest.Config, groupVersion, kind string, logger logr.Logger) bool {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		logger.Error(err, "failed to create discovery client for CRD detection",
+			"groupVersion", groupVersion, "kind", kind)
+		return false
+	}
+
+	_, apiLists, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		// Partial errors are common (e.g. unavailable API services); continue if we got results.
+		if apiLists == nil {
+			logger.Error(err, "failed to discover API resources",
+				"groupVersion", groupVersion, "kind", kind)
+			return false
+		}
+		logger.V(1).Info("partial error discovering API resources (this is usually fine)", "error", err)
+	}
+
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == groupVersion {
+			for _, resource := range apiList.APIResources {
+				if resource.Kind == kind {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// CheckKEDACRD reports whether the KEDA ScaledObject CRD is installed.
+// TODO: checked once at startup; handle KEDA installed after controller starts.
+func CheckKEDACRD(restConfig *rest.Config, logger logr.Logger) bool {
+	return CheckCRDInstalled(restConfig, "keda.sh/v1alpha1", "ScaledObject", logger)
+}
+
+// CheckLeaderWorkerSetCRD reports whether the LeaderWorkerSet CRD is installed.
+// TODO: checked once at startup; handle LWS installed after controller starts.
+func CheckLeaderWorkerSetCRD(restConfig *rest.Config, logger logr.Logger) bool {
+	return CheckCRDInstalled(restConfig, "leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet", logger)
+}

--- a/internal/utils/crd/crd.go
+++ b/internal/utils/crd/crd.go
@@ -1,26 +1,16 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package crd
 
 import (
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
+
+// serverGroupsAndResourcesIface is the minimal discovery surface needed by checkCRDInstalled.
+type serverGroupsAndResourcesIface interface {
+	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
+}
 
 // CheckCRDInstalled reports whether a CRD with the given groupVersion and kind is
 // registered in the cluster. It is called once at startup; dynamic CRD installation
@@ -32,8 +22,11 @@ func CheckCRDInstalled(restConfig *rest.Config, groupVersion, kind string, logge
 			"groupVersion", groupVersion, "kind", kind)
 		return false
 	}
+	return checkCRDInstalled(discoveryClient, groupVersion, kind, logger)
+}
 
-	_, apiLists, err := discoveryClient.ServerGroupsAndResources()
+func checkCRDInstalled(disc serverGroupsAndResourcesIface, groupVersion, kind string, logger logr.Logger) bool {
+	_, apiLists, err := disc.ServerGroupsAndResources()
 	if err != nil {
 		// Partial errors are common (e.g. unavailable API services); continue if we got results.
 		if apiLists == nil {

--- a/internal/utils/crd/crd.go
+++ b/internal/utils/crd/crd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package crd
 
 import (
 	"github.com/go-logr/logr"

--- a/internal/utils/crd/crd_test.go
+++ b/internal/utils/crd/crd_test.go
@@ -1,0 +1,86 @@
+package crd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// fakeDiscovery implements serverGroupsAndResourcesIface for testing.
+type fakeDiscovery struct {
+	apiLists []*metav1.APIResourceList
+	err      error
+}
+
+func (f *fakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, f.apiLists, f.err
+}
+
+func apiList(groupVersion string, kinds ...string) *metav1.APIResourceList {
+	resources := make([]metav1.APIResource, len(kinds))
+	for i, k := range kinds {
+		resources[i] = metav1.APIResource{Kind: k}
+	}
+	return &metav1.APIResourceList{GroupVersion: groupVersion, APIResources: resources}
+}
+
+func TestCheckCRDInstalled(t *testing.T) {
+	log := logr.Discard()
+
+	t.Run("CRD present", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: []*metav1.APIResourceList{
+				apiList("keda.sh/v1alpha1", "ScaledObject", "ScaledJob"),
+			},
+		}
+		if !checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
+			t.Error("want true when CRD is in discovery results")
+		}
+	})
+
+	t.Run("CRD absent — wrong group", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: []*metav1.APIResourceList{
+				apiList("apps/v1", "Deployment"),
+			},
+		}
+		if checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
+			t.Error("want false when group is not in discovery results")
+		}
+	})
+
+	t.Run("CRD absent — right group, wrong kind", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: []*metav1.APIResourceList{
+				apiList("keda.sh/v1alpha1", "ScaledJob"),
+			},
+		}
+		if checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
+			t.Error("want false when kind is not in discovery results")
+		}
+	})
+
+	t.Run("partial error with results — continues checking", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: []*metav1.APIResourceList{
+				apiList("keda.sh/v1alpha1", "ScaledObject"),
+			},
+			err: fmt.Errorf("some api group unavailable"),
+		}
+		if !checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
+			t.Error("want true when CRD is present despite partial error")
+		}
+	})
+
+	t.Run("total failure — nil apiLists", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: nil,
+			err:      fmt.Errorf("discovery completely failed"),
+		}
+		if checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
+			t.Error("want false when discovery returns no results at all")
+		}
+	})
+}

--- a/internal/utils/crd/crd_test.go
+++ b/internal/utils/crd/crd_test.go
@@ -1,7 +1,7 @@
 package crd
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -67,7 +67,7 @@ func TestCheckCRDInstalled(t *testing.T) {
 			apiLists: []*metav1.APIResourceList{
 				apiList("keda.sh/v1alpha1", "ScaledObject"),
 			},
-			err: fmt.Errorf("some api group unavailable"),
+			err: errors.New("some api group unavailable"),
 		}
 		if !checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
 			t.Error("want true when CRD is present despite partial error")
@@ -77,7 +77,7 @@ func TestCheckCRDInstalled(t *testing.T) {
 	t.Run("total failure — nil apiLists", func(t *testing.T) {
 		disc := &fakeDiscovery{
 			apiLists: nil,
-			err:      fmt.Errorf("discovery completely failed"),
+			err:      errors.New("discovery completely failed"),
 		}
 		if checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
 			t.Error("want false when discovery returns no results at all")

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -18,12 +18,17 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
@@ -161,6 +166,9 @@ func filterVariantsByScaleTargetAccessor(ctx context.Context, client client.Clie
 // readyVariantAutoscalings retrieves all VariantAutoscaling resources that are ready for optimization
 // using the informer cache. When CONTROLLER_INSTANCE is configured, only VAs with matching
 // controller-instance labels are returned to enable multi-controller isolation.
+// It also merges in-memory VAs synthesized from annotated ScaledObjects and HPAs
+// (annotation-based discovery, Phase 1 dual-mode). CRD-sourced VAs take precedence
+// when both refer to the same scale target in the same namespace.
 func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -195,7 +203,89 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 	logger.V(logging.DEBUG).Info("Found VariantAutoscaling resources ready for optimization",
 		"count", len(readyVAs),
 		"controllerInstance", controllerInstance)
+
+	// Merge annotation-sourced variants (dual-mode: CRD wins on conflict).
+	annotated, err := annotationSourcedVariants(ctx, k8sClient)
+	if err != nil {
+		// Non-fatal: log and continue with CRD-sourced only.
+		logger.Error(err, "Failed to list annotation-sourced variants, continuing with CRD-sourced only")
+		return readyVAs, nil
+	}
+	if len(annotated) == 0 {
+		return readyVAs, nil
+	}
+
+	// Build set of (namespace/scaleTargetRef.name) already covered by CRD-sourced VAs.
+	crdTargets := make(map[string]bool, len(readyVAs))
+	for _, va := range readyVAs {
+		if va.Spec.ScaleTargetRef.Name != "" {
+			crdTargets[GetNamespacedKey(va.Namespace, va.Spec.ScaleTargetRef.Name)] = true
+		}
+	}
+	for _, va := range annotated {
+		if !crdTargets[GetNamespacedKey(va.Namespace, va.Spec.ScaleTargetRef.Name)] {
+			readyVAs = append(readyVAs, va)
+		}
+	}
+
+	logger.V(logging.DEBUG).Info("Merged annotation-sourced variants",
+		"annotatedCount", len(annotated),
+		"totalCount", len(readyVAs))
+
 	return readyVAs, nil
+}
+
+// annotationSourcedVariants lists HPAs and KEDA ScaledObjects bearing llm-d.ai/managed: "true"
+// and synthesizes in-memory VariantAutoscaling objects from them. ScaledObject discovery is
+// skipped gracefully when the KEDA CRD is not installed.
+func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	var result []wvav1alpha1.VariantAutoscaling
+
+	// HPAs are a core Kubernetes type — always available.
+	var hpaList autoscalingv2.HorizontalPodAutoscalerList
+	if err := k8sClient.List(ctx, &hpaList); err != nil {
+		return nil, fmt.Errorf("listing HPAs: %w", err)
+	}
+	for i := range hpaList.Items {
+		hpa := &hpaList.Items[i]
+		if !annotations.IsManaged(hpa) || !hpa.DeletionTimestamp.IsZero() {
+			continue
+		}
+		va, err := VariantAutoscalingFromHPA(hpa)
+		if err != nil {
+			logger.V(logging.DEBUG).Info("Skipping HPA with invalid WVA annotations",
+				"namespace", hpa.Namespace, "name", hpa.Name, "error", err)
+			continue
+		}
+		result = append(result, *va)
+	}
+
+	// KEDA ScaledObjects — may not be installed; handle gracefully.
+	var soList kedav1alpha1.ScaledObjectList
+	if err := k8sClient.List(ctx, &soList); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			logger.V(logging.DEBUG).Info("KEDA ScaledObject CRD not available, skipping annotation discovery for ScaledObjects")
+		} else {
+			return result, fmt.Errorf("listing ScaledObjects: %w", err)
+		}
+	} else {
+		for i := range soList.Items {
+			so := &soList.Items[i]
+			if !annotations.IsManaged(so) || !so.DeletionTimestamp.IsZero() {
+				continue
+			}
+			va, err := VariantAutoscalingFromScaledObject(so)
+			if err != nil {
+				logger.V(logging.DEBUG).Info("Skipping ScaledObject with invalid WVA annotations",
+					"namespace", so.Namespace, "name", so.Name, "error", err)
+				continue
+			}
+			result = append(result, *va)
+		}
+	}
+
+	return result, nil
 }
 
 // isActive explicitly requires that replicas > 0

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -208,8 +208,7 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 	annotated, err := annotationSourcedVariants(ctx, k8sClient)
 	if err != nil {
 		// Non-fatal: log and continue with CRD-sourced only.
-		logger.Error(err, "Failed to list annotation-sourced variants, continuing with CRD-sourced only")
-		return readyVAs, nil
+		logger.Error(err, "Error while listing annotation-sourced variants (non-fatal)")
 	}
 	if len(annotated) == 0 {
 		return readyVAs, nil

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -215,15 +215,19 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 		return readyVAs, nil
 	}
 
-	// Build set of (namespace/scaleTargetRef.name) already covered by CRD-sourced VAs.
+	// Build set of (namespace/kind/name) already covered by CRD-sourced VAs.
+	// Kind is sufficient for disambiguation: the only in-play kinds are Deployment,
+	// LeaderWorkerSet, and StatefulSet, which are unique names in practice.
 	crdTargets := make(map[string]bool, len(readyVAs))
 	for _, va := range readyVAs {
 		if va.Spec.ScaleTargetRef.Name != "" {
-			crdTargets[GetNamespacedKey(va.Namespace, va.Spec.ScaleTargetRef.Name)] = true
+			key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
+			crdTargets[key] = true
 		}
 	}
 	for _, va := range annotated {
-		if !crdTargets[GetNamespacedKey(va.Namespace, va.Spec.ScaleTargetRef.Name)] {
+		key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
+		if !crdTargets[key] {
 			readyVAs = append(readyVAs, va)
 		}
 	}
@@ -237,12 +241,16 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 
 // annotationSourcedVariants lists HPAs and KEDA ScaledObjects bearing llm-d.ai/managed: "true"
 // and synthesizes in-memory VariantAutoscaling objects from them. ScaledObject discovery is
-// skipped gracefully when the KEDA CRD is not installed.
+// skipped gracefully when the KEDA CRD is not installed. When both an HPA and a ScaledObject
+// target the same scale target, the ScaledObject entry wins.
 func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]wvav1alpha1.VariantAutoscaling, error) {
 	logger := ctrl.LoggerFrom(ctx)
-	var result []wvav1alpha1.VariantAutoscaling
+	// keyed by namespace/kind/name for deduplication; ScaledObject entries overwrite HPA entries.
+	byTarget := make(map[string]wvav1alpha1.VariantAutoscaling)
 
-	// HPAs are a core Kubernetes type — always available.
+	// HPAs are a core Kubernetes type — always available (lower priority for deduplication).
+	// TODO(#1134): scope to tracked namespaces only (client.InNamespace per ds.ListTrackedNamespaces())
+	// to avoid iterating the full cluster cache on every engine tick.
 	var hpaList autoscalingv2.HorizontalPodAutoscalerList
 	if err := k8sClient.List(ctx, &hpaList); err != nil {
 		return nil, fmt.Errorf("listing HPAs: %w", err)
@@ -258,15 +266,23 @@ func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]
 				"namespace", hpa.Namespace, "name", hpa.Name, "error", err)
 			continue
 		}
-		result = append(result, *va)
+		key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
+		byTarget[key] = *va
 	}
 
 	// KEDA ScaledObjects — may not be installed; handle gracefully.
+	// ScaledObject takes precedence over HPA for the same scale target.
+	// TODO(#1134): scope to tracked namespaces only (client.InNamespace per ds.ListTrackedNamespaces())
+	// to avoid iterating the full cluster cache on every engine tick.
 	var soList kedav1alpha1.ScaledObjectList
 	if err := k8sClient.List(ctx, &soList); err != nil {
 		if apimeta.IsNoMatchError(err) {
 			logger.V(logging.DEBUG).Info("KEDA ScaledObject CRD not available, skipping annotation discovery for ScaledObjects")
 		} else {
+			result := make([]wvav1alpha1.VariantAutoscaling, 0, len(byTarget))
+			for _, va := range byTarget {
+				result = append(result, va)
+			}
 			return result, fmt.Errorf("listing ScaledObjects: %w", err)
 		}
 	} else {
@@ -281,10 +297,15 @@ func annotationSourcedVariants(ctx context.Context, k8sClient client.Client) ([]
 					"namespace", so.Namespace, "name", so.Name, "error", err)
 				continue
 			}
-			result = append(result, *va)
+			key := fmt.Sprintf("%s/%s/%s", va.Namespace, va.Spec.ScaleTargetRef.Kind, va.Spec.ScaleTargetRef.Name)
+			byTarget[key] = *va
 		}
 	}
 
+	result := make([]wvav1alpha1.VariantAutoscaling, 0, len(byTarget))
+	for _, va := range byTarget {
+		result = append(result, va)
+	}
 	return result, nil
 }
 

--- a/internal/utils/variant_fromannotations.go
+++ b/internal/utils/variant_fromannotations.go
@@ -22,6 +22,7 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
@@ -103,8 +104,7 @@ func VariantAutoscalingFromHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) (*wva
 		apiVersion = "apps/v1"
 	}
 
-	defaultMin := int32(1)
-	minReplicas := &defaultMin
+	minReplicas := ptr.To(int32(1))
 	if hpa.Spec.MinReplicas != nil {
 		minReplicas = hpa.Spec.MinReplicas
 	}

--- a/internal/utils/variant_fromannotations.go
+++ b/internal/utils/variant_fromannotations.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+)
+
+// IsSynthetic reports whether va was synthesized from annotations on a ScaledObject or HPA
+// rather than read from a VariantAutoscaling CRD instance.
+// Synthetic VAs exist only in-memory and must never be written to the Kubernetes API server.
+func IsSynthetic(va *wvav1alpha1.VariantAutoscaling) bool {
+	return va.GetAnnotations()[annotations.Synthetic] == "true"
+}
+
+// VariantAutoscalingFromScaledObject builds an in-memory VariantAutoscaling from a KEDA
+// ScaledObject that bears the llm-d.ai/managed: "true" annotation.
+// Returns an error if required annotations are absent or the scaleTargetRef is empty.
+func VariantAutoscalingFromScaledObject(so *kedav1alpha1.ScaledObject) (*wvav1alpha1.VariantAutoscaling, error) {
+	parsed, err := annotations.Parse(so)
+	if err != nil {
+		return nil, err
+	}
+	if so.Spec.ScaleTargetRef == nil || so.Spec.ScaleTargetRef.Name == "" {
+		return nil, fmt.Errorf("ScaledObject %s/%s has no scaleTargetRef", so.Namespace, so.Name)
+	}
+
+	kind := so.Spec.ScaleTargetRef.Kind
+	if kind == "" {
+		kind = "Deployment"
+	}
+	apiVersion := so.Spec.ScaleTargetRef.APIVersion
+	if apiVersion == "" {
+		apiVersion = "apps/v1"
+	}
+
+	minReplicas := so.GetHPAMinReplicas()
+	maxReplicas := so.GetHPAMaxReplicas()
+
+	return &wvav1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      so.Name,
+			Namespace: so.Namespace,
+			Annotations: map[string]string{
+				annotations.Synthetic: "true",
+			},
+		},
+		Spec: wvav1alpha1.VariantAutoscalingSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       so.Spec.ScaleTargetRef.Name,
+			},
+			ModelID:     parsed.ModelID,
+			MinReplicas: minReplicas,
+			MaxReplicas: maxReplicas,
+			VariantAutoscalingConfigSpec: wvav1alpha1.VariantAutoscalingConfigSpec{
+				VariantCost: parsed.VariantCost,
+			},
+		},
+	}, nil
+}
+
+// VariantAutoscalingFromHPA builds an in-memory VariantAutoscaling from a Kubernetes HPA
+// that bears the llm-d.ai/managed: "true" annotation.
+// Returns an error if required annotations are absent or the scaleTargetRef is empty.
+func VariantAutoscalingFromHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) (*wvav1alpha1.VariantAutoscaling, error) {
+	parsed, err := annotations.Parse(hpa)
+	if err != nil {
+		return nil, err
+	}
+	if hpa.Spec.ScaleTargetRef.Name == "" {
+		return nil, fmt.Errorf("HPA %s/%s has no scaleTargetRef", hpa.Namespace, hpa.Name)
+	}
+
+	kind := hpa.Spec.ScaleTargetRef.Kind
+	if kind == "" {
+		kind = "Deployment"
+	}
+	apiVersion := hpa.Spec.ScaleTargetRef.APIVersion
+	if apiVersion == "" {
+		apiVersion = "apps/v1"
+	}
+
+	defaultMin := int32(1)
+	minReplicas := &defaultMin
+	if hpa.Spec.MinReplicas != nil {
+		minReplicas = hpa.Spec.MinReplicas
+	}
+
+	return &wvav1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hpa.Name,
+			Namespace: hpa.Namespace,
+			Annotations: map[string]string{
+				annotations.Synthetic: "true",
+			},
+		},
+		Spec: wvav1alpha1.VariantAutoscalingSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       hpa.Spec.ScaleTargetRef.Name,
+			},
+			ModelID:     parsed.ModelID,
+			MinReplicas: minReplicas,
+			MaxReplicas: hpa.Spec.MaxReplicas,
+			VariantAutoscalingConfigSpec: wvav1alpha1.VariantAutoscalingConfigSpec{
+				VariantCost: parsed.VariantCost,
+			},
+		},
+	}, nil
+}

--- a/internal/utils/variant_fromannotations_test.go
+++ b/internal/utils/variant_fromannotations_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
+)
+
+func wvaAnnotations(modelID, cost string) map[string]string {
+	ann := map[string]string{
+		annotations.Managed: "true",
+		annotations.ModelID: modelID,
+	}
+	if cost != "" {
+		ann[annotations.VariantCost] = cost
+	}
+	return ann
+}
+
+func TestVariantAutoscalingFromScaledObject(t *testing.T) {
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-scaler",
+			Namespace:   "production",
+			Annotations: wvaAnnotations("ibm/granite-13b", "40.0"),
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "granite-13b",
+			},
+			MinReplicaCount: ptr.To(int32(1)),
+			MaxReplicaCount: ptr.To(int32(5)),
+		},
+	}
+
+	va, err := utils.VariantAutoscalingFromScaledObject(so)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !utils.IsSynthetic(va) {
+		t.Error("expected IsSynthetic to return true")
+	}
+	if va.Name != "my-scaler" {
+		t.Errorf("Name = %q, want %q", va.Name, "my-scaler")
+	}
+	if va.Namespace != "production" {
+		t.Errorf("Namespace = %q, want %q", va.Namespace, "production")
+	}
+	if va.Spec.ModelID != "ibm/granite-13b" {
+		t.Errorf("ModelID = %q, want %q", va.Spec.ModelID, "ibm/granite-13b")
+	}
+	if va.Spec.VariantCost != "40.0" {
+		t.Errorf("VariantCost = %q, want %q", va.Spec.VariantCost, "40.0")
+	}
+	if va.Spec.ScaleTargetRef.Name != "granite-13b" {
+		t.Errorf("ScaleTargetRef.Name = %q, want %q", va.Spec.ScaleTargetRef.Name, "granite-13b")
+	}
+	if va.Spec.MaxReplicas != 5 {
+		t.Errorf("MaxReplicas = %d, want %d", va.Spec.MaxReplicas, 5)
+	}
+}
+
+func TestVariantAutoscalingFromScaledObject_DefaultKind(t *testing.T) {
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "scaler",
+			Namespace:   "ns",
+			Annotations: wvaAnnotations("model/x", ""),
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "my-deploy"},
+		},
+	}
+	va, err := utils.VariantAutoscalingFromScaledObject(so)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if va.Spec.ScaleTargetRef.Kind != "Deployment" {
+		t.Errorf("Kind = %q, want Deployment", va.Spec.ScaleTargetRef.Kind)
+	}
+	if va.Spec.VariantCost != "10.0" {
+		t.Errorf("VariantCost = %q, want 10.0 (default)", va.Spec.VariantCost)
+	}
+}
+
+func TestVariantAutoscalingFromScaledObject_NoScaleTargetRef(t *testing.T) {
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "scaler",
+			Namespace:   "ns",
+			Annotations: wvaAnnotations("model/x", ""),
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{ScaleTargetRef: nil},
+	}
+	if _, err := utils.VariantAutoscalingFromScaledObject(so); err == nil {
+		t.Error("expected error for nil scaleTargetRef")
+	}
+}
+
+func TestVariantAutoscalingFromHPA(t *testing.T) {
+	minR := int32(2)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-hpa",
+			Namespace:   "staging",
+			Annotations: wvaAnnotations("model/llama", "20.0"),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "llama-deploy",
+			},
+			MinReplicas: &minR,
+			MaxReplicas: 8,
+		},
+	}
+
+	va, err := utils.VariantAutoscalingFromHPA(hpa)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !utils.IsSynthetic(va) {
+		t.Error("expected IsSynthetic to return true")
+	}
+	if va.Name != "my-hpa" {
+		t.Errorf("Name = %q, want %q", va.Name, "my-hpa")
+	}
+	if va.Spec.ModelID != "model/llama" {
+		t.Errorf("ModelID = %q, want %q", va.Spec.ModelID, "model/llama")
+	}
+	if va.Spec.MaxReplicas != 8 {
+		t.Errorf("MaxReplicas = %d, want %d", va.Spec.MaxReplicas, 8)
+	}
+	if va.Spec.MinReplicas == nil || *va.Spec.MinReplicas != 2 {
+		t.Errorf("MinReplicas = %v, want 2", va.Spec.MinReplicas)
+	}
+}
+
+func TestVariantAutoscalingFromHPA_MissingAnnotations(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "h", Namespace: "ns"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Name: "d"},
+			MaxReplicas:    2,
+		},
+	}
+	if _, err := utils.VariantAutoscalingFromHPA(hpa); err == nil {
+		t.Error("expected error for missing managed annotation")
+	}
+}
+
+func TestIsSynthetic_False(t *testing.T) {
+	va, _ := utils.VariantAutoscalingFromHPA(&autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h", Namespace: "ns",
+			Annotations: wvaAnnotations("m", ""),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Name: "d"},
+			MaxReplicas:    1,
+		},
+	})
+	if !utils.IsSynthetic(va) {
+		t.Error("synthesized VA must be marked synthetic")
+	}
+
+	// Remove the synthetic annotation to simulate a CRD-sourced VA
+	delete(va.Annotations, annotations.Synthetic)
+	if utils.IsSynthetic(va) {
+		t.Error("VA without synthetic annotation must not be synthetic")
+	}
+}

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -17,11 +17,23 @@ limitations under the License.
 package utils
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 )
 
 func TestGroupVariantAutoscalingByModel(t *testing.T) {
@@ -129,4 +141,241 @@ func TestGroupVariantAutoscalingByModel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// variantTestScheme builds a scheme with WVA, core Kubernetes (incl. HPA), and KEDA types.
+func variantTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add clientgoscheme: %v", err)
+	}
+	if err := wvav1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add wvav1alpha1: %v", err)
+	}
+	if err := kedav1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add kedav1alpha1: %v", err)
+	}
+	return s
+}
+
+func managedHPA(ns, name, targetKind, targetName, modelID string) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				annotations.Managed: "true",
+				annotations.ModelID: modelID,
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: targetKind, Name: targetName},
+			MaxReplicas:    5,
+		},
+	}
+}
+
+func managedSO(ns, name, targetKind, targetName, modelID string) *kedav1alpha1.ScaledObject {
+	return &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				annotations.Managed: "true",
+				annotations.ModelID: modelID,
+			},
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Kind: targetKind, Name: targetName},
+		},
+	}
+}
+
+func TestAnnotationSourcedVariants(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("HPAs only", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
+			managedHPA("ns1", "hpa-b", "Deployment", "deploy-b", "model-x"),
+			// unmanaged HPA — must be filtered out
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "hpa-unmanaged", Namespace: "ns1"},
+				Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 3},
+			},
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("want 2 VAs, got %d", len(result))
+		}
+	})
+
+	t.Run("ScaledObjects only", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedSO("ns1", "so-a", "Deployment", "deploy-a", "model-x"),
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA, got %d", len(result))
+		}
+	})
+
+	t.Run("mixed HPAs and ScaledObjects", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
+			managedSO("ns1", "so-b", "Deployment", "deploy-b", "model-x"),
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("want 2 VAs, got %d", len(result))
+		}
+	})
+
+	t.Run("KEDA not installed — NoMatchError skipped gracefully", func(t *testing.T) {
+		s := variantTestScheme(t)
+		soGK := schema.GroupKind{Group: "keda.sh", Kind: "ScaledObject"}
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
+		).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*kedav1alpha1.ScaledObjectList); ok {
+					return &apimeta.NoKindMatchError{GroupKind: soGK}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA from HPA, got %d", len(result))
+		}
+	})
+
+	t.Run("KEDA non-NoMatch error propagated", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*kedav1alpha1.ScaledObjectList); ok {
+					return fmt.Errorf("keda api unavailable")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		_, err := annotationSourcedVariants(ctx, cl)
+		if err == nil {
+			t.Fatal("want error for non-NoMatch ScaledObject list failure, got nil")
+		}
+	})
+
+	t.Run("deduplication: ScaledObject wins over HPA for same scale target", func(t *testing.T) {
+		s := variantTestScheme(t)
+		// Both an HPA and a ScaledObject point at the same Deployment — ScaledObject wins.
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-hpa"),
+			managedSO("ns1", "so-a", "Deployment", "deploy-a", "model-so"),
+		).Build()
+
+		result, err := annotationSourcedVariants(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA (deduplicated), got %d", len(result))
+		}
+		if result[0].Spec.ModelID != "model-so" {
+			t.Errorf("want ScaledObject to win, got modelID %q", result[0].Spec.ModelID)
+		}
+	})
+}
+
+func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
+	ctx := context.Background()
+
+	makeCRDVA := func(ns, name, targetKind, targetName string) *wvav1alpha1.VariantAutoscaling {
+		return &wvav1alpha1.VariantAutoscaling{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: wvav1alpha1.VariantAutoscalingSpec{
+				ModelID: "model-crd",
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: targetKind, Name: targetName},
+			},
+		}
+	}
+
+	t.Run("CRD and annotation with different targets — both returned", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			makeCRDVA("ns1", "va-crd", "Deployment", "deploy-crd"),
+			managedHPA("ns1", "hpa-ann", "Deployment", "deploy-ann", "model-ann"),
+		).Build()
+
+		result, err := readyVariantAutoscalings(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("want 2 VAs, got %d", len(result))
+		}
+	})
+
+	t.Run("CRD wins when same namespace/kind/name as annotation-sourced", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			makeCRDVA("ns1", "va-crd", "Deployment", "shared-deploy"),
+			managedHPA("ns1", "hpa-ann", "Deployment", "shared-deploy", "model-ann"),
+		).Build()
+
+		result, err := readyVariantAutoscalings(ctx, cl)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA (CRD wins), got %d", len(result))
+		}
+		if result[0].Spec.ModelID != "model-crd" {
+			t.Errorf("want CRD VA to win, got modelID %q", result[0].Spec.ModelID)
+		}
+	})
+
+	t.Run("annotationSourcedVariants error is non-fatal — CRD-sourced still returned", func(t *testing.T) {
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			makeCRDVA("ns1", "va-crd", "Deployment", "deploy-crd"),
+		).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				// fail HPA listing to force annotationSourcedVariants to return an error
+				if _, ok := list.(*autoscalingv2.HorizontalPodAutoscalerList); ok {
+					return fmt.Errorf("hpa api unavailable")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		result, err := readyVariantAutoscalings(ctx, cl)
+		if err != nil {
+			t.Fatalf("expected non-fatal path, got error: %v", err)
+		}
+		if len(result) != 1 || result[0].Name != "va-crd" {
+			t.Errorf("want 1 CRD VA, got %d VAs", len(result))
+		}
+	})
 }

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -159,7 +159,7 @@ func variantTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func managedHPA(ns, name, targetKind, targetName, modelID string) *autoscalingv2.HorizontalPodAutoscaler {
+func managedHPA(ns, name, targetName, modelID string) *autoscalingv2.HorizontalPodAutoscaler {
 	return &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -170,7 +170,7 @@ func managedHPA(ns, name, targetKind, targetName, modelID string) *autoscalingv2
 			},
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: targetKind, Name: targetName},
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: targetName},
 			MaxReplicas:    5,
 		},
 	}
@@ -198,8 +198,8 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 	t.Run("HPAs only", func(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
-			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
-			managedHPA("ns1", "hpa-b", "Deployment", "deploy-b", "model-x"),
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
+			managedHPA("ns1", "hpa-b", "deploy-b", "model-x"),
 			// unmanaged HPA — must be filtered out
 			&autoscalingv2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: "hpa-unmanaged", Namespace: "ns1"},
@@ -234,7 +234,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 	t.Run("mixed HPAs and ScaledObjects", func(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
-			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
 			managedSO("ns1", "so-b", "Deployment", "deploy-b", "model-x"),
 		).Build()
 
@@ -251,7 +251,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 		s := variantTestScheme(t)
 		soGK := schema.GroupKind{Group: "keda.sh", Kind: "ScaledObject"}
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
-			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-x"),
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-x"),
 		).WithInterceptorFuncs(interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				if _, ok := list.(*kedav1alpha1.ScaledObjectList); ok {
@@ -291,7 +291,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 		s := variantTestScheme(t)
 		// Both an HPA and a ScaledObject point at the same Deployment — ScaledObject wins.
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
-			managedHPA("ns1", "hpa-a", "Deployment", "deploy-a", "model-hpa"),
+			managedHPA("ns1", "hpa-a", "deploy-a", "model-hpa"),
 			managedSO("ns1", "so-a", "Deployment", "deploy-a", "model-so"),
 		).Build()
 
@@ -325,7 +325,7 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
 			makeCRDVA("ns1", "va-crd", "Deployment", "deploy-crd"),
-			managedHPA("ns2", "hpa-ann", "Deployment", "deploy-ann", "model-ann"),
+			managedHPA("ns2", "hpa-ann", "deploy-ann", "model-ann"),
 		).Build()
 
 		result, err := readyVariantAutoscalings(ctx, cl)
@@ -341,7 +341,7 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
 			makeCRDVA("ns1", "va-crd", "Deployment", "shared-deploy"),
-			managedHPA("ns1", "hpa-ann", "Deployment", "shared-deploy", "model-ann"),
+			managedHPA("ns1", "hpa-ann", "shared-deploy", "model-ann"),
 		).Build()
 
 		result, err := readyVariantAutoscalings(ctx, cl)

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -378,4 +378,30 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 			t.Errorf("want 1 CRD VA, got %d VAs", len(result))
 		}
 	})
+
+	t.Run("no CRD VA, annotated HPA, KEDA listing fails — HPA VA still returned", func(t *testing.T) {
+		// annotationSourcedVariants successfully lists the HPA but then fails listing
+		// ScaledObjects with a non-NoMatch error (e.g. transient API error).
+		// readyVariantAutoscalings logs the error as non-fatal and still merges the
+		// partial annotation results, so the HPA-sourced VA is returned.
+		s := variantTestScheme(t)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-ann", "deploy-ann", "model-ann"),
+		).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*kedav1alpha1.ScaledObjectList); ok {
+					return errors.New("keda api unavailable")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		result, err := readyVariantAutoscalings(ctx, cl)
+		if err != nil {
+			t.Fatalf("expected non-fatal path, got error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("want 1 VA (HPA-sourced, KEDA error is non-fatal), got %d", len(result))
+		}
+	})
 }

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -275,7 +275,7 @@ func TestAnnotationSourcedVariants(t *testing.T) {
 		cl := fake.NewClientBuilder().WithScheme(s).WithInterceptorFuncs(interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				if _, ok := list.(*kedav1alpha1.ScaledObjectList); ok {
-					return fmt.Errorf("keda api unavailable")
+					return errors.New("keda api unavailable")
 				}
 				return c.List(ctx, list, opts...)
 			},
@@ -315,7 +315,7 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 		return &wvav1alpha1.VariantAutoscaling{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 			Spec: wvav1alpha1.VariantAutoscalingSpec{
-				ModelID: "model-crd",
+				ModelID:        "model-crd",
 				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: targetKind, Name: targetName},
 			},
 		}
@@ -325,7 +325,7 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
 			makeCRDVA("ns1", "va-crd", "Deployment", "deploy-crd"),
-			managedHPA("ns1", "hpa-ann", "Deployment", "deploy-ann", "model-ann"),
+			managedHPA("ns2", "hpa-ann", "Deployment", "deploy-ann", "model-ann"),
 		).Build()
 
 		result, err := readyVariantAutoscalings(ctx, cl)
@@ -364,7 +364,7 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				// fail HPA listing to force annotationSourcedVariants to return an error
 				if _, ok := list.(*autoscalingv2.HorizontalPodAutoscalerList); ok {
-					return fmt.Errorf("hpa api unavailable")
+					return errors.New("hpa api unavailable")
 				}
 				return c.List(ctx, list, opts...)
 			},

--- a/test/e2e/annotation_discovery_test.go
+++ b/test/e2e/annotation_discovery_test.go
@@ -1,0 +1,131 @@
+package e2e
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+)
+
+// Annotation-based discovery e2e tests verify that WVA can discover variants from
+// annotated HPA / ScaledObject resources without any VariantAutoscaling CRD.
+// These tests are the Phase 1 dual-mode counterpart; the VA-based tests remain
+// untouched and will be migrated in Phase 3.
+var _ = Describe("Annotation-based variant discovery", Serial, func() {
+
+	// ── Scenario A: Basic lifecycle ─────────────────────────────────────────────
+	// Mirrors the "Basic VA lifecycle" block in smoke_test.go, but with no VA CR.
+	Context("basic lifecycle", Ordered, func() {
+		var (
+			poolName         = "ann-disc-pool"
+			modelServiceName = "ann-disc-basic"
+			deploymentName   = modelServiceName + "-decode"
+			// hpaBaseName is the logical base; the HPA object name will be hpaBaseName+"-hpa".
+			// WVA discovers that HPA and uses its object name as variant_name in wva_desired_replicas.
+			hpaBaseName = "ann-disc-basic"
+			hpaName     = hpaBaseName + "-hpa"
+		)
+
+		BeforeAll(func() {
+			By("Creating model service deployment")
+			err := fixtures.EnsureModelService(ctx, k8sClient, cfg.LLMDNamespace, modelServiceName, poolName, cfg.ModelID, cfg.UseSimulator, cfg.MaxNumSeqs)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create model service")
+
+			DeferCleanup(func() {
+				_ = k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
+				_ = k8sClient.CoreV1().Services(cfg.LLMDNamespace).Delete(ctx, modelServiceName+"-service", metav1.DeleteOptions{})
+			})
+
+			By("Waiting for deployment to be ready")
+			Eventually(func(g Gomega) {
+				d, err := k8sClient.AppsV1().Deployments(cfg.LLMDNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(d.Status.ReadyReplicas).To(Equal(int32(1)))
+			}, time.Duration(cfg.PodReadyTimeout)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+
+			By("Creating annotated scaler (no VA CR)")
+			if cfg.ScalerBackend == scalerBackendKeda {
+				err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10, cfg.MonitoringNS,
+					fixtures.WithScaledObjectWVAAnnotations(cfg.ModelID, "30.0"))
+				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated ScaledObject")
+				DeferCleanup(func() { _ = fixtures.DeleteScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaBaseName) })
+			} else {
+				err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaBaseName, deploymentName, hpaName, 1, 10,
+					fixtures.WithWVAAnnotations(cfg.ModelID, "30.0"))
+				Expect(err).NotTo(HaveOccurred(), "Failed to create annotated HPA")
+				DeferCleanup(func() {
+					_ = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).Delete(ctx, hpaName, metav1.DeleteOptions{})
+				})
+			}
+		})
+
+		It("should not create a VariantAutoscaling CR", func() {
+			vaList := &variantautoscalingv1alpha1.VariantAutoscalingList{}
+			err := crClient.List(ctx, vaList, client.InNamespace(cfg.LLMDNamespace))
+			Expect(err).NotTo(HaveOccurred())
+			for _, va := range vaList.Items {
+				Expect(va.Name).NotTo(Equal(hpaName),
+					"No VA should be created for annotation-based discovery")
+			}
+		})
+
+		It("should expose wva_desired_replicas for the annotated scaler", func() {
+			// In both backends WVA emits wva_desired_replicas to Prometheus.
+			// For HPA (Prometheus Adapter): verify the external metrics API returns the metric.
+			// For KEDA: verify KEDA has read the metric from Prometheus by checking that the
+			// KEDA-managed HPA has CurrentMetrics populated (KEDA only sets this after a
+			// successful Prometheus query).
+			if cfg.ScalerBackend == scalerBackendKeda {
+				By("Verifying KEDA has read wva_desired_replicas from Prometheus")
+				Eventually(func(g Gomega) {
+					hpaList, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					var kedaHPA *autoscalingv2.HorizontalPodAutoscaler
+					for i := range hpaList.Items {
+						if hpaList.Items[i].Spec.ScaleTargetRef.Name == deploymentName {
+							kedaHPA = &hpaList.Items[i]
+							break
+						}
+					}
+					g.Expect(kedaHPA).NotTo(BeNil(), "KEDA should have created an HPA for the deployment")
+					g.Expect(kedaHPA.Status.CurrentMetrics).NotTo(BeEmpty(),
+						"KEDA HPA should have CurrentMetrics populated, indicating wva_desired_replicas was read from Prometheus")
+					GinkgoWriter.Printf("KEDA HPA CurrentMetrics populated (%d entries) — wva_desired_replicas is being consumed\n",
+						len(kedaHPA.Status.CurrentMetrics))
+				}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			} else {
+				By("Querying external metrics API for wva_desired_replicas")
+				Eventually(func(g Gomega) {
+					result, err := k8sClient.RESTClient().
+						Get().
+						AbsPath("/apis/external.metrics.k8s.io/v1beta1/namespaces/" + cfg.LLMDNamespace + "/" + constants.WVADesiredReplicas).
+						DoRaw(ctx)
+					if err != nil {
+						if errors.IsNotFound(err) {
+							// API accessible but metric not yet emitted — engine may not have ticked
+							_, discoveryErr := k8sClient.Discovery().ServerResourcesForGroupVersion("external.metrics.k8s.io/v1beta1")
+							g.Expect(discoveryErr).NotTo(HaveOccurred(), "External metrics API should be accessible")
+							return
+						}
+						g.Expect(err).NotTo(HaveOccurred())
+					}
+					if !strings.Contains(string(result), `"items":[]`) {
+						g.Expect(string(result)).To(ContainSubstring(constants.WVADesiredReplicas))
+						GinkgoWriter.Printf("wva_desired_replicas emitted for annotated HPA %s\n", hpaName)
+					}
+				}, time.Duration(cfg.EventuallyLongSec)*time.Second, time.Duration(cfg.PollIntervalSec)*time.Second).Should(Succeed())
+			}
+		})
+
+	})
+
+})

--- a/test/e2e/fixtures/hpa_builder.go
+++ b/test/e2e/fixtures/hpa_builder.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 )
 
 const (
@@ -23,6 +25,19 @@ const (
 
 // HPAOption is a functional option for configuring HPA resources.
 type HPAOption func(*autoscalingv2.HorizontalPodAutoscaler)
+
+// WithWVAAnnotations adds the WVA annotation-based discovery annotations to the HPA.
+// The HPA then serves as both the WVA discovery source and the scaler for the deployment.
+func WithWVAAnnotations(modelID, cost string) HPAOption {
+	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+		if hpa.Annotations == nil {
+			hpa.Annotations = make(map[string]string)
+		}
+		hpa.Annotations[annotations.Managed] = "true"
+		hpa.Annotations[annotations.ModelID] = modelID
+		hpa.Annotations[annotations.VariantCost] = cost
+	}
+}
 
 // WithScaleTargetRefKind sets the Kind and APIVersion on the HPA's ScaleTargetRef.
 func WithScaleTargetRefKind(kind string) HPAOption {

--- a/test/e2e/fixtures/scaled_object_builder.go
+++ b/test/e2e/fixtures/scaled_object_builder.go
@@ -11,30 +11,45 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
 )
 
 const (
 	scaledObjectSuffix = "-so"
 )
 
-// ScaledObjectOption configures a KEDA ScaledObject spec before it is applied.
-type ScaledObjectOption func(*kedav1alpha1.ScaledObjectSpec)
+// ScaledObjectOption configures a KEDA ScaledObject before it is applied.
+type ScaledObjectOption func(*kedav1alpha1.ScaledObject)
 
 // WithScaledObjectScaleTargetKind sets the Kind and APIVersion on the ScaledObject's ScaleTargetRef.
 func WithScaledObjectScaleTargetKind(kind string) ScaledObjectOption {
-	return func(spec *kedav1alpha1.ScaledObjectSpec) {
-		if spec.ScaleTargetRef == nil {
+	return func(so *kedav1alpha1.ScaledObject) {
+		if so.Spec.ScaleTargetRef == nil {
 			return
 		}
-		spec.ScaleTargetRef.Kind = kind
+		so.Spec.ScaleTargetRef.Kind = kind
 		switch kind {
 		case kindLeaderWorkerSet:
-			spec.ScaleTargetRef.APIVersion = apiVersionLWS
+			so.Spec.ScaleTargetRef.APIVersion = apiVersionLWS
 		case kindDeployment:
-			spec.ScaleTargetRef.APIVersion = apiVersionAppsV1
+			so.Spec.ScaleTargetRef.APIVersion = apiVersionAppsV1
 		default:
 			// Keep existing APIVersion for unknown kinds
 		}
+	}
+}
+
+// WithScaledObjectWVAAnnotations adds the WVA annotation-based discovery annotations to the
+// ScaledObject. The ScaledObject then serves as both the WVA discovery source and the KEDA scaler.
+func WithScaledObjectWVAAnnotations(modelID, cost string) ScaledObjectOption {
+	return func(so *kedav1alpha1.ScaledObject) {
+		if so.Annotations == nil {
+			so.Annotations = make(map[string]string)
+		}
+		so.Annotations[annotations.Managed] = "true"
+		so.Annotations[annotations.ModelID] = modelID
+		so.Annotations[annotations.VariantCost] = cost
 	}
 }
 
@@ -136,9 +151,6 @@ func buildScaledObject(namespace, name, scaleTargetName, vaName string, minRepli
 			},
 		},
 	}
-	for _, opt := range opts {
-		opt(&spec)
-	}
 	so := &kedav1alpha1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objName,
@@ -146,6 +158,9 @@ func buildScaledObject(namespace, name, scaleTargetName, vaName string, minRepli
 			Labels:    map[string]string{"test-resource": defaultTestResourceLabelValue},
 		},
 		Spec: spec,
+	}
+	for _, opt := range opts {
+		opt(so)
 	}
 	return so
 }


### PR DESCRIPTION
#1130 Phase 1 

## Summary

Implements Phase 1 (dual-mode) of the VA deprecation proposal (`docs/proposals/deprecate-va-crd.md`), plus the implementation plan and a small refactor.

**docs/plans/va-deprecation.md** — implementation plan for all three phases (dual-mode, deprecation, removal), organized as small semantically-separated tasks.

**Phase 1: annotation-based discovery alongside the existing VA CRD**

- `internal/annotations/` — new package with annotation key constants (`llm-d.ai/managed`, `model-id`, `variant-cost`, `synthetic`) and `Parse`/`IsManaged` helpers.
- `internal/utils/variant_fromannotations.go` — `VariantAutoscalingFromScaledObject`, `VariantAutoscalingFromHPA`, `IsSynthetic`: synthesize in-memory `VariantAutoscaling` objects from annotated objects so the downstream pipeline (collector / analyzer / optimizer / metrics) is unchanged.
- `internal/utils/variant.go` — `readyVariantAutoscalings` merges CRD-sourced and annotation-sourced VAs; new `annotationSourcedVariants` lists HPAs (always) and ScaledObjects (KEDA checked via `NoMatchError`). CRD wins on conflict.
- `internal/engines/saturation/engine.go` — `applySaturationDecisions`: synthetic VAs skip the API-server fetch and `DecisionCache`/`DecisionTrigger` (no CRD status to patch). Metric emission via `act.EmitMetrics` is preserved — KEDA/HPA still read `wva_desired_replicas`.
- `internal/controller/variantautoscaling_controller.go` — adds `kedaEnabled` field, `handleAnnotatedScalerEvent` for namespace tracking, HPA watch (always) and ScaledObject watch (if `kedaEnabled`), RBAC markers for `keda.sh/scaledobjects` and `autoscaling/horizontalpodautoscalers`.
- `cmd/main.go` — registers KEDA scheme unconditionally; detects and logs KEDA presence; passes `kedaEnabled` to the reconciler.
- `config/samples/keda/annotations/`, `config/samples/hpa/annotations/` — new kustomize overlays: annotated ScaledObject and HPA consuming `wva_desired_replicas` without a VA CRD.

**Refactor: CRD detection helpers**

- `internal/utils/crd/` — `CheckCRDInstalled` generic helper + `CheckKEDACRD` and `CheckLeaderWorkerSetCRD` wrappers extracted from `cmd/main.go`, removing duplicated discovery-client boilerplate.

## Test plan

- [x] `make test` — all 29 unit/integration packages pass
- [ ] `make test-e2e-smoke` on a kind cluster with KEDA installed: annotated ScaledObject (no VA) produces `wva_desired_replicas` metric and KEDA scales the Deployment
- [ ] same smoke test with KEDA absent: HPA annotation path still produces the metric
- [ ] existing VA-based e2e tests remain green (CRD path unchanged)


