### PR TITLE
docs: add multi-run results for prefill heavy, decode heavy, and symmetrical scenarios

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -54,38 +54,38 @@ Summary of WVA benchmark runs with configuration details.
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
-**Saturation Engine:** Default(v1)
+**Saturation Engine:** Default(v1), Tuned(v1)
 
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 98,810 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 55.06 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.68 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 65.1% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 236.8 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 4,186 / 4,882 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (prefill) |
+|--------|------------------------------|------------------------------|------------------------------|-----|--------------------------------|
+| P99 TTFT (ms) | 98,810 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 55.06 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.68 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 65.1% | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 236.8 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 4,186 / 4,882 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
 
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
-**Saturation Engine:** Default(v1)
+**Saturation Engine:** Default(v1), Tuned(v1)
 
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 85,612 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 47.09 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.73 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 88.8% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 111.8 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,506 / 4,105 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (decode) |
+|--------|------------------------------|------------------------------|------------------------------|-----|-------------------------------|
+| P99 TTFT (ms) | 85,612 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 47.09 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.73 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 88.8% | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 111.8 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,506 / 4,105 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
 
 ## Symmetrical Scenario
 
@@ -94,8 +94,8 @@ Summary of WVA benchmark runs with configuration details.
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1)
 
-| Metric | Run 1 | Run 2 | Run 3 | Avg |
-|--------|-------|-------|-------|-----|
+| Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg |
+|--------|------------------------------|------------------------------|------------------------------|-----|
 | P99 TTFT (ms) | 101,083 | _TBD_ | _TBD_ | _TBD_ |
 | P99 ITL (ms/token) | 67.61 | _TBD_ | _TBD_ | _TBD_ |
 | Avg replicas | 1.70 | _TBD_ | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -64,7 +64,7 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | 3 | 3 | 3 | _TBD_ |
 | Avg KV cache utilization | 65.1% | 69.2% | 64.5% | 66.3% | _TBD_ |
 | Avg queue depth (EPP) | 236.8 | 252.4 | 220.4 | 236.5 | _TBD_ |
-| Error count | 4,186 / 4,882 | 4,193 | 4,173 | 4,184 | _TBD_ |
+| Error count | 4,186 | 4,193 | 4,173 | 4,184 | _TBD_ |
 | Avg pod startup (s) | _TBD_ | 106 | 109 | 108 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | 1.73 | 1.73 | _TBD_ |
 
@@ -83,7 +83,7 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | 3 | 3 | 3 | _TBD_ |
 | Avg KV cache utilization | 88.8% | 78.2% | 70.7% | 79.2% | _TBD_ |
 | Avg queue depth (EPP) | 111.8 | 111.5 | 103.1 | 108.8 | _TBD_ |
-| Error count | 3,506 / 4,105 | 3,551 | 3,632 | 3,563 | _TBD_ |
+| Error count | 3,506 | 3,551 | 3,632 | 3,563 | _TBD_ |
 | Avg pod startup (s) | _TBD_ | 103 | 106 | 105 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | 1.96 | 1.89 | _TBD_ |
 
@@ -102,6 +102,6 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | 3 | _TBD_ | _TBD_ |
 | Avg KV cache utilization | 66.7% | 70.2% | _TBD_ | _TBD_ |
 | Avg queue depth (EPP) | 135.1 | 176.7 | _TBD_ | _TBD_ |
-| Error count | 3,773 / 4,839 | 3,710 | _TBD_ | _TBD_ |
+| Error count | 3,773 | 3,710 | _TBD_ | _TBD_ |
 | Avg pod startup (s) | _TBD_ | 107 | _TBD_ | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -58,15 +58,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (prefill) |
 |--------|------------------------------|------------------------------|------------------------------|-----|--------------------------------|
-| P99 TTFT (ms) | 98,810 | 97,811 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 55.06 | 54.4 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.68 | 1.77 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 65.1% | 69.2% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 236.8 | 252.4 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 4,186 / 4,882 | 4,193 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | 106 | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 98,810 | 97,811 | 98,638 | 98,420 | _TBD_ |
+| P99 ITL (ms/token) | 55.06 | 54.4 | 54.98 | 54.8 | _TBD_ |
+| Avg replicas | 1.68 | 1.77 | 1.73 | 1.73 | _TBD_ |
+| Max replicas | 3 | 3 | 3 | 3 | _TBD_ |
+| Avg KV cache utilization | 65.1% | 69.2% | 64.5% | 66.3% | _TBD_ |
+| Avg queue depth (EPP) | 236.8 | 252.4 | 220.4 | 236.5 | _TBD_ |
+| Error count | 4,186 / 4,882 | 4,193 | 4,173 | 4,184 | _TBD_ |
+| Avg pod startup (s) | _TBD_ | 106 | 109 | 108 | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | 1.73 | 1.73 | _TBD_ |
 
 ## Decode Heavy Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -77,15 +77,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (decode) |
 |--------|------------------------------|------------------------------|------------------------------|-----|-------------------------------|
-| P99 TTFT (ms) | 85,612 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 47.09 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.73 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 88.8% | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 111.8 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,506 / 4,105 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 85,612 | 85,397 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 47.09 | 47.05 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.73 | 1.82 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 88.8% | 78.2% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 111.8 | 111.5 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,506 / 4,105 | 3,551 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | 103 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | _TBD_ | _TBD_ | _TBD_ |
 
 ## Symmetrical Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -77,15 +77,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (decode) |
 |--------|------------------------------|------------------------------|------------------------------|-----|-------------------------------|
-| P99 TTFT (ms) | 85,612 | 85,397 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 47.09 | 47.05 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.73 | 1.82 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 88.8% | 78.2% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 111.8 | 111.5 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,506 / 4,105 | 3,551 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | 103 | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 85,612 | 85,397 | 63,144 | 78,051 | _TBD_ |
+| P99 ITL (ms/token) | 47.09 | 47.05 | 47.26 | 47.13 | _TBD_ |
+| Avg replicas | 1.73 | 1.82 | 1.96 | 1.84 | _TBD_ |
+| Max replicas | 3 | 3 | 3 | 3 | _TBD_ |
+| Avg KV cache utilization | 88.8% | 78.2% | 70.7% | 79.2% | _TBD_ |
+| Avg queue depth (EPP) | 111.8 | 111.5 | 103.1 | 108.8 | _TBD_ |
+| Error count | 3,506 / 4,105 | 3,551 | 3,632 | 3,563 | _TBD_ |
+| Avg pod startup (s) | _TBD_ | 103 | 106 | 105 | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | 1.96 | 1.89 | _TBD_ |
 
 ## Symmetrical Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -65,7 +65,7 @@ Summary of WVA benchmark runs with configuration details.
 | Avg KV cache utilization | 65.1% | 69.2% | 64.5% | 66.3% | _TBD_ |
 | Avg queue depth (EPP) | 236.8 | 252.4 | 220.4 | 236.5 | _TBD_ |
 | Error count | 4,186 | 4,193 | 4,173 | 4,184 | _TBD_ |
-| Avg pod startup (s) | _TBD_ | 106 | 109 | 108 | _TBD_ |
+| Avg pod startup (s) | 115 | 106 | 109 | 110 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | 1.73 | 1.73 | _TBD_ |
 
 ## Decode Heavy Scenario
@@ -84,7 +84,7 @@ Summary of WVA benchmark runs with configuration details.
 | Avg KV cache utilization | 88.8% | 78.2% | 70.7% | 79.2% | _TBD_ |
 | Avg queue depth (EPP) | 111.8 | 111.5 | 103.1 | 108.8 | _TBD_ |
 | Error count | 3,506 | 3,551 | 3,632 | 3,563 | _TBD_ |
-| Avg pod startup (s) | _TBD_ | 103 | 106 | 105 | _TBD_ |
+| Avg pod startup (s) | 119 | 103 | 106 | 109 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | 1.96 | 1.89 | _TBD_ |
 
 ## Symmetrical Scenario
@@ -103,5 +103,5 @@ Summary of WVA benchmark runs with configuration details.
 | Avg KV cache utilization | 66.7% | 70.2% | _TBD_ | _TBD_ |
 | Avg queue depth (EPP) | 135.1 | 176.7 | _TBD_ | _TBD_ |
 | Error count | 3,773 | 3,710 | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | 107 | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 97 | 107 | _TBD_ | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -96,12 +96,12 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg |
 |--------|------------------------------|------------------------------|------------------------------|-----|
-| P99 TTFT (ms) | 101,083 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 67.61 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.70 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 66.7% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 135.1 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,773 / 4,839 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 101,083 | 99,542 | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 67.61 | 67.0 | _TBD_ | _TBD_ |
+| Avg replicas | 1.70 | 1.75 | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 66.7% | 70.2% | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 135.1 | 176.7 | _TBD_ | _TBD_ |
+| Error count | 3,773 / 4,839 | 3,710 | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | 107 | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -96,12 +96,12 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg |
 |--------|------------------------------|------------------------------|------------------------------|-----|
-| P99 TTFT (ms) | 101,083 | 99,542 | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 67.61 | 67.0 | _TBD_ | _TBD_ |
-| Avg replicas | 1.70 | 1.75 | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 66.7% | 70.2% | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 135.1 | 176.7 | _TBD_ | _TBD_ |
-| Error count | 3,773 | 3,710 | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 97 | 107 | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 101,083 | 99,542 | 99,937 | 100,187 |
+| P99 ITL (ms/token) | 67.61 | 67.0 | 67.25 | 67.29 |
+| Avg replicas | 1.70 | 1.75 | 1.64 | 1.70 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 66.7% | 70.2% | 73.7% | 70.2% |
+| Avg queue depth (EPP) | 135.1 | 176.7 | 188.6 | 166.8 |
+| Error count | 3,773 | 3,710 | 3,705 | 3,729 |
+| Avg pod startup (s) | 97 | 107 | 105 | 103 |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | 1.64 | 1.70 |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -58,15 +58,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | WVA v0.6.0 Default(v1) Run 1 | WVA v0.6.0 Default(v1) Run 2 | WVA v0.6.0 Default(v1) Run 3 | Avg | WVA v0.6.0 Tuned(v1) (prefill) |
 |--------|------------------------------|------------------------------|------------------------------|-----|--------------------------------|
-| P99 TTFT (ms) | 98,810 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 55.06 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.68 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 65.1% | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 236.8 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 4,186 / 4,882 | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 98,810 | 97,811 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 55.06 | 54.4 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.68 | 1.77 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 65.1% | 69.2% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 236.8 | 252.4 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 4,186 / 4,882 | 4,193 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | 106 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | _TBD_ | _TBD_ | _TBD_ |
 
 ## Decode Heavy Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -64,9 +64,9 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
 | Avg KV cache utilization | 65.1% | _TBD_ | _TBD_ | _TBD_ |
 | Avg queue depth (EPP) | 236.8 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 4,186 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 4,186 / 4,882 | _TBD_ | _TBD_ | _TBD_ |
 | Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.68 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
 
 ## Decode Heavy Scenario
 
@@ -83,9 +83,9 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
 | Avg KV cache utilization | 88.8% | _TBD_ | _TBD_ | _TBD_ |
 | Avg queue depth (EPP) | 111.8 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,506 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,506 / 4,105 | _TBD_ | _TBD_ | _TBD_ |
 | Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.73 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
 
 ## Symmetrical Scenario
 
@@ -102,6 +102,6 @@ Summary of WVA benchmark runs with configuration details.
 | Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
 | Avg KV cache utilization | 66.7% | _TBD_ | _TBD_ | _TBD_ |
 | Avg queue depth (EPP) | 135.1 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 3,773 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,773 / 4,839 | _TBD_ | _TBD_ | _TBD_ |
 | Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.70 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -54,36 +54,38 @@ Summary of WVA benchmark runs with configuration details.
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
-**Saturation Engine:** Default(v1), Tuned(v1)
+**Saturation Engine:** Default(v1)
 
-| Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (prefill) |
-|--------|------------------------|--------------------------------|
-| P99 TTFT (ms) | 98,810 | _TBD_ |
-| P99 ITL (ms/token) | 55.06 | _TBD_ |
-| Avg replicas | 1.68 | _TBD_ |
-| Max replicas | 3 | _TBD_ |
-| Avg KV cache utilization | 65.1% | _TBD_ |
-| Avg queue depth (EPP) | 236.8 | _TBD_ |
-| Error count | 4,186 / 4,882 | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 98,810 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 55.06 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.68 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 65.1% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 236.8 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 4,186 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.68 | _TBD_ | _TBD_ | _TBD_ |
 
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
-**Saturation Engine:** Default(v1), Tuned(v1)
+**Saturation Engine:** Default(v1)
 
-| Metric | WVA v0.6.0 Default(v1) | WVA v0.6.0 Tuned(v1) (decode) |
-|--------|------------------------|-------------------------------|
-| P99 TTFT (ms) | 85,612 | _TBD_ |
-| P99 ITL (ms/token) | 47.09 | _TBD_ |
-| Avg replicas | 1.73 | _TBD_ |
-| Max replicas | 3 | _TBD_ |
-| Avg KV cache utilization | 88.8% | _TBD_ |
-| Avg queue depth (EPP) | 111.8 | _TBD_ |
-| Error count | 3,506 / 4,105 | _TBD_ |
-| Cost (avg replicas × GPU/hr) | _TBD_ | _TBD_ |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 85,612 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 47.09 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.73 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 88.8% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 111.8 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,506 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.73 | _TBD_ | _TBD_ | _TBD_ |
 
 ## Symmetrical Scenario
 
@@ -92,13 +94,14 @@ Summary of WVA benchmark runs with configuration details.
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Saturation Engine:** Default(v1)
 
-| Metric | WVA v0.6.0 Default(v1) |
-|--------|------------------------|
-| P99 TTFT (ms) | 101,083 |
-| P99 ITL (ms/token) | 67.61 |
-| Avg replicas | 1.70 |
-| Max replicas | 3 |
-| Avg KV cache utilization | 66.7% |
-| Avg queue depth (EPP) | 135.1 |
-| Error count | 3,773 / 4,839 |
-| Cost (avg replicas × GPU/hr) | _TBD_ |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 101,083 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 67.61 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.70 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 66.7% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 135.1 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 3,773 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.70 | _TBD_ | _TBD_ | _TBD_ |


### PR DESCRIPTION
## Summary

Restructures the Prefill Heavy, Decode Heavy, and Symmetrical scenario tables in \`docs/benchmark.md\` to track 3 independent runs with averages — consistent with the approach used in the Bursty Scenario (#1118).

## Changes

- Adds Run 2, Run 3, and Avg columns to Prefill Heavy, Decode Heavy, and Symmetrical tables
- Adds \`Avg pod startup (s)\` row to each scenario table
- Run 1 data preserved from existing results
- Removes the Tuned(v1) column (separate effort, tracked separately)



Made with [Cursor](https://cursor.com)