### PR TITLE
fix: pin llm-d-benchmark to v0.6.0 in benchmark-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
 # llm-d-benchmark CLI configuration
 BENCHMARK_REPO_URL   ?= https://github.com/llm-d/llm-d-benchmark.git
 BENCHMARK_REPO_DIR   ?= $(CURDIR)/llm-d-benchmark
+# Pin to v0.6.0: v0.6.2 has a broken guidellm harness (missing --target flag, see llm-d/llm-d-benchmark#1231)
+BENCHMARK_REPO_REF   ?= v0.6.0
 BENCHMARK_SPEC       ?= guides/inference-scheduling-wva
 BENCHMARK_NAMESPACE  ?= # set via BENCHMARK_NAMESPACE=<namespace>
 BENCHMARK_WORKSPACE  ?= $(CURDIR)
@@ -403,12 +405,13 @@ LLMDBENCHMARK        = $(BENCHMARK_VENV)/bin/llmdbenchmark
 BENCHMARK_CLI_FLAGS = --spec $(BENCHMARK_SPEC) --workspace $(BENCHMARK_WORKSPACE) --base-dir $(BENCHMARK_REPO_DIR)
 
 .PHONY: benchmark-install
-benchmark-install: ## Clone llm-d-benchmark and install the llmdbenchmark CLI
+benchmark-install: ## Clone llm-d-benchmark at BENCHMARK_REPO_REF (default v0.6.0) and install the llmdbenchmark CLI
 	@if [ ! -d "$(BENCHMARK_REPO_DIR)" ]; then \
-		echo "Cloning llm-d-benchmark..."; \
-		git clone $(BENCHMARK_REPO_URL) $(BENCHMARK_REPO_DIR); \
+		echo "Cloning llm-d-benchmark @ $(BENCHMARK_REPO_REF)..."; \
+		git clone --branch $(BENCHMARK_REPO_REF) $(BENCHMARK_REPO_URL) $(BENCHMARK_REPO_DIR); \
 	else \
-		echo "llm-d-benchmark already cloned at $(BENCHMARK_REPO_DIR)"; \
+		echo "llm-d-benchmark already cloned at $(BENCHMARK_REPO_DIR); checking out $(BENCHMARK_REPO_REF)..."; \
+		cd $(BENCHMARK_REPO_DIR) && git fetch --tags && git checkout $(BENCHMARK_REPO_REF); \
 	fi
 	@cd $(BENCHMARK_REPO_DIR) && ./install.sh $(if $(filter true,$(BENCHMARK_UV)),--uv,--no-uv)
 


### PR DESCRIPTION
## Summary

- `v0.6.2` of `llm-d-benchmark` ships a broken `guidellm` harness that is missing the `--target` flag, causing all benchmark runs to silently fail with no `results.json` produced (upstream bug tracked in [llm-d/llm-d-benchmark#1231](https://github.com/llm-d/llm-d-benchmark/issues/1231))
- This PR adds a `BENCHMARK_REPO_REF` variable (default `v0.6.0`) and wires it into `benchmark-install` so the known-good tag is always checked out, both on fresh clones and existing checkouts
- The variable is overridable (`make benchmark-install BENCHMARK_REPO_REF=<tag>`) so upgrading later requires no Makefile change

## What changed

`Makefile`:
- Added `BENCHMARK_REPO_REF ?= v0.6.0` with an inline comment linking to the upstream bug
- Updated `benchmark-install` to clone with `--branch $(BENCHMARK_REPO_REF)` for fresh clones, and to `git fetch --tags && git checkout $(BENCHMARK_REPO_REF)` for existing checkouts



Made with [Cursor](https://cursor.com)