### PR TITLE
[WIP] feat(deploy): Kustomize-first WVA controller install and Helm deprecation

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -293,7 +293,7 @@ jobs:
           done
 
       - name: Apply latest CRDs
-        run: kubectl apply -f charts/workload-variant-autoscaler/crds/
+        run: kubectl apply -k config/crd
 
       - name: Deploy WVA and llm-d infrastructure
         env:
@@ -309,11 +309,8 @@ jobs:
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
           # See OpenShift e2e: user-workload Prometheus cannot bearer-auth to WVA /metrics.
           WVA_METRICS_SECURE: "false"
-          # Full capacity-scaling chart values (install.sh no longer passes these).
-          KV_CACHE_THRESHOLD: "0.90"
-          QUEUE_LENGTH_THRESHOLD: "10"
-          KV_SPARE_TRIGGER: "0.05"
-          QUEUE_SPARE_TRIGGER: "2"
+          # Saturation tuning: checked-in overlay (config/deploy/overlays/benchmark/openshift).
+          WVA_SATURATION_OVERLAY: benchmark
           VLLM_SVC_PORT: "8000"
           VLLM_MAX_NUM_SEQS: "1024"
           VLLM_GPU_MEM_UTIL: "0.95"
@@ -329,14 +326,8 @@ jobs:
           LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY: "true"
           E2E_DEPLOY_WAIT_TIMEOUT: "300s"
         run: |
-          # Split deploy: WVA base (install.sh) → llm-d (install-llmd-infra.sh) → chart capacity tuning (helm upgrade).
           ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
           ./deploy/install-llmd-infra.sh -e openshift
-          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
-            --set wva.capacityScaling.default.kvCacheThreshold="${KV_CACHE_THRESHOLD}" \
-            --set wva.capacityScaling.default.queueLengthThreshold="${QUEUE_LENGTH_THRESHOLD}" \
-            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
-            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
 
       - name: Label namespaces for OpenShift monitoring
         run: |
@@ -957,6 +948,13 @@ jobs:
         if: always()
         run: |
           helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          export WVA_PROJECT="${GITHUB_WORKSPACE}"
+          export WVA_NS="${WVA_NAMESPACE}"
+          export ENVIRONMENT=openshift
+          export LLMD_NS="${LLMD_NAMESPACE}"
+          export VLLM_SVC_ENABLED=false
+          export LLM_D_MODELSERVICE_NAME=""
+          bash -c 'source deploy/lib/wva_kustomize.sh && wva_kustomize_delete' || true
           for release in $(helm list -n "$LLMD_NAMESPACE" -q 2>/dev/null); do
             helm uninstall "$release" -n "$LLMD_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
           done

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -694,9 +694,7 @@ jobs:
       - name: Apply latest CRDs
         run: |
           echo "Applying latest VariantAutoscaling CRD..."
-          # Helm doesn't auto-update CRDs, so we need to apply them manually
-          # to ensure the cluster has the latest schema (including scaleTargetRef)
-          kubectl apply -f charts/workload-variant-autoscaler/crds/
+          kubectl apply -k config/crd
 
       - name: Deploy WVA and llm-d infrastructure
         env:
@@ -722,13 +720,8 @@ jobs:
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
           # User-workload Prometheus cannot use the controller-manager SA token for /metrics bearer auth.
           WVA_METRICS_SECURE: "false"
-          # Lower saturation thresholds for simulator mode — the simulator's
-          # KV-cache and queue metrics are modest, so default thresholds
-          # (kvSpareTrigger=0.1, queueSpareTrigger=3) are too high to trigger
-          # scale-up reliably. These values trigger when kvUsage > 0.30 or
-          # queueLength > 0.5, which the simulator produces under load.
-          KV_SPARE_TRIGGER: "0.5"
-          QUEUE_SPARE_TRIGGER: "4.5"
+          # Saturation tuning: checked-in overlay (config/deploy/overlays/e2e-simulator/openshift).
+          WVA_SATURATION_OVERLAY: e2e-simulator
           # inference-scheduling guide runs vLLM directly on 8000 (no 8200 routing proxy).
           VLLM_SVC_PORT: "8000"
           MODEL_ID: ${{ env.MODEL_ID }}
@@ -740,28 +733,27 @@ jobs:
           # Avoid kubectl wait --all during install (decode/prefill are slow); workflow waits on decode explicitly.
           LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY: "true"
           E2E_DEPLOY_WAIT_TIMEOUT: "300s"
+          # Must match image built/pushed in build-image (ghcr.io/<repository>:<tag>); install.sh defaults WVA_IMAGE_REPO to upstream org only.
+          IMG: ghcr.io/${{ github.repository }}:${{ needs.build-image.outputs.image_tag }}
         run: |
           echo "Deploying WVA and llm-d infrastructure..."
+          unset PROM_CA_CERT_PATH || true
           echo "  MODEL_ID: $MODEL_ID"
           echo "  ACCELERATOR_TYPE: $ACCELERATOR_TYPE"
           echo "  LLMD_NS: $LLMD_NS"
           echo "  WVA_NS: $WVA_NS"
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
+          echo "  IMG: $IMG"
           echo "  WVA_IMAGE_TAG: $WVA_IMAGE_TAG"
           echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
           echo "  VLLM_MAX_NUM_SEQS: $VLLM_MAX_NUM_SEQS"
           echo "  DECODE_REPLICAS: $DECODE_REPLICAS"
-          echo "  KV_SPARE_TRIGGER: ${KV_SPARE_TRIGGER:-<default>}"
-          echo "  QUEUE_SPARE_TRIGGER: ${QUEUE_SPARE_TRIGGER:-<default>}"
+          echo "  WVA_SATURATION_OVERLAY: ${WVA_SATURATION_OVERLAY:-<unset>}"
           echo "  HF token configuration: ✓"
           # Base monitoring + WVA + scaler (install.sh does not deploy llm-d).
           ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
           # Gateway/EPP/ModelService + WVA poolGroup alignment (see deploy/install-llmd-infra.sh).
           ./deploy/install-llmd-infra.sh -e openshift
-          # Capacity thresholds are not passed from install.sh — tune after install for CI simulators.
-          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
-            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
-            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
 
       - name: Create secondary namespace for Model B
         run: |
@@ -883,31 +875,20 @@ jobs:
           WVA_NS: ${{ env.WVA_NAMESPACE }}
           # Use same controller instance as Model A for HPA selector matching
           CONTROLLER_INSTANCE: ${{ env.WVA_NAMESPACE }}
+          LLMD_NAMESPACE_B: ${{ env.LLMD_NAMESPACE_B }}
+          MODEL_B_RELEASE: ${{ env.MODEL_B_RELEASE }}
+          MODEL_ID: ${{ env.MODEL_ID }}
+          ACCELERATOR_TYPE: ${{ env.ACCELERATOR_TYPE }}
+          HPA_STABILIZATION_SECONDS: ${{ env.HPA_STABILIZATION_SECONDS }}
+          WVA_PROJECT: ${{ github.workspace }}
         run: |
-          echo "Deploying Model B WVA resources..."
-          echo "  Release name: $MODEL_B_RELEASE"
+          echo "Deploying Model B WVA resources (Kustomize client bundle)..."
+          echo "  MODEL_B_RELEASE: $MODEL_B_RELEASE"
+          echo "  LLMD_NAMESPACE_B: $LLMD_NAMESPACE_B"
           echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
 
-          # Deploy WVA resources (VA, HPA, ServiceMonitor) for Model B
-          # controller.enabled=false since we're using the existing WVA controller
-          # Note: llmd.modelName should be base name without -decode suffix (template appends it)
-          helm upgrade -i "$MODEL_B_RELEASE" ./charts/workload-variant-autoscaler \
-            -n "$WVA_NAMESPACE" \
-            --set controller.enabled=false \
-            --set va.enabled=true \
-            --set hpa.enabled=true \
-            --set hpa.behavior.scaleUp.stabilizationWindowSeconds="$HPA_STABILIZATION_SECONDS" \
-            --set hpa.behavior.scaleDown.stabilizationWindowSeconds="$HPA_STABILIZATION_SECONDS" \
-            --set llmd.namespace="$LLMD_NAMESPACE_B" \
-            --set llmd.modelName="ms-inference-scheduling-llm-d-modelservice" \
-            --set llmd.modelID="$MODEL_ID" \
-            --set va.accelerator="$ACCELERATOR_TYPE" \
-            --set wva.baseName="inference-scheduling" \
-            --set wva.prometheus.monitoringNamespace=openshift-user-workload-monitoring \
-            --set wva.metrics.secure=false \
-            --set vllmService.port=8000 \
-            --set vllmService.targetPort=8000 \
-            --set wva.controllerInstance="$CONTROLLER_INSTANCE"
+          # VA + HPA + vLLM metrics Service/ServiceMonitor (replaces charts/workload-variant-autoscaler client-only Helm install).
+          bash deploy/lib/ci_model_b_wva_kustomize.sh apply
 
           echo "Model B WVA resources deployed"
           kubectl get hpa -n "$LLMD_NAMESPACE_B" -l app.kubernetes.io/instance="$MODEL_B_RELEASE" || true
@@ -1120,6 +1101,7 @@ jobs:
           MODEL_ID: ${{ env.MODEL_ID }}
           REQUEST_RATE: ${{ env.REQUEST_RATE }}
           NUM_PROMPTS: ${{ env.NUM_PROMPTS }}
+          WVA_SATURATION_OVERLAY: e2e-simulator
         run: |
           echo "Running consolidated E2E tests on OpenShift with configuration:"
           echo "  ENVIRONMENT: $ENVIRONMENT"
@@ -1135,6 +1117,44 @@ jobs:
           echo "  REQUEST_RATE: $REQUEST_RATE"
           echo "  NUM_PROMPTS: $NUM_PROMPTS"
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
+
+          # Deploy uses SCALER_BACKEND=keda, so install.sh never runs deploy_prometheus_adapter (see
+          # deploy/lib/install_core.sh). KEDA's operator often owns v1beta1.external.metrics.k8s.io;
+          # HPAs in e2e need prometheus-adapter for wva_desired_replicas (default SCALER_BACKEND).
+          # Mirror ci-benchmark.yaml: patch APIService + background guard (see deploy/lib/scaler_runtime.sh).
+          MONITORING_NS="${MONITORING_NAMESPACE:-openshift-user-workload-monitoring}"
+          patch_external_metrics_apiservice() {
+            kubectl patch apiservice v1beta1.external.metrics.k8s.io --type=merge -p "{
+              \"spec\": {
+                \"caBundle\": null,
+                \"insecureSkipTLSVerify\": true,
+                \"service\": {
+                  \"name\": \"prometheus-adapter\",
+                  \"namespace\": \"${MONITORING_NS}\"
+                }
+              }
+            }" 2>&1 || true
+          }
+          patch_external_metrics_apiservice
+          (
+            while true; do
+              sleep 10
+              if ! kubectl cluster-info &>/dev/null; then
+                exit 0
+              fi
+              current_svc=$(kubectl get apiservice v1beta1.external.metrics.k8s.io -o jsonpath='{.spec.service.name}' 2>/dev/null || echo "")
+              current_ns=$(kubectl get apiservice v1beta1.external.metrics.k8s.io -o jsonpath='{.spec.service.namespace}' 2>/dev/null || echo "")
+              if [ "$current_svc" != "prometheus-adapter" ] || [ "$current_ns" != "$MONITORING_NS" ]; then
+                echo "[apiservice-guard] external.metrics APIService is ${current_svc}/${current_ns}; re-patching to prometheus-adapter/${MONITORING_NS}"
+                patch_external_metrics_apiservice
+              fi
+            done
+          ) &
+          GUARD_PID=$!
+          trap 'kill "$GUARD_PID" 2>/dev/null || true' EXIT
+          echo "APIService guard started (PID=$GUARD_PID) for prometheus-adapter in $MONITORING_NS"
+          sleep 12
+
           make test-e2e-full
 
       - name: Cleanup infrastructure
@@ -1149,11 +1169,20 @@ jobs:
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
           echo "  MODEL_B_RELEASE: $MODEL_B_RELEASE"
 
-          # Uninstall all WVA helm releases before deleting namespaces
-          # This ensures proper cleanup of resources and removes helm tracking
-          echo "Uninstalling WVA helm releases..."
+          echo "Uninstalling primary WVA (Helm migration + Kustomize)..."
           helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
-          helm uninstall "$MODEL_B_RELEASE" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          export WVA_PROJECT="${GITHUB_WORKSPACE}"
+          export WVA_NS="${WVA_NAMESPACE}"
+          export ENVIRONMENT=openshift
+          export LLMD_NS="${LLMD_NAMESPACE}"
+          export VLLM_SVC_ENABLED=false
+          export LLM_D_MODELSERVICE_NAME=""
+          export WVA_RELEASE_NAME="${WVA_RELEASE_NAME}"
+          bash -c 'source deploy/lib/wva_kustomize.sh && wva_kustomize_delete' || true
+
+          echo "Deleting Model B Kustomize client bundle (VA/HPA/Service/ServiceMonitor)..."
+          export LLMD_NAMESPACE_B MODEL_B_RELEASE
+          bash deploy/lib/ci_model_b_wva_kustomize.sh delete || true
 
           echo "Uninstalling llm-d helm releases in primary namespace..."
           for release in $(helm list -n "$LLMD_NAMESPACE" -q 2>/dev/null); do

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -326,20 +326,15 @@ jobs:
           # Emulated Kind: chart decode may be removed post-deploy (LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, default true).
           # Pin llm-d release for deterministic CI behavior
           LLM_D_RELEASE: "v0.6.0"
-          # Dual-controller smoke installs a second Helm release; chart path must be explicit in CI.
-          WVA_E2E_CHART_PATH: ${{ github.workspace }}/charts/workload-variant-autoscaler
+          # Dual-controller: repository root for deploy/lib/e2e_secondary_wva.sh (Kustomize secondary install).
+          WVA_E2E_REPO_ROOT: ${{ github.workspace }}
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"
           PROMETHEUS_ADAPTER_WAIT: "false"
           DELETE_CLUSTER: "true"
-          # Lower saturation thresholds for simulator mode — the simulator's
-          # KV-cache and queue metrics are modest, so default thresholds
-          # (kvSpareTrigger=0.1, queueSpareTrigger=3) are too high to trigger
-          # scale-up reliably. These values trigger when kvUsage > 0.30 or
-          # queueLength > 0.5, which the simulator produces under load.
-          KV_SPARE_TRIGGER: "0.5"
-          QUEUE_SPARE_TRIGGER: "4.5"
         run: |
+          # Avoid inherited PROM_CA_CERT_PATH=/dev/null (or other garbage) breaking Prometheus Adapter CA extraction.
+          unset PROM_CA_CERT_PATH || true
           make test-e2e-smoke-with-setup
 
   # Full Kind E2E - runs only when triggered (/ok-to-test or workflow_dispatch with run_full_tests).
@@ -438,14 +433,14 @@ jobs:
           CREATE_CLUSTER: "true"
           INSTALL_GATEWAY_CTRLPLANE: "true"
           LLM_D_RELEASE: "v0.6.0"
+          # Dual-controller: repository root for deploy/lib/e2e_secondary_wva.sh.
+          WVA_E2E_REPO_ROOT: ${{ github.workspace }}
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"
           PROMETHEUS_ADAPTER_WAIT: "false"
           DELETE_CLUSTER: "false"
-          # Same simulator saturation tuning as smoke — defaults are too high for reliable scale-up signals.
-          KV_SPARE_TRIGGER: "0.5"
-          QUEUE_SPARE_TRIGGER: "4.5"
         run: |
+          unset PROM_CA_CERT_PATH || true
           make test-e2e-full-with-setup
 
   # Report status back to PR for issue_comment triggered runs

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ USE_SIMULATOR               ?= true
 SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
 LLM_D_RELEASE               ?= v0.6.0
-KV_SPARE_TRIGGER           ?=
-QUEUE_SPARE_TRIGGER         ?=
+# Checked-in Kustomize overlay for controller saturation ConfigMap (e2e-simulator, benchmark, or empty/default).
+WVA_SATURATION_OVERLAY      ?=
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
-E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
+E2E_WVA_REPO_ROOT           ?= $(CURDIR)
 # llm-d-benchmark CLI configuration
 BENCHMARK_REPO_URL   ?= https://github.com/llm-d/llm-d-benchmark.git
 BENCHMARK_REPO_DIR   ?= $(CURDIR)/llm-d-benchmark
@@ -202,9 +202,10 @@ undeploy-wva-on-k8s:
 # If IMG is set, builds the image locally first (unless SKIP_BUILD=true).
 # Ordering: install.sh first, then install-llmd-infra.sh (WVA poolGroup upgrade runs after InferencePool exists).
 .PHONY: deploy-e2e-infra
-deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HPA). Uses Prometheus Adapter unless SCALER_BACKEND=keda.
+deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HPA). Uses Prometheus Adapter unless SCALER_BACKEND=keda. Forces WVA_NS + clears CONTROLLER_INSTANCE + drops PROM_CA_CERT_PATH for install so local shell env cannot skew e2e. Sets WVA_SATURATION_OVERLAY to e2e-simulator when unset (use WVA_SATURATION_OVERLAY=default for base bundle saturation only).
 	@echo "Deploying e2e test infrastructure..."
-	@if [ -n "$(IMG)" ]; then \
+	@set -e; \
+	if [ -n "$(IMG)" ]; then \
 		echo "IMG is set to '$(IMG)'"; \
 		if [ "$(SKIP_BUILD)" != "true" ]; then \
 			echo "Building local image (SKIP_BUILD not set)..."; \
@@ -221,14 +222,21 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 			IMAGE_TAG="latest"; \
 		fi; \
 		echo "Using local image: $$IMAGE_REPO:$$IMAGE_TAG"; \
+		env -u PROM_CA_CERT_PATH \
+		WVA_NS=workload-variant-autoscaler-system \
+		CONTROLLER_INSTANCE= \
 		ENVIRONMENT=$(ENVIRONMENT) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
 		WVA_IMAGE_REPO=$$IMAGE_REPO \
 		WVA_IMAGE_TAG=$$IMAGE_TAG \
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \
-		./deploy/install.sh && \
+		WVA_SATURATION_OVERLAY=$(or $(WVA_SATURATION_OVERLAY),e2e-simulator) \
+		./deploy/install.sh; \
+		env -u PROM_CA_CERT_PATH \
 		KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) \
+		WVA_NS=workload-variant-autoscaler-system \
+		CONTROLLER_INSTANCE= \
 		ENVIRONMENT=$(ENVIRONMENT) \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
 		CREATE_CLUSTER=false \
@@ -245,11 +253,18 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 		./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"; \
 	else \
 		echo "IMG not set - using default image from registry (latest)"; \
+		env -u PROM_CA_CERT_PATH \
+		WVA_NS=workload-variant-autoscaler-system \
+		CONTROLLER_INSTANCE= \
 		ENVIRONMENT=$(ENVIRONMENT) \
 		SCALER_BACKEND=$(SCALER_BACKEND) \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
-		./deploy/install.sh && \
+		WVA_SATURATION_OVERLAY=$(or $(WVA_SATURATION_OVERLAY),e2e-simulator) \
+		./deploy/install.sh; \
+		env -u PROM_CA_CERT_PATH \
 		KIND=$(KIND) KUBECTL=$(KUBECTL) \
+		WVA_NS=workload-variant-autoscaler-system \
+		CONTROLLER_INSTANCE= \
 		ENVIRONMENT=$(ENVIRONMENT) \
 		NAMESPACE_SCOPED=$(NAMESPACE_SCOPED) \
 		CREATE_CLUSTER=false \
@@ -261,13 +276,6 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 		LLMD_PATCH_EPP_FLOW_CONTROL=true \
 		LLMD_SKIP_INFERENCE_OBJECTIVE=true \
 		./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"; \
-	fi; \
-	REL=$${WVA_RELEASE_NAME:-workload-variant-autoscaler}; NS=$${WVA_NS:-workload-variant-autoscaler-system}; \
-	if [ -n "$(KV_SPARE_TRIGGER)" ] || [ -n "$(QUEUE_SPARE_TRIGGER)" ]; then \
-		echo "Applying optional WVA capacity threshold overrides (KV_SPARE_TRIGGER / QUEUE_SPARE_TRIGGER)..."; \
-		helm upgrade "$$REL" "$(CURDIR)/charts/workload-variant-autoscaler" -n "$$NS" --reuse-values \
-			$(if $(KV_SPARE_TRIGGER),--set wva.capacityScaling.default.kvSpareTrigger=$(KV_SPARE_TRIGGER)) \
-			$(if $(QUEUE_SPARE_TRIGGER),--set wva.capacityScaling.default.queueSpareTrigger=$(QUEUE_SPARE_TRIGGER)); \
 	fi
 
 ## DEPRECATED: prefer ./deploy/install-llmd-infra.sh or upstream llm-d install tooling; kept for Makefile discoverability.
@@ -343,13 +351,15 @@ test-e2e-smoke: ## Run smoke e2e tests
 	KUBECONFIG=$(KUBECONFIG) \
 	ENVIRONMENT=$(ENVIRONMENT) \
 	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
-	LLMD_NAMESPACE=$(E2E_EMULATED_LLMD_NAMESPACE) \
-	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
-	WVA_E2E_CHART_PATH=$${WVA_E2E_CHART_PATH:-$(E2E_WVA_CHART_PATH)} \
+	LLMD_NAMESPACE=$${LLMD_NAMESPACE:-$(E2E_EMULATED_LLMD_NAMESPACE)} \
+	MONITORING_NAMESPACE=$${MONITORING_NAMESPACE:-$(E2E_MONITORING_NAMESPACE)} \
+	WVA_E2E_REPO_ROOT=$${WVA_E2E_REPO_ROOT:-$(E2E_WVA_REPO_ROOT)} \
+	CONTROLLER_INSTANCE=$${CONTROLLER_INSTANCE-} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
+	WVA_SATURATION_OVERLAY=$(or $(WVA_SATURATION_OVERLAY),e2e-simulator) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
 		-ginkgo.label-filter="smoke" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
@@ -361,18 +371,22 @@ test-e2e-smoke: ## Run smoke e2e tests
 
 # Runs the complete e2e test suite (excluding flaky tests).
 .PHONY: test-e2e-full
-test-e2e-full: ## Run full e2e test suite
+test-e2e-full: ## Run full e2e test suite. Uses LLMD_NAMESPACE / MONITORING_NAMESPACE from the environment when set (OpenShift CI); otherwise defaults to E2E_* (Kind emulator).
 	@echo "Running full e2e test suite..."
 	$(eval FOCUS_ARGS := $(if $(FOCUS),-ginkgo.focus="$(FOCUS)",))
 	$(eval SKIP_ARGS := $(if $(SKIP),-ginkgo.skip="$(SKIP)",))
 	KUBECONFIG=$(KUBECONFIG) \
 	ENVIRONMENT=$(ENVIRONMENT) \
 	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
-	WVA_E2E_CHART_PATH=$${WVA_E2E_CHART_PATH:-$(E2E_WVA_CHART_PATH)} \
+	LLMD_NAMESPACE=$${LLMD_NAMESPACE:-$(E2E_EMULATED_LLMD_NAMESPACE)} \
+	MONITORING_NAMESPACE=$${MONITORING_NAMESPACE:-$(E2E_MONITORING_NAMESPACE)} \
+	WVA_E2E_REPO_ROOT=$${WVA_E2E_REPO_ROOT:-$(E2E_WVA_REPO_ROOT)} \
+	CONTROLLER_INSTANCE=$${CONTROLLER_INSTANCE-} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
 	MODEL_ID=$(MODEL_ID) \
+	WVA_SATURATION_OVERLAY=$(or $(WVA_SATURATION_OVERLAY),e2e-simulator) \
 	go test ./test/e2e/ -timeout 35m -v -ginkgo.v \
 		-ginkgo.label-filter="full && !flaky" $(FOCUS_ARGS) $(SKIP_ARGS); \
 	TEST_EXIT_CODE=$$?; \
@@ -610,7 +624,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	{ $(KUSTOMIZE) build config/crd; echo '---'; $(KUSTOMIZE) build config/default; } > dist/install.yaml
 
 ##@ Deployment
 
@@ -629,11 +643,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Dependencies
 

--- a/charts/workload-variant-autoscaler/Chart.yaml
+++ b/charts/workload-variant-autoscaler/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: workload-variant-autoscaler
-description: Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
+description: "[deprecated for controller] Helm chart for Workload-Variant-Autoscaler (WVA) — use Kustomize (config/deploy/*) or deploy/install.sh for the controller"
 type: application
 version: 0.5.1
 appVersion: "v0.5.1"
+deprecated: true

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -2,7 +2,9 @@
 
 ![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
-Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
+Helm chart for Workload-Variant-Autoscaler (WVA) — **deprecated for installing the controller**. Prefer **Kustomize** (`kubectl apply -k config/deploy/kubernetes` or `config/deploy/openshift`, or `deploy/install.sh`). This chart remains useful for **OCI distribution**, migration, and **VA/HPA-only** installs (`controller.enabled=false`).
+
+**Deprecated:** `helm install` / `helm upgrade` for the controller Deployment is superseded by the in-repo Kustomize bundles; see the root [deploy/README.md](../../deploy/README.md).
 
 ### Chart registry (OCI)
 
@@ -11,8 +13,11 @@ The chart is published to GitHub Container Registry under the **llm-d** org (not
 - **OCI URL:** `oci://ghcr.io/llm-d/workload-variant-autoscaler`
 - **Example:** `helm pull oci://ghcr.io/llm-d/workload-variant-autoscaler --version 0.5.1`
 
-## Installation (OpenShift)
-Helm is the recommended installation method. Before running, be sure to delete all previous helm installations for `workload-variant-autoscaler` and `prometheus-adapter`. To list all helm charts installed in the cluster run `helm ls -A`.
+## Installation (OpenShift) — legacy Helm
+
+> Prefer **Kustomize** for new installs (`deploy/install.sh` or `kubectl apply -k config/deploy/openshift`). The steps below remain for operators still on Helm during migration.
+
+Before running, remove prior Helm releases for `workload-variant-autoscaler` and `prometheus-adapter` if you are switching install paths. To list charts: `helm ls -A`.
 
 ### Step 1: Setup Variables, Secret, Helm repo
 ```

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -1,6 +1,7 @@
-# Controller deployment settings
-# Set controller.enabled=false to deploy only VA/HPA/ServiceMonitor resources
-# without deploying another controller instance (use existing cluster-wide controller)
+# Controller deployment settings (Helm template gate only).
+# The supported install path for the manager is Kustomize: config/deploy/wva-controller*
+# via deploy/install.sh → deploy_wva_controller → wva_kustomize_apply. Do not use this chart
+# to install the controller in automation; keep controller.enabled=false for client-only bundles.
 controller:
   enabled: true
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,6 @@
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
-# It should be run by config/default
+# Apply via `kubectl apply -k config/crd`, config/deploy/*, Makefile deploy/install, or wva_kustomize_apply.
 resources:
 - bases/llmd.ai_variantautoscalings.yaml
 # +kubebuilder:scaffold:crdkustomizeresource

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,7 +15,6 @@ namePrefix: workload-variant-autoscaler-
 #    someName: someValue
 
 resources:
-- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
@@ -46,6 +45,18 @@ patches:
 # update when an overlay changes the namespace (e.g. deploying into 'opendatahub'
 # or `redhat-ods-operator`).
 replacements:
+# Keep legacy SA token Secret in sync with namePrefix: the annotation must match the
+# rendered ServiceAccount name or the token controller will not populate / may GC the Secret.
+- source:
+    kind: ServiceAccount
+    name: epp-metrics-reader
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Secret
+      name: epp-metrics-token
+    fieldPaths:
+    - metadata.annotations.[kubernetes.io/service-account.name]
 - source:
     kind: Deployment
     name: controller-manager
@@ -55,7 +66,7 @@ replacements:
       kind: ServiceMonitor
       group: monitoring.coreos.com
       version: v1
-      name: controller-manager-metrics-monitor
+      name: cm-mon
     fieldPaths:
     - spec.namespaceSelector.matchNames.0
 

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,7 +5,8 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  # Short name; must match ServiceMonitor base length (cm-mon) so namePrefix + nameSuffix fits DNS-63.
+  name: cm-mon
   namespace: workload-variant-autoscaler-system
 spec:
   ports:

--- a/config/deploy/ci/openshift-model-b-wva/hpa.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/hpa.yaml
@@ -1,0 +1,40 @@
+# Mirrors charts/workload-variant-autoscaler/templates/hpa.yaml (defaults + stabilization from CI env).
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: __WVA_FULLNAME__-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ms-inference-scheduling-llm-d-modelservice-decode
+  minReplicas: 1
+  maxReplicas: 2
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: __HPA_STABILIZATION_SECONDS__
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 10
+          periodSeconds: 150
+    scaleDown:
+      stabilizationWindowSeconds: __HPA_STABILIZATION_SECONDS__
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 10
+          periodSeconds: 150
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: wva_desired_replicas
+          selector:
+            matchLabels:
+              variant_name: __WVA_FULLNAME__-va
+              exported_namespace: __LLMD_NAMESPACE_B__
+              controller_instance: "__CONTROLLER_INSTANCE__"
+        target:
+          type: AverageValue
+          averageValue: "1"

--- a/config/deploy/ci/openshift-model-b-wva/kustomization.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/kustomization.yaml
@@ -1,0 +1,20 @@
+# OpenShift CI: Model B client-only bundle (VA + HPA + vLLM metrics Service/ServiceMonitor).
+# Placeholders __...__ are substituted by deploy/lib/ci_model_b_wva_kustomize.sh before kubectl apply -k.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: __LLMD_NAMESPACE_B__
+
+# Kustomize v5+: prefer labels over deprecated commonLabels.
+labels:
+  - pairs:
+      app.kubernetes.io/name: workload-variant-autoscaler
+      app.kubernetes.io/instance: __MODEL_B_RELEASE__
+      app.kubernetes.io/version: v0.5.1
+      app.kubernetes.io/managed-by: kustomize
+
+resources:
+  - va.yaml
+  - hpa.yaml
+  - service.yaml
+  - servicemonitor.yaml

--- a/config/deploy/ci/openshift-model-b-wva/kustomization.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/kustomization.yaml
@@ -10,7 +10,6 @@ labels:
   - pairs:
       app.kubernetes.io/name: workload-variant-autoscaler
       app.kubernetes.io/instance: __MODEL_B_RELEASE__
-      app.kubernetes.io/version: v0.5.1
       app.kubernetes.io/managed-by: kustomize
 
 resources:

--- a/config/deploy/ci/openshift-model-b-wva/service.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/service.yaml
@@ -1,0 +1,16 @@
+# Mirrors charts/workload-variant-autoscaler/templates/vllm-service.yaml (OpenShift CI uses direct vLLM :8000).
+apiVersion: v1
+kind: Service
+metadata:
+  name: __WVA_FULLNAME__-vllm
+  labels:
+    llm-d.ai/model: ms-inference-scheduling-llm-d-modelservice
+spec:
+  selector:
+    llm-d.ai/model: ms-inference-scheduling-llm-d-modelservice
+  ports:
+    - name: vllm
+      port: 8000
+      protocol: TCP
+      targetPort: 8000
+  type: NodePort

--- a/config/deploy/ci/openshift-model-b-wva/servicemonitor.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/servicemonitor.yaml
@@ -1,0 +1,19 @@
+# Mirrors charts/workload-variant-autoscaler/templates/vllm-servicemonitor.yaml (http scheme; UWM scrape).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: __WVA_FULLNAME__-vllm-mon
+  labels:
+    llm-d.ai/model: ms-inference-scheduling-llm-d-modelservice
+    openshift.io/user-monitoring: "true"
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: ms-inference-scheduling-llm-d-modelservice
+  endpoints:
+    - port: vllm
+      path: /metrics
+      interval: 15s
+      scheme: http
+  namespaceSelector:
+    any: true

--- a/config/deploy/ci/openshift-model-b-wva/va.yaml
+++ b/config/deploy/ci/openshift-model-b-wva/va.yaml
@@ -1,0 +1,16 @@
+# Mirrors charts/workload-variant-autoscaler/templates/variantautoscaling.yaml (va.enabled, controller disabled).
+apiVersion: llmd.ai/v1alpha1
+kind: VariantAutoscaling
+metadata:
+  name: __WVA_FULLNAME__-va
+  labels:
+    inference.optimization/acceleratorName: "__ACCELERATOR_TYPE__"
+    wva.llmd.ai/controller-instance: "__CONTROLLER_INSTANCE__"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    # inference-scheduling guide ModelService decode name (see deploy/lib/infra_llmd.sh / CI workflows).
+    name: ms-inference-scheduling-llm-d-modelservice-decode
+  modelID: "__MODEL_ID__"
+  variantCost: "10.0"

--- a/config/deploy/kubernetes/kustomization.yaml
+++ b/config/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,8 @@
+# Kustomize entrypoint for generic Kubernetes / kind-style installs (used by deploy/install.sh).
+# OpenShift uses ../openshift. Do not pass a conflicting kubectl -n when the overlay sets namespace.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../crd
+  - ../wva-controller

--- a/config/deploy/openshift/kustomization.yaml
+++ b/config/deploy/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+# Kustomize entrypoint for OpenShift installs (used by deploy/install.sh).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../crd
+  - ../wva-controller-openshift

--- a/config/deploy/overlays/benchmark/kubernetes/kustomization.yaml
+++ b/config/deploy/overlays/benchmark/kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+# Benchmark-style saturation on Kubernetes (parity with openshift/benchmark; used if ENVIRONMENT!=openshift).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../wva-controller
+
+patches:
+  - path: patch-saturation-defaults.yaml
+    target:
+      kind: ConfigMap
+      labelSelector: app.kubernetes.io/component=saturation-scaling

--- a/config/deploy/overlays/benchmark/kubernetes/patch-saturation-defaults.yaml
+++ b/config/deploy/overlays/benchmark/kubernetes/patch-saturation-defaults.yaml
@@ -1,0 +1,13 @@
+# Saturation defaults for benchmark-style capacity scaling (matches former ci-benchmark deploy env).
+# Kept identical to ../openshift/patch-saturation-defaults.yaml (Kustomize patch paths must stay under this dir).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unused
+data:
+  default: |
+    kvCacheThreshold: 0.90
+    queueLengthThreshold: 10
+    kvSpareTrigger: 0.05
+    queueSpareTrigger: 2
+    enableLimiter: false

--- a/config/deploy/overlays/benchmark/openshift/kustomization.yaml
+++ b/config/deploy/overlays/benchmark/openshift/kustomization.yaml
@@ -1,0 +1,12 @@
+# Benchmark-style saturation on OpenShift (see .github/workflows/ci-benchmark.yaml deploy step).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../wva-controller-openshift
+
+patches:
+  - path: patch-saturation-defaults.yaml
+    target:
+      kind: ConfigMap
+      labelSelector: app.kubernetes.io/component=saturation-scaling

--- a/config/deploy/overlays/benchmark/openshift/patch-saturation-defaults.yaml
+++ b/config/deploy/overlays/benchmark/openshift/patch-saturation-defaults.yaml
@@ -1,0 +1,13 @@
+# Saturation defaults for benchmark-style capacity scaling (matches former ci-benchmark deploy env).
+# Kept identical to ../kubernetes/patch-saturation-defaults.yaml (Kustomize patch paths must stay under this dir).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unused
+data:
+  default: |
+    kvCacheThreshold: 0.90
+    queueLengthThreshold: 10
+    kvSpareTrigger: 0.05
+    queueSpareTrigger: 2
+    enableLimiter: false

--- a/config/deploy/overlays/e2e-simulator/kubernetes/kustomization.yaml
+++ b/config/deploy/overlays/e2e-simulator/kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+# E2E simulator saturation tuning on the stock Kubernetes controller bundle (Kind / kube).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../wva-controller
+
+patches:
+  - path: patch-saturation-defaults.yaml
+    target:
+      kind: ConfigMap
+      labelSelector: app.kubernetes.io/component=saturation-scaling

--- a/config/deploy/overlays/e2e-simulator/kubernetes/patch-saturation-defaults.yaml
+++ b/config/deploy/overlays/e2e-simulator/kubernetes/patch-saturation-defaults.yaml
@@ -1,0 +1,14 @@
+# Saturation defaults for Kind/OpenShift e2e with the inference simulator (modest KV/queue signals).
+# Values match former CI env: KV_SPARE_TRIGGER=0.5, QUEUE_SPARE_TRIGGER=4.5 (see docs/developer-guide/testing.md).
+# Kept identical to ../openshift/patch-saturation-defaults.yaml (Kustomize patch paths must stay under this dir).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unused
+data:
+  default: |
+    kvCacheThreshold: 0.80
+    queueLengthThreshold: 5
+    kvSpareTrigger: 0.5
+    queueSpareTrigger: 4.5
+    enableLimiter: false

--- a/config/deploy/overlays/e2e-simulator/openshift/kustomization.yaml
+++ b/config/deploy/overlays/e2e-simulator/openshift/kustomization.yaml
@@ -1,0 +1,12 @@
+# E2E simulator saturation tuning on the OpenShift controller bundle.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../wva-controller-openshift
+
+patches:
+  - path: patch-saturation-defaults.yaml
+    target:
+      kind: ConfigMap
+      labelSelector: app.kubernetes.io/component=saturation-scaling

--- a/config/deploy/overlays/e2e-simulator/openshift/patch-saturation-defaults.yaml
+++ b/config/deploy/overlays/e2e-simulator/openshift/patch-saturation-defaults.yaml
@@ -1,0 +1,14 @@
+# Saturation defaults for Kind/OpenShift e2e with the inference simulator (modest KV/queue signals).
+# Values match former CI env: KV_SPARE_TRIGGER=0.5, QUEUE_SPARE_TRIGGER=4.5 (see docs/developer-guide/testing.md).
+# Kept identical to ../kubernetes/patch-saturation-defaults.yaml (Kustomize patch paths must stay under this dir).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unused
+data:
+  default: |
+    kvCacheThreshold: 0.80
+    queueLengthThreshold: 5
+    kvSpareTrigger: 0.5
+    queueSpareTrigger: 4.5
+    enableLimiter: false

--- a/config/deploy/wva-controller-openshift/kustomization.yaml
+++ b/config/deploy/wva-controller-openshift/kustomization.yaml
@@ -1,0 +1,6 @@
+# OpenShift controller stack without CRDs (see ../wva-controller).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../openshift

--- a/config/deploy/wva-controller/kustomization.yaml
+++ b/config/deploy/wva-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+# Controller RBAC + manager + metrics (no CRDs). CRDs are applied separately so
+# uninstall and multi-instance installs do not delete or duplicate API definitions.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../default

--- a/config/manager/configmap-saturation-scaling.yaml
+++ b/config/manager/configmap-saturation-scaling.yaml
@@ -13,6 +13,8 @@ metadata:
   labels:
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
+    # Used by deploy/lib/wva_kustomize.sh to merge CI/runtime threshold overrides without duplicating namePrefix/nameSuffix.
+    app.kubernetes.io/component: saturation-scaling
 data:
   # Global defaults applied to all variants unless overridden
   default: |

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -55,3 +55,6 @@ data:
   # EPP_METRICS_CACHE_CLEANUP_INTERVAL: "30s"
   WVA_LIMITED_MODE: "false"
   WVA_NODE_SELECTOR: ""
+
+  # Optional: filesystem path to Prometheus CA (e.g. /etc/prometheus-certs/ca.crt when mounted).
+  PROMETHEUS_CA_CERT_PATH: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
 spec:
+  replicas: 2
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -62,7 +63,6 @@ spec:
         args:
           - --leader-elect=true
           - --health-probe-bind-address=:8081
-          - --watch-namespace=$(POD_NAMESPACE)
           # Leader election timeout configuration (optional - defaults shown below)
           # Uncomment and adjust these values if you need to tune for your environment:
           # - --leader-election-lease-duration=60s
@@ -72,6 +72,14 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         env:
+          # Empty = cluster-wide watch
+          # Deploy scripts / overlays may set this to the pod namespace or a specific workload namespace.
+          - name: WATCH_NAMESPACE
+            value: ""
+          - name: POOL_GROUP
+            value: ""
+          - name: CONTROLLER_INSTANCE
+            value: ""
           - name: LOG_LEVEL
             value: "debug"  # or "info", "warn", "error"
           - name: CONFIG_MAP_NAME
@@ -86,6 +94,11 @@ spec:
               configMapKeyRef:
                 name: workload-variant-autoscaler-wva-variantautoscaling-config
                 key: PROMETHEUS_TLS_INSECURE_SKIP_VERIFY
+          - name: PROMETHEUS_CA_CERT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: workload-variant-autoscaler-wva-variantautoscaling-config
+                key: PROMETHEUS_CA_CERT_PATH
           - name: PROMETHEUS_TOKEN_PATH
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
           - name: WVA_SCALE_TO_ZERO

--- a/config/openshift/configmap-patch.yaml
+++ b/config/openshift/configmap-patch.yaml
@@ -10,6 +10,9 @@ data:
   # TLS configuration for OpenShift
   PROMETHEUS_TLS_INSECURE_SKIP_VERIFY: "false"
 
+  # Trust path for Thanos / in-cluster Prometheus (OpenShift injects service CA here).
+  PROMETHEUS_CA_CERT_PATH: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+
   # Optimization configuration
   GLOBAL_OPT_INTERVAL: "60s"
 

--- a/config/openshift/epp-metrics-token-patch.yaml
+++ b/config/openshift/epp-metrics-token-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: epp-metrics-token
-  namespace: system
-  annotations:
-    kubernetes.io/service-account.name: workload-variant-autoscaler-epp-metrics-reader

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -14,10 +14,6 @@ patches:
   target:
     kind: Deployment
     name: controller-manager
-- path: epp-metrics-token-patch.yaml
-  target:
-    kind: Secret
-    name: epp-metrics-token
 - path: epp-metrics-volume-patch.yaml
   target:
     kind: Deployment

--- a/config/openshift/prometheus-patch.yaml
+++ b/config/openshift/prometheus-patch.yaml
@@ -11,8 +11,6 @@ spec:
         env:
         - name: PROMETHEUS_TOKEN_PATH
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        - name: PROMETHEUS_CA_CERT_PATH
-          value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         - name: PROMETHEUS_CLIENT_CERT_PATH
           value: ""
         - name: PROMETHEUS_CLIENT_KEY_PATH

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -2,7 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: controller-manager-metrics-monitor
+  # Paired with metrics_service.yaml (same base name cm-mon); keep short for multi-instance nameSuffix (DNS-63).
+  name: cm-mon
   namespace: workload-variant-autoscaler-system
   labels:
     control-plane: controller-manager

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -7,6 +7,9 @@ roleRef:
   kind: ClusterRole
   name: metrics-auth-role
 subjects:
+# Use the same name/namespace placeholders as manager-rolebinding so Kustomize
+# namePrefix, nameSuffix, and namespace transformers rewrite the subject correctly
+# for multi-instance installs
 - kind: ServiceAccount
-  name: workload-variant-autoscaler-controller-manager
-  namespace: workload-variant-autoscaler-system
+  name: controller-manager
+  namespace: system

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes, OpenShift, and Kind clusters.
 
-> **Central Documentation Hub**: This is the main deployment guide containing comprehensive information about deployment methods, Helm chart configuration, and complete configuration reference. Platform-specific guides ([Kubernetes](kubernetes/README.md), [OpenShift](openshift/README.md), [Kind](kind-emulator/README.md)) provide additional platform-specific details and examples.
+> **Central Documentation Hub**: This is the main deployment guide. **The WVA controller is installed only with Kustomize** in every supported `deploy/install.sh` flow (`config/deploy/wva-controller` / `wva-controller-openshift`, via `deploy/lib/wva_kustomize.sh`). The Helm chart is **not** used to install the manager in this repo’s scripts or CI controller steps; it remains published for OCI consumers, optional client-only manifests (VA/HPA), and tests—see [Method 2: Helm Chart (deprecated)](#method-2-helm-chart-deprecated). Platform-specific guides ([Kubernetes](kubernetes/README.md), [OpenShift](openshift/README.md), [Kind](kind-emulator/README.md)) provide additional details.
 
 ## Table of Contents
 
@@ -10,7 +10,7 @@ Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes
 - [Prerequisites](#prerequisites)
 - [Deployment Methods](#deployment-methods)
   - [Method 1: Automated Deployment Script](#method-1-automated-deployment-script-recommended)
-  - [Method 2: Helm Chart](#method-2-helm-chart)
+  - [Method 2: Helm Chart (deprecated)](#method-2-helm-chart-deprecated)
 - [Platform-Specific Guides](#platform-specific-guides)
 - [Configuration Reference](#configuration-reference)
 - [Post-Deployment](#post-deployment)
@@ -18,10 +18,10 @@ Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes
 
 ## Overview
 
-This guide covers two deployment procedures:
+This guide covers:
 
-1. **Automated Script**: Complete end-to-end and customizable deployment including WVA, llm-d infrastructure, Prometheus, and HPA
-2. **Helm Chart**: Deploy the WVA controller into an existing cluster
+1. **Automated script**: `deploy/install.sh` deploys monitoring, scaler backends, and the **WVA controller exclusively via Kustomize** (`kubectl apply -k` with `config/deploy/...` bundles; never Helm for the manager). Optional llm-d stack is `deploy/install-llmd-infra.sh`.
+2. **Legacy Helm chart**: Deprecated for the controller; retained for OCI consumers and workflows that still template chart-only resources (for example optional VA/HPA installs in CI).
 
 ## Prerequisites
 
@@ -32,6 +32,7 @@ All deployment methods require:
 - **kubectl** (v1.24+) - Kubernetes CLI
 - **helm** (v3.8+) - Package manager for Kubernetes
 - **git** - Git CLI
+- **jq** (1.6+) - JSON processor (`deploy/install.sh` uses it for WVA Kustomize patches and namespace finalize helpers)
 
 Optional but recommended:
 
@@ -160,7 +161,7 @@ export INSTALL_GATEWAY_CTRLPLANE=true
 
 #### Script deployment examples
 
-Chart-managed **VariantAutoscaling** and **HPA** are no longer toggled from `install.sh`; use `helm upgrade` with `--set va.enabled=true` / `hpa.enabled=true` on the WVA chart, or let tests/operators create CRs.
+Chart-managed **VariantAutoscaling** and **HPA** are no longer toggled from `install.sh`; use the deprecated Helm chart with `--set va.enabled=true` / `hpa.enabled=true`, patch manifests, or let tests/operators create CRs.
 
 ##### Example 1: Base infra then llm-d
 
@@ -194,7 +195,11 @@ export DEPLOY_LWS=false
 ./deploy/install.sh -e kubernetes
 ```
 
-### Method 2: Helm Chart
+### Method 2: Helm Chart (deprecated)
+
+> **Deprecation:** Installing the **controller** with this chart is deprecated. Prefer **`deploy/install.sh`** (Kustomize) or `kubectl apply -k config/deploy/<platform>` / `make deploy` as described in the [Kubebuilder book](https://book.kubebuilder.io/quick-start.html) flow. The chart may still be used for **non-controller** manifests (for example VA/HPA-only releases) and remains published as an OCI artifact for transition periods.
+
+The following sections document the legacy Helm workflow.
 
 The WVA can be deployed as a standalone using Helm, assuming you have:
 
@@ -585,14 +590,15 @@ VariantAutoscaling, HPA stabilization, and vLLM ModelService tuning are not cont
 |----------|-------------|---------|
 | `SKIP_TLS_VERIFY` | Skip TLS verification | Auto-detected |
 | `WVA_LOG_LEVEL` | WVA logging level | `info` |
+| `WVA_SATURATION_OVERLAY` | Checked-in saturation profile (`e2e-simulator`, `benchmark`, or `default`/unset for base bundle only) | unset (`deploy-e2e-infra` / `test-e2e-*` Make targets default to `e2e-simulator`) |
 | `VLLM_SVC_ENABLED` | Enable vLLM Service in chart | `true` |
 | `VLLM_SVC_NODEPORT` | vLLM NodePort | `30000` |
 | `LWS_NAMESPACE` | Namespace for LeaderWorkerSet installation | `lws-system` |
 | `LWS_CHART_VERSION` | LeaderWorkerSet Helm chart version | `0.8.0` |
 
-#### Optional: capacity thresholds after `make deploy-e2e-infra`
+#### Saturation overlays (Kustomize)
 
-If `KV_SPARE_TRIGGER` and/or `QUEUE_SPARE_TRIGGER` are set in the environment, the Makefile runs a follow-up `helm upgrade --reuse-values` on the WVA release.
+Set **`WVA_SATURATION_OVERLAY`** to a profile directory under **`config/deploy/overlays/`** (each profile ships **`kubernetes/`** and **`openshift/`** with **`patch-saturation-defaults.yaml`**). **`e2e-simulator`** matches former CI simulator tuning; **`benchmark`** matches the OpenShift benchmark job. **`default`** or an unset variable selects the base **`wva-controller`** / **`wva-controller-openshift`** bundle with no saturation patch.
 
 ### Helm Values Reference
 

--- a/deploy/install-llmd-infra.sh
+++ b/deploy/install-llmd-infra.sh
@@ -7,8 +7,7 @@
 # guides) once your environment can consume it directly. Track removal in a follow-up issue.
 #
 # Ordering: run deploy/install.sh first (WVA + monitoring + scaler backend), then this script
-# when you need llm-d. The poolGroup helm upgrade on WVA requires InferencePool objects created
-# by this deploy.
+# when you need llm-d. Pool group alignment on WVA uses `kubectl set env` / rollout after InferencePools exist.
 #
 # Usage:
 #   ./deploy/install-llmd-infra.sh [-e kubernetes|openshift|kind-emulator] [--undeploy]

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -3,11 +3,15 @@
 # Workload-Variant-Autoscaler infrastructure bootstrap: optional WVA controller,
 # Prometheus monitoring stack, and scaler backend (KEDA or Prometheus Adapter).
 #
+# WVA controller install policy: ONLY Kustomize (deploy/lib/wva_kustomize.sh). This script
+# never installs the controller via Helm; charts/workload-variant-autoscaler is for legacy
+# OCI packaging and optional client-only manifests (VA/HPA), not for the manager Deployment.
+#
 # For llm-d (gateway, EPP, ModelService, HF secret, WVA poolGroup alignment), run
 # deploy/install-llmd-infra.sh after this script when you need that stack.
 #
 # Prerequisites:
-# - kubectl and helm installed
+# - kubectl, helm, git, and jq installed (jq: WVA Kustomize JSON patches + namespace finalize helpers)
 # - Cluster credentials configured
 #
 
@@ -40,7 +44,6 @@ VLLM_SVC_PORT=${VLLM_SVC_PORT:-8200}
 VLLM_SVC_NODEPORT=${VLLM_SVC_NODEPORT:-30000}
 SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-"false"}
 WVA_LOG_LEVEL=${WVA_LOG_LEVEL:-"info"}
-VALUES_FILE=${VALUES_FILE:-"$WVA_PROJECT/charts/workload-variant-autoscaler/values.yaml"}
 # Optional: multi-controller isolation (sets controller_instance on metrics / selectors when non-empty).
 CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
 WVA_BASE_NAME=${WVA_BASE_NAME:-"inference-scheduling"}
@@ -80,7 +83,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT=${ENVIRONMENT:-"kubernetes"}
 COMPATIBLE_ENV_LIST=("kubernetes" "openshift" "kind-emulator")
 NON_EMULATED_ENV_LIST=("kubernetes" "openshift")
-REQUIRED_TOOLS=("kubectl" "helm" "git")
+REQUIRED_TOOLS=("kubectl" "helm" "git" "jq")
 DEPLOY_LIB_DIR="$SCRIPT_DIR/lib"
 
 PRODUCTION_ENV_LIST=("openshift")

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -23,6 +23,7 @@ Quick start guide for local development using Kind (Kubernetes in Docker) with e
 - Kind
 - kubectl
 - Helm
+- **jq** (for `deploy/install.sh` / WVA Kustomize JSON patches)
 
 ## Quick Start
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -546,9 +546,9 @@ helm uninstall prometheus-adapter -n workload-variant-autoscaler-monitoring
 # Delete kube-prometheus-stack
 helm uninstall kube-prometheus-stack -n workload-variant-autoscaler-monitoring
 
-# Delete WVA
+# Delete WVA (controller manifests, then CRDs — matches Makefile undeploy)
 cd /path/to/workload-variant-autoscaler
-kubectl delete -k config/default
+make undeploy ignore-not-found=true
 
 # Delete namespaces
 kubectl delete namespace llm-d-inference-scheduling

--- a/deploy/lib/ci_model_b_wva_kustomize.sh
+++ b/deploy/lib/ci_model_b_wva_kustomize.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Apply or delete OpenShift CI "Model B" client-only manifests (VA, HPA, vLLM Service/ServiceMonitor)
+# via kubectl apply -k from config/deploy/ci/openshift-model-b-wva/, mirroring the former
+# charts/workload-variant-autoscaler Helm client-only install.
+#
+# Required env:
+#   MODEL_B_RELEASE, LLMD_NAMESPACE_B, MODEL_ID, ACCELERATOR_TYPE, CONTROLLER_INSTANCE
+# Optional:
+#   HPA_STABILIZATION_SECONDS (default 240)
+#   WVA_PROJECT (repo root; default: parent of deploy/lib)
+#
+set -euo pipefail
+
+ci_model_b_wva_fullname() {
+  local release="${1:?MODEL_B_RELEASE required}"
+  local cn="workload-variant-autoscaler"
+  local out
+  case "$release" in
+    *"$cn"*) out="$release" ;;
+    *) out="${release}-${cn}" ;;
+  esac
+  echo -n "$out" | cut -c1-63 | sed 's/-$//'
+}
+
+ci_model_b_wva_substitute_and_apply() {
+  local src="${1:?}"
+  local tmp="${2:?}"
+  export WVA_FULLNAME
+  WVA_FULLNAME="$(ci_model_b_wva_fullname "${MODEL_B_RELEASE}")"
+  export HPA_STABILIZATION_SECONDS="${HPA_STABILIZATION_SECONDS:-240}"
+  export MODEL_B_RELEASE LLMD_NAMESPACE_B MODEL_ID ACCELERATOR_TYPE CONTROLLER_INSTANCE
+
+  python3 - "$src" "$tmp" <<'PY'
+import pathlib
+import os
+import shutil
+import sys
+
+src = pathlib.Path(sys.argv[1])
+dst = pathlib.Path(sys.argv[2])
+shutil.rmtree(dst, ignore_errors=True)
+shutil.copytree(src, dst)
+
+subs = {
+    "__LLMD_NAMESPACE_B__": os.environ["LLMD_NAMESPACE_B"],
+    "__MODEL_B_RELEASE__": os.environ["MODEL_B_RELEASE"],
+    "__WVA_FULLNAME__": os.environ["WVA_FULLNAME"],
+    "__MODEL_ID__": os.environ["MODEL_ID"],
+    "__ACCELERATOR_TYPE__": os.environ["ACCELERATOR_TYPE"],
+    "__CONTROLLER_INSTANCE__": os.environ["CONTROLLER_INSTANCE"],
+    "__HPA_STABILIZATION_SECONDS__": os.environ.get("HPA_STABILIZATION_SECONDS", "240"),
+}
+for path in dst.rglob("*.yaml"):
+    text = path.read_text()
+    for k, v in subs.items():
+        text = text.replace(k, v)
+    path.write_text(text)
+PY
+  kubectl apply -k "$tmp"
+}
+
+ci_model_b_wva_apply() {
+  : "${MODEL_B_RELEASE:?MODEL_B_RELEASE is required}"
+  : "${LLMD_NAMESPACE_B:?LLMD_NAMESPACE_B is required}"
+  : "${MODEL_ID:?MODEL_ID is required}"
+  : "${ACCELERATOR_TYPE:?ACCELERATOR_TYPE is required}"
+  : "${CONTROLLER_INSTANCE:?CONTROLLER_INSTANCE is required}"
+
+  local root="${WVA_PROJECT:-}"
+  if [ -z "$root" ]; then
+    root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  fi
+  local base="${root}/config/deploy/ci/openshift-model-b-wva"
+  if [ ! -f "${base}/kustomization.yaml" ]; then
+    echo "error: missing kustomize base at ${base}" >&2
+    return 1
+  fi
+
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/ci-model-b-wva.XXXXXX")"
+  # Expand $tmp when registering the trap (set -u: avoid referencing unset tmp on EXIT).
+  trap "rm -rf '${tmp}'" EXIT
+
+  ci_model_b_wva_substitute_and_apply "$base" "$tmp"
+}
+
+ci_model_b_wva_delete() {
+  : "${MODEL_B_RELEASE:?MODEL_B_RELEASE is required}"
+  : "${LLMD_NAMESPACE_B:?LLMD_NAMESPACE_B is required}"
+
+  kubectl delete servicemonitor,svc,va,hpa \
+    -l "app.kubernetes.io/instance=${MODEL_B_RELEASE},app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/managed-by=kustomize" \
+    -n "${LLMD_NAMESPACE_B}" --ignore-not-found
+}
+
+main() {
+  case "${1:-}" in
+    apply) ci_model_b_wva_apply ;;
+    delete) ci_model_b_wva_delete ;;
+    *)
+      echo "usage: $0 apply|delete" >&2
+      return 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -7,6 +7,10 @@
 # undeploy_prometheus_stack(), delete_namespaces(), log_*().
 #
 
+_wva_cleanup_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/wva_kustomize.sh
+source "${_wva_cleanup_lib}/wva_kustomize.sh"
+
 undeploy_keda() {
     if [ "$ENVIRONMENT" = "openshift" ]; then
         log_info "OpenShift: skipping KEDA uninstall (platform-managed)"
@@ -20,6 +24,7 @@ undeploy_keda() {
     helm uninstall "$KEDA_RELEASE_NAME" -n "$KEDA_NAMESPACE" 2>/dev/null || \
         log_warning "KEDA not found or already uninstalled"
     kubectl delete namespace "$KEDA_NAMESPACE" --ignore-not-found --timeout=120s 2>/dev/null || true
+    
     log_success "KEDA uninstalled"
 }
 
@@ -92,8 +97,10 @@ undeploy_llm_d_infrastructure() {
 undeploy_wva_controller() {
     log_info "Uninstalling Workload-Variant-Autoscaler (release: $WVA_RELEASE_NAME)..."
 
-    helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NS" 2>/dev/null || \
-        log_warning "Workload-Variant-Autoscaler not found or already uninstalled"
+    # Legacy Helm release (migration): remove first so Kustomize-owned objects are not blocked.
+    helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NS" 2>/dev/null || true
+
+    wva_kustomize_delete
 
     rm -f "$PROM_CA_CERT_PATH"
 

--- a/deploy/lib/e2e_secondary_wva.sh
+++ b/deploy/lib/e2e_secondary_wva.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Apply or delete a second WVA controller for dual-controller smoke tests.
+# Usage: WVA_PROJECT=... WVA_NS=... (and other vars required by wva_kustomize_apply) $0 apply|delete
+#
+set -euo pipefail
+ACTION="${1:?apply or delete}"
+WVA_PROJECT="${WVA_PROJECT:?}"
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# wva_kustomize.sh uses log_* from common.sh (install.sh normally sources it first).
+# shellcheck source=lib/common.sh
+source "${_lib_dir}/common.sh"
+# shellcheck source=lib/wva_kustomize.sh
+source "${_lib_dir}/wva_kustomize.sh"
+case "$ACTION" in
+apply) wva_kustomize_apply ;;
+delete) wva_kustomize_delete ;;
+*)
+    echo "usage: $0 apply|delete" >&2
+    exit 1
+    ;;
+esac

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -7,6 +7,12 @@
 # containsElement(), wait_deployment_available_nonfatal(), detect_inference_pool_api_group().
 #
 
+if ! declare -F wva_kustomize_manager_deployment_name >/dev/null 2>&1; then
+    _infra_llmd_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=lib/wva_kustomize.sh
+    source "${_infra_llmd_lib}/wva_kustomize.sh"
+fi
+
 # Post-deploy cleanup for emulated clusters (e.g. Kind): chart ModelService ships both prefill and decode;
 # current WVA flows expect a single user-owned decode workload. Always remove prefill; decode removal is gated
 # by LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS (default true for e2e / local emulated flows).
@@ -218,21 +224,15 @@ deploy_llm_d_infrastructure() {
         VLLM_SVC_PORT=$DETECTED_PORT
         # Update the WVA vllm-service port (WVA was deployed before llm-d infra)
         if [ "$DEPLOY_WVA" == "true" ] && [ "$VLLM_SVC_ENABLED" == "true" ]; then
-          helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-            -n "$WVA_NS" --reuse-values \
-            --set wva.namespaceScoped="${NAMESPACE_SCOPED:-true}" \
-            --set vllmService.port="$VLLM_SVC_PORT" \
-            --set vllmService.targetPort="$VLLM_SVC_PORT"
+            export VLLM_SVC_PORT=$DETECTED_PORT
+            wva_apply_vllm_metrics_manifests || log_warning "Failed to refresh vLLM metrics Service/ServiceMonitor for port ${VLLM_SVC_PORT}"
         fi
       fi
     fi
 
     # Deploy llm-d core components
     log_info "Deploying llm-d core components"
-    # When DEPLOY_WVA is true, skip WVA in helmfile — install.sh deploys it
-    # separately using the local chart (supports dev/test of chart changes).
-    # The helmfile's WVA release uses the published OCI chart which may not
-    # have the latest fixes and uses KIND-specific defaults (e.g. monitoringNamespace).
+    # via Kustomize (config/deploy/*).
     local -a helmfile_selector_exprs=()
     if [ "$DEPLOY_WVA" == "true" ]; then
       helmfile_selector_exprs+=("kind!=autoscaling")
@@ -290,14 +290,15 @@ deploy_llm_d_infrastructure() {
       local svcmon_name="${wva_fullname}-vllm-mon"
       log_info "Aligning WVA Service/ServiceMonitor selectors: llm-d.ai/model=$CURRENT_MODEL_LABEL"
       # Build merge patches with jq so label values cannot break JSON (e.g. quotes, backslashes).
+      # Use --arg key + quoted outer JSON keys; use $model_label (not $label — jq 1.6 reserves `label`).
       local svc_patch svcmon_patch svc_label_patch
-      svc_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"llm-d.ai/model":$label}}}')
+      svc_patch=$(jq -n --arg key "llm-d.ai/model" --arg model_label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{($key):$model_label}}}')
       kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_patch" && log_success "Patched Service $svc_name selector" \
          || log_warning "Failed to patch Service $svc_name selector"
-      svcmon_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"matchLabels":{"llm-d.ai/model":$label}}}}')
+      svcmon_patch=$(jq -n --arg key "llm-d.ai/model" --arg model_label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"matchLabels":{($key):$model_label}}}}')
       kubectl patch servicemonitor "$svcmon_name" -n "$LLMD_NS" --type=merge -p "$svcmon_patch" && log_success "Patched ServiceMonitor $svcmon_name selector" \
          || log_warning "Failed to patch ServiceMonitor $svcmon_name selector"
-      svc_label_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"metadata":{"labels":{"llm-d.ai/model":$label}}}')
+      svc_label_patch=$(jq -n --arg key "llm-d.ai/model" --arg model_label "$CURRENT_MODEL_LABEL" '{"metadata":{"labels":{($key):$model_label}}}')
       kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_label_patch" \
         && log_success "Patched Service $svc_name label" \
         || log_warning "Failed to patch Service $svc_name label"
@@ -482,14 +483,15 @@ deploy_llm_d_infrastructure() {
         detect_inference_pool_api_group
         if [ -n "$DETECTED_POOL_GROUP" ]; then
             log_info "Detected InferencePool API group: $DETECTED_POOL_GROUP; upgrading WVA to watch it (scale-from-zero)"
-            if helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-                -n "$WVA_NS" --reuse-values \
-                --set wva.namespaceScoped="${NAMESPACE_SCOPED:-true}" \
-                --set wva.poolGroup="$DETECTED_POOL_GROUP" --wait --timeout=60s; then
-                log_success "WVA upgraded with wva.poolGroup=$DETECTED_POOL_GROUP"
-            else
-                log_warning "WVA upgrade with poolGroup failed - scale-from-zero may not see the InferencePool"
-            fi
+            local wva_mgr_deploy
+            wva_mgr_deploy=$(wva_kustomize_manager_deployment_name)
+            kubectl -n "$WVA_NS" set env "deployment/${wva_mgr_deploy}" POOL_GROUP="${DETECTED_POOL_GROUP}" >/dev/null 2>&1 || \
+                log_warning "Could not set POOL_GROUP on WVA deployment (deployment missing?)"
+            kubectl -n "$WVA_NS" rollout restart "deployment/${wva_mgr_deploy}" >/dev/null 2>&1 || \
+                log_warning "WVA rollout restart after poolGroup update failed"
+            kubectl -n "$WVA_NS" rollout status "deployment/${wva_mgr_deploy}" --timeout=120s >/dev/null 2>&1 || \
+                log_warning "WVA not ready after poolGroup update"
+            log_success "WVA poolGroup set to $DETECTED_POOL_GROUP"
         else
             log_warning "Could not detect InferencePool API group - WVA may have empty datastore for scale-from-zero"
         fi

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -6,6 +6,12 @@
 # Requires funcs: log_info/log_warning/log_success/log_error, containsElement().
 #
 
+if ! declare -F wva_kustomize_apply >/dev/null 2>&1; then
+    _infra_wva_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=lib/wva_kustomize.sh
+    source "${_infra_wva_lib}/wva_kustomize.sh"
+fi
+
 set_tls_verification() {
     log_info "Setting TLS verification..."
 
@@ -59,48 +65,28 @@ set_wva_logging_level() {
 deploy_wva_controller() {
     log_info "Deploying Workload-Variant-Autoscaler..."
     log_info "Using image: $WVA_IMAGE_REPO:$WVA_IMAGE_TAG"
-    log_info "Using release name: $WVA_RELEASE_NAME"
+    log_info "Using release name: $WVA_RELEASE_NAME (used for vLLM Service name prefix; controller install is Kustomize)"
 
-    # Deploy WVA using Helm chart
-    log_info "Installing Workload-Variant-Autoscaler via Helm chart"
-
-    # Default namespaceScoped to true if not set (matches chart default)
-    # But allow override via env var (e.g. for E2E tests)
     NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
 
-    # Chart baseName is the controller's logical pool name (InferencePool prefix), not necessarily the llm-d guide folder.
-    WVA_BASE_NAME="${WVA_BASE_NAME:-inference-scheduling}"
+    log_info "Installing WVA controller via Kustomize only (Helm chart is not used for the manager; bundle: $(wva_kustomize_controller_bundle_dir); platform: $(wva_kustomize_platform_dir))"
 
-    # VA / HPA / capacity thresholds are chart defaults unless changed via helm --set separately (see deploy README).
-    # llmd.modelName / llmd.modelID are optional Helm overrides here when the vars are exported (often unset for infra-only installs).
-    helm upgrade -i "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-        -n "$WVA_NS" \
-        --values $VALUES_FILE \
-        --set-file wva.prometheus.caCert="$PROM_CA_CERT_PATH" \
-        --set wva.image.repository="$WVA_IMAGE_REPO" \
-        --set wva.image.tag="$WVA_IMAGE_TAG" \
-        --set wva.imagePullPolicy="$WVA_IMAGE_PULL_POLICY" \
-        --set wva.baseName="$WVA_BASE_NAME" \
-        ${LLM_D_MODELSERVICE_NAME:+--set llmd.modelName="$LLM_D_MODELSERVICE_NAME"} \
-        ${MODEL_ID:+--set llmd.modelID="$MODEL_ID"} \
-        --set llmd.namespace="$LLMD_NS" \
-        --set wva.prometheus.baseURL="$PROMETHEUS_URL" \
-        --set wva.prometheus.monitoringNamespace="$MONITORING_NAMESPACE" \
-        --set vllmService.enabled="$VLLM_SVC_ENABLED" \
-        --set vllmService.port="$VLLM_SVC_PORT" \
-        --set vllmService.targetPort="$VLLM_SVC_PORT" \
-        --set vllmService.nodePort="$VLLM_SVC_NODEPORT" \
-        --set wva.logging.level="$WVA_LOG_LEVEL" \
-        --set wva.prometheus.tls.insecureSkipVerify="$SKIP_TLS_VERIFY" \
-        --set wva.namespaceScoped="$NAMESPACE_SCOPED" \
-        --set wva.metrics.secure="$WVA_METRICS_SECURE" \
-        --set wva.scaleToZero="$ENABLE_SCALE_TO_ZERO" \
-        ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE} \
-        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP}
+    # Legacy Helm release: remove so Kustomize can own the same resource names.
+    helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NS" 2>/dev/null || true
 
-    # Wait for WVA to be ready
-    log_info "Waiting for WVA controller to be ready..."
-    if kubectl wait --for=condition=Ready pod -l "$WVA_CONTROLLER_LABEL_SELECTOR" -n "$WVA_NS" --timeout=60s; then
+    wva_kustomize_apply
+
+    local wva_mgr_deploy
+    wva_mgr_deploy=$(wva_kustomize_manager_deployment_name)
+    log_info "Waiting for WVA controller rollout..."
+    if kubectl rollout status "deployment/${wva_mgr_deploy}" -n "$WVA_NS" --timeout=300s 2>/dev/null; then
+        log_success "WVA deployment rollout complete"
+    else
+        log_warning "WVA rollout status timed out or deployment missing — check kubectl get pods -n $WVA_NS"
+    fi
+
+    log_info "Waiting for WVA controller pods to be Ready..."
+    if kubectl wait --for=condition=Ready pod -l "$WVA_CONTROLLER_LABEL_SELECTOR" -n "$WVA_NS" --timeout=120s 2>/dev/null; then
         :
     else
         log_warning "WVA controller is not ready yet - check 'kubectl get pods -n $WVA_NS'"
@@ -162,8 +148,6 @@ delete_namespaces_kube_like() {
 }
 
 # Shared WVA prerequisites for Kubernetes-like environments.
-# Optional:
-#   - KUBE_LIKE_VALUES_DEV_IF_PRESENT=true|false (defaults false)
 deploy_wva_prerequisites_kube_like() {
     log_info "Deploying Workload-Variant-Autoscaler prerequisites for Kubernetes..."
 
@@ -171,19 +155,10 @@ deploy_wva_prerequisites_kube_like() {
     log_info "Extracting Prometheus TLS certificate"
     kubectl get secret "$PROMETHEUS_SECRET_NAME" -n "$MONITORING_NAMESPACE" -o jsonpath='{.data.tls\.crt}' | base64 -d > "$PROM_CA_CERT_PATH"
 
-    local use_values_dev=false
     if [ "$SKIP_TLS_VERIFY" = "true" ]; then
-        use_values_dev=true
-    elif [ "${KUBE_LIKE_VALUES_DEV_IF_PRESENT:-false}" = "true" ] && [ -f "$WVA_PROJECT/charts/workload-variant-autoscaler/values-dev.yaml" ]; then
-        use_values_dev=true
-    fi
-
-    if [ "$use_values_dev" = "true" ]; then
-        log_warning "TLS verification NOT enabled: using values-dev.yaml for dev deployments - NOT FOR PRODUCTION USE"
-        VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values-dev.yaml"
+        log_warning "SKIP_TLS_VERIFY=true (dev-style); Prometheus TLS verification relaxed for this deploy"
     else
-        log_info "TLS verification enabled: using values.yaml for production deployments"
-        VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values.yaml"
+        log_info "TLS verification enabled for Prometheus client configuration"
     fi
 
     # LeaderWorkerSet (WVA dependency; see upstream chart / #910).

--- a/deploy/lib/kube_like_adapter.sh
+++ b/deploy/lib/kube_like_adapter.sh
@@ -5,7 +5,7 @@
 #   - deploy/kind-emulator/install.sh
 # Requires funcs: create_namespaces_shared_loop(), deploy_prometheus_kube_stack(),
 # undeploy_prometheus_kube_stack(), deploy_wva_prerequisites_kube_like().
-# Requires var: KUBE_LIKE_VALUES_DEV_IF_PRESENT to be set by caller.
+# Callers may set KUBE_LIKE_VALUES_DEV_IF_PRESENT (reserved; WVA controller uses Kustomize only).
 #
 materialize_namespace() {
     kubectl create namespace "$1"

--- a/deploy/lib/verify.sh
+++ b/deploy/lib/verify.sh
@@ -75,7 +75,7 @@ print_summary() {
         echo "✓ kube-prometheus-stack (Prometheus + Grafana)"
     fi
     if [ "$DEPLOY_WVA" = "true" ]; then
-        echo "✓ WVA Controller (via Helm chart)"
+        echo "✓ WVA Controller (Kustomize via deploy/install.sh)"
     fi
     if [ "$SCALER_BACKEND" = "keda" ]; then
         echo "✓ KEDA (scaler backend, external metrics API)"
@@ -91,7 +91,7 @@ print_summary() {
     echo "1. Deploy llm-d (EPP, gateway, ModelService) when needed:"
     echo "     ./deploy/install-llmd-infra.sh -e $ENVIRONMENT"
     echo ""
-    echo "2. Create VariantAutoscaling / HPA via tests, operators, or helm with chart toggles."
+    echo "2. Create VariantAutoscaling / HPA via tests, operators, manifests, or the deprecated Helm chart (VA/HPA-only)."
     echo ""
     echo "3. View WVA logs:"
     echo "   kubectl logs -n $WVA_NS -l app.kubernetes.io/name=workload-variant-autoscaler -f"

--- a/deploy/lib/wva_kustomize.sh
+++ b/deploy/lib/wva_kustomize.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+#
+# Build and apply WVA controller manifests via Kustomize (replaces Helm for the controller).
+# Requires deploy script variables: WVA_PROJECT, WVA_NS, ENVIRONMENT, WVA_IMAGE_REPO, WVA_IMAGE_TAG,
+# WVA_IMAGE_PULL_POLICY, NAMESPACE_SCOPED, PROMETHEUS_URL, MONITORING_NAMESPACE, SKIP_TLS_VERIFY,
+# ENABLE_SCALE_TO_ZERO, WVA_LOG_LEVEL, CONTROLLER_INSTANCE, POOL_GROUP, WVA_WATCH_TARGET_NS (optional),
+# PROM_CA_CERT_PATH, VLLM_SVC_ENABLED, LLMD_NS, LLM_D_MODELSERVICE_NAME, VLLM_SVC_PORT, WVA_RELEASE_NAME.
+# jq must be on PATH (JSON strategic-merge patch for the manager Deployment + JSON6902 for EPP metrics token Secret).
+# Optional WVA_SATURATION_OVERLAY: name under config/deploy/overlays/<name>/{kubernetes,openshift}/ that
+# composes the base controller bundle plus checked-in saturation patches (e.g. e2e-simulator, benchmark).
+# Unset or "default" uses config/deploy/wva-controller[-openshift] only.
+# Optional: WVA_KUSTOMIZE_TMP (caller-provided empty dir); otherwise mktemp is used.
+#
+
+wva_resource_prefix() {
+    local chart_name="workload-variant-autoscaler"
+    local r="${WVA_RELEASE_NAME:-workload-variant-autoscaler}"
+    if echo "$r" | grep -q "$chart_name"; then
+        echo "$r"
+    else
+        echo "${r}-${chart_name}"
+    fi | cut -c1-63 | sed 's/-$//'
+}
+
+# Prints "openshift" or "kubernetes" for config/deploy paths (ENVIRONMENT anything other than openshift → kubernetes).
+wva_kustomize_platform_slug() {
+    case "${ENVIRONMENT:-kubernetes}" in
+    openshift) printf '%s\n' openshift ;;
+    *) printf '%s\n' kubernetes ;;
+    esac
+}
+
+wva_kustomize_platform_dir() {
+    printf '%s\n' "${WVA_PROJECT}/config/deploy/$(wva_kustomize_platform_slug)"
+}
+
+# Controller RBAC + workload only (no CRDs). Used for apply/delete overlays so uninstall never
+# removes cluster CRDs, and so temp overlays can add nameSuffix without touching API definitions.
+wva_kustomize_controller_bundle_dir() {
+    local overlay="${WVA_SATURATION_OVERLAY:-}"
+    local platform
+    platform=$(wva_kustomize_platform_slug)
+
+    if [ -n "$overlay" ] && [ "$overlay" != "default" ]; then
+        local d="${WVA_PROJECT}/config/deploy/overlays/${overlay}/${platform}"
+        if [ -f "${d}/kustomization.yaml" ]; then
+            printf '%s\n' "$d"
+            return 0
+        fi
+        if declare -F log_warning >/dev/null 2>&1; then
+            log_warning "WVA_SATURATION_OVERLAY=${overlay} has no kustomization at ${d}; using base controller bundle"
+        fi
+    fi
+
+    case "$platform" in
+    openshift) printf '%s\n' "${WVA_PROJECT}/config/deploy/wva-controller-openshift" ;;
+    *) printf '%s\n' "${WVA_PROJECT}/config/deploy/wva-controller" ;;
+    esac
+}
+
+# Sanitized suffix token for multi-instance installs (e.g. secondary controller in e2e).
+# Prints "-ci-<slug>" or nothing.
+# Slug length 24: prefixed metrics Service name is 35 chars (workload-variant-autoscaler-cm-mon);
+# Kubernetes Service metadata.name must be <=63, so suffix max is 28 (= 4 for "-ci-" + 24 slug).
+wva_kustomize_ci_suffix() {
+    local raw ci
+    raw="${CONTROLLER_INSTANCE:-}"
+    raw=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-')
+    raw=$(echo "$raw" | sed 's/-\{2,\}/-/g;s/^-//;s/-$//')
+    ci=$(echo "$raw" | cut -c1-24)
+    if [ -z "$ci" ]; then
+        return 0
+    fi
+    printf '%s' "-ci-${ci}"
+}
+
+# Controller Deployment metadata.name after config/default namePrefix and optional wva_kustomize_apply nameSuffix.
+wva_kustomize_manager_deployment_name() {
+    printf '%s%s' 'workload-variant-autoscaler-controller-manager' "$(wva_kustomize_ci_suffix)"
+}
+
+# Saturation ConfigMap metadata.name (namePrefix + config/manager/configmap-saturation-scaling.yaml + nameSuffix).
+wva_kustomize_saturation_configmap_name() {
+    printf '%s%s' 'workload-variant-autoscaler-saturation-scaling-config' "$(wva_kustomize_ci_suffix)"
+}
+
+# When set, suffix cluster-scoped RBAC etc. so a second controller install does not overwrite the primary's bindings.
+wva_kustomize_namesuffix_yaml() {
+    local s
+    s=$(wva_kustomize_ci_suffix)
+    if [ -z "$s" ]; then
+        return 0
+    fi
+    printf '%s\n' "nameSuffix: ${s}"
+}
+
+# Writes prometheus-client-cert Secret in WVA_NS from PEM file at PROM_CA_CERT_PATH (skips if empty or missing).
+wva_apply_prometheus_ca_secret() {
+    if [ ! -s "${PROM_CA_CERT_PATH:-}" ]; then
+        return 0
+    fi
+    kubectl -n "$WVA_NS" create secret generic prometheus-client-cert \
+        --from-file=ca.crt="$PROM_CA_CERT_PATH" \
+        --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Renders vLLM metrics Service + ServiceMonitor into LLMD_NS (chart parity).
+wva_apply_vllm_metrics_manifests() {
+    if [ "${VLLM_SVC_ENABLED:-false}" != "true" ]; then
+        return 0
+    fi
+    local template="${WVA_PROJECT}/deploy/manifests/wva-vllm-metrics.yaml.in"
+    if [ ! -f "$template" ]; then
+        log_error "Missing vLLM metrics template: $template"
+        return 1
+    fi
+    local prefix model port
+    prefix=$(wva_resource_prefix)
+    model="${LLM_D_MODELSERVICE_NAME:-}"
+    if [ -z "$model" ]; then
+        log_warning "LLM_D_MODELSERVICE_NAME unset; skipping vLLM metrics Service/ServiceMonitor"
+        return 0
+    fi
+    port="${VLLM_SVC_PORT:-8200}"
+    sed -e "s/__WVA_SVC_PREFIX__/${prefix}/g" \
+        -e "s/__LLMD_NS__/${LLMD_NS}/g" \
+        -e "s/__MODEL_NAME__/${model}/g" \
+        -e "s/__PORT__/${port}/g" \
+        "$template" | kubectl apply -f -
+}
+
+wva_kustomize_require_jq() {
+    if ! command -v jq &>/dev/null; then
+        log_error "jq is required to render WVA Kustomize patches (install jq, or use a deploy image that includes it)."
+        return 1
+    fi
+}
+
+# Symlink controller bundle and write kustomization header (resources + namespace + optional nameSuffix).
+# Apply flows append a "patches:" block afterward; delete uses this as the complete kustomization.
+wva_kustomize_runtime_overlay_base() {
+    local tmp=$1 ns=$2 ctrl_bundle=$3 sfx_line=$4
+    ln -sfn "${ctrl_bundle}" "${tmp}/bundle"
+    cat >"${tmp}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- bundle
+
+namespace: ${ns}
+${sfx_line}
+EOF
+}
+
+# Strategic-merge patch for the manager Deployment (JSON so POOL_GROUP / CONTROLLER_INSTANCE need no manual YAML escaping).
+wva_kustomize_write_patch_deployment_json() {
+    local tmp=$1 ns=$2 ci_suffix_token=$3
+    wva_kustomize_require_jq || return 1
+
+    local watch_type watch_mode="${NAMESPACE_SCOPED:-true}"
+    if [ -n "${WVA_WATCH_TARGET_NS:-}" ]; then
+        watch_type=1
+    elif [ "$watch_mode" = "true" ] || [ "$watch_mode" = "True" ]; then
+        watch_type=0
+    else
+        watch_type=2
+    fi
+
+    local extra_env_json='[]'
+    if [ -n "$ci_suffix_token" ]; then
+        extra_env_json=$(jq -n \
+            --arg v "workload-variant-autoscaler-wva-variantautoscaling-config${ci_suffix_token}" \
+            --arg s "$(wva_kustomize_saturation_configmap_name)" \
+            '[{name:"CONFIG_MAP_NAME",value:$v},{name:"SATURATION_CONFIG_MAP_NAME",value:$s}]')
+    fi
+
+    local watch_env_json
+    case "$watch_type" in
+    1) watch_env_json=$(jq -n --arg v "${WVA_WATCH_TARGET_NS}" '[{name:"WATCH_NAMESPACE",value:$v}]') ;;
+    0) watch_env_json='[{"name":"WATCH_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}]' ;;
+    *) watch_env_json='[{"name":"WATCH_NAMESPACE","value":""}]' ;;
+    esac
+
+    jq -n \
+        --arg ns "$ns" \
+        --arg img "${WVA_IMAGE_REPO}:${WVA_IMAGE_TAG}" \
+        --arg ipp "${WVA_IMAGE_PULL_POLICY:-Always}" \
+        --arg pool "${POOL_GROUP:-}" \
+        --arg ci "${CONTROLLER_INSTANCE:-}" \
+        --arg ll "${WVA_LOG_LEVEL:-info}" \
+        --arg ms "${WVA_METRICS_SECURE:-true}" \
+        --argjson watch_env "$watch_env_json" \
+        --argjson extra_env "$extra_env_json" '
+      ($watch_env + [
+        {name: "POOL_GROUP", value: $pool},
+        {name: "CONTROLLER_INSTANCE", value: $ci},
+        {name: "LOG_LEVEL", value: $ll},
+        {name: "METRICS_SECURE", value: $ms}
+      ] + $extra_env) as $env |
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {name: "workload-variant-autoscaler-controller-manager", namespace: $ns},
+        spec: {
+          template: {
+            spec: {
+              containers: [{
+                name: "manager",
+                image: $img,
+                imagePullPolicy: $ipp,
+                env: $env
+              }]
+            }
+          }
+        }
+      }' >"${tmp}/patch-deployment.json"
+}
+
+# Builds a temp overlay with absolute resource path + patches, then kubectl apply -k.
+wva_kustomize_apply() {
+    local ctrl_bundle
+    ctrl_bundle=$(wva_kustomize_controller_bundle_dir)
+    if [ ! -f "${ctrl_bundle}/kustomization.yaml" ]; then
+        log_error "Missing Kustomize controller bundle: ${ctrl_bundle}/kustomization.yaml"
+        return 1
+    fi
+
+    local tmp="${WVA_KUSTOMIZE_TMP:-}"
+    if [ -z "$tmp" ]; then
+        tmp=$(mktemp -d "${TMPDIR:-/tmp}/wva-kustomize.XXXXXX")
+    fi
+
+    local ns="${WVA_NS:?}"
+
+    # --- patch: ConfigMap runtime keys (Prometheus URL, TLS skip, scale-to-zero, optional CA path on kube)
+    local ca_cm_path=""
+    if [ -s "${PROM_CA_CERT_PATH:-}" ] && [ "${SKIP_TLS_VERIFY:-false}" != "true" ]; then
+        ca_cm_path="/etc/prometheus-certs/ca.crt"
+    fi
+    local kubectl_cm_args=(
+        kubectl create configmap workload-variant-autoscaler-wva-variantautoscaling-config
+        --namespace="$ns"
+        --from-literal=PROMETHEUS_BASE_URL="${PROMETHEUS_URL:-}"
+        --from-literal=PROMETHEUS_TLS_INSECURE_SKIP_VERIFY="${SKIP_TLS_VERIFY:-false}"
+        --from-literal=WVA_SCALE_TO_ZERO="${ENABLE_SCALE_TO_ZERO:-false}"
+        --dry-run=client
+        -o yaml
+    )
+    if [ -n "$ca_cm_path" ]; then
+        kubectl_cm_args+=(--from-literal=PROMETHEUS_CA_CERT_PATH="${ca_cm_path}")
+    fi
+    "${kubectl_cm_args[@]}" >"${tmp}/patch-configmap.yaml"
+
+    # --- patch: Deployment image + pull policy + env (JSON strategic merge via jq — see wva_kustomize_write_patch_deployment_json).
+    # The bundle already resolves config/manager's `images` (controller -> ghcr.io/...:v0.5.1), so a
+    # top-level `images: name: controller` entry in this overlay does not match and would not update
+    # the workload image. Pin the image here so WVA_IMAGE_REPO/TAG always apply.
+    local sfx_line ci_suffix_token
+    sfx_line=$(wva_kustomize_namesuffix_yaml)
+
+    ci_suffix_token=$(wva_kustomize_ci_suffix)
+    # nameSuffix runs after replacements in the base bundle; the epp-metrics-token Secret annotation
+    # would otherwise keep the unsuffixed SA name and the token controller never populates the Secret
+    # (pods stuck ContainerCreating on the epp-metrics-token volume).
+    local extra_patches=""
+    if [ -n "$ci_suffix_token" ]; then
+        # nameSuffix renames ConfigMaps; kustomize updates configMapKeyRef names but not these literals in manager.yaml.
+        local epp_sa_name="workload-variant-autoscaler-epp-metrics-reader${ci_suffix_token}"
+        wva_kustomize_require_jq || return 1
+        jq -n --arg sa "$epp_sa_name" \
+            '[{"op":"replace","path":"/metadata/annotations/kubernetes.io~1service-account.name","value":$sa}]' \
+            >"${tmp}/patch-epp-metrics-token-sa.json"
+        extra_patches="- path: patch-epp-metrics-token-sa.json
+  target:
+    kind: Secret
+    labelSelector: app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/component=epp-metrics"
+    fi
+
+    wva_kustomize_write_patch_deployment_json "$tmp" "$ns" "$ci_suffix_token" || return 1
+
+    wva_kustomize_runtime_overlay_base "$tmp" "$ns" "$ctrl_bundle" "$sfx_line"
+
+    cat >>"${tmp}/kustomization.yaml" <<EOF
+patches:
+- path: patch-configmap.yaml
+  target:
+    kind: ConfigMap
+    name: workload-variant-autoscaler-wva-variantautoscaling-config
+- path: patch-deployment.json
+  target:
+    kind: Deployment
+    name: workload-variant-autoscaler-controller-manager
+${extra_patches}
+EOF
+
+    log_info "Applying CRDs (Kustomize)..."
+    kubectl apply -k "${WVA_PROJECT}/config/crd"
+
+    log_info "Validating WVA controller bundle (preflight)..."
+    kubectl kustomize "${tmp}" >/dev/null
+
+    log_info "Applying WVA controller (Kustomize): bundle=${ctrl_bundle} deployment=$(wva_kustomize_manager_deployment_name)"
+    kubectl apply -k "${tmp}"
+
+    wva_apply_prometheus_ca_secret
+    wva_apply_vllm_metrics_manifests
+
+    if [ -z "${WVA_KUSTOMIZE_TMP:-}" ]; then
+        rm -rf "${tmp}"
+    fi
+}
+
+wva_kustomize_delete() {
+    local tmp ns ctrl_bundle sfx_line
+    ns="${WVA_NS:?}"
+    tmp=$(mktemp -d "${TMPDIR:-/tmp}/wva-kustomize-del.XXXXXX")
+
+    ctrl_bundle=$(wva_kustomize_controller_bundle_dir)
+    sfx_line=$(wva_kustomize_namesuffix_yaml)
+
+    wva_kustomize_runtime_overlay_base "$tmp" "$ns" "$ctrl_bundle" "$sfx_line"
+
+    log_info "Removing WVA controller (Kustomize delete)..."
+    kubectl delete -k "${tmp}" --ignore-not-found=true --wait=false 2>/dev/null || true
+
+    if [ "${VLLM_SVC_ENABLED:-false}" = "true" ] && [ -n "${LLM_D_MODELSERVICE_NAME:-}" ]; then
+        local prefix
+        prefix=$(wva_resource_prefix)
+        kubectl delete service "${prefix}-vllm" -n "${LLMD_NS}" --ignore-not-found=true 2>/dev/null || true
+        kubectl delete servicemonitor "${prefix}-vllm-mon" -n "${LLMD_NS}" --ignore-not-found=true 2>/dev/null || true
+    fi
+
+    rm -rf "${tmp}"
+}

--- a/deploy/manifests/wva-vllm-metrics.yaml.in
+++ b/deploy/manifests/wva-vllm-metrics.yaml.in
@@ -1,0 +1,39 @@
+# Rendered by deploy/lib/wva_kustomize.sh when VLLM_SVC_ENABLED=true (placeholders: __WVA_SVC_PREFIX__, __LLMD_NS__, __MODEL_NAME__, __PORT__).
+apiVersion: v1
+kind: Service
+metadata:
+  name: __WVA_SVC_PREFIX__-vllm
+  namespace: __LLMD_NS__
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+    llm-d.ai/model: __MODEL_NAME__
+spec:
+  selector:
+    llm-d.ai/model: __MODEL_NAME__
+  ports:
+    - name: vllm
+      port: __PORT__
+      protocol: TCP
+      targetPort: __PORT__
+  type: NodePort
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: __WVA_SVC_PREFIX__-vllm-mon
+  namespace: __LLMD_NS__
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+    llm-d.ai/model: __MODEL_NAME__
+    openshift.io/user-monitoring: "true"
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: __MODEL_NAME__
+  endpoints:
+    - port: vllm
+      path: /metrics
+      interval: 30s
+      scheme: http
+  namespaceSelector:
+    any: true

--- a/deploy/openshift/install.sh
+++ b/deploy/openshift/install.sh
@@ -28,7 +28,6 @@ REQUIRED_TOOLS=("oc")
 
 # TLS verification enabled by default on OpenShift
 SKIP_TLS_VERIFY=false
-VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values.yaml"
 
 #### REQUIRED FUNCTION used by deploy/install.sh ####
 check_specific_prerequisites() {

--- a/docs/design/controller-behavior.md
+++ b/docs/design/controller-behavior.md
@@ -154,7 +154,7 @@ func ConfigMapPredicate(namespaceChecker func(string) bool) predicate.Predicate 
 - **Generic**: ❌ Blocked
 
 **Purpose:**
-The controller watches its own ServiceMonitor (`workload-variant-autoscaler-controller-manager-metrics-monitor`) for observability purposes. When the ServiceMonitor is deleted:
+The controller watches its own ServiceMonitor (label `control-plane=controller-manager` in the controller namespace; default Kustomize name `workload-variant-autoscaler-cm-mon`) for observability purposes. When the ServiceMonitor is deleted:
 
 1. Prometheus stops scraping controller metrics
 2. External autoscalers (HPA/KEDA) can't access optimized replica metrics
@@ -165,11 +165,17 @@ The controller watches its own ServiceMonitor (`workload-variant-autoscaler-cont
 **Predicate:**
 
 ```go
-// ServiceMonitorPredicate returns a predicate that filters ServiceMonitor events to only the target ServiceMonitor.
 func ServiceMonitorPredicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return obj.GetName() == defaultServiceMonitorName && 
-		       obj.GetNamespace() == configMapNamespace
+		if obj.GetNamespace() != config.SystemNamespace() {
+			return false
+		}
+		labels := obj.GetLabels()
+		if labels == nil {
+			return false
+		}
+		return labels["control-plane"] == "controller-manager" &&
+			labels["app.kubernetes.io/name"] == "workload-variant-autoscaler"
 	})
 }
 ```
@@ -286,7 +292,7 @@ kubectl logs -n workload-variant-autoscaler-system deployment/workload-variant-a
 **Diagnosis**:
 ```bash
 # Check if ServiceMonitor exists
-kubectl get servicemonitor -n workload-variant-autoscaler-system workload-variant-autoscaler-controller-manager-metrics-monitor
+kubectl get servicemonitor -n workload-variant-autoscaler-system -l control-plane=controller-manager
 
 # Check controller events
 kubectl get events -n workload-variant-autoscaler-system --field-selector involvedObject.kind=ServiceMonitor

--- a/docs/developer-guide/kustomize-helm-migration-plan.md
+++ b/docs/developer-guide/kustomize-helm-migration-plan.md
@@ -1,0 +1,66 @@
+# Kustomize-first controller install — plan and status
+
+> **Note:** This document is temporary. It will be removed once Helm is fully deprecated.
+
+This document is the **migration plan and drift checklist** for moving the WVA **controller** off Helm and onto Kustomize, while keeping Helm where it still owns other stack pieces. Operational learnings from local Kind e2e and CI alignment are captured here so `deploy/README.md` can stay procedural and this file stays the **source of truth for “what we intended vs what shipped.”**
+
+## Goals (original intent)
+
+1. **Install the WVA controller with Kustomize** (`kubectl apply -k` / `deploy/lib/wva_kustomize.sh`) using bundles under `config/deploy/`, not the Helm chart’s controller templates.
+2. **Deprecate Helm for controller install**; keep the chart for OCI distribution, migration, and **chart-only** workloads (e.g. VA/HPA templates in some flows).
+3. **Preserve behavior** for monitoring, llm-d (helmfile), scaler backends, e2e, and OpenShift CI.
+4. **Document** the supported path and deprecation; avoid silent behavior changes for operators.
+
+## In scope vs out of scope
+
+| In scope | Out of scope (unchanged) |
+|----------|---------------------------|
+| WVA Deployment, RBAC, metrics Service/ServiceMonitor, saturation + variant ConfigMaps, EPP metrics token wiring | llm-d releases via **helmfile** (`deploy/install-llmd-infra.sh`) |
+| `deploy/install.sh` + `deploy/lib/infra_wva.sh` + `deploy/lib/wva_kustomize.sh` + `deploy/lib/cleanup.sh` | kube-prometheus-stack, LWS, Prometheus Adapter installs (Helm) |
+| `config/deploy/kubernetes`, `config/deploy/openshift`, `config/deploy/wva-controller*` | Gateway control plane unless we explicitly change that story |
+| CI: Kind smoke/full, OpenShift e2e deploy steps | Removing the chart from the repo or stopping chart publish |
+
+## Implementation checklist — aligned with the tree (drift audit)
+
+Use this as a **merge / review gate**: if the codebase diverges, update either the implementation or this section.
+
+| Item | Status | Where |
+|------|--------|--------|
+| Controller bundles (`config/deploy/wva-controller`, `wva-controller-openshift`) include `../../default` (RBAC + manager + metrics); CRDs applied separately in `wva_kustomize_apply` | Done | `config/deploy/wva-controller/kustomization.yaml`, `deploy/lib/wva_kustomize.sh` |
+| Platform entrypoints `config/deploy/kubernetes`, `config/deploy/openshift` compose CRD + controller as documented | Done | `config/deploy/kubernetes/kustomization.yaml`, `config/deploy/openshift/kustomization.yaml` |
+| `deploy_wva_controller` uses Kustomize; legacy `helm uninstall` no-op then apply | Done | `deploy/lib/infra_wva.sh` |
+| **`IMG` / `WVA_IMAGE_*` reliably set the manager image** after inner `config/manager` resolves `controller` → full registry path (outer `images: name: controller` alone is insufficient) | Done | `deploy/lib/wva_kustomize.sh` — strategic-merge patch sets `spec.template.spec.containers[0].image` |
+| Multi-instance / e2e secondary: `nameSuffix` + `CONTROLLER_INSTANCE` + ConfigMap **literal** env names (`CONFIG_MAP_NAME`, `SATURATION_CONFIG_MAP_NAME`) | Done | `deploy/lib/wva_kustomize.sh` |
+| EPP metrics projected token Secret: SA annotation matches **suffixed** ServiceAccount | Done | JSON 6902 patch in `wva_kustomize.sh` when CI suffix present |
+| Metrics auth `ClusterRoleBinding` subject rewrites with `namePrefix` / `nameSuffix` | Done | `config/rbac/metrics_auth_role_binding.yaml` |
+| `install-llmd-infra` skips WVA in helmfile when `DEPLOY_WVA=true`; poolGroup / infra alignment unchanged in intent | Done | `deploy/lib/infra_llmd.sh` |
+| Post-deploy Service/ServiceMonitor label alignment uses **jq 1.6-safe** patches (no `$label`; dynamic key for `llm-d.ai/model`) | Done | `deploy/lib/infra_llmd.sh` |
+| OpenShift CI passes **full `IMG`** matching `ghcr.io/${{ github.repository }}:$tag` into `install.sh` | Done | `.github/workflows/ci-e2e-openshift.yaml` |
+| Kind smoke + full e2e set **`WVA_E2E_REPO_ROOT`** (dual-controller / `e2e_secondary_wva.sh`) | Done | `.github/workflows/ci-pr-checks.yaml` |
+| Saturation tuning via **`config/deploy/overlays/{e2e-simulator,benchmark}`** + **`WVA_SATURATION_OVERLAY`** (no env-merge in `wva_kustomize.sh`) | Done | `deploy/lib/wva_kustomize.sh`, workflows, `Makefile` |
+| Kind smoke + full unset poisoned **`PROM_CA_CERT_PATH`** before `make` | Done | `.github/workflows/ci-pr-checks.yaml` |
+| `deploy/install.sh` documents controller = Kustomize only; no dead `VALUES_FILE` / chart path for the manager | Done | `deploy/install.sh`, `deploy/openshift/install.sh`, `deploy/lib/infra_wva.sh` |
+| Cleanup deletes Kustomize controller + chart no-op | Done | `deploy/lib/cleanup.sh`, OpenShift workflow `wva_kustomize_delete` |
+
+**Drift:** If any row regresses (e.g. image reverts to chart-only tagging without the merge patch), treat it as a **release blocker** for Kustomize-first claims in `deploy/README.md`.
+
+## Operational learnings (local + CI)
+
+1. **`PROM_CA_CERT_PATH`**: If set to a non-file (e.g. `/dev/null`), `deploy/install.sh` can fail extracting the Prometheus CA and **never run** `install-llmd-infra.sh` — e2e then fails in `BeforeSuite` (missing llm-d CRDs). **Mitigation:** unset before install; CI does `unset PROM_CA_CERT_PATH` in Kind/OpenShift deploy steps.
+2. **`IMG`**: E2e and operators must ensure the **running** Deployment uses the built image (`kubectl get deploy … -o jsonpath='{.spec…image}'`). The merge patch in `wva_kustomize.sh` exists specifically so `IMG` is not ignored.
+3. **`WVA_E2E_REPO_ROOT`**: Dual-controller paths need the repository root for `deploy/lib/e2e_secondary_wva.sh`. `make test-e2e-*` exports **`WVA_E2E_REPO_ROOT=$(CURDIR)`**; CI sets it to the Actions checkout path. Deprecated fallbacks in `e2eRepoRoot()`: **`WVA_E2E_CHART_PATH`**, then **`os.Getwd()`**.
+4. **`jq` 1.6** (Ubuntu runners): avoid `--arg label` / `$label`; use e.g. `--arg model_label` and dynamic object keys for dotted label names.
+5. **`WVA_SATURATION_OVERLAY`**: Saturation tuning for CI/simulator vs benchmark lives in **`config/deploy/overlays/`**; `wva_kustomize_controller_bundle_dir` selects **`overlays/<name>/{kubernetes,openshift}`** when set (otherwise the base **`wva-controller*`** bundle).
+
+## Documentation map (avoid duplicate “plans”)
+
+| Audience | Doc |
+|-----------|-----|
+| Operators / install flow | [`deploy/README.md`](../../deploy/README.md) |
+| E2e env, CI triggers, local simulation | [Testing guide](testing.md) |
+| **This file** | Plan, status, drift checklist, learnings |
+
+## Optional follow-ups (not required for “migration done”)
+
+- Narrow or split jobs if you want CI that only validates Kustomize WVA without full llm-d.
+- Consider `env -u PROM_CA_CERT_PATH` in `Makefile` e2e targets for local parity with CI (today CI unsets in workflow; Makefile leaves env to the user).

--- a/docs/developer-guide/release-process.md
+++ b/docs/developer-guide/release-process.md
@@ -9,7 +9,7 @@ This guide describes how to cut a release of the Workload Variant Autoscaler (WV
 | 1. Pre-release | This repo | Changelog, optional version bumps (see below) |
 | 2. Tag & release | GitHub | Create tag `vX.Y.Z`, push; create GitHub Release (publish) |
 | 3. Automation | GitHub Actions | Image build + push; Helm chart version bump + publish to GHCR; chart files committed back |
-| 4. Post-release | llm-d repo | **Required:** Update [workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) guide (version callout, CRD/sample URLs, helmfile/values) |
+| 4. Post-release | llm-d repo | **Required:** Update [workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) guide (version callout, CRD/sample URLs, Kustomize overlays / values) |
 
 ---
 
@@ -122,7 +122,7 @@ The [llm-d](https://github.com/llm-d/llm-d) repo hosts a **workload-autoscaling 
    - If the new release has breaking changes, add or update the "Breaking Changes" / "Upgrading" content and migration steps in the README.
 
 4. **Helmfile / values**  
-   - If the guide's `helmfile.yaml.gotmpl` or `workload-autoscaling/values.yaml` (or equivalent) pin the WVA image or chart version, update those to the new version.
+   - If the guide's Kustomize overlays, `helmfile.yaml.gotmpl`, or `workload-autoscaling/values.yaml` (or equivalent) pin the WVA image or chart version, update those to the new version.
 
 **Guide location:** [guides/workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) (main branch). After editing, open a PR in the [llm-d/llm-d](https://github.com/llm-d/llm-d) repo so the guide stays in sync with the WVA release.
 
@@ -154,7 +154,7 @@ To allow other team members to perform releases:
 |------|--------|
 | **WVA release** | Tag `vX.Y.Z` → push → create and publish GitHub Release. CI builds image and (on publish) runs Helm release. |
 | **Helm** | Workflow updates chart version and default image tag, publishes to GHCR, and commits chart files back to the default branch. |
-| **Guide / llm-d repo** | **Required:** After release, update the [workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) guide (version callout, CRD/sample URLs, helmfile/values) and open a PR in llm-d/llm-d. |
+| **Guide / llm-d repo** | **Required:** After release, update the [workload-autoscaling](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) guide (version callout, CRD/sample URLs, Kustomize overlays / helmfile / values) and open a PR in llm-d/llm-d. |
 | **Team** | Use this doc plus repo permissions and GHCR secrets so others can run the same process safely.
 
 For workflow details, see [`.github/workflows/ci-release.yaml`](../../.github/workflows/ci-release.yaml) and [`.github/workflows/helm-release.yaml`](../../.github/workflows/helm-release.yaml).

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -175,6 +175,7 @@ When `LLMD_PATCH_EPP_FLOW_CONTROL=true` (set by `make deploy-e2e-infra`) or `ENA
 
 - **`SKIP_HELM_REPO_UPDATE`**: When set to **`true`**, `helm repo update` is skipped during installs (faster, less network churn). Default runs `helm repo update` to refresh repo indexes.
 - **`E2E_DEPLOY_WAIT_TIMEOUT`**: When `LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true` (as in `make deploy-e2e-infra`), caps the `kubectl wait` for the EPP and inference-gateway deployments (default **`120s`**). Raise it if image pulls rollouts routinely exceed that window.
+- **`WVA_SATURATION_OVERLAY`**: Selects a checked-in overlay under `config/deploy/overlays/<name>/{kubernetes,openshift}/` (e.g. **`e2e-simulator`**, **`benchmark`**) that patches the saturation ConfigMap. **`default`** selects the base controller bundle only. `make deploy-e2e-infra` passes **`e2e-simulator`** when this variable is unset; use **`WVA_SATURATION_OVERLAY=default`** if you want upstream `config/manager` saturation defaults on that path.
 
 Alternatively, use the Makefile to deploy infra and run tests in one go:
 
@@ -188,6 +189,8 @@ make test-e2e-full
 ```
 
 See the [E2E Test Suite README](../../test/e2e/README.md) for full configuration options and examples.
+
+**Kustomize-first pitfalls (local / CI):** Ensure **`IMG`** (or `WVA_IMAGE_REPO` / `WVA_IMAGE_TAG`) matches the image you built — the running controller `Deployment` must not silently stay on an older tag. Do not export **`PROM_CA_CERT_PATH`** to a non-file (e.g. `/dev/null`); that can abort `deploy/install.sh` before llm-d installs. Dual-controller specs need **`WVA_E2E_REPO_ROOT`** pointing at the repository root; **`make test-e2e-*`** exports **`WVA_E2E_REPO_ROOT=$(CURDIR)`** by default. Deprecated fallback: **`WVA_E2E_CHART_PATH`**, then **`os.Getwd()`** if you run **`go test`** from the repo root without env. See the [Kustomize / Helm migration plan](kustomize-helm-migration-plan.md) for the full checklist and CI parity notes.
 
 ### Quick Start
 
@@ -223,11 +226,12 @@ Key environment variables (see [E2E Test Suite README](../../test/e2e/README.md)
 | `USE_SIMULATOR` | `true` | Emulated GPUs (true) or real vLLM (false) |
 | `SCALE_TO_ZERO_ENABLED` | `false` | Enable scale-to-zero tests (Kind supports both enabled and disabled) |
 | `SCALER_BACKEND` | `prometheus-adapter` | `prometheus-adapter` or `keda` (KEDA only for kind-emulator) |
+| `WVA_SATURATION_OVERLAY` | _(see install tuning)_ | `e2e-simulator`, `benchmark`, or `default`/unset — see **Install script tuning** |
 | `POD_READY_TIMEOUT` / `SCALE_UP_TIMEOUT` | `300` / `600` | Model ready vs longest scale/job waits (seconds) |
 | `E2E_EVENTUALLY_STANDARD`, etc. | see README | Optional `Eventually` timeouts and poll intervals (`E2E_EVENTUALLY_*`, `E2E_EVENTUALLY_POLL*`) |
 | `RESTART_PROMETHEUS_ADAPTER` | `auto` | kind-emulator: `auto` probes adapter + API before restarting pods; `true`/`false` force always/never |
 
-Deploy-time knobs: `SKIP_HELM_REPO_UPDATE`, `E2E_DEPLOY_WAIT_TIMEOUT`, optional `KV_SPARE_TRIGGER` / `QUEUE_SPARE_TRIGGER` (Makefile applies a follow-up `helm upgrade` when set) — see **Install script tuning** above.
+Deploy-time knobs: `SKIP_HELM_REPO_UPDATE`, `E2E_DEPLOY_WAIT_TIMEOUT`, and **`WVA_SATURATION_OVERLAY`** (see **Install script tuning** above). `make deploy-e2e-infra` / `make test-e2e-*` default **`WVA_SATURATION_OVERLAY`** to **`e2e-simulator`** so Kind/OpenShift simulator runs match CI without extra env.
 
 For running multiple test runs in parallel, use [multi-controller isolation](../user-guide/multi-controller-isolation.md) (`CONTROLLER_INSTANCE`).
 
@@ -266,6 +270,8 @@ E2E workflows run the **consolidated suite** (`test/e2e/`):
 - **Full** (`make test-e2e-full`): Full suite; typically run with infra deployed via `deploy-e2e-infra` or equivalent
 
 Infrastructure is deployed in **infra-only** mode (WVA + llm-d only); tests create VA, HPA, and model services dynamically.
+
+PR checks align Kind e2e with Kustomize-first learnings: **`WVA_E2E_REPO_ROOT`** on smoke and full jobs, **`unset PROM_CA_CERT_PATH`** before `make`, full OpenShift deploy passes **`IMG=ghcr.io/<repo>:<tag>`** into `install.sh` — see [Kustomize / Helm migration plan](kustomize-helm-migration-plan.md).
 
 #### OpenShift E2E Tests Workflow
 

--- a/docs/developer-guide/troubleshooting.md
+++ b/docs/developer-guide/troubleshooting.md
@@ -90,12 +90,11 @@ For e2e-style deploys, **`install-llmd-infra.sh`** enables EPP flow control when
               value: "50"  # Increase for larger clusters
    ```
 
-   Or via Helm:
+   Or patch the controller Deployment (Kustomize installs):
 
    ```bash
-   helm upgrade -i workload-variant-autoscaler ./charts/workload-variant-autoscaler \
-   --namespace workload-variant-autoscaler-system \
-   --set controller.env.SCALE_FROM_ZERO_ENGINE_MAX_CONCURRENCY=50
+   kubectl -n workload-variant-autoscaler-system set env deployment/workload-variant-autoscaler-controller-manager \
+     SCALE_FROM_ZERO_ENGINE_MAX_CONCURRENCY=50
    ```
 
 2. **Inference gateway not receiving requests**:

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -74,15 +74,23 @@ func ConfigMapPredicate(ds datastore.Datastore, cfg *config.Config) predicate.Pr
 	})
 }
 
-// ServiceMonitorPredicate returns a predicate that filters ServiceMonitor events to only the target ServiceMonitor.
-// It checks that the ServiceMonitor name matches serviceMonitorName and namespace matches the configured namespace.
-// This predicate is used to filter only the target ServiceMonitor.
+// ServiceMonitorPredicate returns a predicate that filters ServiceMonitor events to only the controller's ServiceMonitor.
+// It matches namespace (system/controller namespace) and stable labels (control-plane, app.kubernetes.io/name),
+// not metadata.name, so Kustomize nameSuffix and multi-instance installs still enqueue the right object.
 // The ServiceMonitor is watched to enable detection when it is deleted, which would prevent
 // Prometheus from scraping controller metrics (including optimized replicas).
 func ServiceMonitorPredicate() predicate.Predicate {
-	const defaultServiceMonitorName = "workload-variant-autoscaler-controller-manager-metrics-monitor"
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return obj.GetName() == defaultServiceMonitorName && obj.GetNamespace() == config.SystemNamespace()
+		if obj.GetNamespace() != config.SystemNamespace() {
+			return false
+		}
+		labels := obj.GetLabels()
+		if labels == nil {
+			return false
+		}
+		// Match by labels so Kustomize nameSuffix / multi-instance installs still watch the right ServiceMonitor.
+		return labels["control-plane"] == "controller-manager" &&
+			labels["app.kubernetes.io/name"] == "workload-variant-autoscaler"
 	})
 }
 

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -100,11 +100,6 @@ func NewVariantAutoscalingReconciler(
 // +kubebuilder:rbac:groups=inference.networking.x-k8s.io;inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update
 
-const (
-	// ServiceMonitor constants for watching controller's own metrics ServiceMonitor
-	defaultServiceMonitorName = "workload-variant-autoscaler-controller-manager-metrics-monitor"
-)
-
 var (
 	// ServiceMonitor GVK for watching controller's own metrics ServiceMonitor
 	serviceMonitorGVK = schema.GroupVersionKind{

--- a/internal/controller/variantautoscaling_controller_test.go
+++ b/internal/controller/variantautoscaling_controller_test.go
@@ -48,6 +48,16 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils/resources"
 )
 
+// kustomizeControllerServiceMonitorName matches config/prometheus/monitor.yaml + config/default namePrefix.
+const kustomizeControllerServiceMonitorName = "workload-variant-autoscaler-cm-mon"
+
+func controllerMetricsServiceMonitorLabels() map[string]string {
+	return map[string]string{
+		"control-plane":          "controller-manager",
+		"app.kubernetes.io/name": "workload-variant-autoscaler",
+	}
+}
+
 var _ = Describe("VariantAutoscalings Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
@@ -235,8 +245,9 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				now := metav1.Now()
 				serviceMonitor := &promoperator.ServiceMonitor{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              defaultServiceMonitorName,
+						Name:              kustomizeControllerServiceMonitorName,
 						Namespace:         config.SystemNamespace(),
+						Labels:            controllerMetricsServiceMonitorLabels(),
 						DeletionTimestamp: &now,
 					},
 				}
@@ -251,7 +262,7 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				select {
 				case event := <-fakeRecorder.Events:
 					Expect(event).To(ContainSubstring("ServiceMonitorDeleted"))
-					Expect(event).To(ContainSubstring(defaultServiceMonitorName))
+					Expect(event).To(ContainSubstring(kustomizeControllerServiceMonitorName))
 				case <-time.After(2 * time.Second):
 					Fail("Expected event to be emitted but none was received")
 				}
@@ -261,8 +272,9 @@ var _ = Describe("VariantAutoscalings Controller", func() {
 				By("Creating a ServiceMonitor without deletion timestamp")
 				serviceMonitor := &promoperator.ServiceMonitor{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      defaultServiceMonitorName,
+						Name:      kustomizeControllerServiceMonitorName,
 						Namespace: config.SystemNamespace(),
+						Labels:    controllerMetricsServiceMonitorLabels(),
 					},
 				}
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -121,7 +121,9 @@ export E2E_PROM_ADAPTER_PROBE_SEC=90
 
 ### Optional: faster `deploy/install.sh` for e2e
 
-`deploy/install.sh` runs **`helm repo update`** by default. To skip (faster but requires existing repo indexes), set **`SKIP_HELM_REPO_UPDATE=true`**.
+`deploy/install.sh` runs **`helm repo update`** by default (for components such as LWS and Prometheus Adapter). To skip (faster but requires existing repo indexes), set **`SKIP_HELM_REPO_UPDATE=true`**.
+
+Dual-controller smoke tests locate **`deploy/lib/e2e_secondary_wva.sh`** via **`e2eRepoRoot()`**: set **`WVA_E2E_REPO_ROOT`** to the repository root (required for a reliable path). **`make test-e2e-smoke`** / **`make test-e2e-full`** export **`WVA_E2E_REPO_ROOT=$(CURDIR)`** by default; CI sets **`WVA_E2E_REPO_ROOT`** to the checkout directory. If unset, the suite falls back to deprecated **`WVA_E2E_CHART_PATH`** (grandparent of that path) or **`os.Getwd()`** when you run **`go test`** from the repo root.
 
 When using **`LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true`** (as in `make deploy-e2e-infra`), **`E2E_DEPLOY_WAIT_TIMEOUT`** (default **`120s`**) bounds how long `install-llmd-infra.sh` waits for the EPP and inference-gateway deployments to become Available. Increase if your cluster is slow to pull images.
 

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -62,6 +62,12 @@ func LoadConfigFromEnv() E2EConfig {
 	if cfg.Environment == "openshift" && cfg.ScaleToZeroEnabled {
 		cfg.ScaleToZeroEnabled = false
 	}
+	// Default Kind images (e.g. kindest/node) often reject HPA minReplicas=0 the same way unless the
+	// apiserver enables HPAScaleToZero. Our kind-emulator CI/scripts do not turn that gate on, so
+	// prometheus-adapter e2e must not submit minReplicas=0 HPAs when only SCALE_TO_ZERO_ENABLED=true.
+	if cfg.Environment == "kind-emulator" && cfg.ScalerBackend == scalerBackendPrometheusAdapter && cfg.ScaleToZeroEnabled {
+		cfg.ScaleToZeroEnabled = false
+	}
 
 	return cfg
 }

--- a/test/e2e/fixtures/hpa_builder.go
+++ b/test/e2e/fixtures/hpa_builder.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 )
 
 const (
@@ -23,6 +25,28 @@ const (
 
 // HPAOption is a functional option for configuring HPA resources.
 type HPAOption func(*autoscalingv2.HorizontalPodAutoscaler)
+
+// WithExternalMetricControllerInstance adds controller_instance to the wva_desired_replicas
+// external metric selector when non-empty. It must match the VA label and WVA metrics when
+// CONTROLLER_INSTANCE is set (e.g. OpenShift CI); omit for empty instance (default Kind runs).
+func WithExternalMetricControllerInstance(instance string) HPAOption {
+	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+		if instance == "" {
+			return
+		}
+		if len(hpa.Spec.Metrics) == 0 || hpa.Spec.Metrics[0].External == nil {
+			return
+		}
+		ext := hpa.Spec.Metrics[0].External
+		if ext.Metric.Selector == nil {
+			ext.Metric.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{}}
+		}
+		if ext.Metric.Selector.MatchLabels == nil {
+			ext.Metric.Selector.MatchLabels = map[string]string{}
+		}
+		ext.Metric.Selector.MatchLabels[constants.LabelControllerInstance] = instance
+	}
+}
 
 // WithScaleTargetRefKind sets the Kind and APIVersion on the HPA's ScaleTargetRef.
 func WithScaleTargetRefKind(kind string) HPAOption {

--- a/test/e2e/limiter_test.go
+++ b/test/e2e/limiter_test.go
@@ -134,9 +134,11 @@ var _ = Describe("GPU Limiter Feature", Label("full"), Ordered, func() {
 			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaB, modelServiceB+"-decode", vaB, 1, 10, cfg.MonitoringNS)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject B")
 		} else {
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaA, modelServiceA+"-decode", vaA, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaA, modelServiceA+"-decode", vaA, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA A")
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaB, modelServiceB+"-decode", vaB, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaB, modelServiceB+"-decode", vaB, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA B")
 		}
 

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -280,7 +280,8 @@ var _ = Describe("Scale-From-Zero Feature", Serial, Label("full"), Ordered, func
 			err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaName, modelServiceName+"-decode", vaName, 0, 10, cfg.MonitoringNS)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject with scale-to-zero")
 		} else {
-			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, modelServiceName+"-decode", vaName, 0, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, modelServiceName+"-decode", vaName, 0, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA with scale-to-zero")
 		}
 
@@ -789,7 +790,8 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet", Serial, Label("
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject with scale-to-zero")
 		} else {
 			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, lwsName, vaName, 0, 10,
-				fixtures.WithScaleTargetRefKind("LeaderWorkerSet"))
+				fixtures.WithScaleTargetRefKind("LeaderWorkerSet"),
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA with scale-to-zero")
 		}
 
@@ -1210,7 +1212,8 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet (single-node)", S
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject with scale-to-zero")
 		} else {
 			err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, lwsName, vaName, 0, 10,
-				fixtures.WithScaleTargetRefKind("LeaderWorkerSet"))
+				fixtures.WithScaleTargetRefKind("LeaderWorkerSet"),
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create HPA with scale-to-zero")
 		}
 

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,13 +24,27 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
 )
 
+// legacyChartPathEnv is deprecated: prefer WVA_E2E_REPO_ROOT (repository root for deploy/lib/e2e_secondary_wva.sh).
+const legacyChartPathEnv = "WVA_E2E_CHART_PATH"
+
+func e2eRepoRoot() string {
+	if r := os.Getenv("WVA_E2E_REPO_ROOT"); r != "" {
+		return filepath.Clean(r)
+	}
+	if chart := os.Getenv(legacyChartPathEnv); chart != "" {
+		return filepath.Clean(filepath.Join(chart, "..", ".."))
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return filepath.Clean(wd)
+	}
+	return ""
+}
+
 type externalMetricValueList struct {
 	Items []struct {
 		MetricLabels map[string]string `json:"metricLabels"`
 	} `json:"items"`
 }
-
-const secondaryControllerChartPathEnv = "WVA_E2E_CHART_PATH"
 
 func splitImage(image string) (string, string) {
 	lastColon := strings.LastIndex(image, ":")
@@ -169,7 +185,7 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 
 		When("using Prometheus Adapter as scaler backend", func() {
 			It("should have external metrics API available", func() {
-				if cfg.ScalerBackend != "prometheus-adapter" {
+				if cfg.ScalerBackend != scalerBackendPrometheusAdapter {
 					Skip("External metrics API check only applies to Prometheus Adapter backend")
 				}
 				By("Checking for external.metrics.k8s.io API group")
@@ -268,9 +284,11 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			Expect(err).NotTo(HaveOccurred(), "Failed to create secondary VariantAutoscaling")
 
 			By("Creating HPAs in both namespaces for the shared VA name")
-			err = fixtures.EnsureHPA(ctx, k8sClient, primaryNamespace, primaryHPAName, primaryModelName+"-decode", sharedVAName, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, primaryNamespace, primaryHPAName, primaryModelName+"-decode", sharedVAName, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create primary HPA")
-			err = fixtures.EnsureHPA(ctx, k8sClient, secondaryNamespace, secondaryHPAName, secondaryModelName+"-decode", sharedVAName, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, secondaryNamespace, secondaryHPAName, secondaryModelName+"-decode", sharedVAName, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create secondary HPA")
 		})
 
@@ -392,40 +410,67 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 				Expect(err).NotTo(HaveOccurred(), "Failed to create secondary workload namespace")
 			}
 
-			By("Installing secondary namespace-scoped controller via Helm")
+			By("Installing secondary controller via Kustomize (cluster-wide watch; controller-instance isolation)")
 			primaryController, err := k8sClient.AppsV1().Deployments(cfg.WVANamespace).Get(ctx, "workload-variant-autoscaler-controller-manager", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to read primary controller deployment image")
 			Expect(primaryController.Spec.Template.Spec.Containers).NotTo(BeEmpty(), "Primary controller deployment should contain containers")
 			imageRepo, imageTag := splitImage(primaryController.Spec.Template.Spec.Containers[0].Image)
-			chartPath := os.Getenv(secondaryControllerChartPathEnv)
-			Expect(chartPath).NotTo(BeEmpty(),
-				"Missing %s; set it to the workload-variant-autoscaler chart directory (use an absolute path; go test cwd is the test package dir)", secondaryControllerChartPathEnv)
-			_, statErr := os.Stat(chartPath)
-			Expect(statErr).NotTo(HaveOccurred(), "Invalid %s path: %s", secondaryControllerChartPathEnv, chartPath)
+			repoRoot := e2eRepoRoot()
+			Expect(repoRoot).NotTo(BeEmpty(),
+				"set WVA_E2E_REPO_ROOT to the repository root, or deprecated %s to a path under the repo, or run go test from the repo root (see e2eRepoRoot())", legacyChartPathEnv)
+			secondaryScript := filepath.Join(repoRoot, "deploy/lib/e2e_secondary_wva.sh")
+			_, statErr := os.Stat(secondaryScript)
+			Expect(statErr).NotTo(HaveOccurred(), "invalid repo root %q: %v", repoRoot, statErr)
 
-			helmArgs := []string{
-				"upgrade", "-i", secondaryReleaseName, chartPath,
-				"-n", secondaryController, "--create-namespace",
-				"--set", "controller.enabled=true",
-				"--set", "va.enabled=false",
-				"--set", "hpa.enabled=false",
-				"--set", "vllmService.enabled=false",
-				"--set", "wva.namespaceScoped=true",
-				"--set", "wva.controllerInstance=" + controllerInstance,
-				"--set", "llmd.namespace=" + secondaryNamespace,
-				"--set", "wva.image.repository=" + imageRepo,
-				"--set", "wva.image.tag=" + imageTag,
-				"--set", "wva.imagePullPolicy=IfNotPresent",
-				"--set", "wva.prometheus.baseURL=https://kube-prometheus-stack-prometheus." + cfg.MonitoringNS + ".svc.cluster.local:9090",
-				"--set", "wva.prometheus.tls.insecureSkipVerify=true",
+			promURL := "https://kube-prometheus-stack-prometheus." + cfg.MonitoringNS + ".svc.cluster.local:9090"
+			poolGroup := os.Getenv("POOL_GROUP")
+			applyCmd := exec.Command("bash", secondaryScript, "apply")
+			applyCmd.Dir = repoRoot
+			secondaryEnv := append(os.Environ(),
+				"WVA_PROJECT="+repoRoot,
+				"WVA_NS="+secondaryController,
+				"ENVIRONMENT="+cfg.Environment,
+				"LLMD_NS="+secondaryNamespace,
+				"MONITORING_NAMESPACE="+cfg.MonitoringNS,
+				"WVA_IMAGE_REPO="+imageRepo,
+				"WVA_IMAGE_TAG="+imageTag,
+				"WVA_IMAGE_PULL_POLICY=IfNotPresent",
+				"NAMESPACE_SCOPED=false",
+				"PROMETHEUS_URL="+promURL,
+				"SKIP_TLS_VERIFY=true",
+				"ENABLE_SCALE_TO_ZERO="+strconv.FormatBool(cfg.ScaleToZeroEnabled),
+				"WVA_LOG_LEVEL=debug",
+				"CONTROLLER_INSTANCE="+controllerInstance,
+				"POOL_GROUP="+poolGroup,
+				"VLLM_SVC_ENABLED=false",
+				"WVA_METRICS_SECURE=false",
+				"WVA_RELEASE_NAME="+secondaryReleaseName,
+				"PROM_CA_CERT_PATH=",
+			)
+			if sat := os.Getenv("WVA_SATURATION_OVERLAY"); sat != "" {
+				secondaryEnv = append(secondaryEnv, "WVA_SATURATION_OVERLAY="+sat)
+			} else if cfg.Environment == envKindEmulator {
+				// Match deploy-e2e-infra default (config/deploy/overlays/e2e-simulator).
+				secondaryEnv = append(secondaryEnv, "WVA_SATURATION_OVERLAY=e2e-simulator")
 			}
-			cmd := exec.Command("helm", helmArgs...)
-			out, err := cmd.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), "Secondary controller helm install failed: %s", string(out))
+			applyCmd.Env = secondaryEnv
+			out, err := applyCmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "secondary WVA kustomize apply failed: %s", string(out))
 
 			DeferCleanup(func() {
-				uninstall := exec.Command("helm", "uninstall", secondaryReleaseName, "-n", secondaryController)
-				_, _ = uninstall.CombinedOutput()
+				del := exec.Command("bash", secondaryScript, "delete")
+				del.Dir = repoRoot
+				del.Env = append(os.Environ(),
+					"WVA_PROJECT="+repoRoot,
+					"WVA_NS="+secondaryController,
+					"ENVIRONMENT="+cfg.Environment,
+					"LLMD_NS="+secondaryNamespace,
+					"VLLM_SVC_ENABLED=false",
+					"LLM_D_MODELSERVICE_NAME=",
+					"WVA_RELEASE_NAME="+secondaryReleaseName,
+					"CONTROLLER_INSTANCE="+controllerInstance,
+				)
+				_, _ = del.CombinedOutput()
 			})
 
 			By("Waiting for secondary controller to be ready")
@@ -472,9 +517,11 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 			Expect(err).NotTo(HaveOccurred(), "Failed to create secondary VA")
 
 			By("Creating HPAs in both namespaces for the shared VA name")
-			err = fixtures.EnsureHPA(ctx, k8sClient, primaryNamespace, primaryHPAName, primaryModelName+"-decode", sharedVAName, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, primaryNamespace, primaryHPAName, primaryModelName+"-decode", sharedVAName, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create primary HPA")
-			err = fixtures.EnsureHPA(ctx, k8sClient, secondaryNamespace, secondaryHPAName, secondaryModelName+"-decode", sharedVAName, 1, 10)
+			err = fixtures.EnsureHPA(ctx, k8sClient, secondaryNamespace, secondaryHPAName, secondaryModelName+"-decode", sharedVAName, 1, 10,
+				fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 			Expect(err).NotTo(HaveOccurred(), "Failed to create secondary HPA")
 		})
 
@@ -674,7 +721,8 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 				err = fixtures.EnsureScaledObject(ctx, crClient, cfg.LLMDNamespace, hpaName, deploymentName, vaName, minReplicas, 10, cfg.MonitoringNS)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create ScaledObject")
 			} else {
-				err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, deploymentName, vaName, minReplicas, 10)
+				err = fixtures.EnsureHPA(ctx, k8sClient, cfg.LLMDNamespace, hpaName, deploymentName, vaName, minReplicas, 10,
+					fixtures.WithExternalMetricControllerInstance(cfg.ControllerInstance))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create HPA")
 			}
 		})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	scalerBackendKeda = "keda"
-	envKindEmulator   = "kind-emulator"
-	envKind           = "kind"
-	boolTrue          = "true"
+	scalerBackendKeda              = "keda"
+	scalerBackendPrometheusAdapter = "prometheus-adapter"
+	envKindEmulator                = "kind-emulator"
+	envKind                        = "kind"
+	boolTrue                       = "true"
 )
 
 var (
@@ -197,7 +198,7 @@ var _ = BeforeSuite(func() {
 	}).Should(Succeed(), "Prometheus should be running")
 
 	// RESTART_PROMETHEUS_ADAPTER: false (never), true (always delete pods), auto (default: probe then restart only if needed).
-	if cfg.ScalerBackend == "prometheus-adapter" && cfg.Environment == envKindEmulator {
+	if cfg.ScalerBackend == scalerBackendPrometheusAdapter && cfg.Environment == envKindEmulator {
 		mode := strings.ToLower(strings.TrimSpace(os.Getenv("RESTART_PROMETHEUS_ADAPTER")))
 		if mode == "" {
 			mode = "auto"


### PR DESCRIPTION
- Controller install is Kustomize-first
- Install/cleanup/scripts updated - now match Kustomize
- CI is updated - Kustomize-friendly deploy vars
- E2e / Makefile hardening after kustomize switch from helm
- Updated dev documentations 
- Helm will be fully deprecated once kustomize fully stable