### PR TITLE
docs: add Qwen3-0.6B benchmark results

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -106,6 +106,25 @@ Summary of WVA benchmark runs with configuration details.
 | Avg pod startup (s) | 119 | 103 | 106 | 109 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | 1.96 | 1.89 | _TBD_ |
 
+### Decode Heavy — Qwen/Qwen3-0.6B
+
+**llm-d Release:** v0.6.0
+**Model:** Qwen/Qwen3-0.6B
+**Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
+**Saturation Engine:** Default(v1)
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 65,137 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 41.25 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.84 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 60.4% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 56.2 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 1,247 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 98 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.84 | _TBD_ | _TBD_ | _TBD_ |
+
 ## Bursty Scenario
 
 **llm-d Release:** v0.6.0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -172,12 +172,12 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 22,560 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 44.07 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.79 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 53.1% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 12.2 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 0 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 62 | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.79 | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 22,560 | 24,180 | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 44.07 | 43.26 | _TBD_ | _TBD_ |
+| Avg replicas | 1.79 | 1.81 | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 53.1% | 51.9% | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 12.2 | 14.0 | _TBD_ | _TBD_ |
+| Error count | 0 | 52 | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 62 | 64 | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.79 | 1.81 | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -77,15 +77,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 73,754 | 79,724 | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 51.66 | 53.10 | _TBD_ | _TBD_ |
-| Avg replicas | 1.95 | 1.85 | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 68.1% | 61.9% | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 68.6 | 78.9 | _TBD_ | _TBD_ |
-| Error count | 448 | 636 | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 75 | 64 | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.95 | 1.85 | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 73,754 | 79,724 | 77,481 | 76,986 |
+| P99 ITL (ms/token) | 51.66 | 53.10 | 51.84 | 52.20 |
+| Avg replicas | 1.95 | 1.85 | 2.00 | 1.93 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 68.1% | 61.9% | 66.2% | 65.4% |
+| Avg queue depth (EPP) | 68.6 | 78.9 | 84.8 | 77.4 |
+| Error count | 448 | 636 | 182 | 422 |
+| Avg pod startup (s) | 75 | 64 | 65 | 68 |
+| Cost (avg replicas × GPU/hr) | 1.95 | 1.85 | 2.00 | 1.93 |
 
 ## Decode Heavy Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -115,15 +115,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 65,137 | _TBD_ | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 41.25 | _TBD_ | _TBD_ | _TBD_ |
-| Avg replicas | 1.84 | _TBD_ | _TBD_ | _TBD_ |
-| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 60.4% | _TBD_ | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 56.2 | _TBD_ | _TBD_ | _TBD_ |
-| Error count | 1,247 | _TBD_ | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 98 | _TBD_ | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.84 | _TBD_ | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 65,137 | 61,923 | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 41.25 | 40.86 | _TBD_ | _TBD_ |
+| Avg replicas | 1.84 | 1.86 | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 60.4% | 61.6% | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 56.2 | 49.0 | _TBD_ | _TBD_ |
+| Error count | 1,247 | 1,515 | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 98 | 66 | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.84 | 1.86 | _TBD_ | _TBD_ |
 
 ## Bursty Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -115,15 +115,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 65,137 | 61,923 | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 41.25 | 40.86 | _TBD_ | _TBD_ |
-| Avg replicas | 1.84 | 1.86 | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 60.4% | 61.6% | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 56.2 | 49.0 | _TBD_ | _TBD_ |
-| Error count | 1,247 | 1,515 | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 98 | 66 | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.84 | 1.86 | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 65,137 | 61,923 | 63,530 | 63,530 |
+| P99 ITL (ms/token) | 41.25 | 40.86 | 41.22 | 41.11 |
+| Avg replicas | 1.84 | 1.86 | 1.83 | 1.84 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 60.4% | 61.6% | 61.7% | 61.2% |
+| Avg queue depth (EPP) | 56.2 | 49.0 | 46.3 | 50.5 |
+| Error count | 1,247 | 1,515 | 1,430 | 1,397 |
+| Avg pod startup (s) | 98 | 66 | 66 | 77 |
+| Cost (avg replicas × GPU/hr) | 1.84 | 1.86 | 1.83 | 1.84 |
 
 ## Bursty Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -68,6 +68,25 @@ Summary of WVA benchmark runs with configuration details.
 | Avg pod startup (s) | 115 | 106 | 109 | 110 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | 1.73 | 1.73 | _TBD_ |
 
+### Prefill Heavy — Qwen/Qwen3-0.6B
+
+**llm-d Release:** v0.6.0
+**Model:** Qwen/Qwen3-0.6B
+**Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
+**Saturation Engine:** Default(v1)
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 73,754 | 79,724 | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 51.66 | 53.10 | _TBD_ | _TBD_ |
+| Avg replicas | 1.95 | 1.85 | _TBD_ | _TBD_ |
+| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 68.1% | 61.9% | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 68.6 | 78.9 | _TBD_ | _TBD_ |
+| Error count | 448 | 636 | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 75 | 64 | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.95 | 1.85 | _TBD_ | _TBD_ |
+
 ## Decode Heavy Scenario
 
 **llm-d Release:** v0.6.0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -77,15 +77,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 73,754 | 79,724 | 77,481 | 76,986 |
-| P99 ITL (ms/token) | 51.66 | 53.10 | 51.84 | 52.20 |
-| Avg replicas | 1.95 | 1.85 | 2.00 | 1.93 |
+| P99 TTFT (ms) | 86,969 | 79,724 | 77,481 | 81,391 |
+| P99 ITL (ms/token) | 50.87 | 53.10 | 51.84 | 51.94 |
+| Avg replicas | 1.93 | 1.85 | 2.00 | 1.93 |
 | Max replicas | 3 | 3 | 3 | 3 |
-| Avg KV cache utilization | 68.1% | 61.9% | 66.2% | 65.4% |
-| Avg queue depth (EPP) | 68.6 | 78.9 | 84.8 | 77.4 |
-| Error count | 448 | 636 | 182 | 422 |
-| Avg pod startup (s) | 75 | 64 | 65 | 68 |
-| Cost (avg replicas × GPU/hr) | 1.95 | 1.85 | 2.00 | 1.93 |
+| Avg KV cache utilization | 67.3% | 61.9% | 66.2% | 65.1% |
+| Avg queue depth (EPP) | 65.9 | 78.9 | 84.8 | 76.5 |
+| Error count | 384 | 636 | 182 | 401 |
+| Avg pod startup (s) | 65 | 64 | 65 | 65 |
+| Cost (avg replicas × GPU/hr) | 1.93 | 1.85 | 2.00 | 1.93 |
 
 ## Decode Heavy Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -162,3 +162,22 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 3,773 | 3,710 | 3,705 | 3,729 |
 | Avg pod startup (s) | 97 | 107 | 105 | 103 |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | 1.64 | 1.70 |
+
+### Symmetrical — Qwen/Qwen3-0.6B
+
+**llm-d Release:** v0.6.0
+**Model:** Qwen/Qwen3-0.6B
+**Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
+**Saturation Engine:** Default(v1)
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 22,560 | _TBD_ | _TBD_ | _TBD_ |
+| P99 ITL (ms/token) | 44.07 | _TBD_ | _TBD_ | _TBD_ |
+| Avg replicas | 1.79 | _TBD_ | _TBD_ | _TBD_ |
+| Max replicas | 3 | _TBD_ | _TBD_ | _TBD_ |
+| Avg KV cache utilization | 53.1% | _TBD_ | _TBD_ | _TBD_ |
+| Avg queue depth (EPP) | 12.2 | _TBD_ | _TBD_ | _TBD_ |
+| Error count | 0 | _TBD_ | _TBD_ | _TBD_ |
+| Avg pod startup (s) | 62 | _TBD_ | _TBD_ | _TBD_ |
+| Cost (avg replicas × GPU/hr) | 1.79 | _TBD_ | _TBD_ | _TBD_ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -154,15 +154,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 14,900 | 11,671 | 173,102 | 66,558 |
-| P99 ITL (ms/token) | 49.0 | 47.8 | 144.7 | 80.5 |
-| Avg replicas | 2.03 | 1.95 | 2.78 | 2.25 |
-| Max replicas | 3 | 3 | 4 | 4 |
-| Avg KV cache utilization | 36.7% | 34.2% | 41.1% | 37.3% |
-| Avg queue depth (EPP) | 16.5 | 17.0 | 231.2 | 88.2 |
-| Error count | 54 | 49 | 182 | 95 |
-| Avg pod startup (s) | 66 | 65 | 71 | 67 |
-| Cost (avg replicas × GPU/hr) | 2.03 | 1.95 | 2.78 | 2.25 |
+| P99 TTFT (ms) | 14,900 | 11,671 | 13,556 | 13,376 |
+| P99 ITL (ms/token) | 49.0 | 47.8 | 47.3 | 48.0 |
+| Avg replicas | 2.03 | 1.95 | 1.99 | 1.99 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 36.7% | 34.2% | 34.8% | 35.2% |
+| Avg queue depth (EPP) | 16.5 | 17.0 | 14.6 | 16.0 |
+| Error count | 54 | 49 | 49 | 51 |
+| Avg pod startup (s) | 66 | 65 | 66 | 66 |
+| Cost (avg replicas × GPU/hr) | 2.03 | 1.95 | 1.99 | 1.99 |
 
 ## Symmetrical Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -172,12 +172,12 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 22,560 | 24,180 | _TBD_ | _TBD_ |
-| P99 ITL (ms/token) | 44.07 | 43.26 | _TBD_ | _TBD_ |
-| Avg replicas | 1.79 | 1.81 | _TBD_ | _TBD_ |
-| Max replicas | 3 | 3 | _TBD_ | _TBD_ |
-| Avg KV cache utilization | 53.1% | 51.9% | _TBD_ | _TBD_ |
-| Avg queue depth (EPP) | 12.2 | 14.0 | _TBD_ | _TBD_ |
-| Error count | 0 | 52 | _TBD_ | _TBD_ |
-| Avg pod startup (s) | 62 | 64 | _TBD_ | _TBD_ |
-| Cost (avg replicas × GPU/hr) | 1.79 | 1.81 | _TBD_ | _TBD_ |
+| P99 TTFT (ms) | 22,560 | 24,180 | 22,766 | 23,169 |
+| P99 ITL (ms/token) | 44.07 | 43.26 | 42.47 | 43.27 |
+| Avg replicas | 1.79 | 1.81 | 1.81 | 1.80 |
+| Max replicas | 3 | 3 | 3 | 3 |
+| Avg KV cache utilization | 53.1% | 51.9% | 51.1% | 52.0% |
+| Avg queue depth (EPP) | 12.2 | 14.0 | 12.8 | 13.0 |
+| Error count | 0 | 52 | 0 | 17 |
+| Avg pod startup (s) | 62 | 64 | 67 | 64 |
+| Cost (avg replicas × GPU/hr) | 1.79 | 1.81 | 1.81 | 1.80 |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -51,6 +51,8 @@ Summary of WVA benchmark runs with configuration details.
 
 ## Prefill Heavy Scenario
 
+### Prefill Heavy — Qwen/Qwen3-32B
+
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
@@ -88,6 +90,8 @@ Summary of WVA benchmark runs with configuration details.
 | Cost (avg replicas × GPU/hr) | 1.93 | 1.85 | 2.00 | 1.93 |
 
 ## Decode Heavy Scenario
+
+### Decode Heavy — Qwen/Qwen3-32B
 
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
@@ -127,6 +131,8 @@ Summary of WVA benchmark runs with configuration details.
 
 ## Bursty Scenario
 
+### Bursty — Qwen/Qwen3-32B
+
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B
 **Workload:** ~1000 prompt tokens, ~1000 output tokens, multi-stage bursty RPS (15→2→10→15→5→2), 900s total duration
@@ -165,6 +171,8 @@ Summary of WVA benchmark runs with configuration details.
 | Cost (avg replicas × GPU/hr) | 2.03 | 1.95 | 1.99 | 1.99 |
 
 ## Symmetrical Scenario
+
+### Symmetrical — Qwen/Qwen3-32B
 
 **llm-d Release:** v0.6.0
 **Model:** Qwen/Qwen3-32B

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -115,15 +115,15 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 65,137 | 61,923 | 63,530 | 63,530 |
+| P99 TTFT (ms) | 61,435 | 61,923 | 63,530 | 62,296 |
 | P99 ITL (ms/token) | 41.25 | 40.86 | 41.22 | 41.11 |
-| Avg replicas | 1.84 | 1.86 | 1.83 | 1.84 |
+| Avg replicas | 1.98 | 1.86 | 1.83 | 1.89 |
 | Max replicas | 3 | 3 | 3 | 3 |
-| Avg KV cache utilization | 60.4% | 61.6% | 61.7% | 61.2% |
-| Avg queue depth (EPP) | 56.2 | 49.0 | 46.3 | 50.5 |
-| Error count | 1,247 | 1,515 | 1,430 | 1,397 |
-| Avg pod startup (s) | 98 | 66 | 66 | 77 |
-| Cost (avg replicas × GPU/hr) | 1.84 | 1.86 | 1.83 | 1.84 |
+| Avg KV cache utilization | 61.9% | 61.6% | 61.7% | 61.7% |
+| Avg queue depth (EPP) | 58.0 | 49.0 | 46.3 | 51.1 |
+| Error count | 1,280 | 1,515 | 1,430 | 1,408 |
+| Avg pod startup (s) | 63 | 66 | 66 | 65 |
+| Cost (avg replicas × GPU/hr) | 1.98 | 1.86 | 1.83 | 1.89 |
 
 ## Bursty Scenario
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -144,6 +144,26 @@ Summary of WVA benchmark runs with configuration details.
 | Avg pod startup (s) | 109 | 101 | 100 | 103 |
 | Cost (avg replicas × GPU/hr) | 2.46 | 2.29 | 2.55 | 2.43 |
 
+### Bursty — Qwen/Qwen3-0.6B
+
+**llm-d Release:** v0.6.0
+**Model:** Qwen/Qwen3-0.6B
+**Workload:** ~1000 prompt tokens, ~1000 output tokens, multi-stage bursty RPS (15→2→10→15→5→2), 900s total duration
+**Saturation Engine:** Default(v1)
+**Harness:** inference-perf
+
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 14,900 | 11,671 | 173,102 | 66,558 |
+| P99 ITL (ms/token) | 49.0 | 47.8 | 144.7 | 80.5 |
+| Avg replicas | 2.03 | 1.95 | 2.78 | 2.25 |
+| Max replicas | 3 | 3 | 4 | 4 |
+| Avg KV cache utilization | 36.7% | 34.2% | 41.1% | 37.3% |
+| Avg queue depth (EPP) | 16.5 | 17.0 | 231.2 | 88.2 |
+| Error count | 54 | 49 | 182 | 95 |
+| Avg pod startup (s) | 66 | 65 | 71 | 67 |
+| Cost (avg replicas × GPU/hr) | 2.03 | 1.95 | 2.78 | 2.25 |
+
 ## Symmetrical Scenario
 
 **llm-d Release:** v0.6.0


### PR DESCRIPTION
## Summary

- Adds benchmark results for **Qwen/Qwen3-0.6B** model under the all scenarios.



Made with [Cursor](https://cursor.com)