### PR TITLE
fix(config): close Kustomize parity gaps

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -153,6 +153,22 @@ jobs:
         run: |
           make test
 
+  kustomize-build:
+    if: github.event_name != 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Install kustomize
+        run: make kustomize
+
+      - name: Build config/default overlay
+        run: bin/kustomize build config/default/ > /dev/null
+
+      - name: Build config/openshift overlay
+        run: bin/kustomize build config/openshift/ > /dev/null
+
   # Check if full e2e tests should run (via workflow_dispatch or comment trigger)
   check-full-tests:
     runs-on: ubuntu-latest

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - ../default
 - cluster-monitoring-view-binding.yaml
+- prometheus-adapter-monitoring.yaml
 
 patches:
 - path: configmap-patch.yaml

--- a/config/openshift/prometheus-adapter-monitoring.yaml
+++ b/config/openshift/prometheus-adapter-monitoring.yaml
@@ -1,0 +1,18 @@
+# Grants the Prometheus service account in the OpenShift user-workload-monitoring namespace
+# read access to cluster monitoring, allowing Prometheus to scrape WVA metrics.
+# Adjust serviceAccountName and namespace if your Prometheus stack uses a different SA.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workload-variant-autoscaler-prometheus-adapter-monitoring
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: kube-prometheus-stack-prometheus
+  namespace: openshift-user-workload-monitoring

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - metrics_auth_role_binding.yaml
 - prometheus_metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+- metrics_reader_role_binding.yaml
 # EPP metrics reader service account with minimal privileges
 - epp_metrics_service_account.yaml
 - epp_metrics_reader_role.yaml

--- a/config/rbac/metrics_reader_role_binding.yaml
+++ b/config/rbac/metrics_reader_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-reader-rolebinding
+  labels:
+    app.kubernetes.io/name: workload-variant-autoscaler
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system # replaced by the namespace in kustomization.yaml

--- a/config/rbac/variantautoscaling_viewer_role.yaml
+++ b/config/rbac/variantautoscaling_viewer_role.yaml
@@ -11,12 +11,12 @@ metadata:
   labels:
     app.kubernetes.io/name: workload-variant-autoscaler
     app.kubernetes.io/managed-by: kustomize
-  name: VariantAutoscalings-viewer-role
+  name: variantautoscaling-viewer-role
 rules:
 - apiGroups:
   - llmd.llm-d.ai
   resources:
-  - VariantAutoscalingss
+  - variantautoscalings
   verbs:
   - get
   - list
@@ -24,6 +24,6 @@ rules:
 - apiGroups:
   - llmd.llm-d.ai
   resources:
-  - VariantAutoscalingss/status
+  - variantautoscalings/status
   verbs:
   - get


### PR DESCRIPTION
Closes the resource gaps in kustomize so the Kustomize tree is a complete WVA controller install. Missing rbac, bugfix, and add kustomize build dry run in ci so that both config/default and config/openshift render cleanly on every PR. 

Note: Model-serving resources (HPA, vllm Service/ServiceMonitor, sample VA CR) and the unused service-classes-config ConfigMap are intentionally not included. Those belong to the llm-d model serving layer, not the controller install.