### PR TITLE
feat(deploy): Kustomize-first WVA controller install, deprecate Helm, fix e2e/CI

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -293,7 +293,7 @@ jobs:
           done
 
       - name: Apply latest CRDs
-        run: kubectl apply -f charts/workload-variant-autoscaler/crds/
+        run: kubectl apply -f config/crd/bases/
 
       - name: Deploy WVA and llm-d infrastructure
         env:
@@ -329,14 +329,13 @@ jobs:
           LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY: "true"
           E2E_DEPLOY_WAIT_TIMEOUT: "300s"
         run: |
-          # Split deploy: WVA base (install.sh) → llm-d (install-llmd-infra.sh) → chart capacity tuning (helm upgrade).
-          ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
+          # Split deploy: WVA base (install.sh) → llm-d (install-llmd-infra.sh) → capacity tuning via ConfigMap patch.
+          ./deploy/install.sh --environment openshift
           ./deploy/install-llmd-infra.sh -e openshift
-          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
-            --set wva.capacityScaling.default.kvCacheThreshold="${KV_CACHE_THRESHOLD}" \
-            --set wva.capacityScaling.default.queueLengthThreshold="${QUEUE_LENGTH_THRESHOLD}" \
-            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
-            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
+          kubectl patch configmap workload-variant-autoscaler-saturation-scaling-config \
+            -n "$WVA_NAMESPACE" --type=merge \
+            -p "$(printf '{"data":{"default":"kvCacheThreshold: %s\\nqueueLengthThreshold: %s\\nkvSpareTrigger: %s\\nqueueSpareTrigger: %s\\n"}}' \
+              "${KV_CACHE_THRESHOLD}" "${QUEUE_LENGTH_THRESHOLD}" "${KV_SPARE_TRIGGER}" "${QUEUE_SPARE_TRIGGER}")"
 
       - name: Label namespaces for OpenShift monitoring
         run: |
@@ -956,7 +955,7 @@ jobs:
       - name: Cleanup infrastructure
         if: always()
         run: |
-          helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          kubectl delete clusterrole,clusterrolebinding -l app.kubernetes.io/name=workload-variant-autoscaler --ignore-not-found || true
           for release in $(helm list -n "$LLMD_NAMESPACE" -q 2>/dev/null); do
             helm uninstall "$release" -n "$LLMD_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
           done

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -686,9 +686,8 @@ jobs:
       - name: Apply latest CRDs
         run: |
           echo "Applying latest VariantAutoscaling CRD..."
-          # Helm doesn't auto-update CRDs, so we need to apply them manually
-          # to ensure the cluster has the latest schema (including scaleTargetRef)
-          kubectl apply -f charts/workload-variant-autoscaler/crds/
+          # Apply CRDs from the Kustomize source of truth (config/crd/bases/)
+          kubectl apply -f config/crd/bases/
 
       - name: Deploy WVA and llm-d infrastructure
         env:
@@ -747,13 +746,14 @@ jobs:
           echo "  QUEUE_SPARE_TRIGGER: ${QUEUE_SPARE_TRIGGER:-<default>}"
           echo "  HF token configuration: ✓"
           # Base monitoring + WVA + scaler (install.sh does not deploy llm-d).
-          ./deploy/install.sh --release-name "$WVA_RELEASE_NAME" --environment openshift
+          ./deploy/install.sh --environment openshift
           # Gateway/EPP/ModelService + WVA poolGroup alignment (see deploy/install-llmd-infra.sh).
           ./deploy/install-llmd-infra.sh -e openshift
-          # Capacity thresholds are not passed from install.sh — tune after install for CI simulators.
-          helm upgrade "$WVA_RELEASE_NAME" ./charts/workload-variant-autoscaler -n "$WVA_NS" --reuse-values \
-            --set wva.capacityScaling.default.kvSpareTrigger="${KV_SPARE_TRIGGER}" \
-            --set wva.capacityScaling.default.queueSpareTrigger="${QUEUE_SPARE_TRIGGER}"
+          # Capacity thresholds are tuned after install via ConfigMap patch for CI simulators.
+          kubectl patch configmap workload-variant-autoscaler-saturation-scaling-config \
+            -n "$WVA_NAMESPACE" --type=merge \
+            -p "$(printf '{"data":{"default":"kvSpareTrigger: %s\\nqueueSpareTrigger: %s\\n"}}' \
+              "${KV_SPARE_TRIGGER}" "${QUEUE_SPARE_TRIGGER}")"
 
       - name: Label namespaces for OpenShift monitoring
         run: |
@@ -998,11 +998,9 @@ jobs:
           echo "Cleaning up ALL test infrastructure..."
           echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
           echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
-          echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
 
-          # Uninstall WVA helm release before deleting namespace
-          echo "Uninstalling WVA helm release..."
-          helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          echo "Removing cluster-scoped WVA resources..."
+          kubectl delete clusterrole,clusterrolebinding -l app.kubernetes.io/name=workload-variant-autoscaler --ignore-not-found || true
 
           echo "Uninstalling llm-d helm releases..."
           for release in $(helm list -n "$LLMD_NAMESPACE" -q 2>/dev/null); do
@@ -1015,24 +1013,6 @@ jobs:
 
           echo "Deleting WVA namespace $WVA_NAMESPACE..."
           kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || true
-
-          # Clean up cluster-scoped WVA resources for THIS release only
-          # Use both name and instance labels to avoid deleting resources from other PRs
-          echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
-          kubectl delete clusterrole,clusterrolebinding -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" --ignore-not-found || true
-
-          # Also clean up cluster-scoped resources owned by this PR's namespaces
-          # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
-          for kind in clusterrole clusterrolebinding; do
-            kubectl get "$kind" -o json 2>/dev/null | \
-              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-              while IFS=$'\t' read -r name ns; do
-                if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
-                  echo "  Deleting $kind/$name (owned by PR namespace '$ns')"
-                  kubectl delete "$kind" "$name" --ignore-not-found || true
-                fi
-              done
-          done
 
           echo "Cleanup complete"
 

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -342,8 +342,8 @@ jobs:
           # Emulated Kind: chart decode may be removed post-deploy (LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, default true).
           # Pin llm-d release for deterministic CI behavior
           LLM_D_RELEASE: "v0.6.0"
-          # Dual-controller smoke installs a second Helm release; chart path must be explicit in CI.
-          WVA_E2E_CHART_PATH: ${{ github.workspace }}/charts/workload-variant-autoscaler
+          # Dual-controller smoke installs a secondary controller via Kustomize; overlay path must be explicit in CI.
+          WVA_E2E_SECONDARY_OVERLAY_PATH: ${{ github.workspace }}/test/e2e/testdata/secondary-controller
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"
           PROMETHEUS_ADAPTER_WAIT: "false"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ KV_SPARE_TRIGGER           ?=
 QUEUE_SPARE_TRIGGER         ?=
 E2E_MONITORING_NAMESPACE    ?= workload-variant-autoscaler-monitoring
 E2E_EMULATED_LLMD_NAMESPACE ?= llm-d-sim
-E2E_WVA_CHART_PATH          ?= $(CURDIR)/charts/workload-variant-autoscaler
+E2E_WVA_SECONDARY_OVERLAY_PATH ?= $(CURDIR)/test/e2e/testdata/secondary-controller
 # llm-d-benchmark CLI configuration
 BENCHMARK_REPO_URL   ?= https://github.com/llm-d/llm-d-benchmark.git
 BENCHMARK_REPO_DIR   ?= $(CURDIR)/llm-d-benchmark
@@ -260,12 +260,12 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 		LLMD_SKIP_INFERENCE_OBJECTIVE=true \
 		./deploy/install-llmd-infra.sh -e "$(ENVIRONMENT)"; \
 	fi; \
-	REL=$${WVA_RELEASE_NAME:-workload-variant-autoscaler}; NS=$${WVA_NS:-workload-variant-autoscaler-system}; \
+	NS=$${WVA_NS:-workload-variant-autoscaler-system}; \
 	if [ -n "$(KV_SPARE_TRIGGER)" ] || [ -n "$(QUEUE_SPARE_TRIGGER)" ]; then \
 		echo "Applying optional WVA capacity threshold overrides (KV_SPARE_TRIGGER / QUEUE_SPARE_TRIGGER)..."; \
-		helm upgrade "$$REL" "$(CURDIR)/charts/workload-variant-autoscaler" -n "$$NS" --reuse-values \
-			$(if $(KV_SPARE_TRIGGER),--set wva.capacityScaling.default.kvSpareTrigger=$(KV_SPARE_TRIGGER)) \
-			$(if $(QUEUE_SPARE_TRIGGER),--set wva.capacityScaling.default.queueSpareTrigger=$(QUEUE_SPARE_TRIGGER)); \
+		$(KUBECTL) patch configmap workload-variant-autoscaler-saturation-scaling-config \
+			-n "$$NS" --type=merge \
+			-p "{\"data\":{\"default\":\"kvSpareTrigger: $(KV_SPARE_TRIGGER)\\nqueueSpareTrigger: $(QUEUE_SPARE_TRIGGER)\\n\"}}"; \
 	fi
 
 ## DEPRECATED: prefer ./deploy/install-llmd-infra.sh or upstream llm-d install tooling; kept for Makefile discoverability.
@@ -288,7 +288,7 @@ test-e2e-smoke: ## Run smoke e2e tests
 	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
 	LLMD_NAMESPACE=$(E2E_EMULATED_LLMD_NAMESPACE) \
 	MONITORING_NAMESPACE=$(E2E_MONITORING_NAMESPACE) \
-	WVA_E2E_CHART_PATH=$${WVA_E2E_CHART_PATH:-$(E2E_WVA_CHART_PATH)} \
+	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \
@@ -311,7 +311,7 @@ test-e2e-full: ## Run full e2e test suite
 	KUBECONFIG=$(KUBECONFIG) \
 	ENVIRONMENT=$(ENVIRONMENT) \
 	WVA_NAMESPACE=$(CONTROLLER_NAMESPACE) \
-	WVA_E2E_CHART_PATH=$${WVA_E2E_CHART_PATH:-$(E2E_WVA_CHART_PATH)} \
+	WVA_E2E_SECONDARY_OVERLAY_PATH=$${WVA_E2E_SECONDARY_OVERLAY_PATH:-$(E2E_WVA_SECONDARY_OVERLAY_PATH)} \
 	USE_SIMULATOR=$(USE_SIMULATOR) \
 	SCALE_TO_ZERO_ENABLED=$(SCALE_TO_ZERO_ENABLED) \
 	SCALER_BACKEND=$(SCALER_BACKEND) \

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -41,6 +41,20 @@ patches:
   target:
     kind: Deployment
 
+# epp-metrics-token Secret annotation so Kubernetes populates the SA token.
+# Kustomize renames the ServiceAccount to workload-variant-autoscaler-epp-metrics-reader
+# via namePrefix, but does not update annotation values — so we patch it explicitly.
+- patch: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: epp-metrics-token
+      annotations:
+        kubernetes.io/service-account.name: workload-variant-autoscaler-epp-metrics-reader
+  target:
+    kind: Secret
+    name: epp-metrics-token
+
 # [NAMESPACE-SELECTOR] Ensure the ServiceMonitor namespaceSelector matches the
 # deployment namespace. Without this, the hardcoded value in monitor.yaml won't
 # update when an overlay changes the namespace (e.g. deploying into 'opendatahub'

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,7 +62,6 @@ spec:
         args:
           - --leader-elect=true
           - --health-probe-bind-address=:8081
-          - --watch-namespace=$(POD_NAMESPACE)
           # Leader election timeout configuration (optional - defaults shown below)
           # Uncomment and adjust these values if you need to tune for your environment:
           # - --leader-election-lease-duration=60s
@@ -134,7 +133,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi
@@ -161,5 +160,6 @@ spec:
         secret:
           secretName: epp-metrics-token
           defaultMode: 420
+          optional: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/namespace-scoped-patch.yaml
+++ b/config/manager/namespace-scoped-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--watch-namespace=$(POD_NAMESPACE)"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -34,17 +34,11 @@ PROMETHEUS_SECRET_NS=${PROMETHEUS_SECRET_NS:-$MONITORING_NAMESPACE}
 WVA_IMAGE_REPO=${WVA_IMAGE_REPO:-"ghcr.io/llm-d/llm-d-workload-variant-autoscaler"}
 WVA_IMAGE_TAG=${WVA_IMAGE_TAG:-"latest"}
 WVA_IMAGE_PULL_POLICY=${WVA_IMAGE_PULL_POLICY:-"Always"}
-WVA_RELEASE_NAME=${WVA_RELEASE_NAME:-"workload-variant-autoscaler"}
-VLLM_SVC_ENABLED=${VLLM_SVC_ENABLED:-true}
-VLLM_SVC_PORT=${VLLM_SVC_PORT:-8200}
-VLLM_SVC_NODEPORT=${VLLM_SVC_NODEPORT:-30000}
 SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-"false"}
 WVA_LOG_LEVEL=${WVA_LOG_LEVEL:-"info"}
-VALUES_FILE=${VALUES_FILE:-"$WVA_PROJECT/charts/workload-variant-autoscaler/values.yaml"}
 # Optional: multi-controller isolation (sets controller_instance on metrics / selectors when non-empty).
 CONTROLLER_INSTANCE=${CONTROLLER_INSTANCE:-""}
-WVA_BASE_NAME=${WVA_BASE_NAME:-"inference-scheduling"}
-NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
+NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-false}
 
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
 

--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -90,10 +90,27 @@ undeploy_llm_d_infrastructure() {
 }
 
 undeploy_wva_controller() {
-    log_info "Uninstalling Workload-Variant-Autoscaler (release: $WVA_RELEASE_NAME)..."
+    log_info "Uninstalling Workload-Variant-Autoscaler..."
 
-    helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NS" 2>/dev/null || \
-        log_warning "Workload-Variant-Autoscaler not found or already uninstalled"
+    local kustomize_overlay
+    if [ "$ENVIRONMENT" = "openshift" ]; then
+        kustomize_overlay="$(cd "$WVA_PROJECT/config/openshift" && pwd)"
+    else
+        kustomize_overlay="$(cd "$WVA_PROJECT/config/default" && pwd)"
+    fi
+
+    local tmp_overlay
+    tmp_overlay=$(mktemp -d)
+    ln -s "$kustomize_overlay" "$tmp_overlay/base"
+    cat > "$tmp_overlay/kustomization.yaml" <<EOF
+namespace: $WVA_NS
+resources:
+- ./base
+EOF
+
+    kubectl delete -k "$tmp_overlay" --ignore-not-found 2>/dev/null || \
+        log_warning "Workload-Variant-Autoscaler resources not found or already removed"
+    rm -rf "$tmp_overlay"
 
     rm -f "$PROM_CA_CERT_PATH"
 

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # CLI help and argument parsing for deploy/install.sh.
-# Requires vars: WVA_IMAGE_REPO, WVA_IMAGE_TAG, WVA_RELEASE_NAME, COMPATIBLE_ENV_LIST.
+# Requires vars: WVA_IMAGE_REPO, WVA_IMAGE_TAG, COMPATIBLE_ENV_LIST.
 # Requires funcs: log_info/log_warning/log_error, containsElement().
 #
 
@@ -14,18 +14,17 @@ For llm-d (gateway, EPP, ModelService), run deploy/install-llmd-infra.sh after t
 
 Options:
   -i, --wva-image IMAGE        Container image for WVA (default: $WVA_IMAGE_REPO:$WVA_IMAGE_TAG)
-  -r, --release-name NAME      Helm release name for WVA (default: $WVA_RELEASE_NAME)
   -u, --undeploy               Undeploy WVA, monitoring, and scaler backend (not llm-d; use install-llmd-infra.sh --undeploy)
   -e, --environment            kubernetes | openshift | kind-emulator (default: kubernetes)
   -h, --help                   Show this help and exit
 
-Deprecated (ignored by install.sh for chart deploy; passed through for CI/scripts calling install-llmd-infra next):
+Deprecated (ignored by install.sh; Helm chart removed, llm-d overrides use install-llmd-infra.sh):
+  --release-name NAME          Helm release name (no-op; WVA now installed via Kustomize)
   --model MODEL_ID             Same as MODEL_ID env (llm-d / chart overrides use install-llmd-infra.sh)
   --accelerator TYPE           Same as ACCELERATOR_TYPE env
 
 Environment Variables:
   IMG                          WVA image as repo:tag (alternative to -i)
-  WVA_RELEASE_NAME             Helm release name (alternative to -r)
   SKIP_CHECKS                  Skip kubectl/helm/git prerequisite check (default: false). Install scripts are non-interactive and fail fast on errors.
   DEPLOY_PROMETHEUS            Deploy Prometheus stack (default: true)
   DEPLOY_WVA                   Deploy WVA controller (default: true)
@@ -44,7 +43,7 @@ Examples:
 
   IMG=registry.example.com/wva:dev $(basename "$0") -e kind-emulator
 
-  $(basename "$0") -r my-wva-release -e openshift
+  $(basename "$0") -e openshift
 EOF
 }
 
@@ -68,7 +67,6 @@ parse_args() {
         fi
         shift 2
         ;;
-      -r|--release-name)      WVA_RELEASE_NAME="$2"; shift 2 ;;
       -u|--undeploy)          UNDEPLOY=true; shift ;;
       -e|--environment)
         ENVIRONMENT="$2" ; shift 2
@@ -83,6 +81,10 @@ parse_args() {
         ;;
       --accelerator)
         export ACCELERATOR_TYPE="$2"
+        shift 2
+        ;;
+      --release-name)
+        # Legacy CI/Helm — install.sh no longer installs via Helm; value is ignored.
         shift 2
         ;;
       -h|--help)              print_help; exit 0 ;;

--- a/deploy/lib/infra_llmd.sh
+++ b/deploy/lib/infra_llmd.sh
@@ -197,47 +197,9 @@ deploy_llm_d_infrastructure() {
       yq eval ".decode.replicas = $DECODE_REPLICAS" -i "$LLM_D_MODELSERVICE_VALUES"
     fi
 
-    # Check if the guide's llm-d.ai/model label differs from what WVA's vllm-service expects.
-    # If so, we'll patch pod labels post-deploy (not pre-deploy) to avoid violating the
-    # llm-d-modelservice chart schema which disallows extra properties under modelArtifacts.
-    CURRENT_MODEL_LABEL=$(yq eval '.modelArtifacts.labels."llm-d.ai/model"' "$LLM_D_MODELSERVICE_VALUES" 2>/dev/null || echo "")
-    NEEDS_LABEL_ALIGNMENT=false
-    if [ -n "$CURRENT_MODEL_LABEL" ] && [ "$CURRENT_MODEL_LABEL" != "null" ] && [ "$CURRENT_MODEL_LABEL" != "$LLM_D_MODELSERVICE_NAME" ]; then
-      log_info "Will align llm-d.ai/model label post-deploy: '$CURRENT_MODEL_LABEL' -> '$LLM_D_MODELSERVICE_NAME'"
-      NEEDS_LABEL_ALIGNMENT=true
-    fi
-
-    # Auto-detect vLLM port from guide configuration and update WVA vllm-service.
-    # When routing proxy is disabled, vLLM serves directly on containerPort (typically 8000).
-    # When proxy is enabled, vLLM serves on proxy.targetPort (typically 8200).
-    PROXY_ENABLED=$(yq eval '.routing.proxy.enabled // true' "$LLM_D_MODELSERVICE_VALUES" 2>/dev/null || echo "true")
-    if [ "$PROXY_ENABLED" == "false" ]; then
-      DETECTED_PORT=$(yq eval '.decode.containers[0].ports[0].containerPort // 8000' "$LLM_D_MODELSERVICE_VALUES" 2>/dev/null || echo "8000")
-      if [ "$VLLM_SVC_PORT" != "$DETECTED_PORT" ]; then
-        log_info "Routing proxy disabled - updating vLLM service port: $VLLM_SVC_PORT -> $DETECTED_PORT"
-        VLLM_SVC_PORT=$DETECTED_PORT
-        # Update the WVA vllm-service port (WVA was deployed before llm-d infra)
-        if [ "$DEPLOY_WVA" == "true" ] && [ "$VLLM_SVC_ENABLED" == "true" ]; then
-          helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-            -n "$WVA_NS" --reuse-values \
-            --set wva.namespaceScoped="${NAMESPACE_SCOPED:-true}" \
-            --set vllmService.port="$VLLM_SVC_PORT" \
-            --set vllmService.targetPort="$VLLM_SVC_PORT"
-        fi
-      fi
-    fi
-
     # Deploy llm-d core components
     log_info "Deploying llm-d core components"
-    # When DEPLOY_WVA is true, skip WVA in helmfile — install.sh deploys it
-    # separately using the local chart (supports dev/test of chart changes).
-    # The helmfile's WVA release uses the published OCI chart which may not
-    # have the latest fixes and uses KIND-specific defaults (e.g. monitoringNamespace).
     local -a helmfile_selector_exprs=()
-    if [ "$DEPLOY_WVA" == "true" ]; then
-      helmfile_selector_exprs+=("kind!=autoscaling")
-      log_info "Skipping WVA in helmfile (will be deployed separately from local chart)"
-    fi
     if [ "${LLMD_SKIP_DEFAULT_MODELSERVICE:-false}" = "true" ]; then
       # E2E and similar flows create scenario-specific ModelService workloads;
       # skip the default llm-d-modelservice release so baseline infra is clean.
@@ -268,39 +230,6 @@ deploy_llm_d_infrastructure() {
       if helm list -n "$LLMD_NS" --short 2>/dev/null | grep -q '^ms-'; then
         log_warning "Modelservice release still present in $LLMD_NS despite selector; tests may need extra cleanup"
       fi
-    fi
-
-    # Post-deploy: align the WVA vllm-service selector and ServiceMonitor to match
-    # the actual pod labels. The llm-d-modelservice chart sets pod labels from
-    # modelArtifacts.labels (e.g. "Qwen3-32B"), but the WVA chart's Service selector
-    # uses llmd.modelName (e.g. "ms-<GUIDE_NAME>-llm-d-modelservice" from the active llm-d guide).
-    # We patch the Service/ServiceMonitor selectors (which ARE mutable) rather than
-    # the deployment labels (which have immutable selectors).
-    if [ "$NEEDS_LABEL_ALIGNMENT" == "true" ]; then
-      # Compute the chart fullname (mirrors _helpers.tpl logic)
-      local chart_name="workload-variant-autoscaler"
-      local wva_fullname
-      if echo "$WVA_RELEASE_NAME" | grep -q "$chart_name"; then
-        wva_fullname="$WVA_RELEASE_NAME"
-      else
-        wva_fullname="${WVA_RELEASE_NAME}-${chart_name}"
-      fi
-      wva_fullname=$(echo "$wva_fullname" | cut -c1-63 | sed 's/-$//')
-      local svc_name="${wva_fullname}-vllm"
-      local svcmon_name="${wva_fullname}-vllm-mon"
-      log_info "Aligning WVA Service/ServiceMonitor selectors: llm-d.ai/model=$CURRENT_MODEL_LABEL"
-      # Build merge patches with jq so label values cannot break JSON (e.g. quotes, backslashes).
-      local svc_patch svcmon_patch svc_label_patch
-      svc_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"llm-d.ai/model":$label}}}')
-      kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_patch" && log_success "Patched Service $svc_name selector" \
-         || log_warning "Failed to patch Service $svc_name selector"
-      svcmon_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"spec":{"selector":{"matchLabels":{"llm-d.ai/model":$label}}}}')
-      kubectl patch servicemonitor "$svcmon_name" -n "$LLMD_NS" --type=merge -p "$svcmon_patch" && log_success "Patched ServiceMonitor $svcmon_name selector" \
-         || log_warning "Failed to patch ServiceMonitor $svcmon_name selector"
-      svc_label_patch=$(jq -n --arg label "$CURRENT_MODEL_LABEL" '{"metadata":{"labels":{"llm-d.ai/model":$label}}}')
-      kubectl patch service "$svc_name" -n "$LLMD_NS" --type=merge -p "$svc_label_patch" \
-        && log_success "Patched Service $svc_name label" \
-        || log_warning "Failed to patch Service $svc_name label"
     fi
 
     # Apply HTTPRoute with correct resource name references.
@@ -482,13 +411,17 @@ deploy_llm_d_infrastructure() {
         detect_inference_pool_api_group
         if [ -n "$DETECTED_POOL_GROUP" ]; then
             log_info "Detected InferencePool API group: $DETECTED_POOL_GROUP; upgrading WVA to watch it (scale-from-zero)"
-            if helm upgrade "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-                -n "$WVA_NS" --reuse-values \
-                --set wva.namespaceScoped="${NAMESPACE_SCOPED:-true}" \
-                --set wva.poolGroup="$DETECTED_POOL_GROUP" --wait --timeout=60s; then
-                log_success "WVA upgraded with wva.poolGroup=$DETECTED_POOL_GROUP"
+            if kubectl patch deployment workload-variant-autoscaler-controller-manager \
+                -n "$WVA_NS" --type=json \
+                -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/env/-\",\"value\":{\"name\":\"POOL_GROUP\",\"value\":\"${DETECTED_POOL_GROUP}\"}}]"; then
+                log_success "WVA patched with POOL_GROUP=$DETECTED_POOL_GROUP"
+                # Wait for the rolling restart to complete so the datastore is populated
+                kubectl rollout status deployment/workload-variant-autoscaler-controller-manager \
+                    -n "$WVA_NS" --timeout=120s \
+                    && log_success "WVA rollout complete" \
+                    || log_warning "WVA rollout status timed out - datastore may not be ready"
             else
-                log_warning "WVA upgrade with poolGroup failed - scale-from-zero may not see the InferencePool"
+                log_warning "WVA pool-group patch failed - scale-from-zero may not see the InferencePool"
             fi
         else
             log_warning "Could not detect InferencePool API group - WVA may have empty datastore for scale-from-zero"

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -59,44 +59,55 @@ set_wva_logging_level() {
 deploy_wva_controller() {
     log_info "Deploying Workload-Variant-Autoscaler..."
     log_info "Using image: $WVA_IMAGE_REPO:$WVA_IMAGE_TAG"
-    log_info "Using release name: $WVA_RELEASE_NAME"
 
-    # Deploy WVA using Helm chart
-    log_info "Installing Workload-Variant-Autoscaler via Helm chart"
+    NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-false}
 
-    # Default namespaceScoped to true if not set (matches chart default)
-    # But allow override via env var (e.g. for E2E tests)
-    NAMESPACE_SCOPED=${NAMESPACE_SCOPED:-true}
+    # Select the Kustomize overlay for this environment
+    local kustomize_overlay
+    if [ "$ENVIRONMENT" = "openshift" ]; then
+        kustomize_overlay="$(cd "$WVA_PROJECT/config/openshift" && pwd)"
+    else
+        kustomize_overlay="$(cd "$WVA_PROJECT/config/default" && pwd)"
+    fi
 
-    # Chart baseName is the controller's logical pool name (InferencePool prefix), not necessarily the llm-d guide folder.
-    WVA_BASE_NAME="${WVA_BASE_NAME:-inference-scheduling}"
+    # Build a throw-away overlay that pins the image without modifying tracked files.
+    # Symlink the base overlay so kustomization.yaml can reference it with a relative
+    # path — Kustomize rejects absolute paths in resources.
+    local tmp_overlay
+    tmp_overlay=$(mktemp -d)
+    ln -s "$kustomize_overlay" "$tmp_overlay/base"
 
-    # VA / HPA / capacity thresholds are chart defaults unless changed via helm --set separately (see deploy README).
-    # llmd.modelName / llmd.modelID are optional Helm overrides here when the vars are exported (often unset for infra-only installs).
-    helm upgrade -i "$WVA_RELEASE_NAME" ${WVA_PROJECT}/charts/workload-variant-autoscaler \
-        -n "$WVA_NS" \
-        --values $VALUES_FILE \
-        --set-file wva.prometheus.caCert="$PROM_CA_CERT_PATH" \
-        --set wva.image.repository="$WVA_IMAGE_REPO" \
-        --set wva.image.tag="$WVA_IMAGE_TAG" \
-        --set wva.imagePullPolicy="$WVA_IMAGE_PULL_POLICY" \
-        --set wva.baseName="$WVA_BASE_NAME" \
-        ${LLM_D_MODELSERVICE_NAME:+--set llmd.modelName="$LLM_D_MODELSERVICE_NAME"} \
-        ${MODEL_ID:+--set llmd.modelID="$MODEL_ID"} \
-        --set llmd.namespace="$LLMD_NS" \
-        --set wva.prometheus.baseURL="$PROMETHEUS_URL" \
-        --set wva.prometheus.monitoringNamespace="$MONITORING_NAMESPACE" \
-        --set vllmService.enabled="$VLLM_SVC_ENABLED" \
-        --set vllmService.port="$VLLM_SVC_PORT" \
-        --set vllmService.targetPort="$VLLM_SVC_PORT" \
-        --set vllmService.nodePort="$VLLM_SVC_NODEPORT" \
-        --set wva.logging.level="$WVA_LOG_LEVEL" \
-        --set wva.prometheus.tls.insecureSkipVerify="$SKIP_TLS_VERIFY" \
-        --set wva.namespaceScoped="$NAMESPACE_SCOPED" \
-        --set wva.metrics.secure="$WVA_METRICS_SECURE" \
-        --set wva.scaleToZero="$ENABLE_SCALE_TO_ZERO" \
-        ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE} \
-        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP}
+    # config/manager/kustomization.yaml transforms the base image from "controller:latest"
+    # to the published release image. The overlay must match the POST-transform name.
+    local base_image
+    base_image=$(grep 'newName:' "$WVA_PROJECT/config/manager/kustomization.yaml" | awk '{print $2}' | head -1)
+    cat > "$tmp_overlay/kustomization.yaml" <<EOF
+namespace: $WVA_NS
+resources:
+- ./base
+images:
+- name: $base_image
+  newName: $WVA_IMAGE_REPO
+  newTag: "$WVA_IMAGE_TAG"
+EOF
+
+    # When namespace-scoped, restrict the controller to its own namespace only.
+    # The patch itself lives in a tracked file; symlink it into the temp overlay
+    # so the kustomization.yaml can reference it with a relative path.
+    if [ "$NAMESPACE_SCOPED" = "true" ]; then
+        ln -s "$WVA_PROJECT/config/manager/namespace-scoped-patch.yaml" "$tmp_overlay/namespace-scoped-patch.yaml"
+        cat >> "$tmp_overlay/kustomization.yaml" <<'PATCH'
+patches:
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: ./namespace-scoped-patch.yaml
+PATCH
+    fi
+
+    log_info "Applying Kustomize overlay: $kustomize_overlay (namespace-scoped=$NAMESPACE_SCOPED)"
+    kubectl apply -k "$tmp_overlay"
+    rm -rf "$tmp_overlay"
 
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."
@@ -167,24 +178,9 @@ delete_namespaces_kube_like() {
 deploy_wva_prerequisites_kube_like() {
     log_info "Deploying Workload-Variant-Autoscaler prerequisites for Kubernetes..."
 
-    # Extract Prometheus CA certificate
+    # Extract Prometheus CA certificate (used by the Prometheus Adapter scaler backend).
     log_info "Extracting Prometheus TLS certificate"
     kubectl get secret "$PROMETHEUS_SECRET_NAME" -n "$MONITORING_NAMESPACE" -o jsonpath='{.data.tls\.crt}' | base64 -d > "$PROM_CA_CERT_PATH"
-
-    local use_values_dev=false
-    if [ "$SKIP_TLS_VERIFY" = "true" ]; then
-        use_values_dev=true
-    elif [ "${KUBE_LIKE_VALUES_DEV_IF_PRESENT:-false}" = "true" ] && [ -f "$WVA_PROJECT/charts/workload-variant-autoscaler/values-dev.yaml" ]; then
-        use_values_dev=true
-    fi
-
-    if [ "$use_values_dev" = "true" ]; then
-        log_warning "TLS verification NOT enabled: using values-dev.yaml for dev deployments - NOT FOR PRODUCTION USE"
-        VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values-dev.yaml"
-    else
-        log_info "TLS verification enabled: using values.yaml for production deployments"
-        VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values.yaml"
-    fi
 
     # LeaderWorkerSet (WVA dependency; see upstream chart / #910).
     if [ "${DEPLOY_LWS:-true}" = "true" ]; then

--- a/deploy/lib/llm_d_nightly_install.sh
+++ b/deploy/lib/llm_d_nightly_install.sh
@@ -49,12 +49,10 @@ if [[ "$PLATFORM" == openshift ]]; then
 	export WVA_METRICS_SECURE="${WVA_METRICS_SECURE:-false}"
 	export ENVIRONMENT=openshift
 	./deploy/install.sh \
-		--release-name "${WVA_RELEASE_NAME:-workload-variant-autoscaler}" \
 		--environment openshift
 	./deploy/install-llmd-infra.sh -e openshift
 else
 	export ENVIRONMENT=kubernetes
-	./deploy/install.sh \
-		--release-name "${WVA_RELEASE_NAME:-workload-variant-autoscaler}"
+	./deploy/install.sh
 	./deploy/install-llmd-infra.sh -e kubernetes
 fi

--- a/deploy/openshift/install.sh
+++ b/deploy/openshift/install.sh
@@ -28,7 +28,6 @@ REQUIRED_TOOLS=("oc")
 
 # TLS verification enabled by default on OpenShift
 SKIP_TLS_VERIFY=false
-VALUES_FILE="${WVA_PROJECT}/charts/workload-variant-autoscaler/values.yaml"
 
 #### REQUIRED FUNCTION used by deploy/install.sh ####
 check_specific_prerequisites() {

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,7 +29,7 @@ type externalMetricValueList struct {
 	} `json:"items"`
 }
 
-const secondaryControllerChartPathEnv = "WVA_E2E_CHART_PATH"
+const secondaryControllerOverlayPathEnv = "WVA_E2E_SECONDARY_OVERLAY_PATH"
 
 func splitImage(image string) (string, string) {
 	lastColon := strings.LastIndex(image, ":")
@@ -363,17 +364,16 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 
 	Context("Dual namespace-scoped controllers isolation", Serial, Ordered, func() {
 		var (
-			primaryNamespace     = "llm-d-sim"
-			secondaryNamespace   = "llm-d-sim-dual"
-			secondaryController  = "workload-variant-autoscaler-system-dual"
-			secondaryReleaseName = "wva-dual-secondary"
-			primaryHPAName       = "smoke-test-dual-primary-hpa"
-			secondaryHPAName     = "smoke-test-dual-secondary-hpa"
-			primaryModelName     = "smoke-test-dual-primary-ms"
-			secondaryModelName   = "smoke-test-dual-secondary-ms"
-			poolName             = "smoke-test-dual-pool"
-			sharedVAName         = "smoke-test-dual-shared-va"
-			controllerInstance   = "dual-secondary"
+			primaryNamespace    = "llm-d-sim"
+			secondaryNamespace  = "llm-d-sim-dual"
+			secondaryController = "workload-variant-autoscaler-system-dual"
+			primaryHPAName      = "smoke-test-dual-primary-hpa"
+			secondaryHPAName    = "smoke-test-dual-secondary-hpa"
+			primaryModelName    = "smoke-test-dual-primary-ms"
+			secondaryModelName  = "smoke-test-dual-secondary-ms"
+			poolName            = "smoke-test-dual-pool"
+			sharedVAName        = "smoke-test-dual-shared-va"
+			controllerInstance  = "dual-secondary"
 		)
 
 		BeforeAll(func() {
@@ -392,40 +392,108 @@ var _ = Describe("Smoke Tests - Infrastructure Readiness", Label("smoke", "full"
 				Expect(err).NotTo(HaveOccurred(), "Failed to create secondary workload namespace")
 			}
 
-			By("Installing secondary namespace-scoped controller via Helm")
+			By("Installing secondary namespace-scoped controller via Kustomize")
 			primaryController, err := k8sClient.AppsV1().Deployments(cfg.WVANamespace).Get(ctx, "workload-variant-autoscaler-controller-manager", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to read primary controller deployment image")
 			Expect(primaryController.Spec.Template.Spec.Containers).NotTo(BeEmpty(), "Primary controller deployment should contain containers")
 			imageRepo, imageTag := splitImage(primaryController.Spec.Template.Spec.Containers[0].Image)
-			chartPath := os.Getenv(secondaryControllerChartPathEnv)
-			Expect(chartPath).NotTo(BeEmpty(),
-				"Missing %s; set it to the workload-variant-autoscaler chart directory (use an absolute path; go test cwd is the test package dir)", secondaryControllerChartPathEnv)
-			_, statErr := os.Stat(chartPath)
-			Expect(statErr).NotTo(HaveOccurred(), "Invalid %s path: %s", secondaryControllerChartPathEnv, chartPath)
+			overlayPath := os.Getenv(secondaryControllerOverlayPathEnv)
+			Expect(overlayPath).NotTo(BeEmpty(),
+				"Missing %s; set it to the config/e2e/secondary-controller overlay directory (use an absolute path; go test cwd is the test package dir)", secondaryControllerOverlayPathEnv)
+			_, statErr := os.Stat(overlayPath)
+			Expect(statErr).NotTo(HaveOccurred(), "Invalid %s path: %s", secondaryControllerOverlayPathEnv, overlayPath)
 
-			helmArgs := []string{
-				"upgrade", "-i", secondaryReleaseName, chartPath,
-				"-n", secondaryController, "--create-namespace",
-				"--set", "controller.enabled=true",
-				"--set", "va.enabled=false",
-				"--set", "hpa.enabled=false",
-				"--set", "vllmService.enabled=false",
-				"--set", "wva.namespaceScoped=true",
-				"--set", "wva.controllerInstance=" + controllerInstance,
-				"--set", "llmd.namespace=" + secondaryNamespace,
-				"--set", "wva.image.repository=" + imageRepo,
-				"--set", "wva.image.tag=" + imageTag,
-				"--set", "wva.imagePullPolicy=IfNotPresent",
-				"--set", "wva.prometheus.baseURL=https://kube-prometheus-stack-prometheus." + cfg.MonitoringNS + ".svc.cluster.local:9090",
-				"--set", "wva.prometheus.tls.insecureSkipVerify=true",
+			// Read the post-transform base image name from config/manager/kustomization.yaml.
+			// The base overlay transforms "controller" → the published image name; our temp
+			// overlay must match that post-transform name to override it with the local image.
+			managerKustomizationPath := filepath.Join(overlayPath, "../../../../config/manager/kustomization.yaml")
+			managerContent, managerReadErr := os.ReadFile(managerKustomizationPath)
+			Expect(managerReadErr).NotTo(HaveOccurred(), "Failed to read config/manager/kustomization.yaml")
+			var baseImageName string
+			for _, line := range strings.Split(string(managerContent), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "newName:") {
+					baseImageName = strings.TrimSpace(strings.TrimPrefix(trimmed, "newName:"))
+					break
+				}
 			}
-			cmd := exec.Command("helm", helmArgs...)
+			Expect(baseImageName).NotTo(BeEmpty(), "Failed to extract base image name from config/manager/kustomization.yaml")
+
+			tmpOverlay, tmpErr := os.MkdirTemp("", "wva-secondary-overlay-*")
+			Expect(tmpErr).NotTo(HaveOccurred(), "Failed to create temp overlay dir")
+			// Symlink the base overlay so resources can use a relative path —
+			// Kustomize rejects absolute paths in resources.
+			Expect(os.Symlink(overlayPath, tmpOverlay+"/base")).To(Succeed())
+
+			kustomizationContent := strings.Join([]string{
+				"apiVersion: kustomize.config.k8s.io/v1beta1",
+				"kind: Kustomization",
+				"namespace: " + secondaryController,
+				"resources:",
+				"- ./base",
+				"images:",
+				"- name: " + baseImageName,
+				"  newName: " + imageRepo,
+				`  newTag: "` + imageTag + `"`,
+				"patches:",
+				"- target:",
+				"    kind: Deployment",
+				"    name: controller-manager",
+				"  patch: |",
+				`    - op: add`,
+				`      path: /spec/template/spec/containers/0/env/-`,
+				`      value: {"name": "CONTROLLER_INSTANCE", "value": "` + controllerInstance + `"}`,
+			}, "\n")
+			Expect(os.WriteFile(tmpOverlay+"/kustomization.yaml", []byte(kustomizationContent), 0600)).To(Succeed())
+
+			cmd := exec.Command("kubectl", "apply", "-k", tmpOverlay, "--server-side", "--force-conflicts")
 			out, err := cmd.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), "Secondary controller helm install failed: %s", string(out))
+			Expect(err).NotTo(HaveOccurred(), "Secondary controller kustomize install failed: %s", string(out))
+
+			// The secondary overlay shares the same kustomize namePrefix as the primary, so
+			// kubectl apply overwrites the shared ClusterRoleBinding to point at the secondary
+			// namespace.
+			//   1. Restoring the primary's ClusterRoleBinding subject namespace.
+			//   2. Creating a dedicated binding for the secondary SA.
+			const crbName = "workload-variant-autoscaler-manager-rolebinding"
+			const crbNameSecondary = crbName + "-secondary"
+			restoreOut, restoreErr := exec.Command("kubectl", "patch", "clusterrolebinding", crbName,
+				"--type=json",
+				"-p", `[{"op":"replace","path":"/subjects/0/namespace","value":"`+cfg.WVANamespace+`"}]`,
+			).CombinedOutput()
+			Expect(restoreErr).NotTo(HaveOccurred(), "Failed to restore primary ClusterRoleBinding: %s", string(restoreOut))
+
+			createOut, createErr := exec.Command("kubectl", "create", "clusterrolebinding", crbNameSecondary,
+				"--clusterrole=workload-variant-autoscaler-manager-role",
+				"--serviceaccount="+secondaryController+":workload-variant-autoscaler-controller-manager",
+			).CombinedOutput()
+			Expect(createErr).NotTo(HaveOccurred(), "Failed to create secondary ClusterRoleBinding: %s", string(createOut))
+
+			// The epp-metrics-reader ClusterRoleBinding is also cluster-scoped and gets overwritten
+			// by the secondary overlay — restore the primary subject and create a secondary binding.
+			const eppCRBName = "workload-variant-autoscaler-epp-metrics-reader-role-binding"
+			const eppCRBNameSecondary = eppCRBName + "-secondary"
+			eppRestoreOut, eppRestoreErr := exec.Command("kubectl", "patch", "clusterrolebinding", eppCRBName,
+				"--type=json",
+				"-p", `[{"op":"replace","path":"/subjects/0/namespace","value":"`+cfg.WVANamespace+`"}]`,
+			).CombinedOutput()
+			Expect(eppRestoreErr).NotTo(HaveOccurred(), "Failed to restore primary epp-metrics ClusterRoleBinding: %s", string(eppRestoreOut))
+
+			eppCreateOut, eppCreateErr := exec.Command("kubectl", "create", "clusterrolebinding", eppCRBNameSecondary,
+				"--clusterrole=workload-variant-autoscaler-epp-metrics-reader-role",
+				"--serviceaccount="+secondaryController+":workload-variant-autoscaler-epp-metrics-reader",
+			).CombinedOutput()
+			Expect(eppCreateErr).NotTo(HaveOccurred(), "Failed to create secondary epp-metrics ClusterRoleBinding: %s", string(eppCreateOut))
 
 			DeferCleanup(func() {
-				uninstall := exec.Command("helm", "uninstall", secondaryReleaseName, "-n", secondaryController)
-				_, _ = uninstall.CombinedOutput()
+				_ = exec.Command("kubectl", "delete", "clusterrolebinding", crbNameSecondary, "--ignore-not-found=true").Run()
+				_ = exec.Command("kubectl", "delete", "clusterrolebinding", eppCRBNameSecondary, "--ignore-not-found=true").Run()
+				// Delete the secondary controller namespace (cascades to all namespace-scoped
+				// resources). Do NOT use kubectl delete -k here — it would delete the shared
+				// ClusterRoles/ClusterRoleBindings that the primary controller depends on.
+				_ = exec.Command("kubectl", "delete", "namespace", secondaryController, "--ignore-not-found=true").Run()
+				_ = exec.Command("kubectl", "delete", "namespace", secondaryNamespace, "--ignore-not-found=true").Run()
+				_ = os.RemoveAll(tmpOverlay)
 			})
 
 			By("Waiting for secondary controller to be ready")

--- a/test/e2e/testdata/secondary-controller/kustomization.yaml
+++ b/test/e2e/testdata/secondary-controller/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base overlay for a secondary namespace-scoped WVA controller used in dual-controller e2e tests.
+# A caller (test or script) wraps this in a throw-away temp overlay to set:
+#   - namespace (e.g. workload-variant-autoscaler-system-dual)
+#   - images: (controller image repo + tag)
+#   - optional --controller-instance arg patch
+
+resources:
+- ../../../../config/default
+
+patches:
+- target:
+    kind: Deployment
+    name: controller-manager
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--watch-namespace=$(POD_NAMESPACE)"


### PR DESCRIPTION
Replaces all Helm-based WVA controller installs with kustomize. The deploy scripts, CI workflows, and e2e tests now all go through Kustomize overlays. Helm stays for upstream installs (LWS, KEDA, kube-prometheus-stack, Prometheus Adapter), those aren't our charts.

Note: The Helm chart still exists (deprecation + deletion will follow)