### PR TITLE
Helm chart default accelerator changed from H100 to nvidia

### DIFF
--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -100,9 +100,9 @@ llmd:
 va:
   enabled: true
   # accelerator: Optional. If not specified, it will be auto-discovered
-  # from scale target. If specified, it will be used as fall-back value if it can't 
-  # be discovered.
-  accelerator: H100
+  # from scale target. If specified, it will be used as fall-back value if it can't
+  # be discovered. Valid values: nvidia, amd, cpu
+  accelerator: nvidia
   # Cost per replica in arbitrary units (higher = more expensive to scale)
   # Used by saturation analysis to weight scaling decisions across variants
   # Example: H100=10.0, A100=8.0, L40S=5.0 (relative GPU costs)

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -96,7 +96,8 @@ deploy_wva_controller() {
         --set wva.metrics.secure="$WVA_METRICS_SECURE" \
         --set wva.scaleToZero="$ENABLE_SCALE_TO_ZERO" \
         ${CONTROLLER_INSTANCE:+--set wva.controllerInstance=$CONTROLLER_INSTANCE} \
-        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP}
+        ${POOL_GROUP:+--set wva.poolGroup=$POOL_GROUP} \
+        ${ACCELERATOR_TYPE:+--set va.accelerator=$ACCELERATOR_TYPE}
 
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."


### PR DESCRIPTION
Issue #1156 
The default value for va.accelerator in the Helm chart is H100:
This value is stamped directly onto the VariantAutoscaling label:

The WVA controller expects vendor names (nvidia, amd, cpu) in this label, not GPU model names like H100. As a result, any deployment using the chart defaults — or passing ACCELERATOR_TYPE=nvidia through the deploy scripts — will produce a VA with acceleratorName: H100, which the controller doesn't recognize. The VA will immediately show METRICSREADY: False and the controller logs will print "Skipping status update for VA without accelerator info".

Additionally, deploy_wva_controller() in deploy/lib/infra_wva.sh never passes va.accelerator to helm upgrade, so even if ACCELERATOR_TYPE is set in the environment, it has no effect on the VA label.

Fix:
 default accelerator changed from H100 to nvidia, and the comment now documents valid values (nvidia, amd, cpu)
added ${ACCELERATOR_TYPE:+--set va.accelerator=$ACCELERATOR_TYPE} to the helm call so the environment variable is forwarded when set