### PR TITLE
docs(deploy): deprecate Helm chart, promote Kustomize as primary install

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,14 @@ More examples in [config/samples/](config/samples/).
 
 ### CRD Updates
 
-**Important:** Helm does not automatically update CRDs during `helm upgrade`. When upgrading WVA to a new version with CRD changes, you must manually apply the updated CRDs first:
+When upgrading WVA to a new version with CRD changes, apply the updated CRDs before rolling out the new controller:
 
 ```bash
-# Apply the latest CRDs before upgrading
-kubectl apply -f charts/workload-variant-autoscaler/crds/
+# Apply the latest CRDs
+kubectl apply -k config/crd
 
-# Then upgrade the Helm release
-helm upgrade workload-variant-autoscaler ./charts/workload-variant-autoscaler \
-  --namespace workload-variant-autoscaler-system \
-  [your-values...]
+# Then roll out the new controller
+kubectl apply -k config/default    # or config/openshift
 ```
 
 ### Breaking Changes

--- a/charts/workload-variant-autoscaler/Chart.yaml
+++ b/charts/workload-variant-autoscaler/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: workload-variant-autoscaler
 description: Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
 type: application
-version: 0.5.1
-appVersion: "v0.5.1"
+version: 0.7.0
+appVersion: "v0.7.0"
+deprecated: true

--- a/charts/workload-variant-autoscaler/README.md
+++ b/charts/workload-variant-autoscaler/README.md
@@ -1,6 +1,11 @@
 # workload-variant-autoscaler
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
+> **DEPRECATED**: This Helm chart is deprecated. Kustomize is now the recommended install method.
+> Use `kubectl apply -k config/default/` (Kubernetes) or `kubectl apply -k config/openshift/` (OpenShift).
+> See the [Deployment Guide](../../deploy/README.md) for details.
+> This chart will be removed in the next minor release.
+
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads
 
@@ -9,7 +14,7 @@ Helm chart for Workload-Variant-Autoscaler (WVA) - GPU-aware autoscaler for LLM 
 The chart is published to GitHub Container Registry under the **llm-d** org (not llm-d-incubation). Use this OCI URL in Helm or Helmfile:
 
 - **OCI URL:** `oci://ghcr.io/llm-d/workload-variant-autoscaler`
-- **Example:** `helm pull oci://ghcr.io/llm-d/workload-variant-autoscaler --version 0.5.1`
+- **Example:** `helm pull oci://ghcr.io/llm-d/workload-variant-autoscaler --version 0.7.0`
 
 ## Installation (OpenShift)
 Helm is the recommended installation method. Before running, be sure to delete all previous helm installations for `workload-variant-autoscaler` and `prometheus-adapter`. To list all helm charts installed in the cluster run `helm ls -A`.
@@ -18,7 +23,7 @@ Helm is the recommended installation method. Before running, be sure to delete a
 ```
 export OWNER="llm-d"
 export WVA_PROJECT="llm-d-workload-variant-autoscaler"
-export WVA_RELEASE="v0.5.1"
+export WVA_RELEASE="v0.7.0"
 export WVA_NS="workload-variant-autoscaler-system"
 export MON_NS="openshift-user-workload-monitoring"
 

--- a/charts/workload-variant-autoscaler/values.yaml
+++ b/charts/workload-variant-autoscaler/values.yaml
@@ -10,7 +10,7 @@ wva:
 
   image:
     repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
-    tag: v0.5.1
+    tag: v0.7.0
   imagePullPolicy: Always
 
   metrics:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
-  newTag: v0.5.1
+  newTag: v0.7.0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes, OpenShift, and Kind clusters.
 
-> **Central Documentation Hub**: This is the main deployment guide containing comprehensive information about deployment methods, Helm chart configuration, and complete configuration reference. Platform-specific guides ([Kubernetes](kubernetes/README.md), [OpenShift](openshift/README.md), [Kind](kind-emulator/README.md)) provide additional platform-specific details and examples.
+> **Central Documentation Hub**: This is the main deployment guide containing comprehensive information about deployment methods and configuration reference. Platform-specific guides ([Kubernetes](kubernetes/README.md), [OpenShift](openshift/README.md), [Kind](kind-emulator/README.md)) provide additional platform-specific details and examples.
 
 ## Table of Contents
 
@@ -10,7 +10,8 @@ Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes
 - [Prerequisites](#prerequisites)
 - [Deployment Methods](#deployment-methods)
   - [Method 1: Automated Deployment Script](#method-1-automated-deployment-script-recommended)
-  - [Method 2: Helm Chart](#method-2-helm-chart)
+  - [Method 2: Kustomize (direct controller install)](#method-2-kustomize-direct-controller-install)
+  - [Legacy: Helm Chart (Deprecated)](#legacy-helm-chart-deprecated)
 - [Platform-Specific Guides](#platform-specific-guides)
 - [Configuration Reference](#configuration-reference)
 - [Post-Deployment](#post-deployment)
@@ -21,7 +22,7 @@ Complete guide for deploying the Workload-Variant-Autoscaler (WVA) on Kubernetes
 This guide covers two deployment procedures:
 
 1. **Automated Script**: Complete end-to-end and customizable deployment including WVA, llm-d infrastructure, Prometheus, and HPA
-2. **Helm Chart**: Deploy the WVA controller into an existing cluster
+2. **Kustomize**: Install the WVA controller directly into an existing cluster
 
 ## Prerequisites
 
@@ -30,7 +31,8 @@ This guide covers two deployment procedures:
 All deployment methods require:
 
 - **kubectl** (v1.24+) - Kubernetes CLI
-- **helm** (v3.8+) - Package manager for Kubernetes
+- **kustomize** (v5+) - for direct controller installs
+- **helm** (v3.8+) - for upstream dependencies (LWS, KEDA, Prometheus stack)
 - **git** - Git CLI
 
 Optional but recommended:
@@ -53,7 +55,7 @@ Platform-specific requirements:
 **Cluster access**:
 
 - Cluster admin privileges (for full deployment script)
-- Or namespace admin + ability to create ClusterRole/ClusterRoleBinding (for Helm-only)
+- Or namespace admin + ability to create ClusterRole/ClusterRoleBinding (for Kustomize direct install)
 
 ### Required Tokens
 
@@ -118,7 +120,6 @@ bash install.sh [OPTIONS]
 
 Options:
   -i, --wva-image IMAGE    WVA container image (default: ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest)
-  -r, --release-name NAME  Helm release name for WVA
   -u, --undeploy           Undeploy WVA, monitoring, and scaler (not llm-d)
   -e, --environment ENV    kubernetes | openshift | kind-emulator
   -h, --help               Show help
@@ -160,7 +161,7 @@ export INSTALL_GATEWAY_CTRLPLANE=true
 
 #### Script deployment examples
 
-Chart-managed **VariantAutoscaling** and **HPA** are no longer toggled from `install.sh`; use `helm upgrade` with `--set va.enabled=true` / `hpa.enabled=true` on the WVA chart, or let tests/operators create CRs.
+**VariantAutoscaling** and **HPA** resources are not created by `install.sh`; create them directly with `kubectl apply` or let tests/operators manage them.
 
 ##### Example 1: Base infra then llm-d
 
@@ -194,7 +195,40 @@ export DEPLOY_LWS=false
 ./deploy/install.sh -e kubernetes
 ```
 
-### Method 2: Helm Chart
+### Method 2: Kustomize (direct controller install)
+
+Install the WVA controller directly into an existing cluster using Kustomize. This is the recommended method when you already have Prometheus and want to manage the controller install without the full automated script.
+
+#### Kubernetes
+
+```bash
+# Set the controller image
+cd config/manager
+kustomize edit set image controller=ghcr.io/llm-d/llm-d-workload-variant-autoscaler:v0.7.0
+
+# Apply
+kubectl apply -k ../default
+```
+
+#### OpenShift
+
+```bash
+cd config/manager
+kustomize edit set image controller=ghcr.io/llm-d/llm-d-workload-variant-autoscaler:v0.7.0
+
+kubectl apply -k ../openshift
+```
+
+#### Undeploy
+
+```bash
+kubectl delete -k config/default    # or config/openshift
+```
+
+### Legacy: Helm Chart (Deprecated)
+
+> **This Helm chart is deprecated.** Use [Kustomize](#method-2-kustomize-direct-controller-install) instead.
+> The chart will be removed in the next minor release.
 
 The WVA can be deployed as a standalone using Helm, assuming you have:
 
@@ -577,7 +611,7 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | `SKIP_CHECKS` | Skip prerequisite checks | `false` |
 | `SCALER_BACKEND` | `prometheus-adapter`, `keda`, or `none` | `prometheus-adapter` |
 
-VariantAutoscaling, HPA stabilization, and vLLM ModelService tuning are not controlled by `install.sh`; use **Helm** (`va.enabled`, `hpa.*`, `wva.capacityScaling.*`) or **`install-llmd-infra.sh`** (`MODEL_ID`, `VLLM_MAX_NUM_SEQS`, `LLMD_*`, etc.).
+VariantAutoscaling, HPA stabilization, and vLLM ModelService tuning are not controlled by `install.sh`; manage them via `kubectl apply` or **`install-llmd-infra.sh`** (`MODEL_ID`, `VLLM_MAX_NUM_SEQS`, `LLMD_*`, etc.).
 
 #### Advanced (`install.sh`)
 
@@ -592,11 +626,7 @@ VariantAutoscaling, HPA stabilization, and vLLM ModelService tuning are not cont
 
 #### Optional: capacity thresholds after `make deploy-e2e-infra`
 
-If `KV_SPARE_TRIGGER` and/or `QUEUE_SPARE_TRIGGER` are set in the environment, the Makefile runs a follow-up `helm upgrade --reuse-values` on the WVA release.
-
-### Helm Values Reference
-
-See the [values.yaml](../charts/workload-variant-autoscaler/values.yaml) file for complete Helm chart configuration options.
+If `KV_SPARE_TRIGGER` and/or `QUEUE_SPARE_TRIGGER` are set in the environment, the Makefile patches the `saturation-scaling-config` ConfigMap after install.
 
 ## Post-Deployment
 
@@ -915,6 +945,7 @@ kubectl get configmap model-accelerator-data -n workload-variant-autoscaler-syst
 - **Main Project**: [README.md](../README.md)
 - **Kubernetes Guide**: [kubernetes/README.md](kubernetes/README.md)
 - **OpenShift Guide**: [openshift/README.md](openshift/README.md)
-- **Helm Chart**: [charts/workload-variant-autoscaler](../charts/workload-variant-autoscaler/)
+- **Kustomize overlays**: [config/default](../config/default/), [config/openshift](../config/openshift/)
+- **Helm Chart (deprecated)**: [charts/workload-variant-autoscaler](../charts/workload-variant-autoscaler/)
 - **API Reference**: [api/v1alpha1](../api/v1alpha1/)
 - **Architecture**: [docs/design/modeling-optimization.md](../docs/design/modeling-optimization.md)

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -2,7 +2,7 @@
 
 Quick start guide for local development using Kind (Kubernetes in Docker) with emulated GPU resources.
 
-> **Note**: This guide covers Kind-specific deployment for local testing. For a complete overview of deployment methods, Helm chart configuration, and the full configuration reference, see the [main deployment guide](../README.md).
+> **Note**: This guide covers Kind-specific deployment for local testing. For a complete overview of deployment methods and the full configuration reference, see the [main deployment guide](../README.md).
 
 ## Table of Contents
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 Automated deployment script for WVA, llm-d infrastructure, Prometheus, and HPA on Kubernetes clusters.
 
-> **Note**: This guide covers Kubernetes-specific deployment details. For a complete overview of deployment methods, Helm chart configuration, and the full configuration reference, see the [main deployment guide](../README.md).
+> **Note**: This guide covers Kubernetes-specific deployment details. For a complete overview of deployment methods and the full configuration reference, see the [main deployment guide](../README.md).
 
 ## Table of Contents
 
@@ -100,7 +100,7 @@ export HF_TOKEN="hf_xxxxx"                  # Required: HuggingFace token
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B" # Model to deploy
 export ACCELERATOR_TYPE="H100"              # GPU type
 export WVA_IMAGE_TAG="latest"               # WVA version
-# HPA stabilization: set on Helm chart (`hpa.behavior.*`), not install.sh
+# HPA stabilization: configure on the HPA resource directly, not install.sh
 
 # Performance tuning (optional; passed to install-llmd-infra / ModelService)
 export VLLM_MAX_NUM_SEQS=64                 # vLLM max concurrent sequences (batch size)
@@ -108,7 +108,7 @@ export ACCELERATOR_TYPE="A100"              # GPU type (auto-detected)
 export GATEWAY_PROVIDER="istio"             # Gateway: istio or kgateway (for install-llmd-infra.sh)
 ```
 
-**Deployment flags** (`deploy/install.sh`) — use Helm for chart VA/HPA; llm-d is **`deploy/install-llmd-infra.sh`**:
+**Deployment flags** (`deploy/install.sh`) — VA/HPA are managed separately; llm-d is **`deploy/install-llmd-infra.sh`**:
 
 ```bash
 export DEPLOY_PROMETHEUS=true         # Deploy kube-prometheus-stack

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -2,7 +2,7 @@
 
 Automated deployment script for WVA and llm-d infrastructure on OpenShift clusters.
 
-> **Note**: This guide covers OpenShift-specific deployment details. For a complete overview of deployment methods, Helm chart configuration, and the full configuration reference, see the [main deployment guide](../README.md).
+> **Note**: This guide covers OpenShift-specific deployment details. For a complete overview of deployment methods and the full configuration reference, see the [main deployment guide](../README.md).
 
 ## Table of Contents
 

--- a/docs/developer-guide/release-process.md
+++ b/docs/developer-guide/release-process.md
@@ -49,7 +49,7 @@ Do these on the branch you intend to tag (e.g. `main`).
 
 2. **Kustomize default image tag (optional)**  
    - If you want the default kustomize install to use the new version, update `config/manager/kustomization.yaml`: set `newTag` to the new version (e.g. `v0.5.2`) and commit.  
-   - The Helm release workflow does **not** update this file; it only updates `charts/workload-variant-autoscaler/Chart.yaml` and `charts/workload-variant-autoscaler/values.yaml`.
+   - The Helm release workflow also updates `charts/workload-variant-autoscaler/Chart.yaml` and `charts/workload-variant-autoscaler/values.yaml`, but the Helm chart is deprecated and will be removed in a future release.
 
 3. **Upstream dependency pins**  
    - If this release pins a new version of an upstream dependency (e.g. [llm-d-inference-sim](https://github.com/llm-d/llm-d-inference-sim)), update [docs/upstream-versions.md](../upstream-versions.md) and the referenced files (e.g. `test/e2e/fixtures/model_service_builder.go`, `test/utils/resources/llmdsim.go`) before releasing.
@@ -96,12 +96,12 @@ So after the workflow runs, the default branch will have the chart metadata alig
 
 ---
 
-## Helm chart details
+## Helm chart details (deprecated)
+
+> The Helm chart is deprecated. Kustomize (`config/default/` or `config/openshift/`) is the recommended install path. The chart and its release workflow will be removed in a future minor release.
 
 - **Chart location:** `charts/workload-variant-autoscaler/`.
 - **Publish location:** `oci://ghcr.io/llm-d` (package name: `workload-variant-autoscaler`).
-- **Install example:**  
-  `helm install wva oci://ghcr.io/llm-d/workload-variant-autoscaler --version X.Y.Z`
 - The workflow sets the chart **version** and **appVersion** from the release tag and updates the default controller **image tag** in `values.yaml`; it then commits those changes back to the default branch.
 
 ---

--- a/docs/developer-guide/troubleshooting.md
+++ b/docs/developer-guide/troubleshooting.md
@@ -90,14 +90,6 @@ For e2e-style deploys, **`install-llmd-infra.sh`** enables EPP flow control when
               value: "50"  # Increase for larger clusters
    ```
 
-   Or via Helm:
-
-   ```bash
-   helm upgrade -i workload-variant-autoscaler ./charts/workload-variant-autoscaler \
-   --namespace workload-variant-autoscaler-system \
-   --set controller.env.SCALE_FROM_ZERO_ENGINE_MAX_CONCURRENCY=50
-   ```
-
 2. **Inference gateway not receiving requests**:
    
    **Solution**: Verify that requests are being routed through the inference gateway and not directly to model server endpoints.


### PR DESCRIPTION
Mark Helm chart as deprecated and update docs and also pin kustomize image tag to v0.7.0 (current release)