### PR TITLE
ci(deploy): artifact-based diagnostics, opt-in LWS, drop gateway ctrlplane default

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -110,7 +110,7 @@ jobs:
             echo "has_code_changes=true" >> $GITHUB_OUTPUT
           fi
 
-  # Gate: Check permissions and handle /ok-to-test for fork PRs.
+  # Gate: Check permissions and handle /ok-to-test for fork PRs. 
   # - Maintainers (write access): Tests run automatically on pull_request.
   # - Fork PRs: Gate succeeds (no failure) so the PR does not show a false red check; E2E runs
   #   only after a maintainer comments /ok-to-test. Branch protection should require the

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -960,6 +960,7 @@ jobs:
           # Temporary/ To do: real vLLM decode scheduling was flaky on shared GPU runners; tests use llm-d-inference-sim.
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "true"
+          DEPLOY_LWS: "true"
           WVA_NAMESPACE: ${{ env.WVA_NAMESPACE }}
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
           LLMD_NAMESPACE: ${{ env.LLMD_NAMESPACE }}
@@ -1016,31 +1017,25 @@ jobs:
 
           echo "Cleanup complete"
 
-      - name: Dump cluster state
+      - name: Collect cluster diagnostics
         if: always()
         run: |
-          echo "=== Dumping cluster state for diagnostics ==="
-          echo ""
-          echo "=== VAs ==="
-          kubectl get va -n "$LLMD_NAMESPACE" 2>/dev/null || true
-          echo ""
-          echo "=== HPAs ==="
-          kubectl get hpa -n "$LLMD_NAMESPACE" 2>/dev/null || true
-          echo ""
-          echo "=== Controller pods ==="
-          kubectl get pods -n "$WVA_NAMESPACE" 2>/dev/null || true
-          echo ""
-          echo "=== All resources ==="
+          mkdir -p /tmp/cluster-diagnostics
           for ns in "$WVA_NAMESPACE" "$LLMD_NAMESPACE"; do
             if kubectl get namespace "$ns" &>/dev/null; then
-              echo "--- Namespace: $ns ---"
-              kubectl get all -n "$ns" 2>/dev/null || true
-              echo ""
-              echo "--- Events in $ns ---"
-              kubectl get events -n "$ns" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
-              echo ""
+              kubectl get va,hpa,all -n "$ns" 2>/dev/null > /tmp/cluster-diagnostics/${ns}-resources.txt || true
+              kubectl get events -n "$ns" --sort-by='.lastTimestamp' 2>/dev/null > /tmp/cluster-diagnostics/${ns}-events.txt || true
+              kubectl logs -n "$ns" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=500 2>/dev/null > /tmp/cluster-diagnostics/${ns}-wva-logs.txt || true
             fi
           done
+
+      - name: Upload cluster diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-diagnostics-${{ github.run_id }}
+          path: /tmp/cluster-diagnostics/
+          retention-days: 7
 
       - name: Scale down GPU workloads on failure
         # On failure, scale down decode deployments to free GPUs while preserving

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -338,7 +338,6 @@ jobs:
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "false"
           CREATE_CLUSTER: "true"
-          INSTALL_GATEWAY_CTRLPLANE: "true"
           # Emulated Kind: chart decode may be removed post-deploy (LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS, default true).
           # Pin llm-d release for deterministic CI behavior
           LLM_D_RELEASE: "v0.7.0"
@@ -452,8 +451,8 @@ jobs:
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "true"
           CREATE_CLUSTER: "true"
-          INSTALL_GATEWAY_CTRLPLANE: "true"
           LLM_D_RELEASE: "v0.7.0"
+          DEPLOY_LWS: "true"
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"
           PROMETHEUS_ADAPTER_WAIT: "false"

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ deploy-wva-emulated-on-kind: ## Deploy WVA + llm-d on Kind (Prometheus Adapter a
 		LLM_D_RELEASE=$(LLM_D_RELEASE) DECODE_REPLICAS=$(DECODE_REPLICAS) \
 		LLMD_PATCH_EPP_FLOW_CONTROL=true LLMD_SKIP_INFERENCE_OBJECTIVE=true \
 		LLMD_SKIP_DEFAULT_MODELSERVICE=true LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
-		INSTALL_GATEWAY_CTRLPLANE=true \
 		./deploy/install-llmd-infra.sh -e kind-emulator
 
 ## Undeploy WVA from the emulated environment on Kind.
@@ -238,7 +237,6 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 		WVA_IMAGE_PULL_POLICY=IfNotPresent \
 		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		DECODE_REPLICAS=$(DECODE_REPLICAS) \
-		INSTALL_GATEWAY_CTRLPLANE=true \
 		LLMD_SKIP_DEFAULT_MODELSERVICE=true \
 		LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
 		LLMD_PATCH_EPP_FLOW_CONTROL=true \
@@ -256,7 +254,6 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + llm-d; no chart VA/HP
 		CREATE_CLUSTER=false \
 		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		DECODE_REPLICAS=$(DECODE_REPLICAS) \
-		INSTALL_GATEWAY_CTRLPLANE=true \
 		LLMD_SKIP_DEFAULT_MODELSERVICE=true \
 		LLMD_WAIT_FOR_ESSENTIAL_LLM_D_ONLY=true \
 		LLMD_PATCH_EPP_FLOW_CONTROL=true \
@@ -337,8 +334,11 @@ test-e2e-smoke-with-setup: deploy-e2e-infra test-e2e-smoke
 
 # Convenience target that deploys infra + runs full test suite.
 # Set DELETE_CLUSTER=true to delete Kind cluster after tests (default: keep cluster for debugging).
+# LWS is installed because the full suite includes LeaderWorkerSet scale-from-zero tests.
 .PHONY: test-e2e-full-with-setup
-test-e2e-full-with-setup: deploy-e2e-infra test-e2e-full
+test-e2e-full-with-setup:
+	DEPLOY_LWS=true $(MAKE) deploy-e2e-infra
+	$(MAKE) test-e2e-full
 
 
 ##@ llm-d-benchmark CLI (standup / run / teardown)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -145,12 +145,12 @@ export WVA_IMAGE_TAG="latest"
 # Optional
 export DEPLOY_WVA=false            # Monitoring + scaler only
 export DEPLOY_PROMETHEUS=false
-export DEPLOY_LWS=false           # Skip LeaderWorkerSet if already on cluster
+# export DEPLOY_LWS=true           # Install LeaderWorkerSet (needed for full e2e suite; default false)
 
 # llm-d (install-llmd-infra.sh) — examples
 export HF_TOKEN="hf_xxx"
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"
-export INSTALL_GATEWAY_CTRLPLANE=true
+# export INSTALL_GATEWAY_CTRLPLANE=true  # Only needed for Gateway Mode (external Istio/kgateway). Default false (Standalone Mode).
 # Guide basename under llm-d guides/ (llm-d README: GUIDE_NAME). Default optimized-baseline matches v0.7.0+.
 # https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline
 # export GUIDE_NAME=optimized-baseline   # default; change only if using a custom guide path
@@ -158,7 +158,7 @@ export INSTALL_GATEWAY_CTRLPLANE=true
 
 #### Gateway control plane (`install-llmd-infra.sh`)
 
-`INSTALL_GATEWAY_CTRLPLANE` defaults to **true** (install the gateway control plane via helmfile). Set **`INSTALL_GATEWAY_CTRLPLANE=false`** if your cluster already has a suitable gateway.
+`INSTALL_GATEWAY_CTRLPLANE` defaults to **false** (Standalone Mode bundles Envoy inside the EPP pod — no external gateway controller needed). Set to **`true`** only if you are using Gateway Mode with an external Kubernetes Gateway controller (Istio or kgateway).
 
 #### Script deployment examples
 
@@ -189,10 +189,10 @@ export DEPLOY_PROMETHEUS_ADAPTER=true
 ./deploy/install.sh -e kubernetes
 ```
 
-##### Example 4: Skip LeaderWorkerSet (already on cluster)
+##### Example 4: Install with LeaderWorkerSet (for full e2e suite)
 
 ```bash
-export DEPLOY_LWS=false
+export DEPLOY_LWS=true
 ./deploy/install.sh -e kubernetes
 ```
 
@@ -598,7 +598,7 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GATEWAY_PROVIDER` | Gateway implementation | `istio` |
-| `INSTALL_GATEWAY_CTRLPLANE` | Install gateway control plane via helmfile | `true` |
+| `INSTALL_GATEWAY_CTRLPLANE` | Install gateway control plane via helmfile (Gateway Mode only) | `false` |
 | `LLMD_REMOVE_EMULATED_DECODE_DEPLOYMENTS` | On emulated clusters, delete chart decode Deployment after deploy (e2e applies its own) | `true` |
 
 #### Deployment Flags (`install.sh`)
@@ -608,7 +608,7 @@ Each guide includes platform-specific examples, troubleshooting, and quick start
 | `DEPLOY_PROMETHEUS` | Deploy Prometheus stack | `true` |
 | `DEPLOY_WVA` | Deploy WVA controller | `true` |
 | `DEPLOY_PROMETHEUS_ADAPTER` | Deploy Prometheus Adapter (when `SCALER_BACKEND=prometheus-adapter`) | `true` |
-| `DEPLOY_LWS` | Deploy LeaderWorkerSet (skip if already installed or not needed) | `true` |
+| `DEPLOY_LWS` | Deploy LeaderWorkerSet (needed only for full e2e suite; skip for smoke, benchmarks, or pre-installed clusters) | `false` |
 | `SKIP_CHECKS` | Skip prerequisite checks | `false` |
 | `SCALER_BACKEND` | `prometheus-adapter`, `keda`, or `none` | `prometheus-adapter` |
 

--- a/deploy/install-llmd-infra.sh
+++ b/deploy/install-llmd-infra.sh
@@ -56,8 +56,10 @@ TTFT_AVERAGE_LATENCY_MS=${TTFT_AVERAGE_LATENCY_MS:-200}
 ENABLE_SCALE_TO_ZERO=${ENABLE_SCALE_TO_ZERO:-true}
 
 GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-"istio"}
-# Install Gateway control plane via helmfile when true (default). Set false if your cluster already has one.
-INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-true}"
+# Install Gateway control plane (Istio/kgateway) via helmfile. Only needed for Gateway Mode deployments
+# (inferencepool chart with an external Kubernetes Gateway controller). Standalone Mode (default) bundles
+# its own Envoy proxy and does not require an external gateway controller.
+INSTALL_GATEWAY_CTRLPLANE="${INSTALL_GATEWAY_CTRLPLANE:-false}"
 
 # Model identity and vLLM / ModelService chart tuning (wired into llm-d values or overrides).
 DEFAULT_MODEL_ID=${DEFAULT_MODEL_ID:-"Qwen/Qwen3-0.6B"}

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -64,8 +64,8 @@ KEDA_CHART_VERSION=${KEDA_CHART_VERSION:-2.19.0}
 # On kubernetes: default false (cluster-managed KEDA); kind-emulator flows often set true or use cluster path.
 KEDA_HELM_INSTALL=${KEDA_HELM_INSTALL:-false}
 
-# LeaderWorkerSet (WVA dependency). Set false when LWS is pre-installed or not needed (e.g. some benchmarks).
-DEPLOY_LWS=${DEPLOY_LWS:-true}
+# LeaderWorkerSet. Set true when LWS tests run (e.g. full e2e suite). Defaults false so smoke and benchmarks skip it.
+DEPLOY_LWS=${DEPLOY_LWS:-false}
 LWS_NAMESPACE=${LWS_NAMESPACE:-"lws-system"}
 LWS_CHART_VERSION=${LWS_CHART_VERSION:-"0.8.0"}
 


### PR DESCRIPTION
- External gateway installation turned off by default for v0.7.0 standalone chart matching upstream (the standalone chart bundles Envoy inside the EPP pod)
- Clean up CI cluster dump
- LWS deploy is turned off by default (install as needed with DEPLOY_LWS=true)

Full Kind tests pass locally:
```
[AfterSuite] PASSED [0.095 seconds]
------------------------------

Ran 43 of 53 Specs in 1265.259 seconds
SUCCESS! -- 43 Passed | 0 Failed | 0 Pending | 10 Skipped
--- PASS: TestE2E (1265.26s)
PASS
ok      github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e     1265.932s

==========================================
Test execution completed. Exit code: 0
==========================================
```