### PR TITLE
fix(deploy): per-deployment ClusterRoleBinding to fix concurrent CI RBAC collisions

### DIFF
--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -113,6 +113,10 @@ EOF
         log_warning "Workload-Variant-Autoscaler resources not found or already removed"
     rm -rf "$tmp_overlay"
 
+    # Remove the per-deployment ClusterRoleBinding created for shared-cluster isolation.
+    kubectl delete clusterrolebinding "workload-variant-autoscaler-manager-${WVA_NS}" \
+        --ignore-not-found 2>/dev/null || true
+
     rm -f "$PROM_CA_CERT_PATH"
 
     log_success "WVA uninstalled"

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -109,6 +109,18 @@ PATCH
     kubectl apply -k "$tmp_overlay"
     rm -rf "$tmp_overlay"
 
+    # On shared clusters (e.g. OpenShift CI), concurrent runs produce the same
+    # ClusterRoleBinding name (workload-variant-autoscaler-manager-rolebinding) because
+    # Kustomize uses a fixed namePrefix. Each apply overwrites the subject namespace,
+    # breaking any other run that applied first. Create a per-deployment binding named
+    # after WVA_NS so each run has its own authoritative binding that survives concurrent
+    # applies.
+    log_info "Creating per-deployment ClusterRoleBinding for SA in $WVA_NS (shared cluster isolation)"
+    kubectl create clusterrolebinding "workload-variant-autoscaler-manager-${WVA_NS}" \
+        --clusterrole=workload-variant-autoscaler-manager-role \
+        --serviceaccount="${WVA_NS}:workload-variant-autoscaler-controller-manager" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."
     if kubectl wait --for=condition=Ready pod -l "$WVA_CONTROLLER_LABEL_SELECTOR" -n "$WVA_NS" --timeout=60s; then


### PR DESCRIPTION
This bug was observed running two prs concurrently. Each `kubectl apply -k` overwrites the other's ClusterRoleBinding subject namespace. Whichever applies last wins, the other gets RBAC forbidden on everything (VAs, services, deployments).
```
* cannot list resource "variantautoscalings" in API group "llmd.ai" at the cluster scope
* cannot list resource "services" in API group "" at the cluster scope
* cannot get resource "deployments" in API group "apps" in the namespace "llm-d-inference-scheduler-pr-850-b"
```
This was introduced when we switched from Helm to Kustomize:
- Helm: ClusterRoleBinding named `wva-e2e-<run_id>-manager-rolebinding` - was unique per run
- Kustomize: n`amePrefix: workload-variant-autoscaler- is hardcoded always workload-variant-autoscaler-manager-rolebinding` - one shared name on the cluster