### PR TITLE
fix(deploy): add per-deployment cluster-monitoring-view CRB

### DIFF
--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -113,8 +113,10 @@ EOF
         log_warning "Workload-Variant-Autoscaler resources not found or already removed"
     rm -rf "$tmp_overlay"
 
-    # Remove the per-deployment ClusterRoleBinding created for shared-cluster isolation.
+    # Remove the per-deployment ClusterRoleBindings created for shared-cluster isolation.
     kubectl delete clusterrolebinding "workload-variant-autoscaler-manager-${WVA_NS}" \
+        --ignore-not-found 2>/dev/null || true
+    kubectl delete clusterrolebinding "workload-variant-autoscaler-cluster-monitoring-view-${WVA_NS}" \
         --ignore-not-found 2>/dev/null || true
 
     rm -f "$PROM_CA_CERT_PATH"

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -115,9 +115,13 @@ PATCH
     # breaking any other run that applied first. Create a per-deployment binding named
     # after WVA_NS so each run has its own authoritative binding that survives concurrent
     # applies.
-    log_info "Creating per-deployment ClusterRoleBinding for SA in $WVA_NS (shared cluster isolation)"
+    log_info "Creating per-deployment ClusterRoleBindings for SA in $WVA_NS (shared cluster isolation)"
     kubectl create clusterrolebinding "workload-variant-autoscaler-manager-${WVA_NS}" \
         --clusterrole=workload-variant-autoscaler-manager-role \
+        --serviceaccount="${WVA_NS}:workload-variant-autoscaler-controller-manager" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create clusterrolebinding "workload-variant-autoscaler-cluster-monitoring-view-${WVA_NS}" \
+        --clusterrole=cluster-monitoring-view \
         --serviceaccount="${WVA_NS}:workload-variant-autoscaler-controller-manager" \
         --dry-run=client -o yaml | kubectl apply -f -
 


### PR DESCRIPTION
On shared OpenShift CI clusters, concurrent PR runs overwrite the single `workload-variant-autoscaler-cluster-monitoring-view` ClusterRoleBinding (fixed Kustomize namePrefix), stripping the losing run's SA from the subjects list. The controller then gets 403 from Thanos on all cross-namespace metric queries. This pr creates a per `WVA_NS `binding `cluster-monitoring-view-${WVA_NS}` after each kustomize apply, following the same pattern already used for the manager-rolebinding fix. And it deletes it on undeploy.