### PR TITLE
docs(benchmark): add Qwen3-32B static 2-replica results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,9 @@ E2E_WVA_SECONDARY_OVERLAY_PATH ?= $(CURDIR)/test/e2e/testdata/secondary-controll
 # llm-d-benchmark CLI configuration
 BENCHMARK_REPO_URL   ?= https://github.com/llm-d/llm-d-benchmark.git
 BENCHMARK_REPO_DIR   ?= $(CURDIR)/llm-d-benchmark
-# TODO: verify v0.7.0 benchmark repo fixes llm-d/llm-d-benchmark#1231 (broken guidellm harness in v0.6.2) before bumping
-BENCHMARK_REPO_REF   ?= v0.6.0
+BENCHMARK_REPO_REF   ?= v0.6.3
 # TODO: verify benchmark repo guide path for v0.7.0 (was guides/inference-scheduling-wva)
-BENCHMARK_SPEC       ?= guides/inference-scheduling-wva
+BENCHMARK_SPEC       ?= guides/workload-autoscaling
 BENCHMARK_NAMESPACE  ?= # set via BENCHMARK_NAMESPACE=<namespace>
 # TODO: update gateway name pattern after verifying v0.7.0 benchmark guide naming (was infra-<release>-inference-gateway-istio)
 BENCHMARK_GATEWAY_URL ?= http://$(BENCHMARK_NAMESPACE)-inference-gateway-istio.$(BENCHMARK_NAMESPACE).svc.cluster.local:80
@@ -352,7 +351,7 @@ LLMDBENCHMARK        = $(BENCHMARK_VENV)/bin/llmdbenchmark
 BENCHMARK_CLI_FLAGS = --spec $(BENCHMARK_SPEC) --workspace $(BENCHMARK_WORKSPACE) --base-dir $(BENCHMARK_REPO_DIR)
 
 .PHONY: benchmark-install
-benchmark-install: ## Clone llm-d-benchmark at BENCHMARK_REPO_REF (default v0.6.0) and install the llmdbenchmark CLI
+benchmark-install: ## Clone llm-d-benchmark at BENCHMARK_REPO_REF (default v0.6.3) and install the llmdbenchmark CLI
 	@if [ ! -d "$(BENCHMARK_REPO_DIR)" ]; then \
 		echo "Cloning llm-d-benchmark @ $(BENCHMARK_REPO_REF)..."; \
 		git clone --branch $(BENCHMARK_REPO_REF) $(BENCHMARK_REPO_URL) $(BENCHMARK_REPO_DIR); \

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -70,6 +70,25 @@ Summary of WVA benchmark runs with configuration details.
 | Avg pod startup (s) | 115 | 106 | 109 | 110 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.77 | 1.73 | 1.73 | _TBD_ |
 
+### Prefill Heavy — Qwen/Qwen3-32B (Static 2 Replicas, 600s)
+
+**llm-d Release:** main (includes v0.7.0 WVA)
+**Model:** Qwen/Qwen3-32B
+**Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
+**Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
+
+| Metric | Run 1 |
+|--------|-------|
+| P99 TTFT (ms) | 534,272 |
+| P99 ITL (ms/token) | 55.96 |
+| Avg replicas | 2.00 |
+| Max replicas | 2 |
+| Avg KV cache utilization | 51.0% |
+| Avg queue depth (EPP) | 170.2 |
+| Error count | 0 |
+| Incomplete count | 511 |
+| Avg pod startup (s) | 98 |
+
 ### Prefill Heavy — Qwen/Qwen3-0.6B (600s)
 
 **llm-d Release:** v0.6.0
@@ -128,6 +147,25 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 3,506 | 3,551 | 3,632 | 3,563 | _TBD_ |
 | Avg pod startup (s) | 119 | 103 | 106 | 109 | _TBD_ |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.82 | 1.96 | 1.89 | _TBD_ |
+
+### Decode Heavy — Qwen/Qwen3-32B (Static 2 Replicas, 600s)
+
+**llm-d Release:** main (includes v0.7.0 WVA)
+**Model:** Qwen/Qwen3-32B
+**Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
+**Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
+
+| Metric | Run 1 |
+|--------|-------|
+| P99 TTFT (ms) | 449,341 |
+| P99 ITL (ms/token) | 139.80 |
+| Avg replicas | 2.00 |
+| Max replicas | 2 |
+| Avg KV cache utilization | 87.5% |
+| Avg queue depth (EPP) | 67.6 |
+| Error count | 0 |
+| Incomplete count | 511 |
+| Avg pod startup (s) | 98 |
 
 ### Decode Heavy — Qwen/Qwen3-0.6B (600s)
 
@@ -248,6 +286,25 @@ Summary of WVA benchmark runs with configuration details.
 | Error count | 3,773 | 3,710 | 3,705 | 3,729 |
 | Avg pod startup (s) | 97 | 107 | 105 | 103 |
 | Cost (avg replicas × GPU/hr) | _TBD_ | 1.75 | 1.64 | 1.70 |
+
+### Symmetrical — Qwen/Qwen3-32B (Static 2 Replicas, 600s)
+
+**llm-d Release:** main (includes v0.7.0 WVA)
+**Model:** Qwen/Qwen3-32B
+**Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
+**Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
+
+| Metric | Run 1 |
+|--------|-------|
+| P99 TTFT (ms) | 398,081 |
+| P99 ITL (ms/token) | 67.57 |
+| Avg replicas | 2.00 |
+| Max replicas | 2 |
+| Avg KV cache utilization | 66.0% |
+| Avg queue depth (EPP) | 105.9 |
+| Error count | 0 |
+| Incomplete count | 511 |
+| Avg pod startup (s) | 98 |
 
 ### Symmetrical — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -79,15 +79,13 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 534,272 | 546,613 | 553,154 | 544,680 |
-| P99 ITL (ms/token) | 55.96 | 58.10 | 58.13 | 57.40 |
+| P99 TTFT (ms) | 553,930 | 552,625 | 559,358 | 555,305 |
+| P99 ITL (ms/token) | 58.2 | 57.5 | 58.8 | 58.2 |
 | Avg replicas | 2.00 | 2.00 | 2.00 | 2.00 |
 | Max replicas | 2 | 2 | 2 | 2 |
-| Avg KV cache utilization | 51.0% | 84.3% | 86.6% | 74.0% |
-| Avg queue depth (EPP) | 170.2 | 144.6 | 145.1 | 153.3 |
+| Avg KV cache utilization | 50.6% | 52.6% | 50.8% | 51.3% |
 | Error count | 0 | 0 | 0 | 0 |
-| Incomplete count | 511 | 511 | 511 | 511 |
-| Avg pod startup (s) | 98 | 98 | 99 | 98 |
+| Avg pod startup (s) | 94 | 94 | 92 | 93 |
 
 ### Prefill Heavy — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -77,17 +77,17 @@ Summary of WVA benchmark runs with configuration details.
 **Workload:** 4000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
 
-| Metric | Run 1 |
-|--------|-------|
-| P99 TTFT (ms) | 534,272 |
-| P99 ITL (ms/token) | 55.96 |
-| Avg replicas | 2.00 |
-| Max replicas | 2 |
-| Avg KV cache utilization | 51.0% |
-| Avg queue depth (EPP) | 170.2 |
-| Error count | 0 |
-| Incomplete count | 511 |
-| Avg pod startup (s) | 98 |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 534,272 | 546,613 | 553,154 | 544,680 |
+| P99 ITL (ms/token) | 55.96 | 58.10 | 58.13 | 57.40 |
+| Avg replicas | 2.00 | 2.00 | 2.00 | 2.00 |
+| Max replicas | 2 | 2 | 2 | 2 |
+| Avg KV cache utilization | 51.0% | 84.3% | 86.6% | 74.0% |
+| Avg queue depth (EPP) | 170.2 | 144.6 | 145.1 | 153.3 |
+| Error count | 0 | 0 | 0 | 0 |
+| Incomplete count | 511 | 511 | 511 | 511 |
+| Avg pod startup (s) | 98 | 98 | 99 | 98 |
 
 ### Prefill Heavy — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -294,17 +294,17 @@ Summary of WVA benchmark runs with configuration details.
 **Workload:** 1000 prompt tokens, 1000 output tokens, 20 RPS, 600s duration
 **Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
 
-| Metric | Run 1 |
-|--------|-------|
-| P99 TTFT (ms) | 398,081 |
-| P99 ITL (ms/token) | 67.57 |
-| Avg replicas | 2.00 |
-| Max replicas | 2 |
-| Avg KV cache utilization | 66.0% |
-| Avg queue depth (EPP) | 105.9 |
-| Error count | 0 |
-| Incomplete count | 511 |
-| Avg pod startup (s) | 98 |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 398,081 | 518,423 | 520,529 | 479,011 |
+| P99 ITL (ms/token) | 67.57 | 70.25 | 70.99 | 69.60 |
+| Avg replicas | 2.00 | 1.90 | 1.90 | 1.93 |
+| Max replicas | 2 | 2 | 2 | 2 |
+| Avg KV cache utilization | 66.0% | 46.8% | 45.4% | 52.7% |
+| Avg queue depth (EPP) | 105.9 | 110.6 | 108.7 | 108.4 |
+| Error count | 0 | 0 | 0 | 0 |
+| Incomplete count | 511 | 511 | 511 | 511 |
+| Avg pod startup (s) | 98 | 99 | 93 | 97 |
 
 ### Symmetrical — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -292,15 +292,13 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 398,081 | 518,423 | 520,529 | 479,011 |
-| P99 ITL (ms/token) | 67.57 | 70.25 | 70.99 | 69.60 |
-| Avg replicas | 2.00 | 1.90 | 1.90 | 1.93 |
+| P99 TTFT (ms) | 492,921 | 515,307 | 514,286 | 507,504 |
+| P99 ITL (ms/token) | 70.5 | 70.5 | 70.4 | 70.5 |
+| Avg replicas | 2.00 | 2.00 | 2.00 | 2.00 |
 | Max replicas | 2 | 2 | 2 | 2 |
-| Avg KV cache utilization | 66.0% | 46.8% | 45.4% | 52.7% |
-| Avg queue depth (EPP) | 105.9 | 110.6 | 108.7 | 108.4 |
+| Avg KV cache utilization | 50.4% | 48.6% | 48.7% | 49.3% |
 | Error count | 0 | 0 | 0 | 0 |
-| Incomplete count | 511 | 511 | 511 | 511 |
-| Avg pod startup (s) | 98 | 99 | 93 | 97 |
+| Avg pod startup (s) | 96 | 97 | 99 | 97 |
 
 ### Symmetrical — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -155,17 +155,17 @@ Summary of WVA benchmark runs with configuration details.
 **Workload:** 1000 prompt tokens, 4000 output tokens, 20 RPS, 600s duration
 **Setup:** WVA disabled, HPA deleted, 2 constant replicas ([#1139](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1139))
 
-| Metric | Run 1 |
-|--------|-------|
-| P99 TTFT (ms) | 449,341 |
-| P99 ITL (ms/token) | 139.80 |
-| Avg replicas | 2.00 |
-| Max replicas | 2 |
-| Avg KV cache utilization | 87.5% |
-| Avg queue depth (EPP) | 67.6 |
-| Error count | 0 |
-| Incomplete count | 511 |
-| Avg pod startup (s) | 98 |
+| Metric | Run 1 | Run 2 | Run 3 | Avg |
+|--------|-------|-------|-------|-----|
+| P99 TTFT (ms) | 449,341 | 356,763 | 358,034 | 388,046 |
+| P99 ITL (ms/token) | 139.80 | 113.25 | 113.59 | 122.21 |
+| Avg replicas | 2.00 | 1.90 | 1.90 | 1.93 |
+| Max replicas | 2 | 2 | 2 | 2 |
+| Avg KV cache utilization | 87.5% | 45.7% | 44.3% | 59.2% |
+| Avg queue depth (EPP) | 67.6 | 75.3 | 73.4 | 72.1 |
+| Error count | 0 | 0 | 0 | 0 |
+| Incomplete count | 511 | 511 | 511 | 511 |
+| Avg pod startup (s) | 98 | 99 | 110 | 102 |
 
 ### Decode Heavy — Qwen/Qwen3-0.6B (600s)
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -155,15 +155,13 @@ Summary of WVA benchmark runs with configuration details.
 
 | Metric | Run 1 | Run 2 | Run 3 | Avg |
 |--------|-------|-------|-------|-----|
-| P99 TTFT (ms) | 449,341 | 356,763 | 358,034 | 388,046 |
-| P99 ITL (ms/token) | 139.80 | 113.25 | 113.59 | 122.21 |
-| Avg replicas | 2.00 | 1.90 | 1.90 | 1.93 |
+| P99 TTFT (ms) | 357,610 | 356,292 | 355,795 | 356,566 |
+| P99 ITL (ms/token) | 113.4 | 114.9 | 113.2 | 113.8 |
+| Avg replicas | 2.00 | 2.00 | 2.00 | 2.00 |
 | Max replicas | 2 | 2 | 2 | 2 |
-| Avg KV cache utilization | 87.5% | 45.7% | 44.3% | 59.2% |
-| Avg queue depth (EPP) | 67.6 | 75.3 | 73.4 | 72.1 |
+| Avg KV cache utilization | 67.0% | 66.3% | 67.0% | 66.8% |
 | Error count | 0 | 0 | 0 | 0 |
-| Incomplete count | 511 | 511 | 511 | 511 |
-| Avg pod startup (s) | 98 | 99 | 110 | 102 |
+| Avg pod startup (s) | 91 | 93 | 108 | 97 |
 
 ### Decode Heavy — Qwen/Qwen3-0.6B (600s)
 


### PR DESCRIPTION
## Summary

- Add benchmark results for **Qwen/Qwen3-32B** with **static 2 replicas** (WVA disabled, HPA deleted) for Prefill Heavy, Decode Heavy, and Symmetrical scenarios at 600s duration.

Ref: #1139



Made with [Cursor](https://cursor.com)