### PR TITLE
feat(benchmark): add ShareGPT real-dataset profile for llm-d-benchmark

### DIFF
--- a/test/benchmark/scenarios/sharegpt_inferenceperf.yaml
+++ b/test/benchmark/scenarios/sharegpt_inferenceperf.yaml
@@ -1,0 +1,36 @@
+load:
+  type: constant
+  stages:
+  - rate: 5
+    duration: 300
+  - rate: 10
+    duration: 300
+  - rate: 15
+    duration: 300
+  request_timeout: 300
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: shareGPT
+  input_distribution:
+    min: 10
+    max: 2048
+  output_distribution:
+    min: 10
+    max: 1024
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace


### PR DESCRIPTION
## Summary

- Adds a ShareGPT real-dataset workload profile for benchmarking autoscaling behavior with `llm-d-benchmark`.
- Uses `inference-perf` with its built-in `data.type: shareGPT` — no preprocessing or manual data upload needed.
- Multi-stage load ramp (5 → 10 → 15 RPS) over 15 minutes to observe autoscaling under increasing pressure.

> **Built with [Cursor](https://cursor.com)**

## How to Run

```bash
make benchmark-teardown BENCHMARK_NAMESPACE=<ns> MODEL_ID=Qwen/Qwen3-32B
make benchmark-standup  BENCHMARK_NAMESPACE=<ns> MODEL_ID=Qwen/Qwen3-32B
make benchmark-run BENCHMARK_NAMESPACE=<ns> MODEL_ID=Qwen/Qwen3-32B \
  BENCHMARK_HARNESS=inference-perf BENCHMARK_WORKLOAD=sharegpt_inferenceperf.yaml
```

## Results (Qwen/Qwen3-32B, inference-perf, 3 stages: 5→10→15 RPS, 900s)

| Metric | Value |
|--------|-------|
| P99 TTFT (ms) | 13,225 |
| P99 ITL (ms/token) | 173 |
| Avg replicas | 1→2→3 |
| Max replicas | 3 |
| Avg KV cache utilization | 49.8% |
| Avg queue depth (EPP) | 2 |
| Error count | 0 |
| Total requests | 9,000 |
| Avg pod startup (s) | 108 |



Supersedes #1034
