### PR TITLE
feat: add wva_saturation_metrics_up freshness gauge

### DIFF
--- a/internal/actuator/actuator.go
+++ b/internal/actuator/actuator.go
@@ -112,3 +112,12 @@ func (a *Actuator) RecordSaturationMetrics(ctx context.Context, decision interfa
 		decision.KvCacheTokensCapacity,
 	)
 }
+
+// RecordSaturationFreshness publishes the per-VA freshness signal for the
+// saturation/capacity gauges. fresh=true is set in cycles where the optimizer
+// produced a fresh decision for the variant (i.e. RecordSaturationMetrics was
+// just called); fresh=false is set in cycles where the analyzer was aware of
+// the variant but emitted no fresh decision.
+func (a *Actuator) RecordSaturationFreshness(ctx context.Context, variantName, namespace string, fresh bool) {
+	a.MetricsEmitter.RecordSaturationFreshness(ctx, variantName, namespace, fresh)
+}

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -186,6 +186,17 @@ const (
 	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
 
+	// WVASaturationMetricsUp is a per-VA freshness signal for the five
+	// saturation/capacity gauges above. Set to 1.0 in cycles where the
+	// optimizer produced a fresh decision for the variant (i.e. the other
+	// gauges were just refreshed), and 0.0 in cycles where the analyzer was
+	// aware of the variant but no fresh decision was emitted. Lets
+	// dashboards distinguish "the system says utilization is X" from "the
+	// system has not updated utilization in N minutes and X is the stalest
+	// sample" without relying on Prometheus' 5-minute staleness marker.
+	// Labels: variant_name, namespace
+	WVASaturationMetricsUp = "wva_saturation_metrics_up"
+
 	// WVAPodMappingMissTotal is a counter that tracks pods whose metrics could not be
 	// attributed to a managed scaler (neither the llm-d.ai/variant label nor the
 	// pod locator resolved them). Makes the otherwise-silent skip visible.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1564,15 +1564,25 @@ func (e *Engine) applySaturationDecisions(
 		}
 
 		// Record saturation and capacity metrics when this cycle produced a
-		// fresh decision for the variant. These series carry the accelerator_type
-		// label, so they are emitted only when the type is resolved — otherwise
-		// the internal sentinel would leak into a label. When there is no fresh
-		// decision the existing series persist with their last-recorded values
-		// until Prometheus' staleness marker fires; surfacing freshness on the
-		// dashboard side is tracked in #1082 (an explicit "up" gauge per VA,
-		// rather than deleting series here).
+		// fresh decision for the variant. These accelerator-dimensioned series
+		// carry the accelerator_type label, so they are emitted only when the
+		// type is resolved — otherwise the internal sentinel would leak into a
+		// label. When there is no fresh decision the existing series persist with
+		// their last-recorded values until Prometheus' staleness marker fires.
 		if hasDecision && constants.IsAcceleratorResolved(acceleratorName) {
 			act.RecordSaturationMetrics(ctx, decision)
+		}
+
+		// The wva_saturation_metrics_up freshness gauge carries only
+		// {variant_name, namespace} (no accelerator_type), so it is emitted on
+		// every cycle independent of accelerator resolution: 1.0 when a fresh
+		// decision was produced for the variant, 0.0 otherwise. Dashboards gate
+		// alerts on this gauge instead of relying on Prometheus' 5-minute
+		// implicit staleness marker.
+		if hasDecision {
+			act.RecordSaturationFreshness(ctx, decision.VariantName, decision.Namespace, true)
+		} else {
+			act.RecordSaturationFreshness(ctx, va.Name, va.Namespace, false)
 		}
 
 		// Update Shared State and Trigger Reconcile via Channel.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -71,6 +71,7 @@ var (
 	requiredCapacity      *prometheus.GaugeVec
 	kvCacheTokensUsed     *prometheus.GaugeVec
 	kvCacheTokensCapacity *prometheus.GaugeVec
+	saturationMetricsUp   *prometheus.GaugeVec
 
 	// controllerInstance stores the optional controller instance identifier.
 	// When set, it's added as a label to all emitted metrics.
@@ -111,6 +112,10 @@ func InitMetrics(registry prometheus.Registerer) error {
 	// requiredCapacityLabels: satModelLabels + "unit" to disambiguate V1 (binary 0/1)
 	// vs V2 (continuous token demand) values of the wva_required_capacity gauge.
 	requiredCapacityLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelModelName, constants.LabelUnit}
+	// satFreshnessLabels: smallest cardinality shared across the five
+	// saturation/capacity gauges. Freshness is a per-VA property, so
+	// model_name / accelerator_type / unit don't need to be on this series.
+	satFreshnessLabels := []string{constants.LabelVariantName, constants.LabelNamespace}
 
 	if controllerInstance != "" {
 		baseLabels = append(baseLabels, constants.LabelControllerInstance)
@@ -119,6 +124,7 @@ func InitMetrics(registry prometheus.Registerer) error {
 		satAccelLabels = append(satAccelLabels, constants.LabelControllerInstance)
 		satModelLabels = append(satModelLabels, constants.LabelControllerInstance)
 		requiredCapacityLabels = append(requiredCapacityLabels, constants.LabelControllerInstance)
+		satFreshnessLabels = append(satFreshnessLabels, constants.LabelControllerInstance)
 	}
 
 	replicaScalingTotal = prometheus.NewCounterVec(
@@ -190,6 +196,13 @@ func InitMetrics(registry prometheus.Registerer) error {
 			Help: "Total KV cache token capacity across all replicas of a variant (sum of vLLM TotalKvCapacityTokens).",
 		},
 		satModelLabels,
+	)
+	saturationMetricsUp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: constants.WVASaturationMetricsUp,
+			Help: "Per-VA freshness signal for the saturation/capacity gauges: 1.0 in cycles where the optimizer produced a fresh decision for the variant, 0.0 in cycles where the analyzer was aware of the variant but did not refresh those gauges. Pairs with wva_saturation_utilization, wva_spare_capacity, wva_required_capacity, wva_kv_cache_tokens_used, and wva_kv_cache_tokens_capacity so dashboards can gate alerts on this gauge instead of relying on Prometheus' implicit staleness marker.",
+		},
+		satFreshnessLabels,
 	)
 
 	optimizationDurationLabels := []string{constants.LabelStatus}
@@ -440,6 +453,9 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(kvCacheTokensCapacity); err != nil {
 		return fmt.Errorf("failed to register kvCacheTokensCapacity metric: %w", err)
+	}
+	if err := registry.Register(saturationMetricsUp); err != nil {
+		return fmt.Errorf("failed to register saturationMetricsUp metric: %w", err)
 	}
 
 	return nil
@@ -852,4 +868,37 @@ func (m *MetricsEmitter) RecordSaturationMetrics(
 	requiredCapacity.With(requiredLabels).Set(required)
 	kvCacheTokensUsed.With(modelLabels).Set(float64(kvTokensUsed))
 	kvCacheTokensCapacity.With(modelLabels).Set(float64(kvTokensCapacity))
+}
+
+// RecordSaturationFreshness publishes the per-VA freshness signal for the
+// five saturation/capacity gauges recorded by RecordSaturationMetrics.
+//
+// fresh=true means the optimizer just produced a fresh decision for the
+// variant this cycle (the other gauges have just been refreshed). fresh=false
+// means the analyzer was aware of the variant but did not refresh those
+// gauges this cycle, so dashboards see an explicit "stale" signal rather
+// than relying on Prometheus' 5-minute implicit staleness marker.
+//
+// Unlike RecordSaturationMetrics, this method runs on every variant every
+// cycle (not gated on hasDecision), so it must tolerate tests that haven't
+// called InitMetrics — nil-guarded the same way as SetMetricsFreshnessStatus.
+// In production InitMetrics runs at startup from main.go and the guard is a
+// no-op fast path.
+func (m *MetricsEmitter) RecordSaturationFreshness(ctx context.Context, variantName, namespace string, fresh bool) {
+	if saturationMetricsUp == nil {
+		return
+	}
+	labels := prometheus.Labels{
+		constants.LabelVariantName: variantName,
+		constants.LabelNamespace:   namespace,
+	}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+
+	value := 0.0
+	if fresh {
+		value = 1.0
+	}
+	saturationMetricsUp.With(labels).Set(value)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -161,6 +161,7 @@ func resetMetrics() {
 	requiredCapacity = nil
 	kvCacheTokensUsed = nil
 	kvCacheTokensCapacity = nil
+	saturationMetricsUp = nil
 	controllerInstance = ""
 	replicaSeriesMu.Lock()
 	replicaSeriesAccel = map[string]string{}
@@ -483,4 +484,103 @@ var _ = Describe("EmitReplicaScalingMetrics", func() {
 		Expect(counterValue).To(Equal(1.0), "counter should be incremented to 1")
 	})
 
+})
+
+var _ = Describe("RecordSaturationFreshness", func() {
+	var (
+		registry *prometheus.Registry
+		emitter  *MetricsEmitter
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		resetMetrics()
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter = NewMetricsEmitter()
+		ctx = context.Background()
+	})
+
+	It("emits 1.0 on a fresh cycle and 0.0 on a stale cycle", func() {
+		emitter.RecordSaturationFreshness(ctx, "variant-fresh", "ns-a", true)
+		emitter.RecordSaturationFreshness(ctx, "variant-stale", "ns-a", false)
+
+		mf := gatherMetric(registry, constants.WVASaturationMetricsUp)
+		Expect(mf).NotTo(BeNil(), "wva_saturation_metrics_up not registered")
+
+		freshLabels := map[string]string{
+			constants.LabelVariantName: "variant-fresh",
+			constants.LabelNamespace:   "ns-a",
+		}
+		val, ok := gaugeValue(mf, freshLabels)
+		Expect(ok).To(BeTrue(), "fresh series not found")
+		Expect(val).To(Equal(1.0))
+
+		staleLabels := map[string]string{
+			constants.LabelVariantName: "variant-stale",
+			constants.LabelNamespace:   "ns-a",
+		}
+		val, ok = gaugeValue(mf, staleLabels)
+		Expect(ok).To(BeTrue(), "stale series not found")
+		Expect(val).To(Equal(0.0))
+	})
+
+	It("flips an existing series between fresh and stale on subsequent cycles", func() {
+		// Cycle 1: fresh.
+		emitter.RecordSaturationFreshness(ctx, "variant-a", "ns-a", true)
+		mf := gatherMetric(registry, constants.WVASaturationMetricsUp)
+		labels := map[string]string{
+			constants.LabelVariantName: "variant-a",
+			constants.LabelNamespace:   "ns-a",
+		}
+		val, _ := gaugeValue(mf, labels)
+		Expect(val).To(Equal(1.0))
+
+		// Cycle 2: same VA, no fresh decision — the gauge must drop to 0,
+		// not retain its previous 1.0 value (that's the whole point of the
+		// freshness signal vs. relying on Prometheus' implicit staleness).
+		emitter.RecordSaturationFreshness(ctx, "variant-a", "ns-a", false)
+		mf = gatherMetric(registry, constants.WVASaturationMetricsUp)
+		val, _ = gaugeValue(mf, labels)
+		Expect(val).To(Equal(0.0))
+	})
+
+	It("uses only {variant_name, namespace} labels — no accelerator_type or model_name", func() {
+		emitter.RecordSaturationFreshness(ctx, "variant-a", "ns-a", true)
+
+		mf := gatherMetric(registry, constants.WVASaturationMetricsUp)
+		Expect(mf).NotTo(BeNil())
+		Expect(mf.GetMetric()).To(HaveLen(1))
+
+		wantLabels := map[string]bool{
+			constants.LabelVariantName: true,
+			constants.LabelNamespace:   true,
+		}
+		for _, lp := range mf.GetMetric()[0].GetLabel() {
+			Expect(wantLabels).To(HaveKey(lp.GetName()),
+				"unexpected label %q on freshness gauge (must be the smallest cardinality shared across the five saturation gauges)", lp.GetName())
+		}
+		Expect(mf.GetMetric()[0].GetLabel()).To(HaveLen(len(wantLabels)))
+	})
+
+	It("adds controller_instance label when CONTROLLER_INSTANCE is set", func() {
+		resetMetrics()
+		t := GinkgoT()
+		t.Setenv(ControllerInstanceEnvVar, "primary")
+		registry := prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter := NewMetricsEmitter()
+
+		emitter.RecordSaturationFreshness(ctx, "variant-a", "ns-a", true)
+
+		mf := gatherMetric(registry, constants.WVASaturationMetricsUp)
+		Expect(mf).NotTo(BeNil())
+		val, ok := gaugeValue(mf, map[string]string{
+			constants.LabelVariantName:        "variant-a",
+			constants.LabelNamespace:          "ns-a",
+			constants.LabelControllerInstance: "primary",
+		})
+		Expect(ok).To(BeTrue(), "controller_instance label not on series")
+		Expect(val).To(Equal(1.0))
+	})
 })


### PR DESCRIPTION
## Summary

Add `wva_saturation_metrics_up{variant_name, namespace}` — a per-VA freshness signal for the five PR #933 saturation/capacity gauges so dashboards and alerts can distinguish *"the system says utilization is 0.42"* from *"the analyzer was aware of this VA last cycle but produced no fresh decision so 0.42 is the stalest sample"* without relying on Prometheus' 5-minute implicit staleness marker.

Closes #1082.

## Change

In `applySaturationDecisions`, both branches of the `hasDecision` switch now emit the freshness gauge:

```go
if hasDecision {
    act.RecordSaturationMetrics(ctx, decision)
    act.RecordSaturationFreshness(ctx, decision.VariantName, decision.Namespace, true)
} else {
    act.RecordSaturationFreshness(ctx, va.Name, va.Namespace, false)
}
```

The existing TODO comment in `applySaturationDecisions` (which named #1082 as the tracker) is rewritten to describe the implemented behaviour.

- **Constant** in `internal/constants/metrics.go`: `WVASaturationMetricsUp = "wva_saturation_metrics_up"`.
- **Gauge registration** in `internal/metrics/metrics.go`: declared, initialized, registered alongside the other PR #933 gauges. Label set is the smallest cardinality common subset (`variant_name`, `namespace` + optional `controller_instance`); see *Label set rationale* below.
- **Emitter** `MetricsEmitter.RecordSaturationFreshness` in the same file.
- **Actuator wrapper** mirrors the existing `Actuator.RecordSaturationMetrics` style.

## Scope: per-VA, not controller-wide

This gauge is intentionally scoped to **per-VA staleness only**: did the analyzer process this specific variant in the most recent cycle? Controller-wide failures (`optimize()` returning before `applySaturationDecisions`, e.g. `ActiveVariantAutoscaling` errors, limited-mode inventory collection failures) are already observable via the existing `wva_optimization_duration_seconds{status="error"}` histogram. Conflating the two into one gauge would mean either:

- clearing the freshness gauge at the start of each cycle (introduces a scrape race — a healthy controller mid-cycle looks `absent()` if Prometheus scrapes between the reset and the re-emission); or
- bookkeeping a "seen variants" set and explicitly stale-marking on failure (worth its own design discussion if maintainers want it).

Keeping the gauge per-VA matches the issue body's intent (*"Setting to 1.0 whenever RecordSaturationMetrics is called … Setting to 0.0 for variants the analyzer is aware of but did not produce a fresh decision for in this cycle"*) and leaves controller-wide health to the metric already designed for it.

Recommended alert pattern:

```
# Per-VA staleness — the gauge this PR adds:
wva_saturation_metrics_up == 0

# Controller-wide failure — existing metric:
increase(wva_optimization_duration_seconds_count{status="error"}[5m]) > 0
```

## Label set rationale

`{variant_name, namespace}` — the smallest cardinality common subset across the five gauges this is meant to guard. Per the issue body:

> The `accelerator_type` and `analyzer_version` labels on individual gauges are not needed for freshness — **staleness is a per-VA property, not per-label-permutation**.

This also keeps cardinality cheap (2 labels, +1 if `CONTROLLER_INSTANCE` is set) so the gauge is safe at thousands of VAs.

One consequence worth naming explicitly: if a variant changes accelerator or analyzer mode mid-life, the *previous* `wva_saturation_utilization{accelerator_type="A100"}` series stays in Prometheus until the implicit staleness marker fires, and the freshness gauge cannot mark it stale because freshness has no `accelerator_type` label. That's a **series-retirement** concern, not a **label-alignment** concern — the right tool is the sibling `DeleteSaturationMetrics` work (per `issue-wire-delete-saturation-metrics.md` referenced in the issue) which will remove retired series at VA-deletion / label-change time. Expanding the freshness labels to mirror the saturation gauges would multiply cardinality and still wouldn't help with retired series (we don't emit freshness for the old labelset either).

## Scope explicitly NOT in this PR

Per-VA deletion of the gauge series on VA deletion is **not** wired up here. The five existing PR #933 gauges have the same leak-on-VA-deletion behaviour today; the sibling delete-metrics work referenced in the issue will introduce `DeleteSaturationMetrics` and handle all six series at once. If maintainers prefer that I bundle it into this PR, happy to expand scope — let me know.

## Tests

`internal/metrics/metrics_test.go` gains a new `Describe("RecordSaturationFreshness", …)` block covering:

- Fresh (`1.0`) and stale (`0.0`) emission for two distinct VAs.
- Fresh → stale transition on the same series (the whole point of the gauge: the value must drop to `0.0` on a stale cycle, not retain the previous `1.0`).
- Label-set minimality — only `{variant_name, namespace}` appear on the series; the test will fail loud if anyone adds a label by accident.
- `controller_instance` label injection when `CONTROLLER_INSTANCE` is set.

`resetMetrics` is updated to clear the new var so test isolation holds.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./internal/...` (all packages green, including envtest-backed saturation suites)

## Notes for reviewers

- Naming follows Prometheus' `up`-style convention. The issue lists alternatives (`wva_variant_metrics_fresh`, `wva_saturation_freshness`); happy to change if there's a project convention I missed.
- Scope is the five PR #933 gauges. If this freshness pattern proves useful, generalising to `wva_desired_replicas` etc. is a clean follow-up.
