### PR TITLE
fix(collector): drop model_name filter from cache_config_info query

### DIFF
--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -53,11 +53,20 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	// Uses max to deduplicate when multiple series exist per instance with different label combinations
 	// Used by Saturation Analyzer V2 for token capacity computation
 	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), llm_d_ai_variant (for direct pod-to-VA mapping), and config labels
+	//
+	// NOTE: vllm:cache_config_info is an info-style metric. Unlike vLLM's regular
+	// gauges/counters, it is NOT labeled with model_name — its label set is derived
+	// from CacheConfig fields (num_gpu_blocks, block_size, cache_dtype, ...) plus
+	// "engine". Filtering it by model_name would match nothing, so it is queried
+	// namespace-wide and the collector correlates the results to this model's pods
+	// by instance key (see CollectReplicaMetrics, which attaches cache config only
+	// to instances already discovered by the model-scoped KV/queue queries).
+	// Do not add a model_name matcher here.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryCacheConfigInfo,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
-		Params:      []string{source.ParamNamespace, source.ParamModelID},
+		Template:    `max by (instance, pod, llm_d_ai_variant, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}"})`,
+		Params:      []string{source.ParamNamespace},
 		Description: "KV cache configuration info per instance (num_gpu_blocks and block_size as labels)",
 	})
 

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -329,42 +329,49 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	}
 
 	// Process cache config info results (V2)
+	//
+	// vllm:cache_config_info has no model_name label (see QueryCacheConfigInfo),
+	// so it is queried namespace-wide and may include pods of other models in the
+	// same namespace. Attach cache config only to instances already discovered by
+	// the model-scoped KV/queue queries above; skip unknown instances so foreign
+	// pods are not introduced into this model's metrics (and do not inflate the
+	// discovered-pods / freshness counters).
 	if result := results[registration.QueryCacheConfigInfo]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName, _ := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
 
-				if podData[instanceKey] == nil {
-					podData[instanceKey] = &podMetricData{
-						podName: podName,
-						vaName:  vaName,
-					}
+				data := podData[instanceKey]
+				if data == nil {
+					// Instance not seen by the model-scoped queries: it belongs to a
+					// different model (or lacks KV/queue metrics) — not one of ours.
+					continue
 				}
 
 				// Parse num_gpu_blocks and block_size from string labels
 				if blocksStr, ok := value.Labels["num_gpu_blocks"]; ok && blocksStr != "" {
 					if blocks, err := strconv.ParseInt(blocksStr, 10, 64); err == nil {
-						podData[instanceKey].numGpuBlocks = blocks
+						data.numGpuBlocks = blocks
 					}
 				}
 				if sizeStr, ok := value.Labels["block_size"]; ok && sizeStr != "" {
 					if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
-						podData[instanceKey].blockSize = size
+						data.blockSize = size
 					}
 				}
-				if podData[instanceKey].numGpuBlocks > 0 && podData[instanceKey].blockSize > 0 {
-					podData[instanceKey].hasCacheConfig = true
-					podData[instanceKey].cacheConfigTimestamp = value.Timestamp
+				if data.numGpuBlocks > 0 && data.blockSize > 0 {
+					data.hasCacheConfig = true
+					data.cacheConfigTimestamp = value.Timestamp
 				}
 
 				logger.V(logging.DEBUG).Info("Cache config info metric",
 					"instanceKey", instanceKey,
 					"pod", podName,
-					"numGpuBlocks", podData[instanceKey].numGpuBlocks,
-					"blockSize", podData[instanceKey].blockSize)
+					"numGpuBlocks", data.numGpuBlocks,
+					"blockSize", data.blockSize)
 			}
 		}
 	}

--- a/test/e2e/saturation_v2_test.go
+++ b/test/e2e/saturation_v2_test.go
@@ -18,7 +18,7 @@ import (
 
 // V2 smoke calibration via the simulator's --fake-metrics flag.
 //
-// kv-cache-usage = 0.4 is the operating point that deterministically exercises
+// kv-cache-usage = 0.3 is the operating point that deterministically exercises
 // both arcs of the V2 cost-aware optimizer with the suite's chosen thresholds:
 //
 //   - At 1 replica with scaleUpThreshold = 0.30, replicaDemand crosses the
@@ -38,7 +38,7 @@ import (
 // --fake-metrics format:
 //
 //	https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/configuration.md
-const v2SmokeFakeMetricsJSON = `{"kv-cache-usage":0.4,"running-requests":1,"waiting-requests":0}`
+const v2SmokeFakeMetricsJSON = `{"kv-cache-usage":0.3,"running-requests":1,"waiting-requests":0}`
 
 // V2 saturation config knobs. The kvCacheThreshold / queueLength* /
 // *SpareTrigger fields are V1-specific and have no effect on the V2
@@ -225,7 +225,7 @@ var _ = Describe("Saturation V2 engine", Label("smoke", "full"), Ordered, func()
 	// recommends a smaller target. Uses canonical-ordering thresholds
 	// (scaleUpThreshold > scaleDownBoundary):
 	//
-	//   scaleUpThreshold  = 0.95 (high, so kv=0.4 demand does not trigger scale-up)
+	//   scaleUpThreshold  = 0.95 (high, so kv=0.3 demand does not trigger scale-up)
 	//   scaleDownBoundary = 0.85 (chosen so spareCapacity at 2 replicas exceeds
 	//                             one full per-replica capacity — see calibration
 	//                             comment on v2SmokeFakeMetricsJSON for the math)


### PR DESCRIPTION
vllm:cache_config_info is an info-style metric. Its label set is derived from CacheConfig fields (num_gpu_blocks, block_size, cache_dtype, ...) plus the "engine" label — it does NOT carry model_name like vLLM's regular gauges and counters. Filtering it by model_name returns zero rows, which silently forces the saturation V2 analyzer into computeReplicaCapacityFallback (per-step batch budget × kvCacheThreshold ≈ 6.5K tokens/pod for typical vLLM defaults). For Llama-3.1-8B on H100 this under-states real KV memory capacity (~412K tokens/pod, k1 = blocks × block_size) by ~50×, causing runaway scale-up.

Drop the model_name matcher from the QueryCacheConfigInfo template and the corresponding ParamModelID from its Params list. The query is now scoped only by namespace; the collector already correlates the results to the active model's pods by instance key (the kv_cache_usage and queue_length queries remain model-scoped and discover the relevant instance set).

Add a NOTE comment on the query template documenting the rationale so a model_name filter doesn't get re-added by reflex.

Verified end-to-end: with the fix, totalSupply jumps from 13,106 (fallback) to 659,148 (real KV × kvCacheThreshold for 2 H100s) on a benchmark run that previously over-provisioned both variants to maxReplicas=10.