### PR TITLE
feat: always run full e2e test on main repo PR

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -201,6 +201,14 @@ jobs:
               }
             }
 
+            // Same-repo pull_request: always run full tests
+            if (context.eventName === 'pull_request') {
+              const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+              const headRepo = context.payload.pull_request.head.repo?.full_name ?? baseRepo;
+              core.setOutput('run_full', headRepo === baseRepo ? 'true' : 'false');
+              return;
+            }
+
             // Check workflow_dispatch input
             const workflowInput = '${{ github.event.inputs.run_full_tests }}';
             // Handle both boolean and string inputs
@@ -334,7 +342,7 @@ jobs:
         run: |
           make test-e2e-smoke-with-setup
 
-  # Full Kind E2E - runs only when triggered (/ok-to-test or workflow_dispatch with run_full_tests).
+  # Full Kind E2E - runs on same-repo pull_request events, /ok-to-test comments, or workflow_dispatch.
   # Add "e2e-tests-full" as a required status check in branch protection so it appears on every PR
   # and must run and pass before merge (shows as "Expected" until triggered).
   e2e-tests-full:
@@ -342,7 +350,9 @@ jobs:
     needs: [lint-and-test, check-code-changes, check-full-tests]
     if: >-
       always() && needs.check-full-tests.outputs.run_full == 'true' && needs.check-code-changes.result == 'success'
-      && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')
+      && needs.lint-and-test.result != 'failure'
+      && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
+          || github.event_name == 'pull_request')
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

For `issue_comment` events (the `/ok-to-test` trigger), GitHub Actions always loads the workflow file from the **default branch** — not from the PR branch. This is a GitHub security constraint that applies even for same-repo (non-fork) PRs.

This caused two issues:
1. Script paths in the checked-out PR code could diverge from paths referenced in the main-branch workflow (e.g. after #1196 renamed `deploy/ci-pr-checks/` → `deploy/ci/prchecks/`), breaking runs silently.
2. The PR head SHA captured at comment time could be stale if the branch was force-pushed before the run completed.

## Solution

For same-repo `pull_request` events, the workflow file is loaded from the PR branch itself, so script paths always match. Run the full Kind E2E suite automatically on every same-repo PR push, without requiring `/ok-to-test`.

Fork PRs are unchanged — they still require `/ok-to-test` from a maintainer.

## Changes

**`.github/workflows/ci-pr-checks.yaml`**

- `check-full-tests` job: added an early-return branch for `pull_request` events that outputs `run_full: true` for same-repo branches and `false` for forks.
- `e2e-tests-full` job condition: added `pull_request` to the allowed event names; added `needs.lint-and-test.result != 'failure'` guard so full E2E is skipped when lint/unit tests fail.

## Test plan

- [ ] Push a commit to a same-repo PR branch → `e2e-tests-full` runs automatically without `/ok-to-test`
- [ ] Fork PR still requires `/ok-to-test` to trigger full E2E
- [ ] Lint/test failure on a same-repo PR skips full E2E