### PR TITLE
feat(config): add namespace-scoped/kubernetes overlay (1/4)

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -171,6 +171,9 @@ jobs:
       - name: Build openshift overlay
         run: bin/kustomize build config/overlays/namespace-scoped/openshift > /dev/null
 
+      - name: Build namespace-scoped kubernetes overlay
+        run: bin/kustomize build config/overlays/namespace-scoped/kubernetes > /dev/null
+
   # Check if full e2e tests should run (via workflow_dispatch or comment trigger)
   check-full-tests:
     runs-on: ubuntu-latest

--- a/config/overlays/namespace-scoped/kubernetes/kustomization.yaml
+++ b/config/overlays/namespace-scoped/kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: wva-system
+
+namePrefix: wva-
+
+resources:
+- ../../../base/
+
+components:
+- ../../../components/namespace-scoped/


### PR DESCRIPTION
## Summary
- Adds `config/overlays/namespace-scoped/kubernetes/kustomization.yaml`, mirroring the existing `namespace-scoped/openshift` overlay without OpenShift-specific patches (Thanos querier, Service-CA, user-workload-monitoring binding).
- Wires the new overlay into the `kustomize-build` CI check in `.github/workflows/ci-pr-checks.yaml`.

This is **PR 1 of 4** for #1205. Subsequent PRs will:
- PR 2: extract dual-controller test into its own file, repoint `testdata/secondary-controller` to this overlay, add `test-e2e-multi-controller[-with-setup]` Make targets.
- PR 3: stub `ci-e2e-multi-controller.yaml` workflow so branch-protection can reference the job name.
- PR 4: wire the full implementation into the workflow and remove the RBAC patch-and-restore workarounds.

## Test plan
- [x] `bin/kustomize build config/overlays/namespace-scoped/kubernetes` succeeds locally
- [x] Output contains the expected `RoleBinding`s from the namespace-scoped component (no shared `ClusterRoleBinding` collisions when used alongside the cluster-scoped overlay)
- [ ] CI `kustomize-build` job passes

Refs #1205