### PR TITLE
engines/saturation: multi-analyzer registry

### DIFF
--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -117,19 +117,19 @@ Pre-registered:
 External analyzers are registered from `cmd/main.go` via:
 
 ```go
-engine.RegisterAnalyzer(name string, a interfaces.Analyzer)
+engine.MustRegisterAnalyzer(name string, a interfaces.Analyzer)
 ```
 
-`RegisterAnalyzer` appends to the registry. Registration order defines
+`MustRegisterAnalyzer` appends to the registry. Registration order defines
 processing order in the engine loop and should match the operator's
 `analyzers:` config order.
 
 Re-registering an existing name **panics** — the registry is not a
 hot-swap mechanism, and a duplicate registration is a programmer error
 (typically a wiring mistake in `cmd/main.go`). The panic message is
-`RegisterAnalyzer: duplicate analyzer name "<name>"`.
+`MustRegisterAnalyzer: duplicate analyzer name "<name>"`.
 
-`RegisterAnalyzer` must be called before `StartOptimizeLoop`.
+`MustRegisterAnalyzer` must be called before `StartOptimizeLoop`.
 
 ### Configuring Analyzers
 
@@ -154,7 +154,7 @@ When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]
 
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
-| `name` | string | Analyzer name (must match a `RegisterAnalyzer` call) | required |
+| `name` | string | Analyzer name (must match a `MustRegisterAnalyzer` call) | required |
 | `enabled` | bool | Reserved — placeholder for future combine logic | `true` |
 | `score` | float64 | Reserved — placeholder for future combine logic | `1.0` |
 | `scaleUpThreshold` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleUpThreshold` |
@@ -702,7 +702,7 @@ type SaturationScalingConfig struct {
 }
 
 // AnalyzerScoreConfig configures one analyzer in the multi-analyzer pipeline.
-// On this branch, only `Name` is consumed (it must match a RegisterAnalyzer
+// On this branch, only `Name` is consumed (it must match a MustRegisterAnalyzer
 // call); `Enabled`, `Score`, and the per-analyzer threshold overrides are
 // reserved for follow-up PRs.
 type AnalyzerScoreConfig struct {

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -117,19 +117,18 @@ Pre-registered:
 External analyzers are registered from `cmd/main.go` via:
 
 ```go
-engine.MustRegisterAnalyzer(name string, a interfaces.Analyzer)
+if err := engine.RegisterAnalyzer(name, analyzer); err != nil {
+    // handle: duplicate name or called after StartOptimizeLoop
+}
 ```
 
-`MustRegisterAnalyzer` appends to the registry. Registration order defines
-processing order in the engine loop and should match the operator's
-`analyzers:` config order.
+`RegisterAnalyzer` appends to the registry and returns an `error` for
+two misuse conditions: calling it after `StartOptimizeLoop` or
+re-registering an existing name. Callers must check the error. Registration
+order defines processing order in the engine loop and should match the
+operator's `analyzers:` config order.
 
-Re-registering an existing name **panics** — the registry is not a
-hot-swap mechanism, and a duplicate registration is a programmer error
-(typically a wiring mistake in `cmd/main.go`). The panic message is
-`MustRegisterAnalyzer: duplicate analyzer name "<name>"`.
-
-`MustRegisterAnalyzer` must be called before `StartOptimizeLoop`.
+`RegisterAnalyzer` must be called before `StartOptimizeLoop`.
 
 ### Configuring Analyzers
 
@@ -154,7 +153,7 @@ When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]
 
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
-| `name` | string | Analyzer name (must match a `MustRegisterAnalyzer` call) | required |
+| `name` | string | Analyzer name (must match a `RegisterAnalyzer` call) | required |
 | `enabled` | bool | Reserved — placeholder for future combine logic | `true` |
 | `score` | float64 | Reserved — placeholder for future combine logic | `1.0` |
 | `scaleUpThreshold` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleUpThreshold` |
@@ -702,7 +701,7 @@ type SaturationScalingConfig struct {
 }
 
 // AnalyzerScoreConfig configures one analyzer in the multi-analyzer pipeline.
-// On this branch, only `Name` is consumed (it must match a MustRegisterAnalyzer
+// On this branch, only `Name` is consumed (it must match a RegisterAnalyzer
 // call); `Enabled`, `Score`, and the per-analyzer threshold overrides are
 // reserved for follow-up PRs.
 type AnalyzerScoreConfig struct {

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -28,6 +28,18 @@ The saturation scaling configuration is stored in a ConfigMap named `wva-saturat
 | `kvSpareTrigger` | float64 | Scale-up signal if average spare KV capacity < trigger (0.0-1.0) | 0.10 |
 | `queueSpareTrigger` | float64 | Scale-up signal if average spare queue capacity < trigger | 3 |
 
+### V2 Analyzer Parameters
+
+These parameters apply when `analyzerName: "saturation"` is set or when the `analyzers:` list is populated.
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `analyzerName` | string | Selects the V2 token-based analyzer: set to `"saturation"`. Empty string uses V1. | `""` |
+| `priority` | float64 | Multiplier for this model's scaling urgency in fair-share GPU allocation | 1.0 |
+| `analyzers` | list | Multi-analyzer pipeline registration — see [Multi-Analyzer Registration](#multi-analyzer-registration) | `[{name: "saturation", score: 1.0}]` |
+
+> `scaleUpThreshold` and `scaleDownBoundary` are honored only for saturation on this branch; see the `multi-analyzer-threshold` PR for the universal post-step that calibrates RC/SC across all analyzers.
+
 ### Default Configuration
 
 The recommended values for the V1 (percentage-based) saturation analyzer are:
@@ -77,6 +89,91 @@ The saturation analyzer uses a **spare capacity model** to determine when to sca
 This proactive approach ensures adequate headroom and prevents request drops by scaling before saturation occurs.
 
 **For detailed implementation, see:** [Saturation Analyzer Documentation](user-guide/saturation-analyzer.md)
+
+## Multi-Analyzer Registration
+
+The V2 engine carries an analyzer registry so external analyzers (e.g.
+throughput, SLO) can be plugged in without the engine package knowing the
+concrete type. Each cycle the engine iterates every registered analyzer in
+registration order and invokes its `Analyze` method.
+
+> **Scope on this branch.** Saturation drives every scaling decision on
+> its own. Non-saturation analyzers are registered and invoked, but their
+> results are **not yet consumed** — combine semantics, per-analyzer score
+> consumption, and per-analyzer threshold application land in follow-up
+> PRs (`multi-analyzer-optimizer`, `multi-analyzer-threshold`). The hooks
+> below are wired so those follow-ups can hang their behavior off them
+> without further engine changes. When those PRs land, this section will
+> be refactored into a generic multi-analyzer guide.
+
+### Registering Analyzers
+
+Pre-registered:
+
+- The V2 saturation analyzer is pre-registered by `NewEngine` under
+  `interfaces.SaturationAnalyzerName`. It always runs and drives the
+  optimizer.
+
+External analyzers are registered from `cmd/main.go` via:
+
+```go
+engine.RegisterAnalyzer(name string, a interfaces.Analyzer)
+```
+
+`RegisterAnalyzer` appends to the registry. Registration order defines
+processing order in the engine loop and should match the operator's
+`analyzers:` config order.
+
+Re-registering an existing name **panics** — the registry is not a
+hot-swap mechanism, and a duplicate registration is a programmer error
+(typically a wiring mistake in `cmd/main.go`). The panic message is
+`RegisterAnalyzer: duplicate analyzer name "<name>"`.
+
+`RegisterAnalyzer` must be called before `StartOptimizeLoop`.
+
+### Configuring Analyzers
+
+The `analyzers:` list shapes the configuration for the registered analyzers:
+
+```yaml
+analyzerName: saturation
+scaleUpThreshold: 0.85
+scaleDownBoundary: 0.70
+analyzers:
+  - name: saturation
+    score: 1.0
+  - name: throughput
+    score: 1.0
+    # scaleUpThreshold: 0.90    # reserved for multi-analyzer-threshold PR
+    # scaleDownBoundary: 0.75   # reserved for multi-analyzer-threshold PR
+```
+
+When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]`.
+
+### AnalyzerScoreConfig Fields
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `name` | string | Analyzer name (must match a `RegisterAnalyzer` call) | required |
+| `enabled` | bool | Reserved — placeholder for future combine logic | `true` |
+| `score` | float64 | Reserved — placeholder for future combine logic | `1.0` |
+| `scaleUpThreshold` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleUpThreshold` |
+| `scaleDownBoundary` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleDownBoundary` |
+
+### Saturation Always Runs
+
+The saturation analyzer executes on every cycle regardless of any future
+`enabled` flag — its `VariantCapacities` carry `Cost` and `AcceleratorName`
+required by the optimizer for variant selection and GPU accounting. On
+this branch saturation's `RequiredCapacity` and `SpareCapacity` are the
+only signals the optimizer consumes.
+
+### Resilience
+
+Each registered non-saturation analyzer runs in isolation: errors are
+logged and discarded, and panics are recovered. A faulty plugin analyzer
+cannot take down the optimize goroutine or block saturation from driving
+the scaling decision.
 
 ## Best Practices: Coordinating with InferenceScheduler (End Point Picker)
 
@@ -590,19 +687,36 @@ kubectl describe cm wva-saturation-scaling-config -n <workload-variant-autoscale
 **SaturationScalingConfig** (defined in `internal/config/saturation_scaling.go`):
 ```go
 type SaturationScalingConfig struct {
-    ModelID              string  `yaml:"model_id,omitempty"`
-    Namespace            string  `yaml:"namespace,omitempty"`
-    KvCacheThreshold     float64 `yaml:"kvCacheThreshold"`
-    QueueLengthThreshold float64 `yaml:"queueLengthThreshold"`
-    KvSpareTrigger       float64 `yaml:"kvSpareTrigger"`
-    QueueSpareTrigger    float64 `yaml:"queueSpareTrigger"`
-    // ... additional V2-specific fields omitted
+    ModelID              string                `yaml:"model_id,omitempty"`
+    Namespace            string                `yaml:"namespace,omitempty"`
+    KvCacheThreshold     float64               `yaml:"kvCacheThreshold"`
+    QueueLengthThreshold float64               `yaml:"queueLengthThreshold"`
+    KvSpareTrigger       float64               `yaml:"kvSpareTrigger"`
+    QueueSpareTrigger    float64               `yaml:"queueSpareTrigger"`
+    EnableLimiter        bool                  `yaml:"enableLimiter,omitempty"`
+    AnalyzerName         string                `yaml:"analyzerName,omitempty"`
+    ScaleUpThreshold     float64               `yaml:"scaleUpThreshold,omitempty"`   // default 0.85
+    ScaleDownBoundary    float64               `yaml:"scaleDownBoundary,omitempty"`  // default 0.70
+    Priority             float64               `yaml:"priority,omitempty"`           // default 1.0
+    Analyzers            []AnalyzerScoreConfig `yaml:"analyzers,omitempty"`
+}
+
+// AnalyzerScoreConfig configures one analyzer in the multi-analyzer pipeline.
+// On this branch, only `Name` is consumed (it must match a RegisterAnalyzer
+// call); `Enabled`, `Score`, and the per-analyzer threshold overrides are
+// reserved for follow-up PRs.
+type AnalyzerScoreConfig struct {
+    Name              string   `yaml:"name"`
+    Enabled           *bool    `yaml:"enabled,omitempty"`           // default true
+    Score             float64  `yaml:"score,omitempty"`             // default 1.0
+    ScaleUpThreshold  *float64 `yaml:"scaleUpThreshold,omitempty"`  // overrides global (saturation only today)
+    ScaleDownBoundary *float64 `yaml:"scaleDownBoundary,omitempty"` // overrides global (saturation only today)
 }
 ```
 
 **Methods:**
-- `ApplyDefaults()` - Fills in zero-valued V2 fields with their defaults (V1 fields have no hardcoded defaults)
-- `Validate() error` - Validates configuration values (thresholds in range, consistency checks)
+- `ApplyDefaults()` - Fills in zero-valued V2 fields with their defaults and seeds the `Analyzers` list when empty (V1 fields have no hardcoded defaults)
+- `Validate() error` - Validates configuration values (thresholds in range, consistency checks, per-analyzer overrides)
 
 ## Architecture Notes
 

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -149,7 +149,7 @@ type Engine struct {
 
 	// analyzers is the engine's analyzer registry, mutated only during setup
 	// (NewEngine + RegisterAnalyzer). After StartOptimizeLoop it is frozen —
-	// further RegisterAnalyzer calls panic. The optimize goroutine reads
+	// further RegisterAnalyzer calls return an error. The optimize goroutine reads
 	// analyzersSnapshot, never analyzers, so iteration is race-free without
 	// runtime locking.
 	analyzers []analyzerEntry
@@ -163,8 +163,8 @@ type Engine struct {
 	analyzersSnapshot []analyzerEntry
 
 	// started transitions to true in StartOptimizeLoop. Late RegisterAnalyzer
-	// calls panic so the contract "register before Start" is enforced rather
-	// than just documented.
+	// calls return an error so the contract "register before Start" is enforced
+	// rather than just documented.
 	started bool
 
 	// optimizer is the V2 scaling optimizer that produces VariantDecisions from
@@ -276,7 +276,7 @@ func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) error {
 //
 // Before launching the goroutine, the registered analyzers are snapshotted
 // to a frozen slice that runAnalyzersAndScore iterates. The started flag is
-// flipped so subsequent RegisterAnalyzer calls panic. The snapshot is the
+// flipped so subsequent RegisterAnalyzer calls return an error. The snapshot is the
 // natural place to invoke any future per-analyzer Init(ctx) hook.
 func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 	e.analyzersSnapshot = make([]analyzerEntry, len(e.analyzers))

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -52,6 +52,14 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
+// analyzerEntry binds a registered analyzer to its name. The engine stores
+// these in registration order so runAnalyzersAndScore iterates analyzers
+// deterministically.
+type analyzerEntry struct {
+	name     string
+	analyzer interfaces.Analyzer
+}
+
 // v1Analyzer is the minimal surface of *saturation.Analyzer that optimizeV1
 // depends on. Defined here so tests can substitute a stub via Engine's
 // v1AnalyzerFactory field without exposing a public interface.
@@ -128,6 +136,7 @@ type Engine struct {
 	metricsRegistry *source.SourceRegistry
 
 	// saturationV2Analyzer is the V2 token-based saturation analyzer (initialized once).
+	// Also pre-registered in analyzers under interfaces.SaturationAnalyzerName.
 	saturationV2Analyzer *saturation_v2.SaturationAnalyzer
 
 	// queueingModelAnalyzer is the queueing model-based analyzer (initialized once).
@@ -136,6 +145,14 @@ type Engine struct {
 
 	// capacityStore is shared with the V2 analyzer for caching capacity knowledge.
 	capacityStore *saturation_v2.CapacityKnowledgeStore
+
+	// analyzers is the engine's analyzer registry, iterated in registration
+	// order by runAnalyzersAndScore. NewEngine pre-registers the V2 saturation
+	// analyzer; RegisterAnalyzer appends additional analyzers (e.g. throughput).
+	// Saturation always runs and drives scaling decisions; other registered
+	// analyzers are invoked but their results are not consumed yet — combine
+	// and per-analyzer threshold logic lands in follow-up PRs.
+	analyzers []analyzerEntry
 
 	// optimizer is the V2 scaling optimizer that produces VariantDecisions from
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
@@ -170,6 +187,7 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 	gpuLimiter := pipeline.NewDefaultLimiter("gpu-limiter", gpuInventory, gpuAlgorithm)
 
 	capacityStore := saturation_v2.NewCapacityKnowledgeStore()
+	satV2 := saturation_v2.NewSaturationAnalyzer(capacityStore)
 
 	// Initialize with default optimizer. The actual optimizer is selected
 	// per-cycle in optimize() based on dynamic config (enableLimiter flag
@@ -185,12 +203,15 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 		ScaleToZeroEnforcer:     pipeline.NewEnforcer(requestCountFunc),
 		GPULimiter:              gpuLimiter,
 		metricsRegistry:         metricsRegistry,
-		saturationV2Analyzer:    saturation_v2.NewSaturationAnalyzer(capacityStore),
+		saturationV2Analyzer:    satV2,
 		queueingModelAnalyzer:   queueingmodel.NewQueueingModelAnalyzer(),
 		capacityStore:           capacityStore,
 		optimizer:               scalingOptimizer,
 		metricsEmitter:          metrics.NewMetricsEmitter(),
 		v1AnalyzerFactory:       defaultV1AnalyzerFactory,
+		analyzers: []analyzerEntry{
+			{name: interfaces.SaturationAnalyzerName, analyzer: satV2},
+		},
 	}
 
 	engine.executor = executor.NewPollingExecutor(executor.PollingConfig{
@@ -218,6 +239,19 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 	registration.RegisterQueueingModelQueries(metricsRegistry)
 
 	return &engine
+}
+
+// RegisterAnalyzer adds an external analyzer to the engine's analyzer
+// registry. Must be called before StartOptimizeLoop. Re-registering an
+// existing name is a programmer error and panics — the registry is not
+// a hot-swap mechanism. The analyzer is appended in registration order.
+func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) {
+	for i := range e.analyzers {
+		if e.analyzers[i].name == name {
+			panic(fmt.Sprintf("RegisterAnalyzer: duplicate analyzer name %q", name))
+		}
+	}
+	e.analyzers = append(e.analyzers, analyzerEntry{name: name, analyzer: a})
 }
 
 // StartOptimizeLoop starts the optimization loop for the saturation engine.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -18,6 +18,7 @@ package saturation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -253,22 +254,21 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 	return &engine
 }
 
-// MustRegisterAnalyzer adds an external analyzer to the engine's analyzer
-// registry. Must be called before StartOptimizeLoop; calling it after
-// panics with a clear message so the "register before Start" contract is
-// enforced rather than silently corrupting concurrent state.
-// Re-registering an existing name also panics — the registry is not a
-// hot-swap mechanism. The analyzer is appended in registration order.
-func (e *Engine) MustRegisterAnalyzer(name string, a interfaces.Analyzer) {
+// RegisterAnalyzer adds an external analyzer to the engine's analyzer
+// registry. Returns an error if called after StartOptimizeLoop or if name
+// is already registered — callers must check the error. The analyzer is
+// appended in registration order.
+func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) error {
 	if e.started {
-		panic("RegisterAnalyzer called after StartOptimizeLoop")
+		return errors.New("RegisterAnalyzer: called after StartOptimizeLoop")
 	}
 	for i := range e.analyzers {
 		if e.analyzers[i].name == name {
-			panic(fmt.Sprintf("RegisterAnalyzer: duplicate analyzer name %q", name))
+			return fmt.Errorf("RegisterAnalyzer: duplicate analyzer name %q", name)
 		}
 	}
 	e.analyzers = append(e.analyzers, analyzerEntry{name: name, analyzer: a})
+	return nil
 }
 
 // StartOptimizeLoop starts the optimization loop for the saturation engine.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -146,13 +146,25 @@ type Engine struct {
 	// capacityStore is shared with the V2 analyzer for caching capacity knowledge.
 	capacityStore *saturation_v2.CapacityKnowledgeStore
 
-	// analyzers is the engine's analyzer registry, iterated in registration
-	// order by runAnalyzersAndScore. NewEngine pre-registers the V2 saturation
-	// analyzer; RegisterAnalyzer appends additional analyzers (e.g. throughput).
-	// Saturation always runs and drives scaling decisions; other registered
-	// analyzers are invoked but their results are not consumed yet — combine
-	// and per-analyzer threshold logic lands in follow-up PRs.
+	// analyzers is the engine's analyzer registry, mutated only during setup
+	// (NewEngine + RegisterAnalyzer). After StartOptimizeLoop it is frozen —
+	// further RegisterAnalyzer calls panic. The optimize goroutine reads
+	// analyzersSnapshot, never analyzers, so iteration is race-free without
+	// runtime locking.
 	analyzers []analyzerEntry
+
+	// analyzersSnapshot is the frozen, registration-ordered view that
+	// runAnalyzersAndScore iterates. Built from analyzers in StartOptimizeLoop
+	// before the goroutine launches. Saturation always runs and drives scaling
+	// decisions; other registered analyzers are invoked but their results are
+	// not consumed yet — combine and per-analyzer threshold logic lands in
+	// follow-up PRs.
+	analyzersSnapshot []analyzerEntry
+
+	// started transitions to true in StartOptimizeLoop. Late RegisterAnalyzer
+	// calls panic so the contract "register before Start" is enforced rather
+	// than just documented.
+	started bool
 
 	// optimizer is the V2 scaling optimizer that produces VariantDecisions from
 	// AnalyzerResults. Selected per-cycle based on enableLimiter config:
@@ -242,10 +254,15 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 }
 
 // RegisterAnalyzer adds an external analyzer to the engine's analyzer
-// registry. Must be called before StartOptimizeLoop. Re-registering an
-// existing name is a programmer error and panics — the registry is not
-// a hot-swap mechanism. The analyzer is appended in registration order.
+// registry. Must be called before StartOptimizeLoop; calling it after
+// panics with a clear message so the "register before Start" contract is
+// enforced rather than silently corrupting concurrent state.
+// Re-registering an existing name also panics — the registry is not a
+// hot-swap mechanism. The analyzer is appended in registration order.
 func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) {
+	if e.started {
+		panic("RegisterAnalyzer called after StartOptimizeLoop")
+	}
 	for i := range e.analyzers {
 		if e.analyzers[i].name == name {
 			panic(fmt.Sprintf("RegisterAnalyzer: duplicate analyzer name %q", name))
@@ -256,7 +273,16 @@ func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) {
 
 // StartOptimizeLoop starts the optimization loop for the saturation engine.
 // It runs until the context is cancelled.
+//
+// Before launching the goroutine, the registered analyzers are snapshotted
+// to a frozen slice that runAnalyzersAndScore iterates. The started flag is
+// flipped so subsequent RegisterAnalyzer calls panic. The snapshot is the
+// natural place to invoke any future per-analyzer Init(ctx) hook.
 func (e *Engine) StartOptimizeLoop(ctx context.Context) {
+	e.analyzersSnapshot = make([]analyzerEntry, len(e.analyzers))
+	copy(e.analyzersSnapshot, e.analyzers)
+	e.started = true
+
 	e.recordActiveOptimizer() // record active optimizer
 	metrics.SetConfigOptimizationInterval(float64(e.Config.OptimizationInterval().Seconds()))
 	e.executor.Start(ctx)

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -253,13 +253,13 @@ func NewEngine(client client.Client, scheme *runtime.Scheme, recorder record.Eve
 	return &engine
 }
 
-// RegisterAnalyzer adds an external analyzer to the engine's analyzer
+// MustRegisterAnalyzer adds an external analyzer to the engine's analyzer
 // registry. Must be called before StartOptimizeLoop; calling it after
 // panics with a clear message so the "register before Start" contract is
 // enforced rather than silently corrupting concurrent state.
 // Re-registering an existing name also panics — the registry is not a
 // hot-swap mechanism. The analyzer is appended in registration order.
-func (e *Engine) RegisterAnalyzer(name string, a interfaces.Analyzer) {
+func (e *Engine) MustRegisterAnalyzer(name string, a interfaces.Analyzer) {
 	if e.started {
 		panic("RegisterAnalyzer called after StartOptimizeLoop")
 	}

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("snapshot reader does not race with a post-Start RegisterAnalyzer attempt", func() {
 			// Verifies the race-safety contract under -race: the optimize
 			// goroutine reads analyzersSnapshot (immutable after Start) while
-			// any post-Start RegisterAnalyzer panics before mutating anything.
+			// any post-Start RegisterAnalyzer returns an error before mutating anything.
 			sourceRegistry := source.NewSourceRegistry()
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -19,6 +19,7 @@ package saturation
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -100,6 +101,93 @@ var _ = Describe("Engine analyzer registry", func() {
 				e.RegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})
 			}).To(PanicWith(ContainSubstring(`duplicate analyzer name`)))
 		})
+
+		It("panics when called after StartOptimizeLoop has frozen the registry", func() {
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+				},
+				started: true,
+			}
+
+			Expect(func() {
+				e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			}).To(PanicWith("RegisterAnalyzer called after StartOptimizeLoop"))
+		})
+	})
+
+	Describe("StartOptimizeLoop", func() {
+		It("snapshots the analyzer registry and flips started before launching the executor", func() {
+			sourceRegistry := source.NewSourceRegistry()
+			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
+			testConfig := config.NewTestConfig()
+			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+
+			engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			engine.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+
+			// Cancel context so the executor's polling loop exits immediately.
+			startCtx, cancelStart := context.WithCancel(context.Background())
+			cancelStart()
+			engine.StartOptimizeLoop(startCtx)
+
+			Expect(engine.started).To(BeTrue())
+			Expect(engine.analyzersSnapshot).To(HaveLen(len(engine.analyzers)))
+			for i := range engine.analyzers {
+				Expect(engine.analyzersSnapshot[i].name).To(Equal(engine.analyzers[i].name))
+				Expect(engine.analyzersSnapshot[i].analyzer).To(BeIdenticalTo(engine.analyzers[i].analyzer))
+			}
+		})
+
+		It("snapshot reader does not race with a post-Start RegisterAnalyzer attempt", func() {
+			// Verifies the race-safety contract under -race: the optimize
+			// goroutine reads analyzersSnapshot (immutable after Start) while
+			// any post-Start RegisterAnalyzer panics before mutating anything.
+			sourceRegistry := source.NewSourceRegistry()
+			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
+			testConfig := config.NewTestConfig()
+			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+			engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+
+			startCtx, cancelStart := context.WithCancel(context.Background())
+			cancelStart()
+			engine.StartOptimizeLoop(startCtx)
+
+			var wg sync.WaitGroup
+			const iterations = 200
+
+			// Reader: iterate the snapshot repeatedly.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < iterations; i++ {
+					for _, entry := range engine.analyzersSnapshot {
+						_ = entry.name
+					}
+				}
+			}()
+
+			// Writers: each call must panic with the late-register message.
+			panicCount := 0
+			var mu sync.Mutex
+			for i := 0; i < 4; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() {
+						if r := recover(); r != nil {
+							mu.Lock()
+							panicCount++
+							mu.Unlock()
+						}
+					}()
+					engine.RegisterAnalyzer("late", &spyAnalyzer{name: "late"})
+				}()
+			}
+
+			wg.Wait()
+			Expect(panicCount).To(Equal(4))
+		})
 	})
 
 	Describe("runRegisteredAnalyzers", func() {
@@ -118,13 +206,14 @@ var _ = Describe("Engine analyzer registry", func() {
 			sat := &spyAnalyzer{name: interfaces.SaturationAnalyzerName}
 			ta := &spyAnalyzer{name: "throughput"}
 			slo := &spyAnalyzer{name: "slo"}
-			e := &Engine{
-				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: sat},
-					{name: "throughput", analyzer: ta},
-					{name: "slo", analyzer: slo},
-				},
+			// runRegisteredAnalyzers iterates analyzersSnapshot (built by
+			// StartOptimizeLoop). Construct it directly to match.
+			snapshot := []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: sat},
+				{name: "throughput", analyzer: ta},
+				{name: "slo", analyzer: slo},
 			}
+			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
 			e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
 
@@ -140,13 +229,12 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("logs and continues when a registered analyzer returns an error", func() {
 			ta := &spyAnalyzer{name: "throughput", err: errors.New("boom")}
 			slo := &spyAnalyzer{name: "slo"}
-			e := &Engine{
-				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
-					{name: "throughput", analyzer: ta},
-					{name: "slo", analyzer: slo},
-				},
+			snapshot := []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+				{name: "throughput", analyzer: ta},
+				{name: "slo", analyzer: slo},
 			}
+			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
 			Expect(func() {
 				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
@@ -160,13 +248,12 @@ var _ = Describe("Engine analyzer registry", func() {
 		It("recovers from a panicking analyzer and continues with the rest", func() {
 			ta := &spyAnalyzer{name: "throughput", panicMsg: "boom"}
 			slo := &spyAnalyzer{name: "slo"}
-			e := &Engine{
-				analyzers: []analyzerEntry{
-					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
-					{name: "throughput", analyzer: ta},
-					{name: "slo", analyzer: slo},
-				},
+			snapshot := []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+				{name: "throughput", analyzer: ta},
+				{name: "slo", analyzer: slo},
 			}
+			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
 			Expect(func() {
 				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// spyAnalyzer is a minimal interfaces.Analyzer used in registration tests.
+// Configurable to record calls, return an error, or panic.
+type spyAnalyzer struct {
+	name      string
+	callCount int
+	err       error
+	panicMsg  string
+}
+
+func (s *spyAnalyzer) Name() string { return s.name }
+
+func (s *spyAnalyzer) Analyze(_ context.Context, in interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+	s.callCount++
+	if s.panicMsg != "" {
+		panic(s.panicMsg)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &interfaces.AnalyzerResult{AnalyzerName: s.name, ModelID: in.ModelID}, nil
+}
+
+var _ = Describe("Engine analyzer registry", func() {
+
+	Describe("NewEngine", func() {
+		It("pre-registers the V2 saturation analyzer at slot 0", func() {
+			sourceRegistry := source.NewSourceRegistry()
+			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
+			testConfig := config.NewTestConfig()
+			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
+
+			Expect(engine.analyzers).To(HaveLen(1))
+			Expect(engine.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
+			Expect(engine.analyzers[0].analyzer).To(BeIdenticalTo(interfaces.Analyzer(engine.saturationV2Analyzer)))
+		})
+	})
+
+	Describe("RegisterAnalyzer", func() {
+		It("appends new analyzers in registration order", func() {
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+				},
+			}
+
+			e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			e.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+
+			Expect(e.analyzers).To(HaveLen(3))
+			Expect(e.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
+			Expect(e.analyzers[1].name).To(Equal("throughput"))
+			Expect(e.analyzers[2].name).To(Equal("slo"))
+		})
+
+		It("panics with a clear message when re-registering an existing name", func() {
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: "throughput", analyzer: &spyAnalyzer{name: "throughput"}},
+				},
+			}
+
+			Expect(func() {
+				e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			}).To(PanicWith(`RegisterAnalyzer: duplicate analyzer name "throughput"`))
+
+			Expect(func() {
+				e.RegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})
+			}).To(PanicWith(ContainSubstring(`duplicate analyzer name`)))
+		})
+	})
+
+	Describe("runRegisteredAnalyzers", func() {
+
+		var (
+			testCtx    context.Context
+			testLogger logr.Logger
+		)
+
+		BeforeEach(func() {
+			testCtx = context.Background()
+			testLogger = logf.Log
+		})
+
+		It("calls Analyze on every registered non-saturation analyzer exactly once, in registration order", func() {
+			sat := &spyAnalyzer{name: interfaces.SaturationAnalyzerName}
+			ta := &spyAnalyzer{name: "throughput"}
+			slo := &spyAnalyzer{name: "slo"}
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: sat},
+					{name: "throughput", analyzer: ta},
+					{name: "slo", analyzer: slo},
+				},
+			}
+
+			e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+
+			// Saturation entry is skipped — engine runs saturation via
+			// runV2AnalysisOnly with full args. When a future PR unifies
+			// saturation into the loop, this expectation flips and the
+			// surrounding test description should be revised.
+			Expect(sat.callCount).To(Equal(0))
+			Expect(ta.callCount).To(Equal(1))
+			Expect(slo.callCount).To(Equal(1))
+		})
+
+		It("logs and continues when a registered analyzer returns an error", func() {
+			ta := &spyAnalyzer{name: "throughput", err: errors.New("boom")}
+			slo := &spyAnalyzer{name: "slo"}
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: "throughput", analyzer: ta},
+					{name: "slo", analyzer: slo},
+				},
+			}
+
+			Expect(func() {
+				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+			}).NotTo(Panic())
+
+			// Both analyzers are still called even though throughput erred.
+			Expect(ta.callCount).To(Equal(1))
+			Expect(slo.callCount).To(Equal(1))
+		})
+
+		It("recovers from a panicking analyzer and continues with the rest", func() {
+			ta := &spyAnalyzer{name: "throughput", panicMsg: "boom"}
+			slo := &spyAnalyzer{name: "slo"}
+			e := &Engine{
+				analyzers: []analyzerEntry{
+					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
+					{name: "throughput", analyzer: ta},
+					{name: "slo", analyzer: slo},
+				},
+			}
+
+			Expect(func() {
+				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+			}).NotTo(Panic())
+
+			// throughput panicked but was recovered; slo still ran.
+			Expect(ta.callCount).To(Equal(1))
+			Expect(slo.callCount).To(Equal(1))
+		})
+	})
+})

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Engine analyzer registry", func() {
 				},
 			}
 
-			e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			e.MustRegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+			Expect(e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).To(Succeed())
+			Expect(e.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})).To(Succeed())
 
 			Expect(e.analyzers).To(HaveLen(3))
 			Expect(e.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
@@ -85,7 +85,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			Expect(e.analyzers[2].name).To(Equal("slo"))
 		})
 
-		It("panics with a clear message when re-registering an existing name", func() {
+		It("returns an error when re-registering an existing name", func() {
 			e := &Engine{
 				analyzers: []analyzerEntry{
 					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
@@ -93,16 +93,14 @@ var _ = Describe("Engine analyzer registry", func() {
 				},
 			}
 
-			Expect(func() {
-				e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			}).To(PanicWith(`RegisterAnalyzer: duplicate analyzer name "throughput"`))
+			Expect(e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).
+				To(MatchError(ContainSubstring(`duplicate analyzer name "throughput"`)))
 
-			Expect(func() {
-				e.MustRegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})
-			}).To(PanicWith(ContainSubstring(`duplicate analyzer name`)))
+			Expect(e.RegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})).
+				To(MatchError(ContainSubstring(`duplicate analyzer name`)))
 		})
 
-		It("panics when called after StartOptimizeLoop has frozen the registry", func() {
+		It("returns an error when called after StartOptimizeLoop has frozen the registry", func() {
 			e := &Engine{
 				analyzers: []analyzerEntry{
 					{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
@@ -110,9 +108,8 @@ var _ = Describe("Engine analyzer registry", func() {
 				started: true,
 			}
 
-			Expect(func() {
-				e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			}).To(PanicWith("RegisterAnalyzer called after StartOptimizeLoop"))
+			Expect(e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).
+				To(MatchError(ContainSubstring("called after StartOptimizeLoop")))
 		})
 	})
 
@@ -123,8 +120,8 @@ var _ = Describe("Engine analyzer registry", func() {
 			testConfig := config.NewTestConfig()
 			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
 
-			engine.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			engine.MustRegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+			Expect(engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).To(Succeed())
+			Expect(engine.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})).To(Succeed())
 
 			// Cancel context so the executor's polling loop exits immediately.
 			startCtx, cancelStart := context.WithCancel(context.Background())
@@ -147,7 +144,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()
 			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
-			engine.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			Expect(engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})).To(Succeed())
 
 			startCtx, cancelStart := context.WithCancel(context.Background())
 			cancelStart()
@@ -167,26 +164,23 @@ var _ = Describe("Engine analyzer registry", func() {
 				}
 			}()
 
-			// Writers: each call must panic with the late-register message.
-			panicCount := 0
+			// Writers: each call must return an error (called after Start).
+			errCount := 0
 			var mu sync.Mutex
 			for i := 0; i < 4; i++ {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					defer func() {
-						if r := recover(); r != nil {
-							mu.Lock()
-							panicCount++
-							mu.Unlock()
-						}
-					}()
-					engine.MustRegisterAnalyzer("late", &spyAnalyzer{name: "late"})
+					if err := engine.RegisterAnalyzer("late", &spyAnalyzer{name: "late"}); err != nil {
+						mu.Lock()
+						errCount++
+						mu.Unlock()
+					}
 				}()
 			}
 
 			wg.Wait()
-			Expect(panicCount).To(Equal(4))
+			Expect(errCount).To(Equal(4))
 		})
 	})
 

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Engine analyzer registry", func() {
 				},
 			}
 
-			e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			e.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+			e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			e.MustRegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
 
 			Expect(e.analyzers).To(HaveLen(3))
 			Expect(e.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
@@ -94,11 +94,11 @@ var _ = Describe("Engine analyzer registry", func() {
 			}
 
 			Expect(func() {
-				e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+				e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
 			}).To(PanicWith(`RegisterAnalyzer: duplicate analyzer name "throughput"`))
 
 			Expect(func() {
-				e.RegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})
+				e.MustRegisterAnalyzer(interfaces.SaturationAnalyzerName, &spyAnalyzer{name: "x"})
 			}).To(PanicWith(ContainSubstring(`duplicate analyzer name`)))
 		})
 
@@ -111,7 +111,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			}
 
 			Expect(func() {
-				e.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+				e.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
 			}).To(PanicWith("RegisterAnalyzer called after StartOptimizeLoop"))
 		})
 	})
@@ -123,8 +123,8 @@ var _ = Describe("Engine analyzer registry", func() {
 			testConfig := config.NewTestConfig()
 			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
 
-			engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
-			engine.RegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
+			engine.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			engine.MustRegisterAnalyzer("slo", &spyAnalyzer{name: "slo"})
 
 			// Cancel context so the executor's polling loop exits immediately.
 			startCtx, cancelStart := context.WithCancel(context.Background())
@@ -147,7 +147,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			Expect(sourceRegistry.Register("prometheus", source.NewNoOpSource())).To(Succeed())
 			testConfig := config.NewTestConfig()
 			engine := NewEngine(k8sClient, k8sClient.Scheme(), nil, sourceRegistry, testConfig)
-			engine.RegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
+			engine.MustRegisterAnalyzer("throughput", &spyAnalyzer{name: "throughput"})
 
 			startCtx, cancelStart := context.WithCancel(context.Background())
 			cancelStart()
@@ -181,7 +181,7 @@ var _ = Describe("Engine analyzer registry", func() {
 							mu.Unlock()
 						}
 					}()
-					engine.RegisterAnalyzer("late", &spyAnalyzer{name: "late"})
+					engine.MustRegisterAnalyzer("late", &spyAnalyzer{name: "late"})
 				}()
 			}
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -119,6 +119,12 @@ func (e *Engine) runAnalyzersAndScore(
 	}
 
 	// Build AnalyzerInput once; shared by all non-saturation analyzers.
+	// Note: &config has had saturation's per-entry threshold overrides applied
+	// (the loop above). Non-saturation analyzers therefore receive the
+	// saturation-adjusted config rather than the original. This is harmless
+	// on this branch (their results are discarded), and the clean fix —
+	// engine applies thresholds universally after each analyzer runs —
+	// is tracked on multi-analyzer-threshold (PR #1228).
 	input := interfaces.AnalyzerInput{
 		ModelID:        modelID,
 		Namespace:      namespace,
@@ -188,14 +194,17 @@ func runRegisteredAnalyzer(
 ) {
 	defer func() {
 		if r := recover(); r != nil {
-			logger.Error(fmt.Errorf("panic: %v", r),
-				"registered analyzer panicked; result discarded on this branch",
-				"name", entry.name, "modelID", modelID)
+			// Plugin failure is non-fatal; log at debug to avoid spamming
+			// operator logs every optimize cycle.
+			logger.V(logging.DEBUG).Info("registered analyzer panicked; result discarded",
+				"name", entry.name, "modelID", modelID, "panic", fmt.Sprintf("%v", r))
 		}
 	}()
 	if _, err := entry.analyzer.Analyze(ctx, input); err != nil {
-		logger.Error(err, "registered analyzer failed; result discarded on this branch",
-			"name", entry.name, "modelID", modelID)
+		// Plugin failure is non-fatal; log at debug to avoid spamming
+		// operator logs every optimize cycle.
+		logger.V(logging.DEBUG).Info("registered analyzer failed; result discarded",
+			"name", entry.name, "modelID", modelID, "error", err)
 	}
 }
 

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -154,10 +154,11 @@ func (e *Engine) runAnalyzersAndScore(
 }
 
 // runRegisteredAnalyzers invokes Analyze on every registered non-saturation
-// analyzer in registration order. The saturation entry is skipped because
-// the engine runs saturation separately via runV2AnalysisOnly with full
-// args. Each call is isolated: errors are logged and discarded, and panics
-// are recovered so a faulty analyzer cannot take down the optimize goroutine.
+// analyzer in registration order, reading from the frozen analyzersSnapshot
+// built by StartOptimizeLoop. The saturation entry is skipped because the
+// engine runs saturation separately via runV2AnalysisOnly with full args.
+// Each call is isolated: errors are logged and discarded, and panics are
+// recovered so a faulty analyzer cannot take down the optimize goroutine.
 // Results are intentionally discarded on this branch — combine logic lands
 // in follow-up PRs.
 func (e *Engine) runRegisteredAnalyzers(
@@ -166,7 +167,7 @@ func (e *Engine) runRegisteredAnalyzers(
 	modelID string,
 	input interfaces.AnalyzerInput,
 ) {
-	for _, entry := range e.analyzers {
+	for _, entry := range e.analyzersSnapshot {
 		if entry.name == interfaces.SaturationAnalyzerName {
 			continue
 		}

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
@@ -73,8 +74,15 @@ func (e *Engine) runV2AnalysisOnly(
 	return result, nil
 }
 
-// runAnalyzersAndScore runs the V2 saturation analyzer, then computes the
-// weighted composite score from enabled analyzers and model priority.
+// runAnalyzersAndScore runs the V2 saturation analyzer, invokes every other
+// registered analyzer once per cycle to exercise the multi-analyzer pipeline,
+// and computes the weighted composite score from saturation's signal and the
+// model's priority.
+//
+// On this branch only saturation drives scaling decisions: non-saturation
+// analyzer results are intentionally discarded. Combine and per-analyzer
+// threshold consumption land in follow-up PRs (multi-analyzer-optimizer,
+// multi-analyzer-threshold).
 func (e *Engine) runAnalyzersAndScore(
 	ctx context.Context,
 	modelID, namespace string,
@@ -84,9 +92,13 @@ func (e *Engine) runAnalyzersAndScore(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 ) (*interfaces.AnalyzerResult, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// Resolve per-analyzer threshold overrides before running the analyzer.
 	// The saturation analyzer reads thresholds from the config, so we apply
-	// per-analyzer overrides to the config's top-level fields.
+	// per-analyzer overrides to the config's top-level fields. Only saturation
+	// overrides are honored today; per-analyzer overrides for other analyzers
+	// are tracked on the multi-analyzer-threshold branch.
 	for _, aw := range config.Analyzers {
 		if aw.Name == interfaces.SaturationAnalyzerName && (aw.Enabled == nil || *aw.Enabled) {
 			if aw.ScaleUpThreshold != nil {
@@ -99,14 +111,32 @@ func (e *Engine) runAnalyzersAndScore(
 		}
 	}
 
-	// Run saturation analyzer (always needed for PerReplicaCapacity)
+	// Run saturation analyzer (always needed for PerReplicaCapacity).
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings)
 	if err != nil {
 		return nil, err
 	}
 
-	// Compute weighted score from enabled analyzers
+	// Build AnalyzerInput once; shared by all non-saturation analyzers.
+	input := interfaces.AnalyzerInput{
+		ModelID:        modelID,
+		Namespace:      namespace,
+		ReplicaMetrics: replicaMetrics,
+		VariantStates:  variantStates,
+		Config:         &config,
+		// SchedulerQueue: nil — wired in a later PR
+	}
+
+	// Iterate every registered analyzer in registration order. Saturation has
+	// already run above (with full args); the loop calls Analyze on every
+	// other registered analyzer to exercise the multi-analyzer pipeline.
+	// Their results are intentionally discarded on this branch — combine /
+	// per-analyzer-result consumption lands in follow-up PRs.
+	e.runRegisteredAnalyzers(ctx, logger, modelID, input)
+
+	// Compute weighted score from enabled analyzers (saturation only on this
+	// branch — non-saturation analyzer results are not consumed yet).
 	totalWeighted := 0.0
 	for _, aw := range config.Analyzers {
 		if aw.Enabled != nil && !*aw.Enabled {
@@ -121,6 +151,51 @@ func (e *Engine) runAnalyzersAndScore(
 	// Score = priority * weighted sum
 	baseResult.Score = config.Priority * totalWeighted
 	return baseResult, nil
+}
+
+// runRegisteredAnalyzers invokes Analyze on every registered non-saturation
+// analyzer in registration order. The saturation entry is skipped because
+// the engine runs saturation separately via runV2AnalysisOnly with full
+// args. Each call is isolated: errors are logged and discarded, and panics
+// are recovered so a faulty analyzer cannot take down the optimize goroutine.
+// Results are intentionally discarded on this branch — combine logic lands
+// in follow-up PRs.
+func (e *Engine) runRegisteredAnalyzers(
+	ctx context.Context,
+	logger logr.Logger,
+	modelID string,
+	input interfaces.AnalyzerInput,
+) {
+	for _, entry := range e.analyzers {
+		if entry.name == interfaces.SaturationAnalyzerName {
+			continue
+		}
+		runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
+	}
+}
+
+// runRegisteredAnalyzer invokes a single non-saturation analyzer's Analyze
+// method, isolating the call from the rest of the cycle. Errors are logged
+// and discarded; panics are recovered and logged. The result is intentionally
+// discarded on this branch — combine logic lands in follow-up PRs.
+func runRegisteredAnalyzer(
+	ctx context.Context,
+	logger logr.Logger,
+	entry analyzerEntry,
+	modelID string,
+	input interfaces.AnalyzerInput,
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(fmt.Errorf("panic: %v", r),
+				"registered analyzer panicked; result discarded on this branch",
+				"name", entry.name, "modelID", modelID)
+		}
+	}()
+	if _, err := entry.analyzer.Analyze(ctx, input); err != nil {
+		logger.Error(err, "registered analyzer failed; result discarded on this branch",
+			"name", entry.name, "modelID", modelID)
+	}
 }
 
 // computeCurrentGPUUsage iterates over model scaling requests to compute the


### PR DESCRIPTION
## Summary

- Adds an analyzer registry on `Engine`: `analyzers []analyzerEntry` with `RegisterAnalyzer(name, interfaces.Analyzer)`. Saturation V2 is pre-registered at slot 0 by `NewEngine`; external analyzers (throughput, SLO, …) are registered from `cmd/main.go` before `StartOptimizeLoop`.
- The optimize loop iterates the registry snapshot and invokes `Analyze` on every registered non-saturation analyzer. On this branch saturation continues to drive every scaling decision; non-saturation results are intentionally discarded — combine semantics, score consumption, and per-analyzer threshold application land in follow-up PRs (`multi-analyzer-optimizer`, `multi-analyzer-threshold`).
- Race-safety: `StartOptimizeLoop` snapshots the registry to `analyzersSnapshot` and flips `started` before launching the goroutine; later `RegisterAnalyzer` calls panic with `RegisterAnalyzer called after StartOptimizeLoop`. Goroutine launch establishes happens-before, so the loop is race-free without runtime locking.
- Resilience: each registered non-saturation analyzer runs in isolation — errors are logged and discarded, panics are recovered. A faulty plugin analyzer cannot take down the optimize goroutine or block saturation.
- Programmer-error semantics: re-registering an existing name **panics**. The registry is not a hot-swap mechanism; a duplicate registration is a wiring mistake worth surfacing immediately.

## Context

This PR replaces the registration scope previously carried on #1113. Per the design discussion in `planning/PR1113-review.md`, that PR is being split into three independent multi-analyzer-support PRs that can land in any order:

1. **This PR** — analyzer registration (Item 3).
2. **`multi-analyzer-threshold`** — universal threshold post-step applied to every analyzer's result (Item 2).
3. **`multi-analyzer-optimizer`** — delete the engine-side combine; per-analyzer slice flows to the optimizers (Item 1).

#1113 will be closed once this one is reviewed and merged.

## Behavior change worth flagging

`RegisterAnalyzer` previously replaced-in-place on duplicate name; this PR makes it panic. No caller does duplicate registration today (saturation is the only registered analyzer on `main`), so blast radius is zero — but the change is intentional.

## Test plan

- [x] `make build` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `make test` — full unit-test sweep green
- [x] `go test -race ./internal/engines/saturation/...` — clean
- [x] All 3 kustomize overlays build clean (cluster-scoped/k8s, namespace-scoped/openshift, namespace-scoped/k8s)
- [x] DCO sign-off on all 3 commits

Test additions in `internal/engines/saturation/engine_register_test.go`:
- T1 — saturation pre-registered at slot 0 by `NewEngine`
- T2 — `RegisterAnalyzer` appends in registration order
- T3 — duplicate-name registration panics with a clear message
- T4 — `RegisterAnalyzer` after `StartOptimizeLoop` panics with the documented message
- T5 — `StartOptimizeLoop` snapshots the registry and flips `started` before launching the executor
- T6 — one cycle calls `Analyze` on every registered non-saturation analyzer exactly once, in registration order
- T7 — a registered analyzer that returns an error does not abort the cycle
- T8 — a registered analyzer that panics is recovered; cycle continues
- T9 — under \`-race\`, the snapshot reader does not race with concurrent post-Start \`RegisterAnalyzer\` attempts (4 writers all panic; reader iterates 200×)

T10 (saturation's `*AnalyzerResult` is what flows to the optimizer regardless of what other analyzers return) is verified by inspection: `runAnalyzersAndScore` returns `baseResult` and `runRegisteredAnalyzers` discards every non-saturation result. Happy to add behavioral coverage if reviewers prefer.