### PR TITLE
engines: universal threshold post-step + analyzer aggregation helpers

### DIFF
--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -27,6 +27,8 @@ The saturation scaling configuration is stored in a ConfigMap named `wva-saturat
 | `queueLengthThreshold` | float64 | Replica is considered saturated if queue length ≥ threshold | 5 |
 | `kvSpareTrigger` | float64 | Scale-up signal if average spare KV capacity < trigger (0.0-1.0) | 0.10 |
 | `queueSpareTrigger` | float64 | Scale-up signal if average spare queue capacity < trigger | 3 |
+| `scaleUpThreshold` | float64 | Model-level utilization threshold above which scale-up is triggered (0.0-1.0). Applied by the engine post-step to every analyzer's result. | 0.85 |
+| `scaleDownBoundary` | float64 | Model-level utilization boundary below which scale-down is safe (0.0-1.0). Applied by the engine post-step to every analyzer's result. | 0.70 |
 
 ### V2 Analyzer Parameters
 
@@ -97,14 +99,12 @@ throughput, SLO) can be plugged in without the engine package knowing the
 concrete type. Each cycle the engine iterates every registered analyzer in
 registration order and invokes its `Analyze` method.
 
-> **Scope on this branch.** Saturation drives every scaling decision on
-> its own. Non-saturation analyzers are registered and invoked, but their
-> results are **not yet consumed** — combine semantics, per-analyzer score
-> consumption, and per-analyzer threshold application land in follow-up
-> PRs (`multi-analyzer-optimizer`, `multi-analyzer-threshold`). The hooks
-> below are wired so those follow-ups can hang their behavior off them
-> without further engine changes. When those PRs land, this section will
-> be refactored into a generic multi-analyzer guide.
+> **Scope note.** Saturation drives every scaling decision on its own.
+> Non-saturation analyzers are registered and invoked, but their results
+> are **not yet consumed** — combine semantics and per-analyzer score
+> consumption land in a follow-up PR (`multi-analyzer-optimizer`). The
+> hooks below are wired so that follow-up can hang its behavior off them
+> without further engine changes.
 
 ### Registering Analyzers
 
@@ -143,8 +143,6 @@ analyzers:
     score: 1.0
   - name: throughput
     score: 1.0
-    # scaleUpThreshold: 0.90    # reserved for multi-analyzer-threshold PR
-    # scaleDownBoundary: 0.75   # reserved for multi-analyzer-threshold PR
 ```
 
 When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]`.
@@ -156,8 +154,86 @@ When `analyzers:` is omitted, it defaults to `[{name: "saturation", score: 1.0}]
 | `name` | string | Analyzer name (must match a `RegisterAnalyzer` call) | required |
 | `enabled` | bool | Reserved — placeholder for future combine logic | `true` |
 | `score` | float64 | Reserved — placeholder for future combine logic | `1.0` |
-| `scaleUpThreshold` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleUpThreshold` |
-| `scaleDownBoundary` | float64 | Per-analyzer override; honored only for saturation today (other analyzers tracked on the multi-analyzer-threshold PR) | global `scaleDownBoundary` |
+| `scaleUpThreshold` | float64 | Per-analyzer override for the scale-up threshold; honored by the engine post-step (see Universal Threshold Post-Step below) | global `scaleUpThreshold` |
+| `scaleDownBoundary` | float64 | Per-analyzer override for the scale-down boundary; honored by the engine post-step (see Universal Threshold Post-Step below) | global `scaleDownBoundary` |
+
+### Analyzer responsibilities and the universal threshold post-step
+
+#### Per-variant data is canonical
+
+`interfaces.VariantCapacity` is the single source of truth for per-variant primitives. Analyzers populate it; the engine and optimizer read it.
+
+| Field | Written by | Read by |
+|---|---|---|
+| `ReplicaCount`, `PendingReplicas`, `PerReplicaCapacity`, `Cost`, `Role`, `AcceleratorName` | Analyzer | Optimizer (per-variant scaling math + picker) |
+| `TotalCapacity`, `TotalDemand`, `Utilization` | Analyzer | Sat_v2 internal aggregation; `Utilization` passed through to `VariantDecision.Utilization` for metric emission |
+| `r.TotalSupply`, `r.TotalAnticipatedSupply`, `r.TotalDemand` | Analyzer (via shared helpers) | Engine post-step |
+| `r.RoleCapacities[role].TotalSupply/TotalAnticipatedSupply/TotalDemand` | Analyzer (via shared helpers) | Engine post-step |
+| `r.RequiredCapacity`, `r.SpareCapacity` | **Engine post-step only** | Optimizer |
+| `r.RoleCapacities[role].RequiredCapacity/SpareCapacity` | **Engine post-step only** | Optimizer (P/D disaggregation) |
+
+#### Analyzer inputs
+
+`interfaces.AnalyzerInput` carries the shared inputs every analyzer reads:
+replica metrics, variant states, the model's resolved config, and
+`SchedulerQueue`. None of these are analyzer-specific.
+
+`SchedulerQueue` represents requests queued upstream of any pod (in the
+llm-d flow control layer). Queue items are model-scoped and **not yet
+attributed to any variant or role**. Any analyzer with a demand model may
+use it — sat_v2 does today; the throughput analyzer will when it lands.
+
+**Demand extraction from the queue is per-analyzer.** Each analyzer
+converts queue depth/bytes into demand in its own unit (sat_v2:
+kv-tokens; throughput: tokens/sec). Each analyzer also decides how to
+attribute that demand across roles or variants — sat_v2 splits it among
+active roles.
+
+#### Linearity invariant
+
+The optimizer's per-variant scaling math (`bottleneckReplicas`, `safeRemovalReplicas`, `applyAllocation`) assumes that `n` replicas of variant `v` reduce model-level RC by exactly `n × PRC[v]`. That means `Total*` must equal the canonical sum over variants:
+
+```
+r.TotalSupply            == Σ_v vc.ReplicaCount × vc.PerReplicaCapacity
+r.TotalAnticipatedSupply == Σ_v (vc.ReplicaCount + vc.PendingReplicas) × vc.PerReplicaCapacity
+r.TotalDemand            == Σ_v vc.TotalDemand
+r.RoleCapacities[role].* == same sums filtered by vc.Role == role
+```
+
+Use the shared helpers in `internal/engines/aggregation/` to compute these. An analyzer that doesn't use the helpers takes responsibility for producing identical math — otherwise the optimizer's per-variant allocation silently breaks.
+
+#### Shared aggregation helpers
+
+```go
+import "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
+
+r.TotalSupply            = aggregation.SumTotalSupply(variantCapacities)
+r.TotalAnticipatedSupply = aggregation.SumTotalAnticipatedSupply(variantCapacities)
+r.TotalDemand            = aggregation.SumTotalDemand(variantCapacities)
+
+// For P/D disaggregated models:
+totals := aggregation.AggregateByRole(variantCapacities)
+// → map[role]aggregation.ScopeTotals{TotalSupply, TotalAnticipatedSupply, TotalDemand}
+```
+
+`AggregateByRole` canonicalizes empty role to `interfaces.RoleBoth`.
+
+#### Engine post-step formula
+
+After each analyzer's `Analyze()` returns, the engine applies the universal threshold formula at **every scope** — model level and each `RoleCapacity` entry:
+
+```
+RC = max(0, TotalDemand / scaleUpThreshold − TotalAnticipatedSupply)
+SC = max(0, TotalSupply  − TotalDemand / scaleDownBoundary)
+```
+
+`TotalAnticipatedSupply` is read as-is — **zero is a literal value, not a sentinel**. For a model scaled to zero with positive demand, RC = TotalDemand/scaleUp (the correct "this much capacity needed" answer). Analyzers must populate `TotalAnticipatedSupply` via `SumTotalAnticipatedSupply`; the engine does not walk `VariantCapacities` as a fallback.
+
+The asymmetry — anticipated supply for scale-up, steady-state `TotalSupply` for scale-down — preserves the conservative "don't double-scale while replicas are launching, don't count pending as removable" stance.
+
+**P/D disaggregation.** The same formula and the same `(scaleUp, scaleDown)` values are applied to every `RoleCapacity` entry. Threshold configuration is common regardless of role — there are no per-role overrides. The optimizer receives fully calibrated per-role RC/SC and uses them for P/D replica allocation.
+
+**Per-analyzer threshold overrides.** `analyzers[].scaleUpThreshold` / `analyzers[].scaleDownBoundary` are resolved per analyzer: a per-entry override takes precedence over the model-level global. The resolved pair is applied uniformly at model level and every role for that analyzer. An opt-out flag for analyzers with non-universal calibration math is deferred to a follow-up.
 
 ### Saturation Always Runs
 

--- a/internal/config/saturation_scaling.go
+++ b/internal/config/saturation_scaling.go
@@ -40,12 +40,14 @@ type SaturationScalingConfig struct {
 	AnalyzerName string `yaml:"analyzerName,omitempty"`
 
 	// ScaleUpThreshold is the utilization threshold above which scale-up is triggered.
-	// Used by V2 analyzer: requiredCapacity = totalDemand / ScaleUpThreshold - anticipatedSupply
+	// Applied by the engine post-step universally to every analyzer's result:
+	//   requiredCapacity = max(0, totalDemand / ScaleUpThreshold − anticipatedSupply)
 	// Default: 0.85 (85% utilization triggers scale-up)
 	ScaleUpThreshold float64 `yaml:"scaleUpThreshold,omitempty"`
 
 	// ScaleDownBoundary is the utilization boundary below which scale-down is safe.
-	// Used by V2 analyzer: spareCapacity = currentSupply - totalDemand / ScaleDownBoundary
+	// Applied by the engine post-step universally to every analyzer's result:
+	//   spareCapacity = max(0, totalSupply − totalDemand / ScaleDownBoundary)
 	// Default: 0.70 (70% utilization allows scale-down)
 	ScaleDownBoundary float64 `yaml:"scaleDownBoundary,omitempty"`
 

--- a/internal/engines/aggregation/aggregation.go
+++ b/internal/engines/aggregation/aggregation.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aggregation provides pure helper functions for aggregating
+// per-variant capacity data into model-level and per-role totals.
+// Analyzers use these helpers to populate AnalyzerResult.Total* and
+// AnalyzerResult.RoleCapacities[role].Total* fields, ensuring the
+// linearity invariant required by the optimizer's per-variant scaling math:
+//
+//	r.TotalSupply            == Σ_v vc.ReplicaCount × vc.PerReplicaCapacity
+//	r.TotalAnticipatedSupply == Σ_v (vc.ReplicaCount + vc.PendingReplicas) × vc.PerReplicaCapacity
+//	r.TotalDemand            == Σ_v vc.TotalDemand
+//	r.RoleCapacities[role].* == same sums filtered by vc.Role == role
+package aggregation
+
+import "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+
+// ScopeTotals holds the three model-level (or per-role) aggregates that the
+// engine's universal threshold post-step reads to compute RC and SC.
+type ScopeTotals struct {
+	TotalSupply            float64
+	TotalAnticipatedSupply float64
+	TotalDemand            float64
+}
+
+// SumTotalSupply returns Σ_v vc.ReplicaCount × vc.PerReplicaCapacity.
+func SumTotalSupply(vcs []interfaces.VariantCapacity) float64 {
+	var total float64
+	for _, vc := range vcs {
+		total += float64(vc.ReplicaCount) * vc.PerReplicaCapacity
+	}
+	return total
+}
+
+// SumTotalAnticipatedSupply returns
+// Σ_v (vc.ReplicaCount + vc.PendingReplicas) × vc.PerReplicaCapacity.
+// Pending replicas count toward anticipated supply so an in-flight scale-up
+// reduces the computed RC and prevents double-scaling.
+func SumTotalAnticipatedSupply(vcs []interfaces.VariantCapacity) float64 {
+	var total float64
+	for _, vc := range vcs {
+		total += float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
+	}
+	return total
+}
+
+// SumTotalDemand returns Σ_v vc.TotalDemand.
+func SumTotalDemand(vcs []interfaces.VariantCapacity) float64 {
+	var total float64
+	for _, vc := range vcs {
+		total += vc.TotalDemand
+	}
+	return total
+}
+
+// AggregateByRole groups vcs by role and computes ScopeTotals for each group.
+// An empty or blank role string is canonicalized to interfaces.RoleBoth,
+// consistent with saturation_v2's role normalization.
+func AggregateByRole(vcs []interfaces.VariantCapacity) map[string]ScopeTotals {
+	result := make(map[string]ScopeTotals)
+	for _, vc := range vcs {
+		role := vc.Role
+		if role == "" {
+			role = interfaces.RoleBoth
+		}
+		t := result[role]
+		t.TotalSupply += float64(vc.ReplicaCount) * vc.PerReplicaCapacity
+		t.TotalAnticipatedSupply += float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
+		t.TotalDemand += vc.TotalDemand
+		result[role] = t
+	}
+	return result
+}

--- a/internal/engines/aggregation/aggregation_test.go
+++ b/internal/engines/aggregation/aggregation_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func TestAggregation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Aggregation Suite")
+}
+
+var _ = Describe("aggregation helpers", func() {
+
+	Describe("SumTotalSupply", func() {
+		It("returns 0 for empty input", func() {
+			Expect(aggregation.SumTotalSupply(nil)).To(BeZero())
+			Expect(aggregation.SumTotalSupply([]interfaces.VariantCapacity{})).To(BeZero())
+		})
+
+		It("sums ReplicaCount × PerReplicaCapacity across variants", func() {
+			vcs := []interfaces.VariantCapacity{
+				{VariantName: "v1", ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000},
+				{VariantName: "v2", ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000},
+			}
+			// 2×5000 + 3×8000 = 10000 + 24000 = 34000 (pending NOT included)
+			Expect(aggregation.SumTotalSupply(vcs)).To(Equal(34000.0))
+		})
+
+		It("ignores pending replicas", func() {
+			vcs := []interfaces.VariantCapacity{
+				{ReplicaCount: 1, PendingReplicas: 99, PerReplicaCapacity: 1000},
+			}
+			Expect(aggregation.SumTotalSupply(vcs)).To(Equal(1000.0))
+		})
+
+		It("handles zero PRC", func() {
+			vcs := []interfaces.VariantCapacity{
+				{ReplicaCount: 5, PerReplicaCapacity: 0},
+			}
+			Expect(aggregation.SumTotalSupply(vcs)).To(BeZero())
+		})
+	})
+
+	Describe("SumTotalAnticipatedSupply", func() {
+		It("returns 0 for empty input", func() {
+			Expect(aggregation.SumTotalAnticipatedSupply(nil)).To(BeZero())
+		})
+
+		It("sums (ReplicaCount + PendingReplicas) × PRC across variants", func() {
+			vcs := []interfaces.VariantCapacity{
+				{ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000},
+				{ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000},
+			}
+			// (2+1)×5000 + (3+0)×8000 = 15000 + 24000 = 39000
+			Expect(aggregation.SumTotalAnticipatedSupply(vcs)).To(Equal(39000.0))
+		})
+
+		It("equals SumTotalSupply when no variants have pending replicas", func() {
+			vcs := []interfaces.VariantCapacity{
+				{ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 10000},
+			}
+			Expect(aggregation.SumTotalAnticipatedSupply(vcs)).To(Equal(aggregation.SumTotalSupply(vcs)))
+		})
+	})
+
+	Describe("SumTotalDemand", func() {
+		It("returns 0 for empty input", func() {
+			Expect(aggregation.SumTotalDemand(nil)).To(BeZero())
+		})
+
+		It("sums TotalDemand across variants", func() {
+			vcs := []interfaces.VariantCapacity{
+				{TotalDemand: 3000},
+				{TotalDemand: 7000},
+			}
+			Expect(aggregation.SumTotalDemand(vcs)).To(Equal(10000.0))
+		})
+	})
+
+	Describe("AggregateByRole", func() {
+		It("returns empty map for empty input", func() {
+			Expect(aggregation.AggregateByRole(nil)).To(BeEmpty())
+		})
+
+		It("canonicalizes empty role to RoleBoth", func() {
+			vcs := []interfaces.VariantCapacity{
+				{Role: "", ReplicaCount: 1, PerReplicaCapacity: 1000, TotalDemand: 500},
+			}
+			result := aggregation.AggregateByRole(vcs)
+			Expect(result).To(HaveKey(interfaces.RoleBoth))
+			Expect(result).NotTo(HaveKey(""))
+		})
+
+		It("groups variants by role and computes ScopeTotals for each", func() {
+			vcs := []interfaces.VariantCapacity{
+				{Role: "prefill", ReplicaCount: 2, PendingReplicas: 1, PerReplicaCapacity: 5000, TotalDemand: 8000},
+				{Role: "decode", ReplicaCount: 3, PendingReplicas: 0, PerReplicaCapacity: 8000, TotalDemand: 9000},
+				{Role: "decode", ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 4000, TotalDemand: 2000},
+			}
+			result := aggregation.AggregateByRole(vcs)
+
+			Expect(result).To(HaveLen(2))
+
+			prefill := result["prefill"]
+			Expect(prefill.TotalSupply).To(Equal(10000.0))            // 2×5000
+			Expect(prefill.TotalAnticipatedSupply).To(Equal(15000.0)) // (2+1)×5000
+			Expect(prefill.TotalDemand).To(Equal(8000.0))
+
+			decode := result["decode"]
+			Expect(decode.TotalSupply).To(Equal(28000.0))            // 3×8000 + 1×4000
+			Expect(decode.TotalAnticipatedSupply).To(Equal(28000.0)) // no pending
+			Expect(decode.TotalDemand).To(Equal(11000.0))            // 9000 + 2000
+		})
+
+		It("handles a single non-disaggregated variant (empty role → RoleBoth)", func() {
+			vcs := []interfaces.VariantCapacity{
+				{Role: "", ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000, TotalDemand: 15000},
+			}
+			result := aggregation.AggregateByRole(vcs)
+			both := result[interfaces.RoleBoth]
+			Expect(both.TotalSupply).To(Equal(20000.0))
+			Expect(both.TotalAnticipatedSupply).To(Equal(20000.0))
+			Expect(both.TotalDemand).To(Equal(15000.0))
+		})
+
+		It("handles zero ReplicaCount", func() {
+			vcs := []interfaces.VariantCapacity{
+				{Role: "prefill", ReplicaCount: 0, PendingReplicas: 0, PerReplicaCapacity: 5000, TotalDemand: 0},
+			}
+			result := aggregation.AggregateByRole(vcs)
+			prefill := result["prefill"]
+			Expect(prefill.TotalSupply).To(BeZero())
+			Expect(prefill.TotalAnticipatedSupply).To(BeZero())
+			Expect(prefill.TotalDemand).To(BeZero())
+		})
+	})
+})

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/aggregation"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
@@ -87,16 +88,14 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 	// Phase 2: Per-variant aggregation
 	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
 
-	// Phase 3: Model-level aggregation
-	var totalSupply, totalAnticipatedSupply, totalDemand float64
+	// Phase 3: Model-level aggregation via shared helpers (enforces linearity invariant).
+	totalSupply := aggregation.SumTotalSupply(variantCapacities)
+	totalAnticipatedSupply := aggregation.SumTotalAnticipatedSupply(variantCapacities)
+	totalDemand := aggregation.SumTotalDemand(variantCapacities)
+
+	// Track active roles for queue demand attribution.
 	activeRoles := make(map[string]bool)
 	for _, vc := range variantCapacities {
-		totalSupply += vc.TotalCapacity
-		totalDemand += vc.TotalDemand
-		// Anticipated supply includes pending replicas
-		anticipatedCapacity := float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
-		totalAnticipatedSupply += anticipatedCapacity
-		// Track active roles for queue demand attribution
 		role := vc.Role
 		if role == "" {
 			role = interfaces.RoleBoth
@@ -104,7 +103,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 		activeRoles[role] = true
 	}
 
-	// Add scheduler queue demand (requests queued upstream in llm-d flow control)
+	// Add scheduler queue demand (requests queued upstream in llm-d flow control).
 	queueDemand := estimateSchedulerQueueDemand(input.SchedulerQueue, input.ReplicaMetrics, activeRoles)
 	totalDemand += queueDemand.total
 
@@ -113,38 +112,25 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 		utilization = totalDemand / totalSupply
 	}
 
-	// Phase 4: Scaling signals
-	var requiredCapacity, spareCapacity float64
-	if satConfig.ScaleUpThreshold > 0 {
-		requiredCapacity = totalDemand/satConfig.ScaleUpThreshold - totalAnticipatedSupply
-	}
-	if requiredCapacity < 0 {
-		requiredCapacity = 0
-	}
+	// Phase 4: Per-role aggregation (P/D disaggregation).
+	// RequiredCapacity and SpareCapacity are NOT computed here — the engine's
+	// universal threshold post-step writes them after Analyze() returns.
+	roleCapacities := a.aggregateByRole(variantCapacities, queueDemand.byRole)
 
-	if satConfig.ScaleDownBoundary > 0 {
-		spareCapacity = totalSupply - totalDemand/satConfig.ScaleDownBoundary
-	}
-	if spareCapacity < 0 {
-		spareCapacity = 0
-	}
-
-	// Phase 4b: Per-role aggregation (P/D disaggregation)
-	roleCapacities := a.aggregateByRole(variantCapacities, satConfig, queueDemand.byRole)
-
-	// Phase 5: Build result
+	// Phase 5: Build result. RequiredCapacity and SpareCapacity left zero;
+	// the engine post-step overwrites them using TotalDemand, TotalSupply,
+	// and TotalAnticipatedSupply with the resolved thresholds.
 	result := &interfaces.AnalyzerResult{
-		AnalyzerName:      a.Name(),
-		ModelID:           input.ModelID,
-		Namespace:         input.Namespace,
-		AnalyzedAt:        time.Now(),
-		VariantCapacities: variantCapacities,
-		TotalSupply:       totalSupply,
-		TotalDemand:       totalDemand,
-		Utilization:       utilization,
-		RequiredCapacity:  requiredCapacity,
-		SpareCapacity:     spareCapacity,
-		RoleCapacities:    roleCapacities,
+		AnalyzerName:           a.Name(),
+		ModelID:                input.ModelID,
+		Namespace:              input.Namespace,
+		AnalyzedAt:             time.Now(),
+		VariantCapacities:      variantCapacities,
+		TotalSupply:            totalSupply,
+		TotalDemand:            totalDemand,
+		TotalAnticipatedSupply: totalAnticipatedSupply,
+		Utilization:            utilization,
+		RoleCapacities:         roleCapacities,
 	}
 
 	return result, nil
@@ -417,15 +403,19 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 }
 
 // aggregateByRole groups variant capacities by P/D role and computes per-role
-// scaling signals. Returns nil when no disaggregation is active (all variants
-// are role "both" or empty). The queueDemandByRole map adds scheduler queue
-// demand attributed to each role (nil when there's no queue demand).
+// aggregateByRole groups variant capacities by role and returns per-role
+// Total* aggregates for the engine post-step to compute RC/SC from.
+// Returns nil when no disaggregation is active (all variants are role "both"
+// or empty). The queueDemandByRole map adds scheduler queue demand attributed
+// to each role (nil when there's no queue demand).
+//
+// RequiredCapacity and SpareCapacity are left zero — the engine post-step
+// writes them after Analyze() returns using the universal threshold formula.
 func (a *SaturationAnalyzer) aggregateByRole(
 	variantCapacities []interfaces.VariantCapacity,
-	config *config.SaturationScalingConfig,
 	queueDemandByRole map[string]float64,
 ) map[string]interfaces.RoleCapacity {
-	// Check if any variant has a non-"both" role
+	// Check if any variant has a non-"both" role.
 	hasDisaggregation := false
 	for _, vc := range variantCapacities {
 		if vc.Role != "" && vc.Role != interfaces.RoleBoth {
@@ -437,60 +427,24 @@ func (a *SaturationAnalyzer) aggregateByRole(
 		return nil
 	}
 
-	// Group supply/demand by role
-	type roleAccum struct {
-		supply      float64
-		anticipated float64
-		demand      float64
-	}
-	roles := make(map[string]*roleAccum)
-	for _, vc := range variantCapacities {
-		role := vc.Role
-		if role == "" {
-			role = interfaces.RoleBoth
-		}
-		ra, ok := roles[role]
-		if !ok {
-			ra = &roleAccum{}
-			roles[role] = ra
-		}
-		ra.supply += vc.TotalCapacity
-		ra.anticipated += float64(vc.ReplicaCount+vc.PendingReplicas) * vc.PerReplicaCapacity
-		ra.demand += vc.TotalDemand
-	}
+	// Aggregate supply/demand/anticipated per role via shared helpers.
+	totals := aggregation.AggregateByRole(variantCapacities)
 
-	// Add scheduler queue demand attributed to each role
+	// Add scheduler queue demand attributed to each role.
 	for role, qd := range queueDemandByRole {
-		ra, ok := roles[role]
-		if !ok {
-			// Queue demand for a role with no variants — skip
-			continue
+		if t, ok := totals[role]; ok {
+			t.TotalDemand += qd
+			totals[role] = t
 		}
-		ra.demand += qd
 	}
 
-	// Compute per-role scaling signals
-	result := make(map[string]interfaces.RoleCapacity, len(roles))
-	for role, ra := range roles {
-		var required, spare float64
-		if config.ScaleUpThreshold > 0 {
-			required = ra.demand/config.ScaleUpThreshold - ra.anticipated
-		}
-		if required < 0 {
-			required = 0
-		}
-		if config.ScaleDownBoundary > 0 {
-			spare = ra.supply - ra.demand/config.ScaleDownBoundary
-		}
-		if spare < 0 {
-			spare = 0
-		}
+	result := make(map[string]interfaces.RoleCapacity, len(totals))
+	for role, t := range totals {
 		result[role] = interfaces.RoleCapacity{
-			Role:             role,
-			TotalSupply:      ra.supply,
-			TotalDemand:      ra.demand,
-			RequiredCapacity: required,
-			SpareCapacity:    spare,
+			Role:                   role,
+			TotalSupply:            t.TotalSupply,
+			TotalDemand:            t.TotalDemand,
+			TotalAnticipatedSupply: t.TotalAnticipatedSupply,
 		}
 	}
 	return result

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -402,7 +402,6 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 	return result
 }
 
-// aggregateByRole groups variant capacities by P/D role and computes per-role
 // aggregateByRole groups variant capacities by role and returns per-role
 // Total* aggregates for the engine post-step to compute RC/SC from.
 // Returns nil when no disaggregation is active (all variants are role "both"

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -238,10 +238,10 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
-			// readyCount = 2 - 1 = 1
-			// anticipated = (1 + 1) * perReplicaCapacity
-			// This suppresses scale-up signal since anticipated > ready
-			Expect(result.RequiredCapacity).To(BeNumerically(">=", 0))
+			// readyCount = 2 - 1 = 1; anticipated = (1 + 1) × PRC
+			// RC/SC are left zero by the analyzer; engine post-step sets them.
+			Expect(result.TotalAnticipatedSupply).To(BeNumerically(">", result.TotalSupply))
+			Expect(result.RequiredCapacity).To(BeZero())
 		})
 
 		It("should NOT include pending replicas in scale-down calculation", func() {
@@ -257,9 +257,10 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
-			// spareCapacity uses totalSupply (ready only, not pending)
-			// readyCount = 2, totalSupply = 2 * capacity
-			Expect(result.SpareCapacity).To(BeNumerically(">=", 0))
+			// TotalSupply uses ready replicas only; TotalAnticipatedSupply includes pending.
+			// RC/SC are left zero by the analyzer; engine post-step sets them.
+			Expect(result.TotalAnticipatedSupply).To(BeNumerically(">", result.TotalSupply))
+			Expect(result.SpareCapacity).To(BeZero())
 		})
 	})
 
@@ -492,8 +493,10 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
-			// demand is high relative to supply → requiredCapacity > 0
-			Expect(result.RequiredCapacity).To(BeNumerically(">", 0))
+			// demand is high relative to supply — TotalDemand > TotalAnticipatedSupply.
+			// RC/SC are left zero by the analyzer; engine post-step sets them.
+			Expect(result.TotalDemand).To(BeNumerically(">", result.TotalAnticipatedSupply*0.85))
+			Expect(result.RequiredCapacity).To(BeZero())
 		})
 
 		It("should signal scale-down when utilization is below boundary", func() {
@@ -511,9 +514,11 @@ var _ = Describe("SaturationAnalyzer", func() {
 
 			result, err := analyzer.Analyze(ctx, input)
 			Expect(err).NotTo(HaveOccurred())
-			// Very low utilization → spareCapacity > 0
-			Expect(result.SpareCapacity).To(BeNumerically(">", 0))
-			Expect(result.RequiredCapacity).To(Equal(float64(0)))
+			// Very low utilization — TotalSupply well above TotalDemand/scaleDown.
+			// RC/SC are left zero by the analyzer; engine post-step sets them.
+			Expect(result.TotalSupply).To(BeNumerically(">", result.TotalDemand/0.70))
+			Expect(result.SpareCapacity).To(BeZero())
+			Expect(result.RequiredCapacity).To(BeZero())
 		})
 
 		It("should signal steady state when utilization is between thresholds", func() {
@@ -898,11 +903,7 @@ var _ = Describe("aggregateByRole", func() {
 			{VariantName: "v1", Role: "both", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 			{VariantName: "v2", Role: "", TotalCapacity: 20000, TotalDemand: 10000, ReplicaCount: 1, PerReplicaCapacity: 20000},
 		}
-		config := &config.SaturationScalingConfig{
-			ScaleUpThreshold:  0.85,
-			ScaleDownBoundary: 0.70,
-		}
-		result := analyzer.aggregateByRole(vcs, config, nil)
+		result := analyzer.aggregateByRole(vcs, nil)
 		Expect(result).To(BeNil())
 	})
 
@@ -911,11 +912,7 @@ var _ = Describe("aggregateByRole", func() {
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 9000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 			{VariantName: "decode-v1", Role: "decode", TotalCapacity: 20000, TotalDemand: 5000, ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
-		config := &config.SaturationScalingConfig{
-			ScaleUpThreshold:  0.85,
-			ScaleDownBoundary: 0.70,
-		}
-		result := analyzer.aggregateByRole(vcs, config, nil)
+		result := analyzer.aggregateByRole(vcs, nil)
 		Expect(result).NotTo(BeNil())
 		Expect(result).To(HaveLen(2))
 
@@ -923,16 +920,19 @@ var _ = Describe("aggregateByRole", func() {
 		Expect(prefill.Role).To(Equal("prefill"))
 		Expect(prefill.TotalSupply).To(Equal(10000.0))
 		Expect(prefill.TotalDemand).To(Equal(9000.0))
-		// requiredCapacity = 9000/0.85 - 10000 = 10588 - 10000 = 588
-		Expect(prefill.RequiredCapacity).To(BeNumerically(">", 0))
+		Expect(prefill.TotalAnticipatedSupply).To(Equal(10000.0)) // 1 replica, no pending
+		// RC/SC are left zero; engine post-step sets them.
+		Expect(prefill.RequiredCapacity).To(BeZero())
+		Expect(prefill.SpareCapacity).To(BeZero())
 
 		decode := result["decode"]
 		Expect(decode.Role).To(Equal("decode"))
 		Expect(decode.TotalSupply).To(Equal(20000.0))
 		Expect(decode.TotalDemand).To(Equal(5000.0))
-		// spareCapacity = 20000 - 5000/0.70 = 20000 - 7143 = 12857
-		Expect(decode.SpareCapacity).To(BeNumerically(">", 0))
-		Expect(decode.RequiredCapacity).To(Equal(0.0))
+		Expect(decode.TotalAnticipatedSupply).To(Equal(20000.0)) // 2 replicas, no pending
+		// RC/SC are left zero; engine post-step sets them.
+		Expect(decode.SpareCapacity).To(BeZero())
+		Expect(decode.RequiredCapacity).To(BeZero())
 	})
 
 	It("should handle mixed roles including 'both'", func() {
@@ -940,11 +940,7 @@ var _ = Describe("aggregateByRole", func() {
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 9000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 			{VariantName: "both-v1", Role: "both", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PerReplicaCapacity: 10000},
 		}
-		config := &config.SaturationScalingConfig{
-			ScaleUpThreshold:  0.85,
-			ScaleDownBoundary: 0.70,
-		}
-		result := analyzer.aggregateByRole(vcs, config, nil)
+		result := analyzer.aggregateByRole(vcs, nil)
 		// Has disaggregation because prefill-v1 has role != "both"
 		Expect(result).NotTo(BeNil())
 		Expect(result).To(HaveKey("prefill"))
@@ -956,15 +952,11 @@ var _ = Describe("aggregateByRole", func() {
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 2000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 			{VariantName: "decode-v1", Role: "decode", TotalCapacity: 20000, TotalDemand: 3000, ReplicaCount: 2, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
-		config := &config.SaturationScalingConfig{
-			ScaleUpThreshold:  0.85,
-			ScaleDownBoundary: 0.70,
-		}
 		queueByRole := map[string]float64{
 			"prefill": 1000, // inputTokens only
 			"decode":  1500, // inputTokens + outputTokens
 		}
-		result := analyzer.aggregateByRole(vcs, config, queueByRole)
+		result := analyzer.aggregateByRole(vcs, queueByRole)
 		Expect(result).NotTo(BeNil())
 
 		prefill := result["prefill"]
@@ -980,16 +972,12 @@ var _ = Describe("aggregateByRole", func() {
 		vcs := []interfaces.VariantCapacity{
 			{VariantName: "prefill-v1", Role: "prefill", TotalCapacity: 10000, TotalDemand: 5000, ReplicaCount: 1, PendingReplicas: 0, PerReplicaCapacity: 10000},
 		}
-		config := &config.SaturationScalingConfig{
-			ScaleUpThreshold:  0.85,
-			ScaleDownBoundary: 0.70,
-		}
 		// Queue demand for decode, but no decode variants exist
 		queueByRole := map[string]float64{
 			"prefill": 1000,
 			"decode":  1500,
 		}
-		result := analyzer.aggregateByRole(vcs, config, queueByRole)
+		result := analyzer.aggregateByRole(vcs, queueByRole)
 		Expect(result).NotTo(BeNil())
 		Expect(result).To(HaveLen(1))
 		Expect(result).To(HaveKey("prefill"))

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			}
 			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
-			e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+			e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
 
 			// Saturation entry is skipped — engine runs saturation via
 			// runV2AnalysisOnly with full args. When a future PR unifies
@@ -231,7 +231,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
 			Expect(func() {
-				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
 			}).NotTo(Panic())
 
 			// Both analyzers are still called even though throughput erred.
@@ -250,7 +250,7 @@ var _ = Describe("Engine analyzer registry", func() {
 			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
 
 			Expect(func() {
-				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"})
+				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
 			}).NotTo(Panic())
 
 			// throughput panicked but was recovered; slo still ran.

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -74,15 +74,18 @@ func (e *Engine) runV2AnalysisOnly(
 	return result, nil
 }
 
-// runAnalyzersAndScore runs the V2 saturation analyzer, invokes every other
-// registered analyzer once per cycle to exercise the multi-analyzer pipeline,
-// and computes the weighted composite score from saturation's signal and the
-// model's priority.
+// runAnalyzersAndScore runs the V2 saturation analyzer, applies the universal
+// threshold post-step to every analyzer's result (using per-analyzer config
+// overrides where set), and computes the weighted composite score from
+// saturation's signal and the model's priority.
 //
-// On this branch only saturation drives scaling decisions: non-saturation
-// analyzer results are intentionally discarded. Combine and per-analyzer
-// threshold consumption land in follow-up PRs (multi-analyzer-optimizer,
-// multi-analyzer-threshold).
+// The engine applies applyUniversalThreshold to every analyzer — saturation and
+// all registered non-saturation analyzers. Per-analyzer ScaleUpThreshold /
+// ScaleDownBoundary overrides from AnalyzerScoreConfig are resolved and used for
+// each analyzer's calibration call. Non-saturation results are calibrated but
+// intentionally discarded on this branch; the optimizer only receives saturation's
+// result. Combine semantics and per-analyzer score consumption land in a follow-up
+// PR (multi-analyzer-optimizer).
 func (e *Engine) runAnalyzersAndScore(
 	ctx context.Context,
 	modelID, namespace string,
@@ -94,29 +97,17 @@ func (e *Engine) runAnalyzersAndScore(
 ) (*interfaces.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	// Resolve per-analyzer threshold overrides before running the analyzer.
-	// The saturation analyzer reads thresholds from the config, so we apply
-	// per-analyzer overrides to the config's top-level fields. Only saturation
-	// overrides are honored today; per-analyzer overrides for other analyzers
-	// are tracked on the multi-analyzer-threshold branch.
-	for _, aw := range config.Analyzers {
-		if aw.Name == interfaces.SaturationAnalyzerName && (aw.Enabled == nil || *aw.Enabled) {
-			if aw.ScaleUpThreshold != nil {
-				config.ScaleUpThreshold = *aw.ScaleUpThreshold
-			}
-			if aw.ScaleDownBoundary != nil {
-				config.ScaleDownBoundary = *aw.ScaleDownBoundary
-			}
-			break
-		}
-	}
-
 	// Run saturation analyzer (always needed for PerReplicaCapacity).
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings)
 	if err != nil {
 		return nil, err
 	}
+
+	// Universal threshold post-step for saturation: recalibrate RC/SC using the
+	// resolved threshold for the saturation entry (per-analyzer override over global).
+	satUp, satDown := resolveThresholds(interfaces.SaturationAnalyzerName, config)
+	applyUniversalThreshold(baseResult, satUp, satDown)
 
 	// Build AnalyzerInput once; shared by all non-saturation analyzers.
 	// Note: &config has had saturation's per-entry threshold overrides applied
@@ -134,15 +125,15 @@ func (e *Engine) runAnalyzersAndScore(
 		// SchedulerQueue: nil — wired in a later PR
 	}
 
-	// Iterate every registered analyzer in registration order. Saturation has
-	// already run above (with full args); the loop calls Analyze on every
-	// other registered analyzer to exercise the multi-analyzer pipeline.
-	// Their results are intentionally discarded on this branch — combine /
+	// Iterate every registered non-saturation analyzer. Each result is
+	// calibrated with the universal threshold post-step (using per-analyzer
+	// config overrides where set), then discarded on this branch — combine /
 	// per-analyzer-result consumption lands in follow-up PRs.
-	e.runRegisteredAnalyzers(ctx, logger, modelID, input)
+	e.runRegisteredAnalyzers(ctx, logger, modelID, input, config)
 
-	// Compute weighted score from enabled analyzers (saturation only on this
-	// branch — non-saturation analyzer results are not consumed yet).
+	// Compute weighted score from enabled analyzers.
+	// On this branch only saturation drives the score; non-saturation results
+	// are not yet consumed by the optimizer (see multi-analyzer-optimizer PR).
 	totalWeighted := 0.0
 	for _, aw := range config.Analyzers {
 		if aw.Enabled != nil && !*aw.Enabled {
@@ -154,57 +145,139 @@ func (e *Engine) runAnalyzersAndScore(
 		}
 	}
 
-	// Score = priority * weighted sum
+	// Score = priority * weighted sum; used by GreedyByScoreOptimizer for
+	// fair-share ordering across models. Computed from saturation's calibrated
+	// RC only; will be recomputed per-analyzer in the multi-analyzer-optimizer PR.
 	baseResult.Score = config.Priority * totalWeighted
 	return baseResult, nil
 }
 
+// resolveThresholds returns the effective scaleUp and scaleDown threshold values
+// for the named analyzer. If config.Analyzers contains an entry for that name,
+// its per-entry overrides (ScaleUpThreshold / ScaleDownBoundary) take precedence
+// over the model-level globals. Falls back to the global values when no matching
+// entry exists or the override fields are nil.
+func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) (scaleUp, scaleDown float64) {
+	for _, aw := range cfg.Analyzers {
+		if aw.Name == analyzerName {
+			return aw.EffectiveScaleUpThreshold(cfg.ScaleUpThreshold),
+				aw.EffectiveScaleDownBoundary(cfg.ScaleDownBoundary)
+		}
+	}
+	return cfg.ScaleUpThreshold, cfg.ScaleDownBoundary
+}
+
 // runRegisteredAnalyzers invokes Analyze on every registered non-saturation
 // analyzer in registration order, reading from the frozen analyzersSnapshot
-// built by StartOptimizeLoop. The saturation entry is skipped because the
-// engine runs saturation separately via runV2AnalysisOnly with full args.
-// Each call is isolated: errors are logged and discarded, and panics are
-// recovered so a faulty analyzer cannot take down the optimize goroutine.
-// Results are intentionally discarded on this branch — combine logic lands
-// in follow-up PRs.
+// built by StartOptimizeLoop. For each result the universal threshold post-step
+// is applied using per-analyzer config overrides where set (falling back to the
+// model-level globals). Results are discarded on this branch — combine logic
+// lands in follow-up PRs. Saturation is skipped; it runs via runV2AnalysisOnly.
 func (e *Engine) runRegisteredAnalyzers(
 	ctx context.Context,
 	logger logr.Logger,
 	modelID string,
 	input interfaces.AnalyzerInput,
+	cfg config.SaturationScalingConfig,
 ) {
 	for _, entry := range e.analyzersSnapshot {
 		if entry.name == interfaces.SaturationAnalyzerName {
 			continue
 		}
-		runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
+		result := runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
+		if result != nil {
+			up, down := resolveThresholds(entry.name, cfg)
+			applyUniversalThreshold(result, up, down)
+		}
+		// result discarded: optimizer receives only saturation on this branch
 	}
 }
 
 // runRegisteredAnalyzer invokes a single non-saturation analyzer's Analyze
 // method, isolating the call from the rest of the cycle. Errors are logged
-// and discarded; panics are recovered and logged. The result is intentionally
-// discarded on this branch — combine logic lands in follow-up PRs.
+// and nil is returned; panics are recovered and logged. Returns the result
+// so the caller can apply the universal threshold post-step before discarding.
 func runRegisteredAnalyzer(
 	ctx context.Context,
 	logger logr.Logger,
 	entry analyzerEntry,
 	modelID string,
 	input interfaces.AnalyzerInput,
-) {
+) (result *interfaces.AnalyzerResult) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Plugin failure is non-fatal; log at debug to avoid spamming
 			// operator logs every optimize cycle.
 			logger.V(logging.DEBUG).Info("registered analyzer panicked; result discarded",
 				"name", entry.name, "modelID", modelID, "panic", fmt.Sprintf("%v", r))
+			result = nil
 		}
 	}()
-	if _, err := entry.analyzer.Analyze(ctx, input); err != nil {
+	var err error
+	result, err = entry.analyzer.Analyze(ctx, input)
+	if err != nil {
 		// Plugin failure is non-fatal; log at debug to avoid spamming
 		// operator logs every optimize cycle.
 		logger.V(logging.DEBUG).Info("registered analyzer failed; result discarded",
 			"name", entry.name, "modelID", modelID, "error", err)
+		return nil
+	}
+	return result
+}
+
+// applyUniversalThreshold recalibrates RequiredCapacity and SpareCapacity in
+// place for the analyzer result and every RoleCapacity entry using the pure
+// formula:
+//
+//	RC = max(0, TotalDemand/scaleUp − TotalAnticipatedSupply)
+//	SC = max(0, TotalSupply    − TotalDemand/scaleDown)
+//
+// TotalAnticipatedSupply is read as-is — zero is a literal value, not a
+// sentinel. The analyzer is responsible for populating it correctly (see
+// internal/engines/aggregation for shared helpers). The asymmetry preserves
+// the conservative "don't double-scale while replicas are launching, don't
+// count pending as removable" stance.
+//
+// The same formula and the same (scaleUp, scaleDown) are applied at every
+// scope — model-level and each RoleCapacity entry. There are no per-role
+// threshold overrides. A non-positive scaleUp or scaleDown leaves the
+// corresponding signal unchanged.
+func applyUniversalThreshold(r *interfaces.AnalyzerResult, scaleUp, scaleDown float64) {
+	if r == nil {
+		return
+	}
+
+	if scaleUp > 0 {
+		rc := r.TotalDemand/scaleUp - r.TotalAnticipatedSupply
+		if rc < 0 {
+			rc = 0
+		}
+		r.RequiredCapacity = rc
+	}
+	if scaleDown > 0 {
+		sc := r.TotalSupply - r.TotalDemand/scaleDown
+		if sc < 0 {
+			sc = 0
+		}
+		r.SpareCapacity = sc
+	}
+
+	for role, rc := range r.RoleCapacities {
+		if scaleUp > 0 {
+			v := rc.TotalDemand/scaleUp - rc.TotalAnticipatedSupply
+			if v < 0 {
+				v = 0
+			}
+			rc.RequiredCapacity = v
+		}
+		if scaleDown > 0 {
+			v := rc.TotalSupply - rc.TotalDemand/scaleDown
+			if v < 0 {
+				v = 0
+			}
+			rc.SpareCapacity = v
+		}
+		r.RoleCapacities[role] = rc
 	}
 }
 

--- a/internal/engines/saturation/engine_v2_threshold_test.go
+++ b/internal/engines/saturation/engine_v2_threshold_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+var _ = Describe("applyUniversalThreshold", func() {
+	const (
+		scaleUp   = 0.85
+		scaleDown = 0.70
+	)
+
+	It("scales up when demand exceeds the scale-up threshold against anticipated supply", func() {
+		// RC = 10000/0.85 − 10000 = 1764.7...
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            10000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		Expect(r.RequiredCapacity).To(BeNumerically("~", 10000/scaleUp-10000, 1e-9))
+		// SC clamps to 0: TotalDemand/scaleDown = 14285.7 > TotalSupply.
+		Expect(r.SpareCapacity).To(BeZero())
+	})
+
+	It("scales down when demand is well below the scale-down boundary", func() {
+		// SC = 10000 − 5000/0.70 = 2857.1
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            5000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		Expect(r.RequiredCapacity).To(BeZero()) // 5000/0.85 = 5882.3 < 10000
+		Expect(r.SpareCapacity).To(BeNumerically("~", 10000-5000/scaleDown, 1e-9))
+	})
+
+	It("yields RC=SC=0 when demand sits in the hysteresis band", func() {
+		// utilization 0.80: above scaleDown 0.70 (no SC) but below scaleUp 0.85 (no RC)
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            8000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		Expect(r.RequiredCapacity).To(BeZero())
+		Expect(r.SpareCapacity).To(BeZero())
+	})
+
+	It("clamps RC and SC to zero exactly at the respective thresholds", func() {
+		rUp := &interfaces.AnalyzerResult{
+			TotalDemand:            10000 * scaleUp,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(rUp, scaleUp, scaleDown)
+		Expect(rUp.RequiredCapacity).To(BeNumerically("~", 0, 1e-9))
+
+		rDown := &interfaces.AnalyzerResult{
+			TotalDemand:            10000 * scaleDown,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(rDown, scaleUp, scaleDown)
+		Expect(rDown.SpareCapacity).To(BeNumerically("~", 0, 1e-9))
+	})
+
+	It("uses anticipated supply for RC but steady-state TotalSupply for SC", func() {
+		// Pending replica: anticipated=10000 > steady-state=7000 → RC=0 despite demand>supply.
+		// SC still uses TotalSupply (7000), not anticipated.
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            8000,
+			TotalSupply:            7000,
+			TotalAnticipatedSupply: 10000,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		// 8000/0.85 = 9411.7 < 10000 anticipated → RC = 0
+		Expect(r.RequiredCapacity).To(BeZero())
+		// 7000 − 8000/0.70 = 7000 − 11428.57 → clamps to 0
+		Expect(r.SpareCapacity).To(BeZero())
+	})
+
+	It("treats TotalAnticipatedSupply == 0 as a literal value — RC = TotalDemand/scaleUp", func() {
+		// No fallback: zero means zero anticipated supply.
+		// RC = 10000/0.85 − 0 = 11764.7...
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            10000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 0,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		Expect(r.RequiredCapacity).To(BeNumerically("~", 10000/scaleUp, 1e-9))
+	})
+
+	It("does not divide by zero when scaleUp or scaleDown is non-positive", func() {
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            5000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+			RequiredCapacity:       42,
+			SpareCapacity:          17,
+		}
+		applyUniversalThreshold(r, 0, 0)
+		Expect(r.RequiredCapacity).To(Equal(42.0))
+		Expect(r.SpareCapacity).To(Equal(17.0))
+
+		applyUniversalThreshold(r, -1, -1)
+		Expect(r.RequiredCapacity).To(Equal(42.0))
+		Expect(r.SpareCapacity).To(Equal(17.0))
+	})
+
+	It("is idempotent on its own output under the same inputs", func() {
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            12000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 11000,
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		rc1, sc1 := r.RequiredCapacity, r.SpareCapacity
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		Expect(r.RequiredCapacity).To(Equal(rc1))
+		Expect(r.SpareCapacity).To(Equal(sc1))
+	})
+
+	It("is a no-op on a nil result", func() {
+		Expect(func() { applyUniversalThreshold(nil, scaleUp, scaleDown) }).NotTo(Panic())
+	})
+
+	It("recalibrates RoleCapacities with the same formula and threshold values", func() {
+		// P/D disaggregated: two roles with distinct demand/anticipated/supply.
+		// prefill: RC = 8000/0.85 − 11000 = 9411.7 − 11000 → 0; SC = 10000 − 8000/0.70 → 0
+		// decode:  RC = 9500/0.85 − 10000 = 11176.4 − 10000 = 1176.4; SC = 10000 − 9500/0.70 → 0
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            17500,
+			TotalSupply:            20000,
+			TotalAnticipatedSupply: 21000,
+			RoleCapacities: map[string]interfaces.RoleCapacity{
+				"prefill": {
+					TotalDemand:            8000,
+					TotalSupply:            10000,
+					TotalAnticipatedSupply: 11000,
+				},
+				"decode": {
+					TotalDemand:            9500,
+					TotalSupply:            10000,
+					TotalAnticipatedSupply: 10000,
+				},
+			},
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+
+		prefill := r.RoleCapacities["prefill"]
+		Expect(prefill.RequiredCapacity).To(BeZero())
+		Expect(prefill.SpareCapacity).To(BeZero())
+
+		decode := r.RoleCapacities["decode"]
+		Expect(decode.RequiredCapacity).To(BeNumerically("~", 9500/scaleUp-10000, 1e-9))
+		Expect(decode.SpareCapacity).To(BeZero())
+	})
+
+	It("treats per-role TotalAnticipatedSupply == 0 as a literal value — RC = TotalDemand/scaleUp", func() {
+		// No fallback to TotalSupply; zero means zero anticipated supply for that role.
+		// RC = 5000/0.85 − 0 = 5882.3
+		r := &interfaces.AnalyzerResult{
+			TotalDemand:            5000,
+			TotalSupply:            10000,
+			TotalAnticipatedSupply: 10000,
+			RoleCapacities: map[string]interfaces.RoleCapacity{
+				"both": {
+					TotalDemand:            5000,
+					TotalSupply:            10000,
+					TotalAnticipatedSupply: 0,
+				},
+			},
+		}
+		applyUniversalThreshold(r, scaleUp, scaleDown)
+		both := r.RoleCapacities["both"]
+		Expect(both.RequiredCapacity).To(BeNumerically("~", 5000/scaleUp, 1e-9))
+		Expect(both.SpareCapacity).To(BeNumerically("~", 10000-5000/scaleDown, 1e-9))
+	})
+})

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -38,7 +38,11 @@ type AnalyzerInput struct {
 
 	// SchedulerQueue holds model-level queue metrics from the llm-d inference
 	// scheduler flow control layer. These represent requests queued upstream
-	// before reaching any vLLM pod and contribute to demand estimation.
+	// of any pod and are not yet attributed to a specific variant or role.
+	// Any analyzer with a demand model may convert this into per-analyzer
+	// demand using its own unit (e.g., kv-tokens for saturation_v2,
+	// tokens/sec for a future throughput analyzer). Demand attribution to
+	// roles or variants is each analyzer's choice.
 	// Nil when flow control is disabled or metrics are unavailable.
 	SchedulerQueue *SchedulerQueueMetrics
 }

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -66,11 +66,16 @@ type SchedulerQueueMetrics struct {
 
 // RoleCapacity holds per-role capacity aggregation for P/D disaggregated models.
 type RoleCapacity struct {
-	Role             string
-	TotalSupply      float64
-	TotalDemand      float64
-	RequiredCapacity float64
-	SpareCapacity    float64
+	Role        string
+	TotalSupply float64
+	TotalDemand float64
+	// TotalAnticipatedSupply is the per-role anticipated supply used by the
+	// engine's universal threshold post-step for the RC formula. Analyzer-
+	// supplied; the engine reads it as-is (zero is a literal value, not a
+	// sentinel). Use aggregation.AggregateByRole to populate this correctly.
+	TotalAnticipatedSupply float64
+	RequiredCapacity       float64
+	SpareCapacity          float64
 }
 
 // AnalyzerResult is the common output produced by all analyzers.
@@ -91,10 +96,22 @@ type AnalyzerResult struct {
 	TotalDemand float64 // Sum of all variant TotalDemand
 	Utilization float64 // TotalDemand / TotalSupply (0.0-1.0)
 
-	// Scaling signals — the core output consumed by the engine.
-	// These are the primary inputs for the engine's signal combination logic.
-	RequiredCapacity float64 // >0 means scale-up needed (demand/threshold - supply)
-	SpareCapacity    float64 // >0 means scale-down possible (supply - demand/boundary)
+	// TotalAnticipatedSupply is the anticipated supply the engine's universal
+	// threshold post-step subtracts from TotalDemand/scaleUp to compute RC.
+	// Analyzer-supplied; the engine reads it as-is (zero is a literal value,
+	// not a sentinel). Saturation V2 sets this to
+	// Σ_v (ReplicaCount + PendingReplicas) × PerReplicaCapacity so pending
+	// replicas count against demand, preventing double-scaling. Use
+	// aggregation.SumTotalAnticipatedSupply to populate this correctly.
+	TotalAnticipatedSupply float64
+
+	// Scaling signals — written by the engine post-step; read by the optimizer.
+	// The engine overwrites both fields after each analyzer's Analyze() returns:
+	//   RC = max(0, TotalDemand/scaleUp − TotalAnticipatedSupply)
+	//   SC = max(0, TotalSupply    − TotalDemand/scaleDown)
+	// Analyzer-written values are discarded; analyzers should leave these zero.
+	RequiredCapacity float64 // >0 means scale-up needed
+	SpareCapacity    float64 // >0 means scale-down possible
 
 	// Score is the composite priority score for this model.
 	// Computed as: priority * sum(requiredCapacity_i * analyzerScore_i)


### PR DESCRIPTION
## Summary

- Engine post-step applies a pure threshold formula to `RequiredCapacity` / `SpareCapacity` at model level and every `RoleCapacity` entry, replacing the saturation-only override-resolution loop. `TotalAnticipatedSupply` is read as-is — zero is a literal value, not a sentinel; no fallback walk over `VariantCapacities`.
- New `internal/engines/aggregation/` package with pure helpers (`SumTotalSupply`, `SumTotalAnticipatedSupply`, `SumTotalDemand`, `AggregateByRole`) over `[]VariantCapacity`. Analyzers use these to populate per-scope `Total*` fields and enforce the linearity invariant the optimizer's per-variant scaling math depends on.
- Saturation V2 simplified: drops in-analyzer RC/SC computation (engine post-step is now the sole writer); calls helpers for per-scope aggregation. Phase 4 redundancy removed.
- Per-analyzer threshold overrides resolved per analyzer (`AnalyzerScoreConfig.ScaleUpThreshold` / `ScaleDownBoundary` over the model-level globals) and applied uniformly at every scope. No per-role overrides.
- Dev-guide rewritten to document the architecture: per-variant `VariantCapacity` is canonical; analyzer publishes per-variant primitives + per-scope `Total*`; engine post-step computes RC/SC; `SchedulerQueue` is shared input across analyzers, but demand extraction is per-analyzer.

## Context

This PR is **stacked on #1225** (\`engines/saturation: multi-analyzer registry\`). The 4 threshold commits sit on top of #1225's 3 registration commits. When #1225 merges, this branch will be rebased onto main and the diff will reduce to the 4 threshold commits.

Implements Item 2 of the design discussion in \`planning/PR1113-review.md\`. Items 1 (combine deletion / per-analyzer slice → optimizers) and 3 (analyzer registration) are tracked separately.

## Test plan

- [x] \`make build\` — clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`make test\` — all packages pass
- [x] \`go test -race ./internal/engines/saturation/...\` — clean
- [x] \`internal/engines/aggregation/aggregation_test.go\` — full coverage of helper edge cases (empty input, single/multi variant, mixed roles, empty-role canonicalization, zero replicas, zero PRC)
- [x] \`internal/engines/saturation/engine_v2_threshold_test.go\` — pure-formula specs at model + per-role (12 specs covering scale-up/down, hysteresis band, exact-boundary clamps, anticipated-vs-steady asymmetry, literal-zero \`TotalAnticipatedSupply\`, non-positive thresholds, idempotency, nil-result, P/D disaggregation)
- [x] DCO sign-off on all 4 commits

## Behavior change

\`AnalyzerResult.RequiredCapacity\` and \`SpareCapacity\` are now **written exclusively by the engine post-step**. Analyzer-written values are discarded. Saturation V2's in-analyzer RC/SC computation has been removed; the engine's universal formula produces the same values for the same inputs. Any analyzer extending this path must populate per-scope \`Total*\` fields (use the shared helpers) and leave RC/SC zero.