### PR TITLE
fix(openshift): wire OCP user-workload-monitoring metrics scraping

### DIFF
--- a/config/overlays/namespace-scoped/openshift/controller-manager-token-secret.yaml
+++ b/config/overlays/namespace-scoped/openshift/controller-manager-token-secret.yaml
@@ -1,0 +1,9 @@
+# SA token Secret used by the ServiceMonitor to authenticate when scraping
+# the WVA controller's /metrics endpoint.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager-token
+  annotations:
+    kubernetes.io/service-account.name: controller-manager
+type: kubernetes.io/service-account-token

--- a/config/overlays/namespace-scoped/openshift/kustomization.yaml
+++ b/config/overlays/namespace-scoped/openshift/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
 # Grant OpenShift's user-workload Prometheus cluster-monitoring-view so it can
 # scrape the controller's secure /metrics endpoint.
 - prometheus-cluster-monitoring-view-clusterrolebinding.yaml
+# Long-lived SA token referenced by the ServiceMonitor's bearerTokenSecret.
+- controller-manager-token-secret.yaml
 
 components:
 - ../../../components/namespace-scoped/
@@ -30,12 +32,35 @@ patches:
   target:
     kind: Deployment
     name: controller-manager
-# The base metrics-reader-clusterrolebinding targets the kube-prometheus-stack
-# Prometheus SA. On OpenShift, scrape access is granted via the
-# cluster-monitoring-view binding above, so drop the base binding here.
+# Grant the WVA controller manager SA read access to its own /metrics endpoint
+# so the ServiceMonitor can scrape it.
 - patch: |-
-    $patch: delete
-    apiVersion: rbac.authorization.k8s.io/v1
+    - op: replace
+      path: /subjects/0
+      value:
+        kind: ServiceAccount
+        name: controller-manager
+  target:
     kind: ClusterRoleBinding
-    metadata:
-      name: metrics-reader-rolebinding
+    name: metrics-reader-rolebinding
+# Label the WVA namespace so OCP user-workload-monitoring Prometheus discovers
+# ServiceMonitors inside it (required for UWM to watch the namespace).
+- patch: |-
+    - op: add
+      path: /metadata/labels/openshift.io~1user-monitoring
+      value: "true"
+  target:
+    kind: Namespace
+# Configure the ServiceMonitor to authenticate using the WVA SA token Secret,
+# which is granted metrics-reader access via the patch above.
+- patch: |-
+    - op: add
+      path: /spec/endpoints/0/bearerTokenSecret
+      value:
+        name: controller-manager-token
+        key: token
+    - op: remove
+      path: /spec/endpoints/0/bearerTokenFile
+  target:
+    kind: ServiceMonitor
+    name: controller-manager-metrics-monitor

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -92,6 +92,32 @@ images:
   newTag: "$WVA_IMAGE_TAG"
 EOF
 
+    # On OpenShift shared clusters, all ClusterRoleBindings share the same fixed
+    # names. Concurrent deployments overwrite each other's subject namespace.
+    # Append name-rename patches so each namespace gets its own uniquely named CRBs.
+    if [ "$ENVIRONMENT" = "openshift" ]; then
+        local ns_hash
+        ns_hash="$(printf '%s' "${WVA_NS}" | sha256sum | cut -c1-8)"
+        printf 'patches:\n' >> "$tmp_overlay/kustomization.yaml"
+        for crb in \
+            wva-epp-metrics-reader-role-binding \
+            wva-manager-cluster-monitoring-view \
+            wva-manager-rolebinding \
+            wva-metrics-auth-rolebinding \
+            wva-metrics-reader-rolebinding \
+            wva-prometheus-cluster-monitoring-view; do
+            cat >> "$tmp_overlay/kustomization.yaml" <<EOF
+- patch: |-
+    - op: replace
+      path: /metadata/name
+      value: ${crb}-${ns_hash}
+  target:
+    kind: ClusterRoleBinding
+    name: ${crb}
+EOF
+        done
+    fi
+
     log_info "Installing WVA CRDs..."
     kubectl apply -k "$WVA_PROJECT/config/base/crd/"
 
@@ -103,34 +129,6 @@ EOF
         kubectl patch configmap wva-manager-config \
             -n "$WVA_NS" --type=merge \
             -p '{"data":{"WVA_SCALE_TO_ZERO":"true"}}'
-    fi
-
-    # On shared clusters (e.g. OpenShift CI), concurrent runs produce the same
-    # ClusterRoleBinding name (wva-manager-rolebinding) because the overlay uses a
-    # fixed name. Each apply overwrites the subject namespace, breaking any other
-    # run that applied first. Create a per-deployment binding named after WVA_NS so
-    # each run has its own authoritative binding that survives concurrent applies.
-    log_info "Creating per-deployment ClusterRoleBindings for SA in $WVA_NS (shared cluster isolation)"
-    kubectl create clusterrolebinding "workload-variant-autoscaler-manager-${WVA_NS}" \
-        --clusterrole=wva-manager-role \
-        --serviceaccount="${WVA_NS}:wva-controller-manager" \
-        --dry-run=client -o yaml | kubectl apply -f -
-    if kubectl get clusterrole cluster-monitoring-view &>/dev/null; then
-        kubectl create clusterrolebinding "workload-variant-autoscaler-cluster-monitoring-view-${WVA_NS}" \
-            --clusterrole=cluster-monitoring-view \
-            --serviceaccount="${WVA_NS}:wva-controller-manager" \
-            --dry-run=client -o yaml | kubectl apply -f -
-    else
-        log_info "cluster-monitoring-view ClusterRole not found — skipping binding (non-OpenShift cluster)"
-    fi
-    # metrics-reader-rolebinding is a shared-name CRB that gets overwritten on
-    # shared clusters. Create a per-namespace named binding as the authoritative
-    # grant so each deployment is independent regardless of apply order.
-    if kubectl get clusterrole wva-metrics-reader &>/dev/null; then
-        kubectl create clusterrolebinding "workload-variant-autoscaler-metrics-reader-${WVA_NS}" \
-            --clusterrole=wva-metrics-reader \
-            --serviceaccount="${WVA_NS}:wva-controller-manager" \
-            --dry-run=client -o yaml | kubectl apply -f -
     fi
 
     # Wait for WVA to be ready

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -123,6 +123,15 @@ EOF
     else
         log_info "cluster-monitoring-view ClusterRole not found — skipping binding (non-OpenShift cluster)"
     fi
+    # metrics-reader-rolebinding is a shared-name CRB that gets overwritten on
+    # shared clusters. Create a per-namespace named binding as the authoritative
+    # grant so each deployment is independent regardless of apply order.
+    if kubectl get clusterrole wva-metrics-reader &>/dev/null; then
+        kubectl create clusterrolebinding "workload-variant-autoscaler-metrics-reader-${WVA_NS}" \
+            --clusterrole=wva-metrics-reader \
+            --serviceaccount="${WVA_NS}:wva-controller-manager" \
+            --dry-run=client -o yaml | kubectl apply -f -
+    fi
 
     # Wait for WVA to be ready
     log_info "Waiting for WVA controller to be ready..."


### PR DESCRIPTION
OCP deploy had 3 gaps that silently broke UWM metrics scraping. 
- UWM Prometheus ignores namespaces without `openshift.io/user-monitoring=true` the label was never applied. 
- The ServiceMonitor was sending the Prometheus pod's own token instead of the WVA SA token, so kube-rbac-proxy denied every scrape.
- The metrics-reader-rolebinding subject pointed to the kube-prometheus SA from the base manifest, not the WVA SA
All three are now fixed in the openshift overlay via kustomize patches + a new SA token Secret. The developer deploy script also creates a per-namespace metrics-reader CRB for shared-cluster isolation, matching the pattern already used for the other two CRBs.

Verified end-to-end with a kustomize-only deploy, the UWM target came up healthy.