### PR TITLE
fix(optimizer): role-aware scale-down for disaggregated models

### DIFF
--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -144,6 +144,9 @@ func costAwareScaleDown(
 	if len(result.RoleCapacities) > 0 {
 		// Each role owns a disjoint set of variants and sheds against its own
 		// spare, so the map's iteration order does not affect the outcome.
+		// Assumes RoleCapacities keys partition VariantCapacities by role
+		// (one role per variant; no overlap); mixed-role configurations would
+		// break disjointness.
 		for role, rc := range result.RoleCapacities {
 			if rc.SpareCapacity <= 0 {
 				continue // saturated or under-supplied role — never trim it

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -121,29 +121,58 @@ func costAwareScaleUp(
 	}
 }
 
-// costAwareScaleDown removes replicas from the most expensive variant.
-// Sorts by absolute cost descending, removes from most expensive first.
-// Respects minReplicas per variant — will not scale below the annotation floor.
-// The cheapest variant is protected at min 1 replica only when no other variant
-// has replicas — this prevents scale-down deadlocks where the expensive variant's
-// per-replica capacity exceeds spare but cheaper replicas could be removed.
+// costAwareScaleDown removes replicas to shed spare capacity, most-expensive
+// variant first, respecting minReplicas.
+//
+// For disaggregated (prefill/decode) models it sheds each role independently
+// against that role's own spare. Prefill and decode capacity are not fungible, so
+// removing by the model-level SpareCapacity — which aggregates all roles — would
+// let a role with slack drive removal of replicas from a saturated role (e.g.
+// trimming prefill because decode has spare). RoleCapacities is non-nil only when
+// disaggregation is active; non-disaggregated models keep the model-level shed.
 func costAwareScaleDown(
 	ctx context.Context,
 	result *interfaces.AnalyzerResult,
 	targets map[string]int,
 	stateMap ...map[string]interfaces.VariantReplicaState,
 ) {
-	logger := ctrl.LoggerFrom(ctx)
-
-	sorted := sortByCostDesc(result.VariantCapacities)
-	cheapest := findCheapestVariant(result.VariantCapacities)
-	remaining := result.SpareCapacity
-
-	// Build state lookup if provided
 	var states map[string]interfaces.VariantReplicaState
 	if len(stateMap) > 0 {
 		states = stateMap[0]
 	}
+
+	if len(result.RoleCapacities) > 0 {
+		// Each role owns a disjoint set of variants and sheds against its own
+		// spare, so the map's iteration order does not affect the outcome.
+		for role, rc := range result.RoleCapacities {
+			if rc.SpareCapacity <= 0 {
+				continue // saturated or under-supplied role — never trim it
+			}
+			scaleDownVariantSet(ctx, variantsForRole(result.VariantCapacities, role), rc.SpareCapacity, targets, states)
+		}
+		return
+	}
+
+	scaleDownVariantSet(ctx, result.VariantCapacities, result.SpareCapacity, targets, states)
+}
+
+// scaleDownVariantSet removes replicas from the given variant set, most-expensive
+// first, until `spare` capacity is shed or each variant's minReplicas floor is
+// reached. The cheapest variant in the set is protected at one replica when it
+// would otherwise be the last variant with replicas in the set — preventing a
+// scale-to-zero deadlock.
+func scaleDownVariantSet(
+	ctx context.Context,
+	variants []interfaces.VariantCapacity,
+	spare float64,
+	targets map[string]int,
+	states map[string]interfaces.VariantReplicaState,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	sorted := sortByCostDesc(variants)
+	cheapest := findCheapestVariant(variants)
+	remaining := spare
 
 	for _, vc := range sorted {
 		if remaining <= 0 {
@@ -164,10 +193,10 @@ func costAwareScaleDown(
 		}
 		if vc.VariantName == cheapest {
 			// Protect cheapest at 1 only if it's the last variant with replicas
-			// and no higher annotation min is set
+			// in the set and no higher annotation min is set
 			otherHasReplicas := false
-			for name, t := range targets {
-				if name != cheapest && t > 0 {
+			for _, other := range variants {
+				if other.VariantName != cheapest && targets[other.VariantName] > 0 {
 					otherHasReplicas = true
 					break
 				}
@@ -198,6 +227,24 @@ func costAwareScaleDown(
 			"removed", replicasToRemove,
 			"cost", vc.Cost)
 	}
+}
+
+// variantsForRole returns the capacities whose role matches exactly (an empty
+// role is treated as "both"). Unlike filterVariantCapacitiesByRole, which treats
+// "both" as a wildcard for scale-up allocation, this matches the role exactly so
+// per-role scale-down operates on disjoint variant sets.
+func variantsForRole(capacities []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
+	out := make([]interfaces.VariantCapacity, 0, len(capacities))
+	for _, vc := range capacities {
+		r := vc.Role
+		if r == "" {
+			r = interfaces.RoleBoth
+		}
+		if r == role {
+			out = append(out, vc)
+		}
+	}
+	return out
 }
 
 // buildStateMap creates a lookup map from variant name to VariantReplicaState.

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -161,9 +161,9 @@ func costAwareScaleDown(
 
 // scaleDownVariantSet removes replicas from the given variant set, most-expensive
 // first, until `spare` capacity is shed or each variant's minReplicas floor is
-// reached. The cheapest variant in the set is protected at one replica when it
-// would otherwise be the last variant with replicas in the set — preventing a
-// scale-to-zero deadlock.
+// reached. The cheapest variant — last in the cost-descending order — is protected
+// at one replica when it would otherwise be the last variant with replicas in the
+// set, preventing a scale-to-zero deadlock.
 func scaleDownVariantSet(
 	ctx context.Context,
 	variants []interfaces.VariantCapacity,
@@ -174,10 +174,9 @@ func scaleDownVariantSet(
 	logger := ctrl.LoggerFrom(ctx)
 
 	sorted := sortByCostDesc(variants)
-	cheapest := findCheapestVariant(variants)
 	remaining := spare
 
-	for _, vc := range sorted {
+	for i, vc := range sorted {
 		if remaining <= 0 {
 			break
 		}
@@ -187,49 +186,54 @@ func scaleDownVariantSet(
 
 		current := targets[vc.VariantName]
 
-		// Determine minReplicas: annotation floor takes priority, then cheapest-variant logic
+		// Annotation floor caps removal.
 		minReplicas := 0
 		if states != nil {
 			if state, ok := states[vc.VariantName]; ok && state.MinReplicas != nil {
 				minReplicas = *state.MinReplicas
 			}
 		}
-		if vc.VariantName == cheapest {
-			// Protect cheapest at 1 only if it's the last variant with replicas
-			// in the set and no higher annotation min is set
-			otherHasReplicas := false
-			for _, other := range variants {
-				if other.VariantName != cheapest && targets[other.VariantName] > 0 {
-					otherHasReplicas = true
-					break
-				}
-			}
-			if !otherHasReplicas && minReplicas < 1 {
-				minReplicas = 1
-			}
-		}
-
 		removable := current - minReplicas
 		if removable <= 0 {
 			continue
 		}
 
-		replicasToRemove := int(math.Floor(remaining / vc.PerReplicaCapacity))
-		if replicasToRemove > removable {
-			replicasToRemove = removable
+		toRemove := int(math.Floor(remaining / vc.PerReplicaCapacity))
+		if toRemove > removable {
+			toRemove = removable
 		}
-		if replicasToRemove <= 0 {
+
+		// Protect the cheapest variant (last in cost-descending order) at one
+		// replica when removing toRemove would drop it below one and no
+		// more-expensive variant still holds replicas — i.e. it is the last with
+		// replicas in the set. When minReplicas >= 1, removable <= current-1 so
+		// toRemove <= current-1 and current-toRemove >= 1 already, so this clause
+		// never triggers.
+		if i == len(sorted)-1 && current-toRemove < 1 && !anyHasReplicas(sorted[:i], targets) {
+			toRemove = current - 1
+		}
+		if toRemove <= 0 {
 			continue
 		}
 
-		targets[vc.VariantName] = current - replicasToRemove
-		remaining -= float64(replicasToRemove) * vc.PerReplicaCapacity
+		targets[vc.VariantName] = current - toRemove
+		remaining -= float64(toRemove) * vc.PerReplicaCapacity
 
 		logger.V(logging.DEBUG).Info("Scale-down allocation",
 			"variant", vc.VariantName,
-			"removed", replicasToRemove,
+			"removed", toRemove,
 			"cost", vc.Cost)
 	}
+}
+
+// anyHasReplicas reports whether any of the given variants has a positive target.
+func anyHasReplicas(variants []interfaces.VariantCapacity, targets map[string]int) bool {
+	for _, vc := range variants {
+		if targets[vc.VariantName] > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // variantsForRole returns the capacities whose role matches exactly (an empty
@@ -277,19 +281,6 @@ func initTargets(states []interfaces.VariantReplicaState) map[string]int {
 	return targets
 }
 
-// findCheapestVariant returns the variant name with the lowest cost.
-func findCheapestVariant(capacities []interfaces.VariantCapacity) string {
-	cheapest := ""
-	minCost := math.MaxFloat64
-	for _, vc := range capacities {
-		if vc.Cost < minCost {
-			minCost = vc.Cost
-			cheapest = vc.VariantName
-		}
-	}
-	return cheapest
-}
-
 // sortByCostEfficiencyAsc returns variants sorted by cost/perReplicaCapacity ascending.
 func sortByCostEfficiencyAsc(capacities []interfaces.VariantCapacity) []interfaces.VariantCapacity {
 	sorted := make([]interfaces.VariantCapacity, len(capacities))
@@ -300,12 +291,19 @@ func sortByCostEfficiencyAsc(capacities []interfaces.VariantCapacity) []interfac
 	return sorted
 }
 
-// sortByCostDesc returns variants sorted by absolute cost descending.
+// sortByCostDesc returns variants sorted by absolute cost descending. Equal-cost
+// variants are tie-broken by per-replica capacity ascending, so the highest-PRC
+// variant at the cheapest cost tier lands last — the deterministic slot the
+// scale-down protection keeps at one replica (prefer keeping the more capable
+// replica among equal-cost variants).
 func sortByCostDesc(capacities []interfaces.VariantCapacity) []interfaces.VariantCapacity {
 	sorted := make([]interfaces.VariantCapacity, len(capacities))
 	copy(sorted, capacities)
 	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Cost > sorted[j].Cost
+		if sorted[i].Cost != sorted[j].Cost {
+			return sorted[i].Cost > sorted[j].Cost
+		}
+		return sorted[i].PerReplicaCapacity < sorted[j].PerReplicaCapacity
 	})
 	return sorted
 }

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -335,6 +335,81 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// decode sheds floor(20000/10000)=2 → 3 - 2 = 1.
 			Expect(dm["decode"].TargetReplicas).To(Equal(1))
 		})
+
+		It("sheds within a single role when only one role has capacity", func() {
+			// Only decode has a RoleCapacities entry (e.g. a prefill data-collection
+			// gap). The one-iteration path must shed decode against its own spare and
+			// keep the cheapest decode variant at one replica.
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-1",
+					Namespace: "default",
+					Result: &interfaces.AnalyzerResult{
+						SpareCapacity: 20000,
+						VariantCapacities: []interfaces.VariantCapacity{
+							{VariantName: "decode-exp", Role: "decode", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+							{VariantName: "decode-cheap", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+						},
+						RoleCapacities: map[string]interfaces.RoleCapacity{
+							"decode": {Role: "decode", SpareCapacity: 20000}, // 2 replicas
+						},
+					},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "decode-exp", Role: "decode", CurrentReplicas: 1},
+						{VariantName: "decode-cheap", Role: "decode", CurrentReplicas: 1},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// Most-expensive-first removes decode-exp (1→0); decode-cheap is then the
+			// last with replicas in the role → protected at one.
+			Expect(dm["decode-exp"].TargetReplicas).To(Equal(0))
+			Expect(dm["decode-cheap"].TargetReplicas).To(Equal(1))
+		})
+
+		It("leaves an empty-role variant untouched when RoleCapacities is per-role", func() {
+			// A variant with Role "" canonicalizes to RoleBoth, which has no entry in a
+			// prefill/decode RoleCapacities map — so the per-role sheds never include it.
+			// The design assumes one role per variant; this pins the defensive behavior
+			// if that assumption is violated: the orphan is left as-is.
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-1",
+					Namespace: "default",
+					Result: &interfaces.AnalyzerResult{
+						SpareCapacity: 20000,
+						VariantCapacities: []interfaces.VariantCapacity{
+							{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+							{VariantName: "orphan", Role: "", Cost: 20.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+						},
+						RoleCapacities: map[string]interfaces.RoleCapacity{
+							"prefill": {Role: "prefill", SpareCapacity: 0},
+							"decode":  {Role: "decode", SpareCapacity: 20000},
+						},
+					},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
+						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
+						{VariantName: "orphan", Role: "", CurrentReplicas: 2},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// orphan (role "") matches no per-role set → never trimmed, despite being
+			// the most expensive variant.
+			Expect(dm["orphan"].TargetReplicas).To(Equal(2))
+			Expect(dm["orphan"].Action).To(Equal(interfaces.ActionNoChange))
+			// prefill saturated → untouched; decode sheds its own spare → 3 - 2 = 1.
+			Expect(dm["prefill"].TargetReplicas).To(Equal(2))
+			Expect(dm["decode"].TargetReplicas).To(Equal(1))
+		})
 	})
 
 	Context("Steady State", func() {

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -665,14 +665,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(sorted[2].VariantName).To(Equal("cheap"))
 		})
 
-		It("findCheapestVariant should return lowest cost variant", func() {
+		It("sortByCostDesc should tie-break equal cost by per-replica capacity ascending", func() {
+			// Among equal-cost variants, the higher-PRC one must land last — the
+			// deterministic slot scale-down protects at one replica.
 			capacities := []interfaces.VariantCapacity{
-				{VariantName: "mid", Cost: 10.0},
-				{VariantName: "cheap", Cost: 5.0},
-				{VariantName: "expensive", Cost: 15.0},
+				{VariantName: "lo-prc", Cost: 5.0, PerReplicaCapacity: 1000},
+				{VariantName: "hi-prc", Cost: 5.0, PerReplicaCapacity: 9000},
 			}
 
-			Expect(findCheapestVariant(capacities)).To(Equal("cheap"))
+			sorted := sortByCostDesc(capacities)
+
+			Expect(sorted[len(sorted)-1].VariantName).To(Equal("hi-prc"))
 		})
 
 		It("mergeConstraints should take minimum available per type", func() {

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -263,6 +263,78 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(dm["mid"].TargetReplicas).To(Equal(2))
 			Expect(dm["cheap"].TargetReplicas).To(Equal(1))
 		})
+
+		It("should shed only the role with spare for disaggregated models", func() {
+			// Prefill is saturated (zero role spare) and is the more expensive role;
+			// decode has spare. Model-level SpareCapacity aggregates both roles, so a
+			// role-blind scale-down would trim the expensive prefill. Role-aware
+			// scale-down must leave the saturated prefill untouched and shed decode.
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-1",
+					Namespace: "default",
+					Result: &interfaces.AnalyzerResult{
+						SpareCapacity: 20000, // aggregate (decode's spare) — gates scale-down
+						VariantCapacities: []interfaces.VariantCapacity{
+							{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+						},
+						RoleCapacities: map[string]interfaces.RoleCapacity{
+							"prefill": {Role: "prefill", SpareCapacity: 0},
+							"decode":  {Role: "decode", SpareCapacity: 20000},
+						},
+					},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
+						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// Prefill (saturated role) is never trimmed despite being most expensive.
+			Expect(dm["prefill"].TargetReplicas).To(Equal(2))
+			Expect(dm["prefill"].Action).To(Equal(interfaces.ActionNoChange))
+			// Decode sheds its own spare: floor(20000/10000)=2 → 3 - 2 = 1.
+			Expect(dm["decode"].TargetReplicas).To(Equal(1))
+			Expect(dm["decode"].Action).To(Equal(interfaces.ActionScaleDown))
+		})
+
+		It("should shed each role by its own spare when both have slack", func() {
+			// Both roles have spare, but different amounts. Each role must shed by
+			// its own per-role spare, not the aggregate.
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-1",
+					Namespace: "default",
+					Result: &interfaces.AnalyzerResult{
+						SpareCapacity: 30000, // aggregate — gates scale-down
+						VariantCapacities: []interfaces.VariantCapacity{
+							{VariantName: "prefill", Role: "prefill", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+						},
+						RoleCapacities: map[string]interfaces.RoleCapacity{
+							"prefill": {Role: "prefill", SpareCapacity: 10000}, // 1 replica
+							"decode":  {Role: "decode", SpareCapacity: 20000},  // 2 replicas
+						},
+					},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 3},
+						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
+					},
+				},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// prefill sheds floor(10000/10000)=1 → 3 - 1 = 2.
+			Expect(dm["prefill"].TargetReplicas).To(Equal(2))
+			// decode sheds floor(20000/10000)=2 → 3 - 2 = 1.
+			Expect(dm["decode"].TargetReplicas).To(Equal(1))
+		})
 	})
 
 	Context("Steady State", func() {

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -233,7 +233,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 		return o.allocateByRole(ctx, w, target, stateMap, available)
 	}
 
-	return o.allocateToVariants(ctx, w, target, w.req.Result.VariantCapacities, stateMap, available, "both")
+	return o.allocateToVariants(ctx, w, target, w.req.Result.VariantCapacities, stateMap, available, interfaces.RoleBoth)
 }
 
 // allocateByRole distributes replicas between roles proportional to their demand.
@@ -367,16 +367,16 @@ func (o *GreedyByScoreOptimizer) allocateToVariants(
 }
 
 // filterVariantCapacitiesByRole returns variant capacities matching the specified role.
-// For role "both" or empty, returns all capacities.
+// For role RoleBoth or empty, returns all capacities.
 func filterVariantCapacitiesByRole(capacities []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
-	if role == "both" || role == "" {
+	if role == interfaces.RoleBoth || role == "" {
 		return capacities
 	}
 	var filtered []interfaces.VariantCapacity
 	for _, vc := range capacities {
 		vcRole := vc.Role
 		if vcRole == "" {
-			vcRole = "both"
+			vcRole = interfaces.RoleBoth
 		}
 		if vcRole == role {
 			filtered = append(filtered, vc)


### PR DESCRIPTION
## Summary

`costAwareScaleDown` sheds replicas using the **model-level** `SpareCapacity`,
which aggregates prefill and decode. Because prefill and decode capacity are not
fungible, this lets a role with slack drive removal of replicas from a **saturated**
role — and because removal is most-expensive-variant-first regardless of role, it
can even remove the wrong role's replicas entirely.

This PR makes scale-down **role-aware**: for disaggregated models it sheds each
role independently against that role's own spare and never trims a role with no
spare. Non-disaggregated models are unchanged.

## The bug

For a disaggregated model, model-level spare is
`totalSupply − totalDemand/boundary` summed over **all** variants
(`saturation_v2/analyzer.go`). So when prefill is saturated (`spare_prefill = 0`)
but decode has slack (`spare_decode > 0`), the aggregate is positive and
`costAwareScaleDown` runs — then removes the **most-expensive** variant first,
which can be prefill. The saturated role loses replicas while the role with actual
slack keeps them.

Concretely (1 GPU/replica):

| variant | role | cost | replicas | role spare |
|---|---|---:|---:|---:|
| prefill | prefill | 15 | 2 | 0 (saturated) |
| decode | decode | 5 | 3 | 20000 (2 replicas) |

Model-level spare = `20000` (decode's), so scale-down fires. **Before:** sorted by
cost desc → prefill removed first → `prefill 2 → 0`, decode untouched. The model
loses its entire prefill role. **After:** prefill (no spare) is skipped; decode
sheds its own spare → `decode 3 → 1`, prefill stays at 2.

Latent in the additive optimizer (scale-down only fires on small aggregate spare,
so the skew is small and self-corrects), but it becomes significant for any caller
that drives large reclaims through this primitive.

## The fix

- When `RoleCapacities` is present (disaggregation active), shed **each role**
  against its own `RoleCapacities[role].SpareCapacity`; skip roles with no spare.
- When it is absent, keep the existing model-level shed verbatim.
- Extract the per-variant removal loop into `scaleDownVariantSet` and add an
  exact-match `variantsForRole` helper so per-role sheds operate on disjoint
  variant sets.

Both optimizers (`GreedyByScoreOptimizer`, `CostAwareOptimizer`) call
`costAwareScaleDown`, so both benefit with no other changes.

## Behavior change to note

The cheapest-variant-at-1 protection is now scoped **per role**, so scale-down
keeps **≥ 1 replica in each active role** — a disaggregated model can no longer
have its prefill *or* decode role zeroed by normal scale-down (the old model-wide
protection could zero a whole role). This is more correct for P/D serving; full
model scale-to-zero is a separate path and is unaffected.
