### PR TITLE
Minor Fixes for WVA OCP Deployment

### DIFF
--- a/config/base/kustomizeconfig.yaml
+++ b/config/base/kustomizeconfig.yaml
@@ -5,3 +5,13 @@ nameReference:
   - kind: Secret
     path: metadata/annotations/kubernetes.io\/service-account.name
     create: false
+# Track Secret renames inside ServiceMonitor's bearerTokenSecret.name so
+# overlay JSON patches can use the unprefixed Secret name and have kustomize
+# apply namePrefix/nameSuffix automatically.
+- kind: Secret
+  version: v1
+  fieldSpecs:
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com
+    path: spec/endpoints/bearerTokenSecret/name
+    create: false

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -129,11 +129,19 @@ EOF
         # Flip WVA_SCALE_TO_ZERO inside data["config.yaml"] — the file the
         # controller actually reads (mounted at /etc/wva/config.yaml).
         # Patch only that single field so we don't echo back server-managed
-        # metadata (resourceVersion, managedFields, etc.).
+        # metadata (resourceVersion, managedFields, etc.). Use yq so the edit
+        # is idempotent and tolerates quoting/whitespace variance — sed would
+        # silently fail to match e.g. unquoted or single-quoted values.
+        local current_config
+        current_config=$(kubectl get configmap wva-manager-config -n "$WVA_NS" \
+            -o jsonpath='{.data.config\.yaml}')
+        if [ -z "$current_config" ]; then
+            log_error "ConfigMap wva-manager-config has no data['config.yaml'] key"
+        fi
+
         local updated_config
-        updated_config=$(kubectl get configmap wva-manager-config -n "$WVA_NS" \
-            -o jsonpath='{.data.config\.yaml}' \
-            | sed 's/WVA_SCALE_TO_ZERO: "false"/WVA_SCALE_TO_ZERO: "true"/')
+        updated_config=$(echo "$current_config" | yq '.WVA_SCALE_TO_ZERO = "true"')
+
         kubectl patch configmap wva-manager-config -n "$WVA_NS" --type=merge \
             -p "$(jq -n --arg cfg "$updated_config" '{data:{"config.yaml":$cfg}}')"
     fi

--- a/deploy/lib/infra_wva.sh
+++ b/deploy/lib/infra_wva.sh
@@ -126,9 +126,16 @@ EOF
 
     if [ "${ENABLE_SCALE_TO_ZERO:-false}" = "true" ]; then
         log_info "Enabling scale-to-zero in WVA ConfigMap (ENABLE_SCALE_TO_ZERO=true)..."
-        kubectl patch configmap wva-manager-config \
-            -n "$WVA_NS" --type=merge \
-            -p '{"data":{"WVA_SCALE_TO_ZERO":"true"}}'
+        # Flip WVA_SCALE_TO_ZERO inside data["config.yaml"] — the file the
+        # controller actually reads (mounted at /etc/wva/config.yaml).
+        # Patch only that single field so we don't echo back server-managed
+        # metadata (resourceVersion, managedFields, etc.).
+        local updated_config
+        updated_config=$(kubectl get configmap wva-manager-config -n "$WVA_NS" \
+            -o jsonpath='{.data.config\.yaml}' \
+            | sed 's/WVA_SCALE_TO_ZERO: "false"/WVA_SCALE_TO_ZERO: "true"/')
+        kubectl patch configmap wva-manager-config -n "$WVA_NS" --type=merge \
+            -p "$(jq -n --arg cfg "$updated_config" '{data:{"config.yaml":$cfg}}')"
     fi
 
     # Wait for WVA to be ready


### PR DESCRIPTION
Two installer fixes for the OpenShift overlay path:

  1. ServiceMonitor bearerTokenSecret.name is rewritten by namePrefix. Added a nameReference rule in `config/base/kustomizeconfig.yaml` so the unprefixed Secret name inside the SM JSON patch (controller-manager-token) is automatically rewritten to the actual prefixed Secret (wva-controller-manager-token). Without this, the SM references a non-existent Secret and the Prometheus Operator rejects it with unable to get secret "controller-manager-token": not found — silently breaking metrics scraping.
  
  3. ENABLE_SCALE_TO_ZERO=true now patches the right ConfigMap field. `deploy/lib/infra_wva.sh` previously added a sibling data.WVA_SCALE_TO_ZERO key to the ConfigMap, but the controller only reads `data.config.yaml` (mounted at `/etc/wva/config.yaml`). The new patch updates the value inside that embedded YAML, so the runtime behavior matches the flag.

  **Why this matters**

  Both bugs caused the installer to appear successful while leaving the cluster in a broken state — UWM-rejected ServiceMonitor (no `wva_desired_replicas` reaches the external metrics API) and `WVA_SCALE_TO_ZERO` silently stuck at false. 