### PR TITLE
feat(coordinator): introduce Coordinator component

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller/indexers"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/coordinator"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/datastore"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/saturation"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/scalefromzero"
@@ -535,6 +536,30 @@ func main() {
 	if err = configMapReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create configmap controller")
 		os.Exit(1)
+	}
+
+	// Coordinator: cluster-wide leader-elected loop that dispatches a
+	// selected set of HPAs and ScaledObjects to registered plugins.
+	// Off by default; opt in via coordinator.enabled in the unified config.
+	if cfg.CoordinatorEnabled() {
+		coord, err := coordinator.New(mgr.GetClient(), nil, coordinator.Options{
+			Interval:    cfg.CoordinatorInterval(),
+			KEDAEnabled: kedaEnabled,
+		})
+		if err != nil {
+			setupLog.Error(err, "unable to construct Coordinator")
+			os.Exit(1)
+		}
+		if err := mgr.Add(coord); err != nil {
+			setupLog.Error(err, "unable to add Coordinator to manager")
+			os.Exit(1)
+		}
+		setupLog.Info("Coordinator enabled",
+			"interval", cfg.CoordinatorInterval(),
+			"kedaEnabled", kedaEnabled,
+		)
+	} else {
+		setupLog.Info("Coordinator disabled (set coordinator.enabled=true to enable)")
 	}
 
 	if metricsCertWatcher != nil {

--- a/docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md
+++ b/docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md
@@ -59,7 +59,7 @@ The detailed design for this use case will be addressed in a future proposal.
 │  │ (per-pool, existing)│         │ (cluster-wide, this spec)   │   │
 │  │                     │         │                             │   │
 │  │ emits               │         │ writes                      │   │
-│  │ wva_desired_replicas│         │ spec.maxReplicas (HPA) and  │   │
+│  │ wva_desired_replicas│         │ spec.maxReplicas (HPA) or   │   │
 │  │                     │         │ spec.maxReplicaCount (SO)   │   │
 │  │                     │         │ (+ future: Deployment/LWS   │   │
 │  │                     │         │   replicas for UC2)         │   │

--- a/docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md
+++ b/docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md
@@ -1,0 +1,220 @@
+# Coordinator Component — Introduction
+
+## Context
+
+The WVA engine produces a `wva_desired_replicas` metric per InferencePool variant. When HPA is configured to consume this metric, it scales replicas according to the WVA engine's cluster-wide view of GPU supply and per-pool demand.
+
+When HPA is **not** configured to consume `wva_desired_replicas` — either because the operator wired HPA to a different metric (CPU, custom, queue depth) or because no HPA exists at all on a managed Deployment/LWS — WVA has no path to influence replica counts. Several capabilities that depend on a cluster-wide view of GPU supply and per-pool demand (among otherthings) simply do not exist in that mode.
+
+This proposal introduces a new top-level component, the **Coordinator**, whose job is to close that gap.
+
+## Glossary
+
+**WVA** - Workload Variant Autoscaler, the project as a whole.
+**WVA engine** - the existing control loop that produces `wva_desired_replicas`. Code mostly lives in `internal/engine/`.
+**Coordinator** - the new component proposed here, which runs a controller-wide loop and acts on scale targets (HPAs and KEDA ScaledObjects) that don't consume `wva_desired_replicas`.
+**Scale target** - either a `HorizontalPodAutoscaler` (`autoscaling/v2`) or a KEDA `ScaledObject` (`keda.sh/v1alpha1`). The Coordinator treats these uniformly as the objects whose replica bounds it may write.
+
+## Use Cases
+
+The Coordinator is motivated by a small set of cluster-wide concerns that no per-variant loop can address. This is by no means an exhaustive list of what the Coordinator *could* do, but these are the most pressing use cases that motivated its creation:
+
+### UC1 — GPU allocation rebalancing under constrained supply
+
+When the sum of per-pool maximum replicas (multiplied by GPUs/replica) exceeds the GPU inventory, HPAs and KEDA ScaledObjects can independently raise replicas that don't fit. The result: Pending pods, evictions, or noisy-neighbor failures.
+
+The Coordinator rebalances the upper replica bound on managed scale targets — `spec.maxReplicas` on HPAs and `spec.maxReplicaCount` on ScaledObjects — so that the cluster-wide or namespace-wide allocation respects total GPU inventory, with each pool getting a share proportional to a pluggable load signal.
+
+
+### UC2 — Replica buffer management for burst handling
+
+For each variant or InferencePool, operators may want to keep a small buffer of **idle replicas** — replicas that are running but receive no traffic — so that an incoming traffic burst is absorbed without waiting for cold-start.
+
+A buffer policy is inherently cluster-wide: it competes with UC1 for the same GPU inventory, and the size of each pool's buffer depends on burst characteristics, GPU cost, and remaining headroom after live demand is satisfied.
+
+The Coordinator is the natural place for this policy because it already holds (a) per-pool demand signals and (b) the cluster GPU budget.
+
+The detailed design for this use case will be addressed in a future proposal.
+
+## What the Coordinator Is (and Is Not)
+
+**Is:**
+- A new, independent component in the WVA control plane.
+- Leader-elected, with its own loop interval and its own goroutine.
+- A **plugin host**: it computes the set of scale targets (HPAs and ScaledObjects) that are "under Coordinator control" each tick and dispatches that set to every registered plugin. Each plugin is treated as an opaque, self-contained unit; the Coordinator does not look inside one or share state across them.
+
+
+**Is not:**
+- A replacement for the existing WVA engine that produces `wva_desired_replicas`. Pools that *do* feed HPA via that metric continue to work unchanged.
+- A scheduler or admission controller. It does not pre-empt pods, taint nodes, or interact with the kube-scheduler beyond setting replica counts.
+
+## Relationship to Existing WVA
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                        WVA control plane                           │
+│                                                                    │
+│  ┌─────────────────────┐         ┌─────────────────────────────┐   │
+│  │ WVA engine          │         │ Coordinator (new)           │   │
+│  │ (per-pool, existing)│         │ (cluster-wide, this spec)   │   │
+│  │                     │         │                             │   │
+│  │ emits               │         │ writes                      │   │
+│  │ wva_desired_replicas│         │ spec.maxReplicas (HPA) and  │   │
+│  │                     │         │ spec.maxReplicaCount (SO)   │   │
+│  │                     │         │ (+ future: Deployment/LWS   │   │
+│  │                     │         │   replicas for UC2)         │   │
+│  └──────────┬──────────┘         └──────────────┬──────────────┘   │
+│             │                                   │                  │
+└─────────────┼───────────────────────────────────┼──────────────────┘
+              │                                   │
+              ▼                                   ▼
+        ┌──────────┐                      ┌────────────────────┐
+        │   HPA    │ (when wired to       │ Managed HPAs and   │
+        │          │  wva_desired_repls)  │ KEDA ScaledObjects │
+        └──────────┘                      └────────────────────┘
+```
+
+Both components observe the same pools, but they act on disjoint surfaces and serve disjoint use cases.
+
+## Loop Algorithm
+
+The Coordinator runs a single periodic loop (leader-only, default interval `15s`) that drives all use-case modules registered against it. The loop itself is fixed and lives in `internal/coordinator/coordinator.go`. This proposal specifies *only* the loop skeleton and the set of scale targets the Coordinator considers under its control; what each tick *does* is the responsibility of the modules wired in.
+
+```
+every Coordinator.Interval, on the leader:
+
+  1. Compute the set of scale targets under Coordinator control (see
+     "Scale-target selection" below). The set is a single mixed slice
+     containing HorizontalPodAutoscaler and ScaledObject objects. If
+     listing fails, skip the cycle, log, and increment
+     wva_coordinator_cycle_errors_total{kind="discovery"}.
+
+  2. For each registered plugin, in declared order:
+       call plugin.Tick(ctx, selected)
+     The Coordinator passes the same selected slice to every plugin.
+     A plugin that has nothing to do simply returns nil.
+
+  3. (Plugin-driven, not loop-driven) any writes, reconciliation,
+     damping, conflict handling, metrics, and events are owned by
+     the plugin that produced them. The loop itself does not write
+     to the cluster.
+```
+
+### Scale-target selection — which objects the Coordinator considers under its control
+
+A scale target is **under Coordinator control** in a given tick iff it satisfies the rule for its kind. Both rules require the canonical `llm-d.ai/managed: "true"` annotation (see `internal/annotations/annotations.go` and `internal/controller/hpa_reconciler.go`) and additionally exclude objects already steered by the WVA engine via `wva_desired_replicas`.
+
+**HorizontalPodAutoscaler — under control iff all of:**
+
+1. The HPA carries `llm-d.ai/managed: "true"`.
+2. The HPA's `spec.metrics` does **not** include the `wva_desired_replicas` external metric. When that metric is present, WVA's per-pool engine is already steering this HPA via the metric pipeline, and the Coordinator must not also act on it.
+3. The HPA is **not** owned by a `ScaledObject`. KEDA generates an HPA per ScaledObject and reconciles it from the SO; writes to such an HPA are reverted by KEDA on its next reconcile. Detected via `metav1.GetControllerOf(hpa)` returning an OwnerReference with `apiVersion: keda.sh/v1alpha1, kind: ScaledObject`. KEDA-generated HPAs reach plugins only via their parent ScaledObject.
+
+**ScaledObject — under control iff both of:**
+
+1. The ScaledObject carries `llm-d.ai/managed: "true"`.
+2. The ScaledObject's `spec.triggers` does **not** include a Prometheus trigger whose `metadata.query` references `wva_desired_replicas`. Same intent as the HPA rule — if the WVA engine is already steering this target via that metric, the Coordinator stays out.
+
+ScaledObject discovery is conditional on the KEDA CRD being installed at startup, mirroring the existing `ScaledObjectReconciler` registration guard in `cmd/main.go`. When the CRD is absent the Coordinator simply produces no ScaledObjects in the selected set.
+
+Objects failing the rule for their kind are excluded from the set passed to plugins. Each plugin then decides for itself whether it applies to a given selected object — for example, the gpu-rebalance plugin further requires that the target's pool resolves and that GPUs/replica is known. The Coordinator does not pre-filter beyond the conditions above.
+
+**Safety invariants enforced by the loop itself (not delegated to plugins):**
+- Leader-only: registered via `mgr.Add(...)` so non-leaders never enter the loop body.
+- Empty-input fail-safe: if no scale target satisfies the selection conditions, or no plugins are registered, the loop is a no-op for that tick.
+- The loop never writes to the cluster directly; all cluster writes are issued by plugins.
+
+## Plugin Contract
+
+Each Coordinator capability is implemented as a **plugin** — a self-contained Go type that registers with the Coordinator at startup and is invoked once per tick. Plugins are the only place writes happen.
+
+The minimum interface a plugin must satisfy:
+
+```go
+// internal/coordinator/plugin.go
+
+import (
+    "context"
+    "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Plugin is the contract every Coordinator capability satisfies. The
+// Coordinator does not inspect anything inside a plugin beyond this
+// interface and the plugin's name.
+type Plugin interface {
+    // Name uniquely identifies the plugin (e.g. "gpu-rebalance").
+    // Used in metrics labels, event reasons, and the per-plugin
+    // damping cache key.
+    Name() string
+
+    // Tick is called once per Coordinator interval, on the leader, with
+    // the set of scale targets the loop has decided are under
+    // Coordinator control this tick. Each element is one of:
+    //   - *autoscalingv2.HorizontalPodAutoscaler
+    //   - *kedav1alpha1.ScaledObject
+    //
+    // Plugins type-switch on the concrete kind and ignore kinds they do
+    // not handle.
+    //
+    // Plugins MUST be deterministic given the same input.
+    // Plugins MUST return nil for "no work this cycle" and only return a
+    //   non-nil error for failures the operator should see in the
+    //   Coordinator's cycle-error counter.
+    Tick(ctx context.Context, selected []client.Object) error
+}
+```
+
+**Plugin isolation rules** (these define what "treated as a plugin" means here):
+
+- **Independent surface area.** Each plugin owns its own package under `internal/coordinator/plugins/<name>/`.
+- **No shared state.** Plugins MUST NOT read or mutate state owned by another plugin. If two plugins need to coordinate, that coordination is added at the Coordinator level by an explicit future proposal — not by plugins reaching into each other.
+- **Per-plugin damping and metrics.** A plugin's damping cache, Prometheus metrics, and Kubernetes events carry its `Name()` so writes are attributable. The damping cache key is `(plugin-name, kind, namespaced-name)` — `kind` is part of the key because an HPA and a ScaledObject can share a name in the same namespace.
+- **Per-plugin configuration.** Each plugin owns one entry under `coordinator.plugins.<name>:` in the unified config. Plugins MUST NOT read configuration from another plugin's sub-block.
+- **Cluster writes via standard API patches with `resourceVersion` precondition.** Plugins use optimistic concurrency so concurrent writes from another plugin (or a human operator) race-detect rather than silently overwrite.
+
+
+## Scope of This Proposal
+
+What this proposal *does* establish:
+
+1. The Coordinator exists as a distinct, leader-elected component.
+2. It lives under a new package: `internal/coordinator/`.
+3. It is registered as an `mgr.Add(...)` runnable in `cmd/main.go`, mirroring the saturation engine pattern (see `cmd/main.go:431-458`).
+4. It is opt-in: a top-level `coordinator.enabled` flag in the unified config, off by default in v0.
+5. It defines the rule for which scale targets (HPAs and ScaledObjects) are "under Coordinator control" (the conditions above).
+6. It runs the per-tick loop and dispatches the selected scale-target set to every registered plugin.
+7. It defines the plugin contract (`Plugin` interface) and the isolation rules every plugin must follow.
+
+What this proposal *does not* establish (deferred to plugin proposals):
+
+- Cluster writes, reconciliation, damping caches, conflict handling, and per-plugin metrics or events.
+- Pool grouping, demand signals, allocation strategies, buffer policies, or any other plugin-specific data.
+- Configuration beyond `coordinator.enabled`, the loop interval, and the `coordinator.plugins.*` map shape.
+
+## Out of Scope (for any Coordinator proposal)
+
+- Replacing or modifying the WVA engine.
+- Per-accelerator partitioning of GPU inventory (treated as fungible in v0).
+- Scheduling decisions normally handled by kube-scheduler or descheduler.
+- Cross-cluster or multi-cluster coordination.
+- Touching `VariantAutoscaling` resources (CRD is deprecated).
+
+## Verification
+
+This proposal is structural; verification is limited to confirming the component is wired in correctly, the scale-target selection rule behaves as specified, and no cluster writes happen from the loop itself:
+
+1. With `coordinator.enabled: false` (default), the Coordinator goroutine is not started; existing WVA engine behavior is unchanged.
+2. With `coordinator.enabled: true` but no plugins registered, the Coordinator starts, computes the selected scale-target set each tick, logs it at debug level, and performs no cluster writes.
+3. HPA selection unit tests:
+   - HPA without `llm-d.ai/managed` → excluded.
+   - HPA with `llm-d.ai/managed: "true"` and no `wva_desired_replicas` external metric → included.
+   - HPA with `llm-d.ai/managed: "true"` *and* `wva_desired_replicas` listed in `spec.metrics` → excluded.
+   - HPA with `llm-d.ai/managed: "true"` whose controller OwnerReference points at a `keda.sh/v1alpha1, ScaledObject` → excluded (KEDA-generated).
+4. ScaledObject selection unit tests (run only when KEDA CRD is present):
+   - SO without `llm-d.ai/managed` → excluded.
+   - SO with `llm-d.ai/managed: "true"` and no Prometheus trigger referencing `wva_desired_replicas` → included.
+   - SO with `llm-d.ai/managed: "true"` whose `spec.triggers` contains a Prometheus trigger whose `metadata.query` references `wva_desired_replicas` → excluded.
+   - With KEDA CRD absent, SO discovery is skipped entirely; the selected set contains only HPAs.
+5. Plugin contract test: a stub plugin that records calls to `Tick` is registered; verify the Coordinator passes the same `selected` slice (mixed HPAs and ScaledObjects) to every plugin and continues the loop when a plugin returns an error.
+
+Detailed behavioral verification (writes, allocation, damping, etc.) belongs to the plugin proposals.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,15 @@ type Config struct {
 	saturation  saturationConfig  // namespace-aware
 	qmAnalyzer  qmAnalyzerConfig  // namespace-aware
 	scaleToZero scaleToZeroConfig // namespace-aware
+	coordinator coordinatorConfig
+}
 
+// coordinatorConfig holds Coordinator loop configuration. Plugin
+// sub-blocks (under coordinator.plugins.<name>) are owned by individual
+// plugins and live in their own packages.
+type coordinatorConfig struct {
+	enabled  bool
+	interval time.Duration
 }
 
 // configSyncState tracks configuration sync state used for startup/readiness checks.
@@ -277,6 +285,24 @@ func (c *Config) OptimizationInterval() time.Duration {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.infrastructure.optimizationInterval
+}
+
+// CoordinatorEnabled reports whether the Coordinator loop is enabled.
+// Thread-safe.
+func (c *Config) CoordinatorEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.coordinator.enabled
+}
+
+// CoordinatorInterval returns the Coordinator loop interval. Returns the
+// configured value or zero when unset; callers should treat zero as
+// "use the package default".
+// Thread-safe.
+func (c *Config) CoordinatorInterval() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.coordinator.interval
 }
 
 // ============================================================================

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -85,6 +85,8 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	v.SetDefault("WVA_LIMITED_MODE", false)
 	v.SetDefault("SCALE_FROM_ZERO_ENGINE_MAX_CONCURRENCY", 10)
 	v.SetDefault("GLOBAL_OPT_INTERVAL", "60s")
+	v.SetDefault("COORDINATOR_ENABLED", false)
+	v.SetDefault("COORDINATOR_INTERVAL", "15s")
 
 	// Load from config file (mounted in the container) — sits between env and defaults in precedence
 	if configFilePath != "" {
@@ -147,6 +149,11 @@ func loadConfig(cfg *Config, flagSet *flag.FlagSet, configFilePath string) error
 	cfg.scaleToZero = scaleToZeroConfig{
 		global:           make(ScaleToZeroConfigData),
 		namespaceConfigs: make(map[string]ScaleToZeroConfigData),
+	}
+
+	cfg.coordinator = coordinatorConfig{
+		enabled:  v.GetBool("COORDINATOR_ENABLED"),
+		interval: v.GetDuration("COORDINATOR_INTERVAL"),
 	}
 
 	// Prometheus cache config from config file / env / defaults

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -185,6 +185,13 @@ const (
 	// WVAKvCacheTokensCapacity is a gauge that tracks total KV cache token capacity per variant.
 	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
+
+	// WVACoordinatorCycleErrorsTotal is a counter that tracks the total number
+	// of Coordinator-loop-level cycle errors (e.g., scale-target discovery
+	// failures). Errors raised inside individual plugins are reported by the
+	// plugins themselves under their own metric names.
+	// Labels: kind (e.g. "discovery")
+	WVACoordinatorCycleErrorsTotal = "wva_coordinator_cycle_errors_total"
 )
 
 // Metric Label Names

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -185,13 +185,6 @@ const (
 	// WVAKvCacheTokensCapacity is a gauge that tracks total KV cache token capacity per variant.
 	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
-
-	// WVACoordinatorCycleErrorsTotal is a counter that tracks the total number
-	// of Coordinator-loop-level cycle errors (e.g., scale-target discovery
-	// failures). Errors raised inside individual plugins are reported by the
-	// plugins themselves under their own metric names.
-	// Labels: kind (e.g. "discovery")
-	WVACoordinatorCycleErrorsTotal = "wva_coordinator_cycle_errors_total"
 )
 
 // Metric Label Names

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package coordinator
 
 import (
@@ -93,10 +77,6 @@ func New(c client.Client, plugins []Plugin, opts Options) (*Coordinator, error) 
 		opts:    opts,
 	}, nil
 }
-
-// NeedLeaderElection makes the Coordinator a leader-only manager
-// runnable: non-leaders never enter Start.
-func (c *Coordinator) NeedLeaderElection() bool { return true }
 
 // Start runs the Coordinator loop until ctx is cancelled. It satisfies
 // controller-runtime's manager.Runnable interface.

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DefaultInterval is the default Coordinator loop interval.
+const DefaultInterval = 15 * time.Second
+
+// Options configures the Coordinator.
+type Options struct {
+	// Interval between successive Coordinator ticks. Defaults to
+	// DefaultInterval when zero.
+	Interval time.Duration
+
+	// KEDAEnabled controls whether the Coordinator lists KEDA
+	// ScaledObjects each tick. When false, the selected set contains
+	// only HPAs.
+	KEDAEnabled bool
+
+	// CycleErrorCounter is invoked once per kind of cycle-level failure
+	// (e.g. discovery). It is the loop's only metrics emission point;
+	// plugins emit their own metrics. May be nil for tests.
+	CycleErrorCounter CycleErrorCounter
+}
+
+// CycleErrorCounter records loop-level cycle errors. The loop calls Inc
+// with a "kind" label (e.g. "discovery").
+type CycleErrorCounter func(kind string)
+
+// Coordinator is a leader-elected periodic loop that selects scale
+// targets under its control and dispatches them to a registered set of
+// plugins. Wire one into the controller manager via mgr.Add(c) so the
+// loop only runs on the leader.
+type Coordinator struct {
+	client  client.Client
+	plugins []Plugin
+	opts    Options
+}
+
+// New constructs a Coordinator. Plugins are dispatched in declared order
+// each tick. Plugin names must be unique across the registered set.
+func New(c client.Client, plugins []Plugin, opts Options) (*Coordinator, error) {
+	if c == nil {
+		return nil, errors.New("coordinator: client must not be nil")
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = DefaultInterval
+	}
+	seen := make(map[string]struct{}, len(plugins))
+	for _, p := range plugins {
+		if p == nil {
+			return nil, errors.New("coordinator: nil plugin in registration list")
+		}
+		name := p.Name()
+		if name == "" {
+			return nil, errors.New("coordinator: plugin Name() must not be empty")
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("coordinator: duplicate plugin name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return &Coordinator{
+		client:  c,
+		plugins: plugins,
+		opts:    opts,
+	}, nil
+}
+
+// NeedLeaderElection makes the Coordinator a leader-only manager
+// runnable: non-leaders never enter Start.
+func (c *Coordinator) NeedLeaderElection() bool { return true }
+
+// Start runs the Coordinator loop until ctx is cancelled. It satisfies
+// controller-runtime's manager.Runnable interface.
+func (c *Coordinator) Start(ctx context.Context) error {
+	logger := ctrl.LoggerFrom(ctx).WithName("coordinator")
+	logger.Info("Coordinator loop starting",
+		"interval", c.opts.Interval,
+		"plugins", c.pluginNames(),
+		"kedaEnabled", c.opts.KEDAEnabled,
+	)
+
+	ticker := time.NewTicker(c.opts.Interval)
+	defer ticker.Stop()
+
+	// Run a tick immediately on start, then at every interval, so the
+	// first dispatch does not wait one full interval.
+	c.tick(ctx, logger)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("Coordinator loop stopping", "reason", ctx.Err())
+			return nil
+		case <-ticker.C:
+			c.tick(ctx, logger)
+		}
+	}
+}
+
+// tick executes one Coordinator cycle: list scale targets, filter, and
+// dispatch. The loop never writes to the cluster directly; plugin errors
+// do not abort the loop.
+func (c *Coordinator) tick(ctx context.Context, logger logr.Logger) {
+	selected, err := c.discover(ctx)
+	if err != nil {
+		logger.Error(err, "Coordinator discovery failed; skipping cycle")
+		c.recordCycleError("discovery")
+		return
+	}
+
+	if len(selected) == 0 || len(c.plugins) == 0 {
+		logger.V(1).Info("Coordinator tick is a no-op",
+			"selected", len(selected),
+			"plugins", len(c.plugins),
+		)
+		return
+	}
+
+	logger.V(1).Info("Coordinator dispatching to plugins",
+		"selected", len(selected),
+		"plugins", len(c.plugins),
+	)
+
+	for _, p := range c.plugins {
+		if err := p.Tick(ctx, selected); err != nil {
+			// Plugins are expected to handle their own errors and
+			// only return one for failures the operator should see.
+			// The loop continues to the next plugin regardless.
+			logger.Error(err, "Coordinator plugin returned an error", "plugin", p.Name())
+		}
+	}
+}
+
+// discover lists all HPAs and (if KEDA is enabled) ScaledObjects, applies
+// the per-kind selection rule, and returns the union as a single mixed
+// slice of client.Object.
+//
+// Discovery errors return immediately so the loop counts a cycle error
+// rather than dispatching a partial set.
+func (c *Coordinator) discover(ctx context.Context) ([]client.Object, error) {
+	var selected []client.Object
+
+	hpaList := &autoscalingv2.HorizontalPodAutoscalerList{}
+	if err := c.client.List(ctx, hpaList); err != nil {
+		return nil, fmt.Errorf("listing HorizontalPodAutoscalers: %w", err)
+	}
+	for i := range hpaList.Items {
+		hpa := &hpaList.Items[i]
+		if IsHPAUnderControl(hpa) {
+			selected = append(selected, hpa)
+		}
+	}
+
+	if c.opts.KEDAEnabled {
+		soList := &kedav1alpha1.ScaledObjectList{}
+		if err := c.client.List(ctx, soList); err != nil {
+			// NoKindMatchError can occur if the CRD was uninstalled
+			// after startup; tolerate it instead of failing the cycle.
+			if apimeta.IsNoMatchError(err) {
+				return selected, nil
+			}
+			return nil, fmt.Errorf("listing ScaledObjects: %w", err)
+		}
+		for i := range soList.Items {
+			so := &soList.Items[i]
+			if IsScaledObjectUnderControl(so) {
+				selected = append(selected, so)
+			}
+		}
+	}
+
+	return selected, nil
+}
+
+// pluginNames returns the registered plugin names in declared order, for
+// logging.
+func (c *Coordinator) pluginNames() []string {
+	out := make([]string, 0, len(c.plugins))
+	for _, p := range c.plugins {
+		out = append(out, p.Name())
+	}
+	return out
+}
+
+// recordCycleError forwards to the configured counter when set.
+func (c *Coordinator) recordCycleError(kind string) {
+	if c.opts.CycleErrorCounter != nil {
+		c.opts.CycleErrorCounter(kind)
+	}
+}

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+)
+
+const hpaManagedName = "hpa-managed"
+
+// stubPlugin records every Tick invocation it receives and returns a
+// pre-configured error.
+type stubPlugin struct {
+	name string
+	mu   sync.Mutex
+	got  [][]client.Object
+	err  error
+}
+
+func (s *stubPlugin) Name() string { return s.name }
+
+func (s *stubPlugin) Tick(_ context.Context, selected []client.Object) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.got = append(s.got, selected)
+	return s.err
+}
+
+func (s *stubPlugin) calls() [][]client.Object {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]client.Object, len(s.got))
+	copy(out, s.got)
+	return out
+}
+
+// newScheme returns a runtime.Scheme with the kinds the Coordinator
+// lists registered.
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme.AddToScheme: %v", err)
+	}
+	if err := kedav1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("keda AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestNew_Validations(t *testing.T) {
+	if _, err := New(nil, nil, Options{}); err == nil {
+		t.Fatal("expected error for nil client")
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	if _, err := New(c, []Plugin{nil}, Options{}); err == nil {
+		t.Fatal("expected error for nil plugin")
+	}
+
+	if _, err := New(c, []Plugin{&stubPlugin{name: ""}}, Options{}); err == nil {
+		t.Fatal("expected error for empty plugin name")
+	}
+
+	if _, err := New(c, []Plugin{&stubPlugin{name: "p"}, &stubPlugin{name: "p"}}, Options{}); err == nil {
+		t.Fatal("expected error for duplicate plugin name")
+	}
+
+	c2, err := New(c, []Plugin{&stubPlugin{name: "p"}}, Options{})
+	if err != nil {
+		t.Fatalf("unexpected New error: %v", err)
+	}
+	if c2.opts.Interval != DefaultInterval {
+		t.Errorf("expected default interval %v, got %v", DefaultInterval, c2.opts.Interval)
+	}
+	if !c2.NeedLeaderElection() {
+		t.Errorf("Coordinator must request leader election")
+	}
+}
+
+// TestDiscover_FiltersAndMixesScaleTargets builds a fake cluster with a
+// mix of HPAs and ScaledObjects and verifies discover() returns exactly
+// the items that satisfy the selection rules.
+func TestDiscover_FiltersAndMixesScaleTargets(t *testing.T) {
+	scheme := newScheme(t)
+
+	managedHPA := hpaWith(managedAnn(), nil)
+	managedHPA.Name = hpaManagedName
+
+	unmanagedHPA := hpaWith(nil, nil)
+	unmanagedHPA.Name = "hpa-unmanaged"
+
+	managedHPAWithWVA := hpaWith(managedAnn(), []autoscalingv2.MetricSpec{wvaExternalMetric()})
+	managedHPAWithWVA.Name = "hpa-managed-wva"
+
+	managedKEDAOwnedHPA := hpaWith(managedAnn(), nil, kedaOwnerRef())
+	managedKEDAOwnedHPA.Name = "hpa-keda-owned"
+
+	managedSO := soWith(managedAnn(), nil)
+	managedSO.Name = "so-managed"
+
+	managedSOWithWVA := soWith(managedAnn(), []kedav1alpha1.ScaleTriggers{promTriggerWVA()})
+	managedSOWithWVA.Name = "so-managed-wva"
+
+	unmanagedSO := soWith(nil, nil)
+	unmanagedSO.Name = "so-unmanaged"
+
+	objs := []client.Object{
+		managedHPA,
+		unmanagedHPA,
+		managedHPAWithWVA,
+		managedKEDAOwnedHPA,
+		managedSO,
+		managedSOWithWVA,
+		unmanagedSO,
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	coord, err := New(c, nil, Options{KEDAEnabled: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := coord.discover(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	gotNames := map[string]string{}
+	for _, o := range got {
+		kind := "?"
+		switch o.(type) {
+		case *autoscalingv2.HorizontalPodAutoscaler:
+			kind = "HPA"
+		case *kedav1alpha1.ScaledObject:
+			kind = "SO"
+		}
+		gotNames[o.GetName()] = kind
+	}
+
+	want := map[string]string{
+		hpaManagedName: "HPA",
+		"so-managed":   "SO",
+	}
+	if fmt.Sprintf("%v", gotNames) != fmt.Sprintf("%v", want) {
+		t.Fatalf("discover names = %v, want %v", gotNames, want)
+	}
+}
+
+// TestDiscover_KEDADisabled_OmitsScaledObjects asserts that when the
+// KEDA CRD is absent (KEDAEnabled=false), the loop never lists SOs.
+func TestDiscover_KEDADisabled_OmitsScaledObjects(t *testing.T) {
+	scheme := newScheme(t)
+
+	managedHPA := hpaWith(managedAnn(), nil)
+	managedHPA.Name = hpaManagedName
+
+	managedSO := soWith(managedAnn(), nil)
+	managedSO.Name = "so-managed"
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(managedHPA, managedSO).
+		Build()
+
+	coord, err := New(c, nil, Options{KEDAEnabled: false})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, err := coord.discover(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 selected target (HPA only), got %d", len(got))
+	}
+	if got[0].GetName() != hpaManagedName {
+		t.Fatalf("expected hpa-managed, got %s", got[0].GetName())
+	}
+}
+
+// TestStart_DispatchesToAllPluginsAndContinuesOnError starts the loop
+// briefly, verifies every registered plugin receives the same selected
+// slice, and that an error from one plugin does not prevent the next
+// plugin from being called.
+func TestStart_DispatchesToAllPluginsAndContinuesOnError(t *testing.T) {
+	scheme := newScheme(t)
+
+	managedHPA := hpaWith(managedAnn(), nil)
+	managedHPA.Name = hpaManagedName
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(managedHPA).
+		Build()
+
+	failing := &stubPlugin{name: "failing", err: errors.New("boom")}
+	healthy := &stubPlugin{name: "healthy"}
+
+	cycleErrs := map[string]int{}
+	var cycleErrsMu sync.Mutex
+
+	coord, err := New(c, []Plugin{failing, healthy}, Options{
+		Interval:    20 * time.Millisecond,
+		KEDAEnabled: false,
+		CycleErrorCounter: func(kind string) {
+			cycleErrsMu.Lock()
+			defer cycleErrsMu.Unlock()
+			cycleErrs[kind]++
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- coord.Start(ctx) }()
+
+	<-ctx.Done()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	failingCalls := failing.calls()
+	healthyCalls := healthy.calls()
+	if len(failingCalls) == 0 {
+		t.Fatal("failing plugin received no Tick calls")
+	}
+	if len(healthyCalls) == 0 {
+		t.Fatal("healthy plugin received no Tick calls (loop aborted on plugin error?)")
+	}
+	if len(failingCalls) != len(healthyCalls) {
+		t.Fatalf("mismatched call counts: failing=%d healthy=%d", len(failingCalls), len(healthyCalls))
+	}
+	// Each tick must dispatch the same selected slice to every plugin.
+	for i := range failingCalls {
+		if len(failingCalls[i]) != 1 || len(healthyCalls[i]) != 1 {
+			t.Fatalf("tick %d dispatched %d/%d items, want 1/1", i, len(failingCalls[i]), len(healthyCalls[i]))
+		}
+		if failingCalls[i][0].GetName() != hpaManagedName || healthyCalls[i][0].GetName() != hpaManagedName {
+			t.Fatalf("tick %d dispatched wrong target: failing=%s healthy=%s",
+				i, failingCalls[i][0].GetName(), healthyCalls[i][0].GetName())
+		}
+	}
+
+	cycleErrsMu.Lock()
+	if cycleErrs["discovery"] != 0 {
+		t.Errorf("unexpected discovery cycle errors: %d", cycleErrs["discovery"])
+	}
+	cycleErrsMu.Unlock()
+}
+
+// TestStart_NoPluginsIsNoop verifies that with zero plugins registered,
+// Start does not error and quietly waits for cancellation.
+func TestStart_NoPluginsIsNoop(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	coord, err := New(c, nil, Options{Interval: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("Start with no plugins should not error, got %v", err)
+	}
+}
+
+// TestStart_NoSelectionIsNoop ensures that with no scale targets in the
+// cluster, plugins are not invoked.
+func TestStart_NoSelectionIsNoop(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	p := &stubPlugin{name: "p"}
+	coord, err := New(c, []Plugin{p}, Options{Interval: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if err := coord.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(p.calls()) != 0 {
+		t.Fatalf("plugin called %d times despite empty selection set", len(p.calls()))
+	}
+}
+
+// quiet a lint about unused import of annotations when only used in helper
+var _ = annotations.Managed

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package coordinator
 
 import (
@@ -101,9 +85,6 @@ func TestNew_Validations(t *testing.T) {
 	}
 	if c2.opts.Interval != DefaultInterval {
 		t.Errorf("expected default interval %v, got %v", DefaultInterval, c2.opts.Interval)
-	}
-	if !c2.NeedLeaderElection() {
-		t.Errorf("Coordinator must request leader election")
 	}
 }
 

--- a/internal/coordinator/plugin.go
+++ b/internal/coordinator/plugin.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coordinator hosts the Coordinator component: a leader-elected,
+// periodic loop that computes the set of scale targets (HPAs and KEDA
+// ScaledObjects) under Coordinator control and dispatches them to a
+// registered set of plugins.
+//
+// The loop and the selection rules live here; what each tick does is the
+// responsibility of plugins, which are self-contained packages under
+// internal/coordinator/plugins/<name>/.
+package coordinator
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Plugin is the contract every Coordinator capability satisfies. The
+// Coordinator does not inspect anything inside a plugin beyond this
+// interface and the plugin's name.
+type Plugin interface {
+	// Name uniquely identifies the plugin (e.g. "gpu-rebalance"). It is
+	// used in metrics labels, event reasons, and the per-plugin damping
+	// cache key.
+	Name() string
+
+	// Tick is called once per Coordinator interval, on the leader, with
+	// the set of scale targets the loop has decided are under
+	// Coordinator control this tick. Each element is one of:
+	//   - *autoscalingv2.HorizontalPodAutoscaler
+	//   - *kedav1alpha1.ScaledObject
+	//
+	// Plugins type-switch on the concrete kind and ignore kinds they do
+	// not handle.
+	//
+	// Plugins MUST be deterministic given the same input. Plugins MUST
+	// return nil for "no work this cycle" and only return a non-nil
+	// error for failures the operator should see in the Coordinator's
+	// cycle-error counter.
+	Tick(ctx context.Context, selected []client.Object) error
+}

--- a/internal/coordinator/plugin.go
+++ b/internal/coordinator/plugin.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 // Package coordinator hosts the Coordinator component: a leader-elected,
 // periodic loop that computes the set of scale targets (HPAs and KEDA
 // ScaledObjects) under Coordinator control and dispatches them to a

--- a/internal/coordinator/selection.go
+++ b/internal/coordinator/selection.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package coordinator
 
 import (

--- a/internal/coordinator/selection.go
+++ b/internal/coordinator/selection.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coordinator
+
+import (
+	"strings"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+// scaledObjectGroup is the API group reported on OwnerReferences for KEDA
+// ScaledObjects, used to recognize KEDA-generated HPAs.
+const scaledObjectGroup = "keda.sh"
+
+// scaledObjectKind is the OwnerReference Kind reported by KEDA for the HPA
+// it generates per ScaledObject.
+const scaledObjectKind = "ScaledObject"
+
+// IsHPAUnderControl reports whether an HPA is under Coordinator control.
+//
+// An HPA qualifies iff all of:
+//  1. It carries the canonical llm-d.ai/managed: "true" annotation.
+//  2. Its spec.metrics does NOT include the wva_desired_replicas external
+//     metric. When that metric is present, the WVA engine is already
+//     steering replicas via the metric pipeline and the Coordinator must
+//     stay out.
+//  3. It is NOT owned by a KEDA ScaledObject. KEDA generates an HPA per
+//     ScaledObject and reconciles spec.maxReplicas from the SO's
+//     spec.maxReplicaCount; writes to such an HPA would be reverted on
+//     KEDA's next reconcile. KEDA-generated HPAs reach plugins only via
+//     their parent ScaledObject.
+func IsHPAUnderControl(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	if hpa == nil {
+		return false
+	}
+	if !annotations.IsManaged(hpa) {
+		return false
+	}
+	if hpaHasWVADesiredReplicasMetric(hpa) {
+		return false
+	}
+	if isOwnedByKEDAScaledObject(hpa) {
+		return false
+	}
+	return true
+}
+
+// IsScaledObjectUnderControl reports whether a KEDA ScaledObject is under
+// Coordinator control.
+//
+// A ScaledObject qualifies iff both of:
+//  1. It carries the canonical llm-d.ai/managed: "true" annotation.
+//  2. Its spec.triggers does NOT include a Prometheus trigger whose
+//     metadata.query references wva_desired_replicas. Same intent as the
+//     HPA rule: the Coordinator must not act when the WVA engine is
+//     already steering this target via that metric.
+func IsScaledObjectUnderControl(so *kedav1alpha1.ScaledObject) bool {
+	if so == nil {
+		return false
+	}
+	if !annotations.IsManaged(so) {
+		return false
+	}
+	if scaledObjectHasWVADesiredReplicasTrigger(so) {
+		return false
+	}
+	return true
+}
+
+// hpaHasWVADesiredReplicasMetric returns true if the HPA's spec.metrics
+// contains an External metric named WVADesiredReplicas
+// ("wva_desired_replicas").
+func hpaHasWVADesiredReplicasMetric(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	for i := range hpa.Spec.Metrics {
+		m := &hpa.Spec.Metrics[i]
+		if m.Type != autoscalingv2.ExternalMetricSourceType || m.External == nil {
+			continue
+		}
+		if m.External.Metric.Name == constants.WVADesiredReplicas {
+			return true
+		}
+	}
+	return false
+}
+
+// isOwnedByKEDAScaledObject returns true if obj has a controller
+// OwnerReference whose APIVersion is in the keda.sh API group and whose
+// Kind is "ScaledObject".
+func isOwnedByKEDAScaledObject(obj metav1.Object) bool {
+	ctrl := metav1.GetControllerOf(obj)
+	if ctrl == nil {
+		return false
+	}
+	if ctrl.Kind != scaledObjectKind {
+		return false
+	}
+	// APIVersion is "<group>/<version>"; match the group prefix.
+	if i := strings.IndexByte(ctrl.APIVersion, '/'); i > 0 {
+		return ctrl.APIVersion[:i] == scaledObjectGroup
+	}
+	return ctrl.APIVersion == scaledObjectGroup
+}
+
+// scaledObjectHasWVADesiredReplicasTrigger returns true if any Prometheus
+// trigger on the ScaledObject queries wva_desired_replicas.
+func scaledObjectHasWVADesiredReplicasTrigger(so *kedav1alpha1.ScaledObject) bool {
+	for i := range so.Spec.Triggers {
+		t := &so.Spec.Triggers[i]
+		if t.Type != "prometheus" {
+			continue
+		}
+		query := t.Metadata["query"]
+		if query == "" {
+			continue
+		}
+		if strings.Contains(query, constants.WVADesiredReplicas) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/coordinator/selection_test.go
+++ b/internal/coordinator/selection_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coordinator
+
+import (
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/annotations"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+// hpaWith builds a minimal HPA with the given annotations and metrics.
+func hpaWith(ann map[string]string, metrics []autoscalingv2.MetricSpec, owners ...metav1.OwnerReference) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "h",
+			Namespace:       "ns",
+			Annotations:     ann,
+			OwnerReferences: owners,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			Metrics: metrics,
+		},
+	}
+}
+
+func managedAnn() map[string]string {
+	return map[string]string{annotations.Managed: "true"}
+}
+
+func wvaExternalMetric() autoscalingv2.MetricSpec {
+	return autoscalingv2.MetricSpec{
+		Type: autoscalingv2.ExternalMetricSourceType,
+		External: &autoscalingv2.ExternalMetricSource{
+			Metric: autoscalingv2.MetricIdentifier{Name: constants.WVADesiredReplicas},
+		},
+	}
+}
+
+func otherExternalMetric() autoscalingv2.MetricSpec {
+	return autoscalingv2.MetricSpec{
+		Type: autoscalingv2.ExternalMetricSourceType,
+		External: &autoscalingv2.ExternalMetricSource{
+			Metric: autoscalingv2.MetricIdentifier{Name: "queue_depth"},
+		},
+	}
+}
+
+func kedaOwnerRef() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "keda.sh/v1alpha1",
+		Kind:       scaledObjectKind,
+		Name:       "my-so",
+		UID:        "uid-1",
+		Controller: ptr.To(true),
+	}
+}
+
+func TestIsHPAUnderControl(t *testing.T) {
+	tests := []struct {
+		name string
+		hpa  *autoscalingv2.HorizontalPodAutoscaler
+		want bool
+	}{
+		{
+			name: "nil hpa is excluded",
+			hpa:  nil,
+			want: false,
+		},
+		{
+			name: "missing managed annotation is excluded",
+			hpa:  hpaWith(nil, nil),
+			want: false,
+		},
+		{
+			name: "managed=false annotation is excluded",
+			hpa:  hpaWith(map[string]string{annotations.Managed: "false"}, nil),
+			want: false,
+		},
+		{
+			name: "managed and no wva_desired_replicas metric is included",
+			hpa:  hpaWith(managedAnn(), nil),
+			want: true,
+		},
+		{
+			name: "managed with unrelated external metric is included",
+			hpa:  hpaWith(managedAnn(), []autoscalingv2.MetricSpec{otherExternalMetric()}),
+			want: true,
+		},
+		{
+			name: "managed with wva_desired_replicas external metric is excluded",
+			hpa:  hpaWith(managedAnn(), []autoscalingv2.MetricSpec{wvaExternalMetric()}),
+			want: false,
+		},
+		{
+			name: "managed but owned by KEDA ScaledObject is excluded",
+			hpa:  hpaWith(managedAnn(), nil, kedaOwnerRef()),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsHPAUnderControl(tc.hpa); got != tc.want {
+				t.Fatalf("IsHPAUnderControl=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func soWith(ann map[string]string, triggers []kedav1alpha1.ScaleTriggers) *kedav1alpha1.ScaledObject {
+	return &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "s",
+			Namespace:   "ns",
+			Annotations: ann,
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			Triggers: triggers,
+		},
+	}
+}
+
+func promTriggerWVA() kedav1alpha1.ScaleTriggers {
+	return kedav1alpha1.ScaleTriggers{
+		Type: "prometheus",
+		Metadata: map[string]string{
+			"query": "wva_desired_replicas{variant_name=\"v\"}",
+		},
+	}
+}
+
+func promTriggerOther() kedav1alpha1.ScaleTriggers {
+	return kedav1alpha1.ScaleTriggers{
+		Type: "prometheus",
+		Metadata: map[string]string{
+			"query": "vllm:num_requests_waiting",
+		},
+	}
+}
+
+func cpuTrigger() kedav1alpha1.ScaleTriggers {
+	return kedav1alpha1.ScaleTriggers{Type: "cpu", Metadata: map[string]string{"value": "70"}}
+}
+
+func TestIsScaledObjectUnderControl(t *testing.T) {
+	tests := []struct {
+		name string
+		so   *kedav1alpha1.ScaledObject
+		want bool
+	}{
+		{
+			name: "nil so is excluded",
+			so:   nil,
+			want: false,
+		},
+		{
+			name: "missing managed annotation is excluded",
+			so:   soWith(nil, nil),
+			want: false,
+		},
+		{
+			name: "managed and no triggers is included",
+			so:   soWith(managedAnn(), nil),
+			want: true,
+		},
+		{
+			name: "managed with non-prometheus trigger is included",
+			so:   soWith(managedAnn(), []kedav1alpha1.ScaleTriggers{cpuTrigger()}),
+			want: true,
+		},
+		{
+			name: "managed with non-WVA prometheus trigger is included",
+			so:   soWith(managedAnn(), []kedav1alpha1.ScaleTriggers{promTriggerOther()}),
+			want: true,
+		},
+		{
+			name: "managed with wva_desired_replicas prometheus trigger is excluded",
+			so:   soWith(managedAnn(), []kedav1alpha1.ScaleTriggers{promTriggerWVA()}),
+			want: false,
+		},
+		{
+			name: "managed with mixed triggers including WVA is excluded",
+			so:   soWith(managedAnn(), []kedav1alpha1.ScaleTriggers{cpuTrigger(), promTriggerWVA()}),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsScaledObjectUnderControl(tc.so); got != tc.want {
+				t.Fatalf("IsScaledObjectUnderControl=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/coordinator/selection_test.go
+++ b/internal/coordinator/selection_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 The llm-d Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package coordinator
 
 import (


### PR DESCRIPTION
## Summary

Introduces a new top-level **Coordinator** component: a  periodic loop that selects HPAs and KEDA ScaledObjects under WVA control and dispatches them to a registered set of plugins via a single `Plugin` interface. The coordinator itself does no cluster writes — that is reserved for plugins, which are added in follow-up PRs.

This is the foundation for use cases that need a cluster-wide view of GPU supply and per-pool demand and that cannot be addressed by the per-pool WVA engine when HPA is wired to a metric other than `wva_desired_replicas`. 

Design spec: [`docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md`](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/docs/superpowers/specs/coordinator/2026-06-05-coordinator-component-introduction.md).

### What's in this PR

- New package `internal/coordinator/`:
  - `Plugin` interface — `Name()` and `Tick(ctx, []client.Object)`. Plugins type-switch on the concrete kind to handle HPAs and/or ScaledObjects.
  - `Coordinator` runnable — periodic loop, no direct cluster writes, plugin errors don't abort the cycle.
  - Selection helpers (`IsHPAUnderControl`, `IsScaledObjectUnderControl`) implementing the agreed rules.
- `coordinator.enabled` and `coordinator.interval` in the unified config (off by default).
- Wired into `cmd/main.go` via `mgr.Add(...)`. ScaledObject discovery follows the existing KEDA CRD detection pattern.
- New cycle-error metric constant `wva_coordinator_cycle_errors_total` (registration deferred until a plugin needs metrics).

### Selection rules

- **HPA** is under control iff: `llm-d.ai/managed=true`, no `wva_desired_replicas` external metric, **and** not owned by a KEDA ScaledObject (KEDA-generated HPAs would be reverted by KEDA on the next reconcile).
- **ScaledObject** is under control iff: `llm-d.ai/managed=true` **and** no Prometheus trigger whose `metadata.query` references `wva_desired_replicas`.

### Out of scope here

Cluster writes, damping caches, conflict handling, per-plugin metrics/events, pool grouping, demand signals, and allocation strategies all live with the plugins.

## Test plan

- [x] Unit tests for HPA and ScaledObject selection rules (managed/unmanaged, with/without WVA metric, KEDA-owned HPAs).
- [x] Unit tests for the loop: dispatch to all plugins, continues on plugin error, no-op on empty selection, no-op with no plugins, KEDA-disabled mode skips ScaledObject listing.
- [x] `make test` passes (coordinator package coverage 87.5%).
- [x] `make build` passes.
- [ ] Manual on-cluster verification: with `coordinator.enabled=false`, no Coordinator goroutine starts; with `enabled=true` and no plugins, the loop runs and logs the selected set without writing.
 