### PR TITLE
engines/pipeline: per-analyzer slice optimizer — delete engine-side combine

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -1,0 +1,50 @@
+# Multi-Analyzer Pipeline (developer reference)
+
+> **Status: STUB.** This doc summarises the multi-analyzer pipeline at a
+> high level and points to the design doc for detailed architecture,
+> alternatives considered, and future direction. Full developer-guide
+> content covering all three multi-analyzer PRs (registration, threshold,
+> optimizer) will be added post-review.
+
+The Workload Variant Autoscaler's scaling engine runs multiple **analyzers**
+in series each cycle. Each analyzer consumes the same per-replica metrics
+and produces an `*interfaces.AnalyzerResult` carrying per-variant capacity,
+model-level totals, and (for P/D disaggregated models) per-role capacity.
+The engine post-step calibrates `RequiredCapacity` / `SpareCapacity` at
+every scope using a uniform threshold formula. The optimizer reads a
+per-analyzer slice (`[]NamedAnalyzerResult`) and decides scaling actions
+over it via shared free functions in `internal/engines/pipeline/`.
+
+## Components
+
+- **Registration** — `internal/engines/saturation/engine.go`:
+  `RegisterAnalyzer(name, analyzer) error`. `cmd/main.go` registers external
+  analyzers (e.g., throughput) before `StartOptimizeLoop`. Saturation V2 is
+  pre-registered. Registry is snapshotted at Start; late registration
+  returns an error.
+- **Engine post-step** — `internal/engines/saturation/engine_v2.go`:
+  `applyUniversalThreshold(*AnalyzerResult, scaleUp, scaleDown)` applies a
+  pure formula `RC = max(0, TD/scaleUp − Anticipated)` /
+  `SC = max(0, TS − TD/scaleDown)` at model scope and every role.
+- **Aggregation helpers** — `internal/engines/aggregation/`:
+  `SumTotalSupply`, `SumTotalAnticipatedSupply`, `SumTotalDemand`,
+  `AggregateByRole` over `[]VariantCapacity`. Analyzer authors use these to
+  populate per-scope `Total*` fields.
+- **Optimizer slice flow** — `internal/engines/pipeline/`:
+  `NamedAnalyzerResult` slice carries each analyzer's result + working
+  scratch state for allocation. `CostAwareOptimizer` and
+  `GreedyByScoreOptimizer` consume the slice via shared free functions
+  (single-variant + paired + role-iterated helpers).
+
+## Detailed design
+
+For full architecture (per-variant canonical model; linearity invariant;
+α coupling for P/D; paired scale-up + role-iterated scale-down;
+alternatives considered including the rejected combine-in-engine
+algorithm; future direction), see the design doc:
+
+https://github.com/deanlorenz/llm-d-workload-variant-autoscaler/blob/plans/planning/multi-analyzer-design.md
+
+This is the Type-1 design doc for the multi-analyzer mission. It will be
+folded into this developer-guide post-review across all three multi-analyzer
+PRs (#1225 registration, #1228 threshold, optimizer pending).

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -1,0 +1,192 @@
+package pipeline
+
+import (
+	"context"
+	"math"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+)
+
+// needsScaleUp reports whether any analyzer in s signals a need for more capacity.
+// Implements the any-up gate: scale-up proceeds if at least one analyzer has Remaining > 0.
+func needsScaleUp(s []NamedAnalyzerResult) bool {
+	for _, e := range s {
+		if e.Result != nil && e.Remaining > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// needsScaleDown reports whether all analyzers in s permit capacity removal.
+// Implements the all-down gate: scale-down is blocked unless every analyzer
+// has Spare > 0. Returns false for an empty slice (no consensus).
+func needsScaleDown(s []NamedAnalyzerResult) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, e := range s {
+		if e.Result == nil || e.Spare <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// bottleneckReplicas returns the number of replicas of variant v needed to
+// satisfy the most-demanding analyzer. It is the maximum of
+// ceil(Remaining_i / PRC_i[v]) across analyzers that have variant v with PRC > 0.
+// Returns 0 if no analyzer covers variant v or all PRCs are zero (cold-start guard).
+func bottleneckReplicas(s []NamedAnalyzerResult, v string) int {
+	max := 0
+	for _, e := range s {
+		if e.Result == nil {
+			continue
+		}
+		prc := prcForVariant(e.Result, v)
+		if prc <= 0 {
+			continue
+		}
+		n := int(math.Ceil(e.Remaining / prc))
+		if n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// safeRemovalReplicas returns the number of replicas of variant v that can be
+// safely removed — the minimum of floor(Spare_i / PRC_i[v]) across analyzers
+// that have variant v with PRC > 0. Returns 0 if any contributing analyzer has
+// Spare ≤ 0 or if no analyzer covers v.
+func safeRemovalReplicas(s []NamedAnalyzerResult, v string) int {
+	smallest := math.MaxInt
+	found := false
+	for _, e := range s {
+		if e.Result == nil {
+			continue
+		}
+		prc := prcForVariant(e.Result, v)
+		if prc <= 0 {
+			continue
+		}
+		n := int(math.Floor(e.Spare / prc))
+		if n < smallest {
+			smallest = n
+		}
+		found = true
+	}
+	if !found || smallest < 0 {
+		return 0
+	}
+	return smallest
+}
+
+// applyAllocation subtracts the capacity provided by n replicas of variant v
+// from each analyzer's Remaining counter. Clamps to 0. The slice is the working
+// allocation state; Result.RequiredCapacity is never mutated.
+//
+// Contract: Remaining/Spare are engine-calibrated on entry (via the universal
+// threshold post-step). Helpers do not read or mutate PendingReplicas.
+func applyAllocation(s []NamedAnalyzerResult, v string, n int) {
+	for i := range s {
+		if s[i].Result == nil {
+			continue
+		}
+		prc := prcForVariant(s[i].Result, v)
+		if prc <= 0 {
+			continue
+		}
+		s[i].Remaining -= float64(n) * prc
+		if s[i].Remaining < 0 {
+			s[i].Remaining = 0
+		}
+	}
+}
+
+// applyDeallocation subtracts the capacity freed by removing n replicas of
+// variant v from each analyzer's Spare counter. Clamps to 0. Mutates in place.
+func applyDeallocation(s []NamedAnalyzerResult, v string, n int) {
+	for i := range s {
+		if s[i].Result == nil {
+			continue
+		}
+		prc := prcForVariant(s[i].Result, v)
+		if prc <= 0 {
+			continue
+		}
+		s[i].Spare -= float64(n) * prc
+		if s[i].Spare < 0 {
+			s[i].Spare = 0
+		}
+	}
+}
+
+// PickVariantFn is the optimizer-specific variant selector used by allocateForModel.
+// It receives the working slice, available variants, state, GPU budget, and current
+// targets, and returns the next variant to allocate to and a replica cap
+// (math.MaxInt for unlimited). Returning ("", 0) signals nothing can be allocated.
+type PickVariantFn func(
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+) (variant string, capN int)
+
+// allocateForModel runs the generic scale-up inner loop for one model.
+// It calls pick to select a variant and cap, computes how many replicas to add
+// (bottleneckReplicas capped by capN), applies the allocation, and updates targets.
+// Loops until needsScaleUp is false or pick returns no selectable variant.
+func allocateForModel(
+	ctx context.Context,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+	pick PickVariantFn,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+	for needsScaleUp(s) {
+		v, capN := pick(s, variants, stateMap, available, targets)
+		if v == "" {
+			break
+		}
+		n := min(bottleneckReplicas(s, v), capN)
+		if n <= 0 {
+			break
+		}
+		applyAllocation(s, v, n)
+		targets[v] += n
+		logger.V(logging.DEBUG).Info("scale-up: allocated replicas",
+			"variant", v, "replicas", n)
+	}
+}
+
+// saturationEntry returns the saturation analyzer's result from s, or nil if not present.
+// The saturation entry is the keeper of per-variant metadata (Cost, AcceleratorName, Role,
+// replica counts) that the optimizer uses for variant selection and GPU accounting.
+// TODO: remove the sat_v2 special role once all analyzers populate variant metadata.
+func saturationEntry(s []NamedAnalyzerResult) *interfaces.AnalyzerResult {
+	for _, e := range s {
+		if e.Name == interfaces.SaturationAnalyzerName {
+			return e.Result
+		}
+	}
+	return nil
+}
+
+// prcForVariant returns the PerReplicaCapacity for variant v in result r.
+// Returns 0 if the variant is not present.
+func prcForVariant(r *interfaces.AnalyzerResult, v string) float64 {
+	for _, vc := range r.VariantCapacities {
+		if vc.VariantName == v {
+			return vc.PerReplicaCapacity
+		}
+	}
+	return 0
+}

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -190,3 +190,262 @@ func prcForVariant(r *interfaces.AnalyzerResult, v string) float64 {
 	}
 	return 0
 }
+
+// =============================================================================
+// Paired helpers — disaggregated (P/D) models
+// =============================================================================
+
+// isDisaggregated reports whether the variant set contains any role-tagged variant
+// (role other than "" or "both"). Used to dispatch to the paired allocation path.
+func isDisaggregated(vcs []interfaces.VariantCapacity) bool {
+	for _, vc := range vcs {
+		if vc.Role != "" && vc.Role != "both" {
+			return true
+		}
+	}
+	return false
+}
+
+// initDisaggregatedRemaining re-initializes the working counters in s for
+// disaggregated (P/D) models before the paired allocation path:
+//   - Remaining ← prefill RC (P-scope)
+//   - RoleSpare[role] ← SpareCapacity for each role in RoleCapacities
+//   - Model-level Spare is left unchanged (unused for disaggregated)
+//
+// Analyzers without RoleCapacities are left unchanged.
+func initDisaggregatedRemaining(s []NamedAnalyzerResult) {
+	for i := range s {
+		if s[i].Result == nil || s[i].Result.RoleCapacities == nil {
+			continue
+		}
+		s[i].Remaining = s[i].Result.RoleCapacities["prefill"].RequiredCapacity
+		s[i].RoleSpare = make(map[string]float64, len(s[i].Result.RoleCapacities))
+		for role, rc := range s[i].Result.RoleCapacities {
+			s[i].RoleSpare[role] = rc.SpareCapacity
+		}
+	}
+}
+
+// analyzerAlpha computes the D:P demand coupling ratio α for one analyzer result.
+// α is derived from TotalDemand — a workload invariant, not from RequiredCapacity
+// (which tracks the gap relative to current supply and would tie α to allocation state).
+// Returns (α, tracksP, tracksD).
+//
+//   - Both sides: P>0, D>0 → α = D/P; tracksP, tracksD = true
+//   - P only:     P>0, D=0 → α = 0;   tracksP = true,  tracksD = false
+//   - D only:     P=0, D>0 → α = 1 (Dean's default); tracksP = false, tracksD = true
+//   - Neither:    P=0, D=0 → tracksP, tracksD = false
+func analyzerAlpha(r *interfaces.AnalyzerResult) (alpha float64, tracksP, tracksD bool) {
+	if r == nil || r.RoleCapacities == nil {
+		return 0, false, false
+	}
+	p := r.RoleCapacities["prefill"].TotalDemand
+	d := r.RoleCapacities["decode"].TotalDemand
+	switch {
+	case p > 0 && d > 0:
+		return d / p, true, true
+	case p > 0:
+		return 0, true, false
+	case d > 0:
+		return 1, false, true
+	default:
+		return 0, false, false
+	}
+}
+
+// bottleneckReplicasPaired computes the (n_P, n_D) replica pair needed to serve
+// the current P-side remaining demand across all analyzers.
+//
+//	n_P = max_i (tracksP) of ceil(Remaining_i / PRC_i[vP])
+//	n_D = max_i (tracksD) of ceil(α_i × Remaining_i / PRC_i[vD])
+//
+// Returns (0, 0) if no analyzer covers the requested sides or all PRCs are zero.
+func bottleneckReplicasPaired(s []NamedAnalyzerResult, vP, vD string) (n_P, n_D int) {
+	for _, e := range s {
+		if e.Result == nil {
+			continue
+		}
+		alpha, tracksP, tracksD := analyzerAlpha(e.Result)
+		if tracksP {
+			prc := prcForVariant(e.Result, vP)
+			if prc > 0 {
+				n := int(math.Ceil(e.Remaining / prc))
+				if n > n_P {
+					n_P = n
+				}
+			}
+		}
+		if tracksD {
+			prc := prcForVariant(e.Result, vD)
+			if prc > 0 {
+				dRemaining := alpha * e.Remaining
+				n := int(math.Ceil(dRemaining / prc))
+				if n > n_D {
+					n_D = n
+				}
+			}
+		}
+	}
+	return
+}
+
+// variantsForRole returns variant capacities whose Role exactly matches role.
+// An empty variant Role is canonicalized to interfaces.RoleBoth.
+func variantsForRole(vcs []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
+	if role == "" || role == interfaces.RoleBoth {
+		return vcs
+	}
+	var out []interfaces.VariantCapacity
+	for _, vc := range vcs {
+		vcRole := vc.Role
+		if vcRole == "" {
+			vcRole = interfaces.RoleBoth
+		}
+		if vcRole == role {
+			out = append(out, vc)
+		}
+	}
+	return out
+}
+
+// safeRemovalReplicasForRole returns the number of replicas of variant v that
+// can safely be removed — the minimum of floor(RoleSpare[role]_i / PRC_i[v])
+// across analyzers that have variant v and a non-zero PRC. Returns 0 if any
+// contributing analyzer has RoleSpare[role] ≤ 0 or RoleSpare is nil.
+func safeRemovalReplicasForRole(s []NamedAnalyzerResult, v, role string) int {
+	smallest := math.MaxInt
+	found := false
+	for _, e := range s {
+		if e.Result == nil || e.RoleSpare == nil {
+			continue
+		}
+		prc := prcForVariant(e.Result, v)
+		if prc <= 0 {
+			continue
+		}
+		n := int(math.Floor(e.RoleSpare[role] / prc))
+		if n < smallest {
+			smallest = n
+		}
+		found = true
+	}
+	if !found || smallest < 0 {
+		return 0
+	}
+	return smallest
+}
+
+// applyDeallocationForRole decrements each analyzer's RoleSpare[role] by
+// n × PRC_i[v]. Clamps to 0. Never mutates Result.
+func applyDeallocationForRole(s []NamedAnalyzerResult, v, role string, n int) {
+	for i := range s {
+		if s[i].Result == nil || s[i].RoleSpare == nil {
+			continue
+		}
+		prc := prcForVariant(s[i].Result, v)
+		if prc <= 0 {
+			continue
+		}
+		s[i].RoleSpare[role] -= float64(n) * prc
+		if s[i].RoleSpare[role] < 0 {
+			s[i].RoleSpare[role] = 0
+		}
+	}
+}
+
+// needsScaleDownForRole reports whether every analyzer agrees this role has
+// spare capacity (all-down gate, scoped to one role). Returns false if any
+// analyzer's RoleSpare[role] ≤ 0 or RoleSpare is nil.
+func needsScaleDownForRole(s []NamedAnalyzerResult, role string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, e := range s {
+		if e.Result == nil || e.RoleSpare == nil {
+			return false
+		}
+		if e.RoleSpare[role] <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// applyAllocationPaired updates each analyzer's Remaining after committing a
+// paired (n_P, n_D) allocation. The capacity served in P-units is the minimum
+// of what the P-side and D-side contribute (bottleneck of the pair).
+// Clamps Remaining to 0. Never mutates Result.
+func applyAllocationPaired(s []NamedAnalyzerResult, vP string, nP int, vD string, nD int) {
+	for i := range s {
+		e := &s[i]
+		if e.Result == nil {
+			continue
+		}
+		alpha, tracksP, tracksD := analyzerAlpha(e.Result)
+		prcP := prcForVariant(e.Result, vP)
+		prcD := prcForVariant(e.Result, vD)
+
+		var served float64
+		switch {
+		case tracksP && tracksD && prcP > 0 && prcD > 0 && alpha > 0:
+			// Both sides: served = min(P-capacity, D-capacity-in-P-units)
+			servedP := float64(nP) * prcP
+			servedD := float64(nD) * prcD / alpha
+			served = math.Min(servedP, servedD)
+		case tracksP && prcP > 0:
+			served = float64(nP) * prcP
+		case tracksD && prcD > 0 && alpha > 0:
+			served = float64(nD) * prcD / alpha
+		default:
+			continue
+		}
+		e.Remaining -= served
+		if e.Remaining < 0 {
+			e.Remaining = 0
+		}
+	}
+}
+
+// PickPairFn is the optimizer-specific paired variant selector for disaggregated models.
+// It returns the chosen (vP, vD) variants and per-side replica caps.
+// Returning ("", "", 0, 0) signals no allocatable pair exists.
+type PickPairFn func(
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+) (vP, vD string, capN_P, capN_D int)
+
+// allocateForModelPaired runs the generic paired scale-up loop for one
+// disaggregated model. Loops while needsScaleUp(s) is true and the picker
+// returns a valid (vP, vD) pair. Each iteration commits one (n_P, n_D) step.
+func allocateForModelPaired(
+	ctx context.Context,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+	pick PickPairFn,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+	for needsScaleUp(s) {
+		vP, vD, capNP, capND := pick(s, variants, stateMap, available, targets)
+		if vP == "" || vD == "" {
+			break
+		}
+		nP, nD := bottleneckReplicasPaired(s, vP, vD)
+		nP = min(nP, capNP)
+		nD = min(nD, capND)
+		if nP <= 0 && nD <= 0 {
+			break
+		}
+		applyAllocationPaired(s, vP, nP, vD, nD)
+		targets[vP] += nP
+		targets[vD] += nD
+		logger.V(logging.DEBUG).Info("scale-up paired: allocated replicas",
+			"prefill-variant", vP, "prefill-replicas", nP,
+			"decode-variant", vD, "decode-replicas", nD)
+	}
+}

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -226,67 +226,77 @@ func initDisaggregatedRemaining(s []NamedAnalyzerResult) {
 	}
 }
 
-// analyzerAlpha computes the D:P demand coupling ratio α for one analyzer result.
-// α is derived from TotalDemand — a workload invariant, not from RequiredCapacity
-// (which tracks the gap relative to current supply and would tie α to allocation state).
-// Returns (α, tracksP, tracksD).
+// =============================================================================
+// B2 paired scale-up helpers (per-role independent sizing + joint-commit trim)
+// =============================================================================
 //
-//   - Both sides: P>0, D>0 → α = D/P; tracksP, tracksD = true
-//   - P only:     P>0, D=0 → α = 0;   tracksP = true,  tracksD = false
-//   - D only:     P=0, D>0 → α = 1 (Dean's default); tracksP = false, tracksD = true
-//   - Neither:    P=0, D=0 → tracksP, tracksD = false
-func analyzerAlpha(r *interfaces.AnalyzerResult) (alpha float64, tracksP, tracksD bool) {
-	if r == nil || r.RoleCapacities == nil {
-		return 0, false, false
+// Design § Architecture/D: (model, role) is the unit of allocation math.
+// Per-role sizing uses the same bottleneck primitives as non-disaggregated
+// allocation, scoped to one role. The joint-commit step bounds by the min-util
+// role (the coupling constraint). α no longer appears in serve-math — only in
+// picker sizing when one role's demand is derived from the other.
+//
+// RolePairedState holds picker-local per-role demand tracked during one
+// model's allocation pass. Indexed as [analyzer-index][role] → remaining demand
+// (in that role's own capacity units). Initialized from RoleCapacities[role].RC;
+// decremented per joint commit. Lives only inside the allocation loop — not
+// stored on NamedAnalyzerResult (per design A10).
+type RolePairedState []map[string]float64
+
+// InitRolePairedState initializes picker-local per-role demand from the
+// engine-calibrated RoleCapacities[role].RequiredCapacity in each analyzer result.
+func InitRolePairedState(s []NamedAnalyzerResult) RolePairedState {
+	state := make(RolePairedState, len(s))
+	for i, e := range s {
+		state[i] = make(map[string]float64)
+		if e.Result != nil && e.Result.RoleCapacities != nil {
+			for role, rc := range e.Result.RoleCapacities {
+				state[i][role] = rc.RequiredCapacity
+			}
+		}
 	}
-	p := r.RoleCapacities["prefill"].TotalDemand
-	d := r.RoleCapacities["decode"].TotalDemand
-	switch {
-	case p > 0 && d > 0:
-		return d / p, true, true
-	case p > 0:
-		return 0, true, false
-	case d > 0:
-		return 1, false, true
-	default:
-		return 0, false, false
-	}
+	return state
 }
 
-// bottleneckReplicasPaired computes the (n_P, n_D) replica pair needed to serve
-// the current P-side remaining demand across all analyzers.
-//
-//	n_P = max_i (tracksP) of ceil(Remaining_i / PRC_i[vP])
-//	n_D = max_i (tracksD) of ceil(α_i × Remaining_i / PRC_i[vD])
-//
-// Returns (0, 0) if no analyzer covers the requested sides or all PRCs are zero.
-func bottleneckReplicasPaired(s []NamedAnalyzerResult, vP, vD string) (n_P, n_D int) {
-	for _, e := range s {
+// roleBottleneckReplicas computes the cross-analyzer bottleneck replica count
+// for variant v in a specific role. Returns max_i ceil(state[i][role] / PRC_i[v]).
+func roleBottleneckReplicas(s []NamedAnalyzerResult, state RolePairedState, role, v string) int {
+	max := 0
+	for i, e := range s {
 		if e.Result == nil {
 			continue
 		}
-		alpha, tracksP, tracksD := analyzerAlpha(e.Result)
-		if tracksP {
-			prc := prcForVariant(e.Result, vP)
-			if prc > 0 {
-				n := int(math.Ceil(e.Remaining / prc))
-				if n > n_P {
-					n_P = n
-				}
-			}
+		prc := prcForVariant(e.Result, v)
+		if prc <= 0 {
+			continue
 		}
-		if tracksD {
-			prc := prcForVariant(e.Result, vD)
-			if prc > 0 {
-				dRemaining := alpha * e.Remaining
-				n := int(math.Ceil(dRemaining / prc))
-				if n > n_D {
-					n_D = n
-				}
-			}
+		n := int(math.Ceil(state[i][role] / prc))
+		if n > max {
+			max = n
 		}
 	}
-	return
+	return max
+}
+
+// roleAggRemaining returns max cross-analyzer remaining demand for role.
+func roleAggRemaining(s []NamedAnalyzerResult, state RolePairedState, role string) float64 {
+	max := 0.0
+	for i := range s {
+		if d := state[i][role]; d > max {
+			max = d
+		}
+	}
+	return max
+}
+
+// needsScaleUpPaired reports whether any role still has aggregate remaining demand > 0.
+func needsScaleUpPaired(s []NamedAnalyzerResult, state RolePairedState, roles []string) bool {
+	for _, role := range roles {
+		if roleAggRemaining(s, state, role) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // variantsForRole returns variant capacities whose Role exactly matches role.
@@ -371,44 +381,9 @@ func needsScaleDownForRole(s []NamedAnalyzerResult, role string) bool {
 	return true
 }
 
-// applyAllocationPaired updates each analyzer's Remaining after committing a
-// paired (n_P, n_D) allocation. The capacity served in P-units is the minimum
-// of what the P-side and D-side contribute (bottleneck of the pair).
-// Clamps Remaining to 0. Never mutates Result.
-func applyAllocationPaired(s []NamedAnalyzerResult, vP string, nP int, vD string, nD int) {
-	for i := range s {
-		e := &s[i]
-		if e.Result == nil {
-			continue
-		}
-		alpha, tracksP, tracksD := analyzerAlpha(e.Result)
-		prcP := prcForVariant(e.Result, vP)
-		prcD := prcForVariant(e.Result, vD)
-
-		var served float64
-		switch {
-		case tracksP && tracksD && prcP > 0 && prcD > 0 && alpha > 0:
-			// Both sides: served = min(P-capacity, D-capacity-in-P-units)
-			servedP := float64(nP) * prcP
-			servedD := float64(nD) * prcD / alpha
-			served = math.Min(servedP, servedD)
-		case tracksP && prcP > 0:
-			served = float64(nP) * prcP
-		case tracksD && prcD > 0 && alpha > 0:
-			served = float64(nD) * prcD / alpha
-		default:
-			continue
-		}
-		e.Remaining -= served
-		if e.Remaining < 0 {
-			e.Remaining = 0
-		}
-	}
-}
-
 // PickPairFn is the optimizer-specific paired variant selector for disaggregated models.
-// It returns the chosen (vP, vD) variants and per-side replica caps.
-// Returning ("", "", 0, 0) signals no allocatable pair exists.
+// It returns the chosen (vP, vD) variants and per-side replica caps (GPU budget +
+// maxReplicas headroom). Returning ("", "", 0, 0) signals no allocatable pair exists.
 type PickPairFn func(
 	s []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
@@ -417,10 +392,15 @@ type PickPairFn func(
 	targets map[string]int,
 ) (vP, vD string, capN_P, capN_D int)
 
-// allocateForModelPaired runs the generic paired scale-up loop for one
-// disaggregated model. Loops while needsScaleUp(s) is true and the picker
-// returns a valid (vP, vD) pair. Each iteration commits one (n_P, n_D) step.
-func allocateForModelPaired(
+// allocateForModelPairedB2 runs the B2 paired scale-up loop for one disaggregated
+// model. Per-role sizing is independent (same bottleneck primitive as non-disag,
+// scoped to each role's picker-local demand). Joint commit is bounded by
+// min_role { util_role } to advance both roles by the same utilization delta.
+//
+// 0-cases (per design § Architecture/D):
+//   - Demand_role = 0 → util_role = 1 (role drops from min).
+//   - Demand_role > 0, no capacity → util_role = 0 → joint bound = 0.
+func allocateForModelPairedB2(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
@@ -428,24 +408,76 @@ func allocateForModelPaired(
 	available map[string]int,
 	targets map[string]int,
 	pick PickPairFn,
+	pickerState RolePairedState,
+	roles []string,
 ) {
 	logger := ctrl.LoggerFrom(ctx)
-	for needsScaleUp(s) {
+	for needsScaleUpPaired(s, pickerState, roles) {
 		vP, vD, capNP, capND := pick(s, variants, stateMap, available, targets)
 		if vP == "" || vD == "" {
 			break
 		}
-		nP, nD := bottleneckReplicasPaired(s, vP, vD)
-		nP = min(nP, capNP)
-		nD = min(nD, capND)
-		if nP <= 0 && nD <= 0 {
+		prcP := prcFromVCs(variants, vP)
+		prcD := prcFromVCs(variants, vD)
+		if prcP <= 0 || prcD <= 0 {
 			break
 		}
-		applyAllocationPaired(s, vP, nP, vD, nD)
-		targets[vP] += nP
-		targets[vD] += nD
-		logger.V(logging.DEBUG).Info("scale-up paired: allocated replicas",
-			"prefill-variant", vP, "prefill-replicas", nP,
-			"decode-variant", vD, "decode-replicas", nD)
+
+		// Per-role independent sizing capped by picker resource limits.
+		nP := min(roleBottleneckReplicas(s, pickerState, "prefill", vP), capNP)
+		nD := min(roleBottleneckReplicas(s, pickerState, "decode", vD), capND)
+
+		// Aggregate demand per role for util computation.
+		demandP := roleAggRemaining(s, pickerState, "prefill")
+		demandD := roleAggRemaining(s, pickerState, "decode")
+
+		// util_role = served / demand (0-case: demand=0 → util=1, drops from min).
+		var utilP, utilD float64
+		if demandP <= 0 {
+			utilP = 1.0
+		} else {
+			utilP = float64(nP) * prcP / demandP
+		}
+		if demandD <= 0 {
+			utilD = 1.0
+		} else {
+			utilD = float64(nD) * prcD / demandD
+		}
+
+		deltaUtil := math.Min(utilP, utilD)
+		if deltaUtil <= 0 {
+			break
+		}
+
+		// Trim over-allocated role to the joint util bound.
+		// floor(Δ_util × demand / prc) trims integer replicas to the bottleneck util.
+		// When demand < prc (one replica over-serves), floor rounds to 0 — use
+		// min(1, n_role) as minimum so fractional demand still gets a replica.
+		kP, kD := 0, 0
+		if prcP > 0 && demandP > 0 {
+			kP = max(int(math.Floor(deltaUtil*demandP/prcP)), min(1, nP))
+		}
+		if prcD > 0 && demandD > 0 {
+			kD = max(int(math.Floor(deltaUtil*demandD/prcD)), min(1, nD))
+		}
+		if kP <= 0 && kD <= 0 {
+			break
+		}
+
+		// Commit.
+		targets[vP] += kP
+		targets[vD] += kD
+		for i := range pickerState {
+			pickerState[i]["prefill"] = math.Max(0, pickerState[i]["prefill"]-float64(kP)*prcP)
+			pickerState[i]["decode"] = math.Max(0, pickerState[i]["decode"]-float64(kD)*prcD)
+		}
+		applyAllocation(s, vP, kP) // decrement model-level Remaining (P-anchor)
+		if available != nil {
+			available[accFromVCs(variants, vP)] -= kP * gpusPerReplicaFromState(stateMap, vP)
+			available[accFromVCs(variants, vD)] -= kD * gpusPerReplicaFromState(stateMap, vD)
+		}
+
+		logger.V(logging.DEBUG).Info("scale-up paired B2: joint commit",
+			"vP", vP, "kP", kP, "vD", vD, "kD", kD, "deltaUtil", deltaUtil)
 	}
 }

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -11,81 +11,6 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
-// needsScaleUp reports whether any analyzer in s signals a need for more capacity.
-// Implements the any-up gate: scale-up proceeds if at least one analyzer has Remaining > 0.
-func needsScaleUp(s []NamedAnalyzerResult) bool {
-	for _, e := range s {
-		if e.Result != nil && e.Remaining > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// needsScaleDown reports whether all analyzers in s permit capacity removal.
-// Implements the all-down gate: scale-down is blocked unless every analyzer
-// has Spare > 0. Returns false for an empty slice (no consensus).
-func needsScaleDown(s []NamedAnalyzerResult) bool {
-	if len(s) == 0 {
-		return false
-	}
-	for _, e := range s {
-		if e.Result == nil || e.Spare <= 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// bottleneckReplicas returns the number of replicas of variant v needed to
-// satisfy the most-demanding analyzer. It is the maximum of
-// ceil(Remaining_i / PRC_i[v]) across analyzers that have variant v with PRC > 0.
-// Returns 0 if no analyzer covers variant v or all PRCs are zero (cold-start guard).
-func bottleneckReplicas(s []NamedAnalyzerResult, v string) int {
-	max := 0
-	for _, e := range s {
-		if e.Result == nil {
-			continue
-		}
-		prc := prcForVariant(e.Result, v)
-		if prc <= 0 {
-			continue
-		}
-		n := int(math.Ceil(e.Remaining / prc))
-		if n > max {
-			max = n
-		}
-	}
-	return max
-}
-
-// safeRemovalReplicas returns the number of replicas of variant v that can be
-// safely removed — the minimum of floor(Spare_i / PRC_i[v]) across analyzers
-// that have variant v with PRC > 0. Returns 0 if any contributing analyzer has
-// Spare ≤ 0 or if no analyzer covers v.
-func safeRemovalReplicas(s []NamedAnalyzerResult, v string) int {
-	smallest := math.MaxInt
-	found := false
-	for _, e := range s {
-		if e.Result == nil {
-			continue
-		}
-		prc := prcForVariant(e.Result, v)
-		if prc <= 0 {
-			continue
-		}
-		n := int(math.Floor(e.Spare / prc))
-		if n < smallest {
-			smallest = n
-		}
-		found = true
-	}
-	if !found || smallest < 0 {
-		return 0
-	}
-	return smallest
-}
-
 // applyAllocation subtracts the capacity provided by n replicas of variant v
 // from each analyzer's Remaining counter. Clamps to 0. The slice is the working
 // allocation state; Result.RequiredCapacity is never mutated.
@@ -105,66 +30,6 @@ func applyAllocation(s []NamedAnalyzerResult, v string, n int) {
 		if s[i].Remaining < 0 {
 			s[i].Remaining = 0
 		}
-	}
-}
-
-// applyDeallocation subtracts the capacity freed by removing n replicas of
-// variant v from each analyzer's Spare counter. Clamps to 0. Mutates in place.
-func applyDeallocation(s []NamedAnalyzerResult, v string, n int) {
-	for i := range s {
-		if s[i].Result == nil {
-			continue
-		}
-		prc := prcForVariant(s[i].Result, v)
-		if prc <= 0 {
-			continue
-		}
-		s[i].Spare -= float64(n) * prc
-		if s[i].Spare < 0 {
-			s[i].Spare = 0
-		}
-	}
-}
-
-// PickVariantFn is the optimizer-specific variant selector used by allocateForModel.
-// It receives the working slice, available variants, state, GPU budget, and current
-// targets, and returns the next variant to allocate to and a replica cap
-// (math.MaxInt for unlimited). Returning ("", 0) signals nothing can be allocated.
-type PickVariantFn func(
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	targets map[string]int,
-) (variant string, capN int)
-
-// allocateForModel runs the generic scale-up inner loop for one model.
-// It calls pick to select a variant and cap, computes how many replicas to add
-// (bottleneckReplicas capped by capN), applies the allocation, and updates targets.
-// Loops until needsScaleUp is false or pick returns no selectable variant.
-func allocateForModel(
-	ctx context.Context,
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	targets map[string]int,
-	pick PickVariantFn,
-) {
-	logger := ctrl.LoggerFrom(ctx)
-	for needsScaleUp(s) {
-		v, capN := pick(s, variants, stateMap, available, targets)
-		if v == "" {
-			break
-		}
-		n := min(bottleneckReplicas(s, v), capN)
-		if n <= 0 {
-			break
-		}
-		applyAllocation(s, v, n)
-		targets[v] += n
-		logger.V(logging.DEBUG).Info("scale-up: allocated replicas",
-			"variant", v, "replicas", n)
 	}
 }
 
@@ -195,17 +60,6 @@ func prcForVariant(r *interfaces.AnalyzerResult, v string) float64 {
 // =============================================================================
 // Paired helpers — disaggregated (P/D) models
 // =============================================================================
-
-// isDisaggregated reports whether the variant set contains any role-tagged variant
-// (role other than "" or "both"). Used to dispatch to the paired allocation path.
-func isDisaggregated(vcs []interfaces.VariantCapacity) bool {
-	for _, vc := range vcs {
-		if vc.Role != "" && vc.Role != "both" {
-			return true
-		}
-	}
-	return false
-}
 
 // initRoleState initialises picker-local role state for one model's allocation pass.
 // It unifies disaggregated and non-disaggregated models into one (model, role) view:
@@ -258,14 +112,12 @@ func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePai
 }
 
 // =============================================================================
-// B2 paired scale-up helpers (per-role independent sizing + joint-commit trim)
+// Paired helpers — role-generic scale-up and scale-down
 // =============================================================================
 //
 // Design § Architecture/D: (model, role) is the unit of allocation math.
-// Per-role sizing uses the same bottleneck primitives as non-disaggregated
-// allocation, scoped to one role. The joint-commit step bounds by the min-util
-// role (the coupling constraint). α no longer appears in serve-math — only in
-// picker sizing when one role's demand is derived from the other.
+// Per-role sizing is independent, scoped to each role's picker-local demand.
+// The joint-commit step bounds by the min-util role (the coupling constraint).
 //
 // RolePairedState holds picker-local per-role demand tracked during one
 // model's allocation pass. Indexed as [analyzer-index][role] → remaining demand
@@ -273,13 +125,6 @@ func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePai
 // decremented per joint commit. Lives only inside the allocation loop — not
 // stored on NamedAnalyzerResult (per design A10).
 type RolePairedState []map[string]float64
-
-// InitRolePairedState is kept as a wrapper for call sites not yet migrated to
-// initRoleState. New code should call initRoleState directly.
-func InitRolePairedState(s []NamedAnalyzerResult) RolePairedState {
-	_, ps := initRoleState(s)
-	return ps
-}
 
 // roleBottleneckReplicas computes the cross-analyzer bottleneck replica count
 // for variant v in a specific role. Returns max_i ceil(state[i][role] / PRC_i[v]).
@@ -312,8 +157,7 @@ func roleAggRemaining(s []NamedAnalyzerResult, state RolePairedState, role strin
 	return max
 }
 
-// anyRoleNeedsScaleUp is the Phase-3 per-role scale-up gate used by the unified
-// dispatcher. It replaces both needsScaleUp (model-level) and needsScaleUpPaired.
+// anyRoleNeedsScaleUp is the per-role scale-up gate for the unified dispatcher.
 // Returns true when any role has aggregate remaining demand > 0.
 func anyRoleNeedsScaleUp(state RolePairedState, roles []string) bool {
 	for _, role := range roles {
@@ -326,29 +170,16 @@ func anyRoleNeedsScaleUp(state RolePairedState, roles []string) bool {
 	return false
 }
 
-// needsScaleUpPaired reports whether any role still has aggregate remaining demand > 0.
-func needsScaleUpPaired(s []NamedAnalyzerResult, state RolePairedState, roles []string) bool {
-	for _, role := range roles {
-		if roleAggRemaining(s, state, role) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// variantsForRole returns variant capacities whose Role exactly matches role.
-// An empty variant Role is canonicalized to interfaces.RoleBoth.
+// variantsForRole returns the capacities whose role matches role exactly,
+// canonicalizing an empty Role to interfaces.RoleBoth.
 func variantsForRole(vcs []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
-	if role == "" || role == interfaces.RoleBoth {
-		return vcs
-	}
-	var out []interfaces.VariantCapacity
+	out := make([]interfaces.VariantCapacity, 0, len(vcs))
 	for _, vc := range vcs {
-		vcRole := vc.Role
-		if vcRole == "" {
-			vcRole = interfaces.RoleBoth
+		r := vc.Role
+		if r == "" {
+			r = interfaces.RoleBoth
 		}
-		if vcRole == role {
+		if r == role {
 			out = append(out, vc)
 		}
 	}
@@ -430,16 +261,6 @@ type RolePickFn func(
 	available map[string]int,
 	targets map[string]int,
 ) (variant string, capN int)
-
-// PickPairFn is kept for call sites not yet migrated to RolePickFn + allocateForModelPaired.
-// New code should use RolePickFn.
-type PickPairFn func(
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	targets map[string]int,
-) (vP, vD string, capN_P, capN_D int)
 
 // allocateForModelPaired is the Phase-3 role-generic scale-up loop.
 // Handles any set of roles (including the arity-1 "both" single-role case).
@@ -542,95 +363,5 @@ func allocateForModelPaired(
 			}
 		}
 		logger.V(logging.DEBUG).Info("scale-up: joint role commit", "deltaUtil", deltaUtil)
-	}
-}
-
-// allocateForModelPairedB2 runs the B2 paired scale-up loop for one disaggregated
-// model. Per-role sizing is independent (same bottleneck primitive as non-disag,
-// scoped to each role's picker-local demand). Joint commit is bounded by
-// min_role { util_role } to advance both roles by the same utilization delta.
-//
-// 0-cases (per design § Architecture/D):
-//   - Demand_role = 0 → util_role = 1 (role drops from min).
-//   - Demand_role > 0, no capacity → util_role = 0 → joint bound = 0.
-func allocateForModelPairedB2(
-	ctx context.Context,
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	targets map[string]int,
-	pick PickPairFn,
-	pickerState RolePairedState,
-	roles []string,
-) {
-	logger := ctrl.LoggerFrom(ctx)
-	for needsScaleUpPaired(s, pickerState, roles) {
-		vP, vD, capNP, capND := pick(s, variants, stateMap, available, targets)
-		if vP == "" || vD == "" {
-			break
-		}
-		prcP := prcFromVCs(variants, vP)
-		prcD := prcFromVCs(variants, vD)
-		if prcP <= 0 || prcD <= 0 {
-			break
-		}
-
-		// Per-role independent sizing capped by picker resource limits.
-		nP := min(roleBottleneckReplicas(s, pickerState, "prefill", vP), capNP)
-		nD := min(roleBottleneckReplicas(s, pickerState, "decode", vD), capND)
-
-		// Aggregate demand per role for util computation.
-		demandP := roleAggRemaining(s, pickerState, "prefill")
-		demandD := roleAggRemaining(s, pickerState, "decode")
-
-		// util_role = served / demand (0-case: demand=0 → util=1, drops from min).
-		var utilP, utilD float64
-		if demandP <= 0 {
-			utilP = 1.0
-		} else {
-			utilP = float64(nP) * prcP / demandP
-		}
-		if demandD <= 0 {
-			utilD = 1.0
-		} else {
-			utilD = float64(nD) * prcD / demandD
-		}
-
-		deltaUtil := math.Min(utilP, utilD)
-		if deltaUtil <= 0 {
-			break
-		}
-
-		// Trim over-allocated role to the joint util bound.
-		// floor(Δ_util × demand / prc) trims integer replicas to the bottleneck util.
-		// When demand < prc (one replica over-serves), floor rounds to 0 — use
-		// min(1, n_role) as minimum so fractional demand still gets a replica.
-		kP, kD := 0, 0
-		if prcP > 0 && demandP > 0 {
-			kP = max(int(math.Floor(deltaUtil*demandP/prcP)), min(1, nP))
-		}
-		if prcD > 0 && demandD > 0 {
-			kD = max(int(math.Floor(deltaUtil*demandD/prcD)), min(1, nD))
-		}
-		if kP <= 0 && kD <= 0 {
-			break
-		}
-
-		// Commit.
-		targets[vP] += kP
-		targets[vD] += kD
-		for i := range pickerState {
-			pickerState[i]["prefill"] = math.Max(0, pickerState[i]["prefill"]-float64(kP)*prcP)
-			pickerState[i]["decode"] = math.Max(0, pickerState[i]["decode"]-float64(kD)*prcD)
-		}
-		applyAllocation(s, vP, kP) // decrement model-level Remaining (P-anchor)
-		if available != nil {
-			available[accFromVCs(variants, vP)] -= kP * gpusPerReplicaFromState(stateMap, vP)
-			available[accFromVCs(variants, vD)] -= kD * gpusPerReplicaFromState(stateMap, vD)
-		}
-
-		logger.V(logging.DEBUG).Info("scale-up paired B2: joint commit",
-			"vP", vP, "kP", kP, "vD", vD, "kD", kD, "deltaUtil", deltaUtil)
 	}
 }

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -257,21 +257,6 @@ func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePai
 	return
 }
 
-// initDisaggregatedRemaining is kept as a wrapper for call sites not yet
-// migrated to initRoleState. Preserves the pre-Phase-3 behaviour of setting
-// Remaining to the prefill RC (P-anchor). New code should call initRoleState.
-func initDisaggregatedRemaining(s []NamedAnalyzerResult) {
-	_, _ = initRoleState(s) // side-effect: populates RoleSpare
-	// Preserve P-anchor: set Remaining from prefill RC so needsScaleUp(s) works
-	// for callers that haven't moved to anyRoleNeedsScaleUp yet.
-	for i := range s {
-		if s[i].Result == nil || s[i].Result.RoleCapacities == nil {
-			continue
-		}
-		s[i].Remaining = s[i].Result.RoleCapacities["prefill"].RequiredCapacity
-	}
-}
-
 // =============================================================================
 // B2 paired scale-up helpers (per-role independent sizing + joint-commit trim)
 // =============================================================================
@@ -433,9 +418,21 @@ func needsScaleDownForRole(s []NamedAnalyzerResult, role string) bool {
 	return true
 }
 
-// PickPairFn is the optimizer-specific paired variant selector for disaggregated models.
-// It returns the chosen (vP, vD) variants and per-side replica caps (GPU budget +
-// maxReplicas headroom). Returning ("", "", 0, 0) signals no allocatable pair exists.
+// RolePickFn is the role-generic optimizer variant selector for the unified
+// allocateForModelPaired loop. Called once per role per iteration; returns the
+// chosen variant and its resource cap. Returning ("", 0) signals no variant
+// is available for this role.
+type RolePickFn func(
+	role string,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+) (variant string, capN int)
+
+// PickPairFn is kept for call sites not yet migrated to RolePickFn + allocateForModelPaired.
+// New code should use RolePickFn.
 type PickPairFn func(
 	s []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
@@ -443,6 +440,110 @@ type PickPairFn func(
 	available map[string]int,
 	targets map[string]int,
 ) (vP, vD string, capN_P, capN_D int)
+
+// allocateForModelPaired is the Phase-3 role-generic scale-up loop.
+// Handles any set of roles (including the arity-1 "both" single-role case).
+// Per iteration: pick one variant per role, size independently, compute
+// Δ_util = min_role util_role, trim to matched joint commit.
+// Arity-1 (roles = ["both"]) reduces to plain per-variant allocation.
+func allocateForModelPaired(
+	ctx context.Context,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	targets map[string]int,
+	pick RolePickFn,
+	pickerState RolePairedState,
+	roles []string,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+	for anyRoleNeedsScaleUp(pickerState, roles) {
+		variantByRole := make(map[string]string, len(roles))
+		capByRole := make(map[string]int, len(roles))
+		prcByRole := make(map[string]float64, len(roles))
+		allPicked := true
+		for _, role := range roles {
+			v, capN := pick(role, s, variants, stateMap, available, targets)
+			if v == "" {
+				allPicked = false
+				break
+			}
+			variantByRole[role] = v
+			capByRole[role] = capN
+			prcByRole[role] = prcFromVCs(variants, v)
+		}
+		if !allPicked {
+			break
+		}
+
+		nByRole := make(map[string]int, len(roles))
+		utilByRole := make(map[string]float64, len(roles))
+		for _, role := range roles {
+			prc := prcByRole[role]
+			n := min(roleBottleneckReplicas(s, pickerState, role, variantByRole[role]), capByRole[role])
+			nByRole[role] = n
+			demand := roleAggRemaining(s, pickerState, role)
+			if demand <= 0 {
+				utilByRole[role] = 1.0
+			} else {
+				utilByRole[role] = float64(n) * prc / demand
+			}
+		}
+
+		deltaUtil := math.MaxFloat64
+		for _, role := range roles {
+			if utilByRole[role] < deltaUtil {
+				deltaUtil = utilByRole[role]
+			}
+		}
+		if deltaUtil <= 0 {
+			break
+		}
+
+		kByRole := make(map[string]int, len(roles))
+		anyPositive := false
+		for _, role := range roles {
+			demand := roleAggRemaining(s, pickerState, role)
+			prc := prcByRole[role]
+			n := nByRole[role]
+			k := 0
+			if prc > 0 && demand > 0 {
+				k = max(int(math.Floor(deltaUtil*demand/prc)), min(1, n))
+			}
+			kByRole[role] = k
+			if k > 0 {
+				anyPositive = true
+			}
+		}
+		if !anyPositive {
+			break
+		}
+
+		for _, role := range roles {
+			v := variantByRole[role]
+			k := kByRole[role]
+			prc := prcByRole[role]
+			targets[v] += k
+			for i := range pickerState {
+				pickerState[i][role] = math.Max(0, pickerState[i][role]-float64(k)*prc)
+			}
+			if available != nil {
+				available[accFromVCs(variants, v)] -= k * gpusPerReplicaFromState(stateMap, v)
+			}
+		}
+		// Update model-level Remaining via the P-anchor role so fairShareValue
+		// reflects committed capacity. For "both" (non-disaggregated) use the
+		// single role; for P/D prefer "prefill".
+		for _, anchor := range []string{"prefill", interfaces.RoleBoth} {
+			if v, ok := variantByRole[anchor]; ok {
+				applyAllocation(s, v, kByRole[anchor])
+				break
+			}
+		}
+		logger.V(logging.DEBUG).Info("scale-up: joint role commit", "deltaUtil", deltaUtil)
+	}
+}
 
 // allocateForModelPairedB2 runs the B2 paired scale-up loop for one disaggregated
 // model. Per-role sizing is independent (same bottleneck primitive as non-disag,

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -108,7 +108,7 @@ func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePai
 		roles = append(roles, role)
 	}
 	sort.Strings(roles)
-	return
+	return roles, pickerState
 }
 
 // =============================================================================

--- a/internal/engines/pipeline/analyzer_helpers.go
+++ b/internal/engines/pipeline/analyzer_helpers.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"math"
+	"sort"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -206,23 +207,68 @@ func isDisaggregated(vcs []interfaces.VariantCapacity) bool {
 	return false
 }
 
-// initDisaggregatedRemaining re-initializes the working counters in s for
-// disaggregated (P/D) models before the paired allocation path:
-//   - Remaining ← prefill RC (P-scope)
-//   - RoleSpare[role] ← SpareCapacity for each role in RoleCapacities
-//   - Model-level Spare is left unchanged (unused for disaggregated)
+// initRoleState initialises picker-local role state for one model's allocation pass.
+// It unifies disaggregated and non-disaggregated models into one (model, role) view:
 //
-// Analyzers without RoleCapacities are left unchanged.
+//   - Disaggregated (RoleCapacities != nil): roles = sorted keys of RoleCapacities;
+//     per-role RC → pickerState[i][role]; per-role SC → s[i].RoleSpare[role].
+//   - Non-disaggregated (RoleCapacities == nil): one synthetic role "both" using
+//     the engine-calibrated model-level RC/SC (Result.RequiredCapacity / SpareCapacity).
+//     No re-aggregation — the engine already summed all variants into those scalars.
+//
+// Returns the list of active roles and the picker-local RolePairedState.
+// Remaining/Spare scalars on NamedAnalyzerResult are read-only after this call;
+// all dynamic bookkeeping moves to pickerState (scale-up) and RoleSpare (scale-down).
+func initRoleState(s []NamedAnalyzerResult) (roles []string, pickerState RolePairedState) {
+	pickerState = make(RolePairedState, len(s))
+	roleSet := make(map[string]struct{})
+
+	for i, e := range s {
+		pickerState[i] = make(map[string]float64)
+		if e.Result == nil {
+			continue
+		}
+		if e.Result.RoleCapacities != nil {
+			// Disaggregated: per-role RC/SC from engine-calibrated RoleCapacities.
+			if s[i].RoleSpare == nil {
+				s[i].RoleSpare = make(map[string]float64, len(e.Result.RoleCapacities))
+			}
+			for role, rc := range e.Result.RoleCapacities {
+				pickerState[i][role] = rc.RequiredCapacity
+				s[i].RoleSpare[role] = rc.SpareCapacity
+				roleSet[role] = struct{}{}
+			}
+		} else {
+			// Non-disaggregated: synthesize a single "both" role from model-level scalars.
+			pickerState[i][interfaces.RoleBoth] = e.Remaining
+			if s[i].RoleSpare == nil {
+				s[i].RoleSpare = make(map[string]float64, 1)
+			}
+			s[i].RoleSpare[interfaces.RoleBoth] = e.Spare
+			roleSet[interfaces.RoleBoth] = struct{}{}
+		}
+	}
+
+	roles = make([]string, 0, len(roleSet))
+	for role := range roleSet {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	return
+}
+
+// initDisaggregatedRemaining is kept as a wrapper for call sites not yet
+// migrated to initRoleState. Preserves the pre-Phase-3 behaviour of setting
+// Remaining to the prefill RC (P-anchor). New code should call initRoleState.
 func initDisaggregatedRemaining(s []NamedAnalyzerResult) {
+	_, _ = initRoleState(s) // side-effect: populates RoleSpare
+	// Preserve P-anchor: set Remaining from prefill RC so needsScaleUp(s) works
+	// for callers that haven't moved to anyRoleNeedsScaleUp yet.
 	for i := range s {
 		if s[i].Result == nil || s[i].Result.RoleCapacities == nil {
 			continue
 		}
 		s[i].Remaining = s[i].Result.RoleCapacities["prefill"].RequiredCapacity
-		s[i].RoleSpare = make(map[string]float64, len(s[i].Result.RoleCapacities))
-		for role, rc := range s[i].Result.RoleCapacities {
-			s[i].RoleSpare[role] = rc.SpareCapacity
-		}
 	}
 }
 
@@ -243,19 +289,11 @@ func initDisaggregatedRemaining(s []NamedAnalyzerResult) {
 // stored on NamedAnalyzerResult (per design A10).
 type RolePairedState []map[string]float64
 
-// InitRolePairedState initializes picker-local per-role demand from the
-// engine-calibrated RoleCapacities[role].RequiredCapacity in each analyzer result.
+// InitRolePairedState is kept as a wrapper for call sites not yet migrated to
+// initRoleState. New code should call initRoleState directly.
 func InitRolePairedState(s []NamedAnalyzerResult) RolePairedState {
-	state := make(RolePairedState, len(s))
-	for i, e := range s {
-		state[i] = make(map[string]float64)
-		if e.Result != nil && e.Result.RoleCapacities != nil {
-			for role, rc := range e.Result.RoleCapacities {
-				state[i][role] = rc.RequiredCapacity
-			}
-		}
-	}
-	return state
+	_, ps := initRoleState(s)
+	return ps
 }
 
 // roleBottleneckReplicas computes the cross-analyzer bottleneck replica count
@@ -287,6 +325,20 @@ func roleAggRemaining(s []NamedAnalyzerResult, state RolePairedState, role strin
 		}
 	}
 	return max
+}
+
+// anyRoleNeedsScaleUp is the Phase-3 per-role scale-up gate used by the unified
+// dispatcher. It replaces both needsScaleUp (model-level) and needsScaleUpPaired.
+// Returns true when any role has aggregate remaining demand > 0.
+func anyRoleNeedsScaleUp(state RolePairedState, roles []string) bool {
+	for _, role := range roles {
+		for _, m := range state {
+			if m[role] > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // needsScaleUpPaired reports whether any role still has aggregate remaining demand > 0.

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -323,91 +323,54 @@ var _ = Describe("paired helpers", func() {
 		})
 	})
 
-	Describe("analyzerAlpha", func() {
-		It("returns α=D/P and both-tracks when P>0, D>0", func() {
-			r := &interfaces.AnalyzerResult{
-				RoleCapacities: map[string]interfaces.RoleCapacity{
-					"prefill": {TotalDemand: 10000},
-					"decode":  {TotalDemand: 30000},
-				},
-			}
-			alpha, tracksP, tracksD := analyzerAlpha(r)
-			Expect(alpha).To(BeNumerically("~", 3.0, 1e-9))
-			Expect(tracksP).To(BeTrue())
-			Expect(tracksD).To(BeTrue())
+	Describe("InitRolePairedState", func() {
+		It("initializes per-role demand from RoleCapacities.RequiredCapacity", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 0, 0, 15000, 5000, "pf", 10000, "dc", 10000)}
+			ps := InitRolePairedState(s)
+			Expect(ps[0]["prefill"]).To(BeNumerically("~", 15000.0, 1e-9))
+			Expect(ps[0]["decode"]).To(BeNumerically("~", 5000.0, 1e-9))
 		})
 
-		It("returns P-only when D=0", func() {
-			r := &interfaces.AnalyzerResult{
-				RoleCapacities: map[string]interfaces.RoleCapacity{
-					"prefill": {TotalDemand: 10000},
-					"decode":  {TotalDemand: 0},
-				},
-			}
-			_, tracksP, tracksD := analyzerAlpha(r)
-			Expect(tracksP).To(BeTrue())
-			Expect(tracksD).To(BeFalse())
-		})
-
-		It("returns D-only with α=1 default when P=0, D>0", func() {
-			r := &interfaces.AnalyzerResult{
-				RoleCapacities: map[string]interfaces.RoleCapacity{
-					"prefill": {TotalDemand: 0},
-					"decode":  {TotalDemand: 5000},
-				},
-			}
-			alpha, tracksP, tracksD := analyzerAlpha(r)
-			Expect(alpha).To(Equal(1.0))
-			Expect(tracksP).To(BeFalse())
-			Expect(tracksD).To(BeTrue())
-		})
-
-		It("returns false for both when P=0, D=0", func() {
-			r := &interfaces.AnalyzerResult{
-				RoleCapacities: map[string]interfaces.RoleCapacity{
-					"prefill": {TotalDemand: 0},
-					"decode":  {TotalDemand: 0},
-				},
-			}
-			_, tracksP, tracksD := analyzerAlpha(r)
-			Expect(tracksP).To(BeFalse())
-			Expect(tracksD).To(BeFalse())
-		})
-
-		It("returns false for nil result", func() {
-			_, tracksP, tracksD := analyzerAlpha(nil)
-			Expect(tracksP).To(BeFalse())
-			Expect(tracksD).To(BeFalse())
+		It("returns zero map for analyzer without RoleCapacities", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 20000, 0, "v", 10.0)}
+			ps := InitRolePairedState(s)
+			Expect(ps[0]["prefill"]).To(Equal(0.0))
+			Expect(ps[0]["decode"]).To(Equal(0.0))
 		})
 	})
 
-	Describe("bottleneckReplicasPaired", func() {
-		It("computes n_P and n_D from single analyzer with α=2", func() {
-			// P-Remaining=10000, PRC_P=5000 → n_P=ceil(10000/5000)=2
-			// D=α×P=20000, PRC_D=8000 → n_D=ceil(20000/8000)=3
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
-			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
-			Expect(nP).To(Equal(2))
-			Expect(nD).To(Equal(3))
-		})
-
-		It("takes max across analyzers", func() {
-			// analyzer1: P-Remaining=10000, PRC_P=5000 → nP=2; D=20000, PRC_D=8000 → nD=3
-			// analyzer2: P-Remaining=15000, PRC_P=5000 → nP=3; D=15000, PRC_D=8000 → nD=2
+	Describe("roleBottleneckReplicas", func() {
+		It("computes max cross-analyzer ceil(roleRemaining/PRC)", func() {
+			// analyzer0: prefill remaining=10000, PRC=5000 → ceil(10000/5000)=2
+			// analyzer1: prefill remaining=15000, PRC=5000 → ceil(15000/5000)=3 (max)
 			s := []NamedAnalyzerResult{
 				makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000),
 				makeNamedPD("ta", 15000, 15000, 0, 0, 15000, 15000, "pf", 5000, "dc", 8000),
 			}
-			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
-			Expect(nP).To(Equal(3)) // max(2,3)
-			Expect(nD).To(Equal(3)) // max(3,2)=3 for first, then second gives 2; max=3
+			ps := InitRolePairedState(s)
+			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(3))
+			// decode: max(ceil(20000/8000)=3, ceil(15000/8000)=2) = 3
+			Expect(roleBottleneckReplicas(s, ps, "decode", "dc")).To(Equal(3))
 		})
 
-		It("returns (0,0) when PRC=0 (cold-start guard)", func() {
+		It("returns 0 when PRC=0 (cold-start guard)", func() {
 			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 0, "dc", 0)}
-			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
-			Expect(nP).To(Equal(0))
-			Expect(nD).To(Equal(0))
+			ps := InitRolePairedState(s)
+			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(0))
+		})
+	})
+
+	Describe("needsScaleUpPaired", func() {
+		It("returns true when any role has aggregate remaining demand", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 5000, 0, 0, 10000, 5000, "pf", 10000, "dc", 10000)}
+			ps := InitRolePairedState(s)
+			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeTrue())
+		})
+
+		It("returns false when all roles have zero remaining demand", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 0, 10000, 5000, "pf", 10000, "dc", 10000)}
+			ps := InitRolePairedState(s)
+			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeFalse())
 		})
 	})
 
@@ -491,51 +454,62 @@ var _ = Describe("paired helpers", func() {
 		})
 	})
 
-	Describe("applyAllocationPaired", func() {
-		It("decrements Remaining by min(P-capacity, D-capacity-in-P-units)", func() {
-			// α=2 (D=2×P), PRC_P=5000, PRC_D=8000, nP=2, nD=3
-			// servedP = 2×5000=10000; servedD = 3×8000/2=12000; served=min=10000
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 20000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
-			applyAllocationPaired(s, "pf", 2, "dc", 3)
-			Expect(s[0].Remaining).To(BeNumerically("~", 10000.0, 1e-9))
-		})
-
-		It("clamps Remaining to 0 on over-allocation", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 5000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
-			applyAllocationPaired(s, "pf", 5, "dc", 5) // more than needed
-			Expect(s[0].Remaining).To(Equal(0.0))
-		})
-
-		It("does not mutate Result fields", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
-			applyAllocationPaired(s, "pf", 1, "dc", 2)
-			Expect(s[0].Result.RequiredCapacity).To(Equal(0.0)) // Result.RC unchanged (makeNamedPD sets 0)
-		})
-	})
-
-	Describe("allocateForModelPaired", func() {
-		It("allocates until needsScaleUp is false", func() {
-			// P-Remaining=10000, PRC_P=5000 → needs 2 prefill replicas
-			// D=α×P=20000, PRC_D=8000 → needs 3 decode replicas
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+	Describe("allocateForModelPairedB2", func() {
+		// B2.1 — Joint-commit atomicity: one role exhausted.
+		It("B2.1: commits only what both roles can satisfy (decode exhausted → kP=0, kD=0)", func() {
+			// P-demand=10000, D-demand=0 (no decode demand) → decode drops from min (util=1).
+			// Reduced to single-role P allocation.
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 0, "pf", 5000, "dc", 8000)}
 			variants := []interfaces.VariantCapacity{
 				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: 5000},
 				{VariantName: "dc", Role: "decode", PerReplicaCapacity: 8000},
 			}
-			targets := map[string]int{"pf": 1, "dc": 1}
+			targets := map[string]int{"pf": 1, "dc": 3}
+			ps := InitRolePairedState(s)
 			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
 				_ map[string]interfaces.VariantReplicaState,
 				_ map[string]int, _ map[string]int) (string, string, int, int) {
 				return "pf", "dc", math.MaxInt, math.MaxInt
 			}
-			allocateForModelPaired(context.Background(), s, variants, nil, nil, targets, pick)
+			allocateForModelPairedB2(context.Background(), s, variants, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
+			// Only P has demand; decode drops from min → single-role P allocation
+			// demandP=10000, prcP=5000: nP=2, util_P=2*5000/10000=1.0, util_D=1.0 (demand=0)
+			// Δ_util=1.0, kP=floor(1.0*10000/5000)=2, kD=floor(1.0*0/8000)=0
 			Expect(targets["pf"]).To(Equal(3)) // 1 + 2
-			Expect(targets["dc"]).To(Equal(4)) // 1 + 3
-			Expect(needsScaleUp(s)).To(BeFalse())
+			Expect(targets["dc"]).To(Equal(3)) // unchanged (kD=0)
+		})
+
+		// B2.2 — Util-bottleneck trim: ceil-rounded sizing over-allocates one role.
+		// Step 1: nP=4 (ceil(10000/3000)), nD=1 (ceil(10000/10000)).
+		//   util_P=1.2, util_D=1.0 → Δ_util=1.0 → kP=floor(3.33)=3 (trim!), kD=1.
+		//   After step 1: P-remaining=10000-9000=1000, D-remaining=0.
+		// Step 2: P still has demand; D has none → commits 1 more P replica.
+		//   Final: kP=4, kD=1. The trim in step 1 prevented over-committing D.
+		It("B2.2: util-bottleneck trim — each step advances both roles by same Δ_util", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 10000, 0, 0, 10000, 10000, "pf", 3000, "dc", 10000)}
+			variants := []interfaces.VariantCapacity{
+				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: 3000},
+				{VariantName: "dc", Role: "decode", PerReplicaCapacity: 10000},
+			}
+			targets := map[string]int{"pf": 0, "dc": 0}
+			ps := InitRolePairedState(s)
+			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
+				_ map[string]interfaces.VariantReplicaState,
+				_ map[string]int, _ map[string]int) (string, string, int, int) {
+				return "pf", "dc", math.MaxInt, math.MaxInt
+			}
+			allocateForModelPairedB2(context.Background(), s, variants, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
+			// Both roles fully served at end (no over-commitment beyond demand).
+			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeFalse())
+			// D satisfied in 1 replica (trim prevented committing decode beyond demand).
+			Expect(targets["dc"]).To(Equal(1))
+			// P served with ceil(10000/3000)=4 replicas (loop ran twice to cover residual).
+			Expect(targets["pf"]).To(Equal(4))
 		})
 
 		It("stops when pick returns empty pair", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 10000, 0, 0, 10000, 10000, "pf", 5000, "dc", 10000)}
+			ps := InitRolePairedState(s)
 			targets := map[string]int{"pf": 0, "dc": 0}
 			calls := 0
 			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
@@ -544,7 +518,7 @@ var _ = Describe("paired helpers", func() {
 				calls++
 				return "", "", 0, 0
 			}
-			allocateForModelPaired(context.Background(), s, nil, nil, nil, targets, pick)
+			allocateForModelPairedB2(context.Background(), s, nil, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
 			Expect(calls).To(Equal(1))
 		})
 	})

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -339,6 +339,26 @@ var _ = Describe("paired helpers", func() {
 		})
 	})
 
+	Describe("initRoleState", func() {
+		It("disaggregated: roles from RoleCapacities; picker-state from RC; RoleSpare from SC", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 20000, 10000, 15000, 5000, "pf", 10000, "dc", 10000)}
+			roles, ps := initRoleState(s)
+			Expect(roles).To(ConsistOf("prefill", "decode"))
+			Expect(ps[0]["prefill"]).To(BeNumerically("~", 15000.0, 1e-9))
+			Expect(ps[0]["decode"]).To(BeNumerically("~", 5000.0, 1e-9))
+			Expect(s[0].RoleSpare["prefill"]).To(BeNumerically("~", 20000.0, 1e-9))
+			Expect(s[0].RoleSpare["decode"]).To(BeNumerically("~", 10000.0, 1e-9))
+		})
+
+		It("non-disaggregated: synthetic 'both' role using model-level Remaining/Spare", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 20000, 5000, "v", 10.0)}
+			roles, ps := initRoleState(s)
+			Expect(roles).To(ConsistOf(interfaces.RoleBoth))
+			Expect(ps[0][interfaces.RoleBoth]).To(BeNumerically("~", 20000.0, 1e-9))
+			Expect(s[0].RoleSpare[interfaces.RoleBoth]).To(BeNumerically("~", 5000.0, 1e-9))
+		})
+	})
+
 	Describe("roleBottleneckReplicas", func() {
 		It("computes max cross-analyzer ceil(roleRemaining/PRC)", func() {
 			// analyzer0: prefill remaining=10000, PRC=5000 → ceil(10000/5000)=2

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -9,7 +9,7 @@ import (
 
 // makeNamed builds a NamedAnalyzerResult with the given RC, SC, and per-variant
 // (variantName, perReplicaCapacity) pairs.
-func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
+func makeNamed(name string, rc, sc float64, vcs ...any) NamedAnalyzerResult {
 	var caps []interfaces.VariantCapacity
 	for i := 0; i+1 < len(vcs); i += 2 {
 		vName := vcs[i].(string)
@@ -22,12 +22,12 @@ func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
 	return NamedAnalyzerResult{
 		Name: name,
 		Result: &interfaces.AnalyzerResult{
-			RequiredCapacity:  RC,
-			SpareCapacity:     SC,
+			RequiredCapacity:  rc,
+			SpareCapacity:     sc,
 			VariantCapacities: caps,
 		},
-		Remaining: RC,
-		Spare:     SC,
+		Remaining: rc,
+		Spare:     sc,
 	}
 }
 
@@ -79,13 +79,13 @@ var _ = Describe("analyzer helpers", func() {
 
 // makeNamedPD builds a NamedAnalyzerResult with RoleCapacities for P/D tests.
 // RoleSpare is initialized from pSC/dSC (as initDisaggregatedRemaining would do).
-func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float64, vPName string, vPPRC float64, vDName string, vDPRC float64) NamedAnalyzerResult {
+func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float64, vPPRC float64, vDPRC float64) NamedAnalyzerResult {
 	return NamedAnalyzerResult{
 		Name: name,
 		Result: &interfaces.AnalyzerResult{
 			VariantCapacities: []interfaces.VariantCapacity{
-				{VariantName: vPName, Role: "prefill", PerReplicaCapacity: vPPRC},
-				{VariantName: vDName, Role: "decode", PerReplicaCapacity: vDPRC},
+				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: vPPRC},
+				{VariantName: "dc", Role: "decode", PerReplicaCapacity: vDPRC},
 			},
 			RoleCapacities: map[string]interfaces.RoleCapacity{
 				"prefill": {Role: "prefill", RequiredCapacity: pRC, SpareCapacity: pSC, TotalDemand: pDemand},
@@ -101,7 +101,7 @@ var _ = Describe("paired helpers", func() {
 
 	Describe("initRoleState", func() {
 		It("disaggregated: roles from RoleCapacities; picker-state from RC; RoleSpare from SC", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 20000, 10000, 15000, 5000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 20000, 10000, 15000, 5000, 10000, 10000)}
 			roles, ps := initRoleState(s)
 			Expect(roles).To(ConsistOf("prefill", "decode"))
 			Expect(ps[0]["prefill"]).To(BeNumerically("~", 15000.0, 1e-9))
@@ -124,8 +124,8 @@ var _ = Describe("paired helpers", func() {
 			// analyzer0: prefill remaining=10000, PRC=5000 → ceil(10000/5000)=2
 			// analyzer1: prefill remaining=15000, PRC=5000 → ceil(15000/5000)=3 (max)
 			s := []NamedAnalyzerResult{
-				makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000),
-				makeNamedPD("ta", 15000, 15000, 0, 0, 15000, 15000, "pf", 5000, "dc", 8000),
+				makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, 5000, 8000),
+				makeNamedPD("ta", 15000, 15000, 0, 0, 15000, 15000, 5000, 8000),
 			}
 			_, ps := initRoleState(s)
 			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(3))
@@ -134,7 +134,7 @@ var _ = Describe("paired helpers", func() {
 		})
 
 		It("returns 0 when PRC=0 (cold-start guard)", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 0, "dc", 0)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, 0, 0)}
 			_, ps := initRoleState(s)
 			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(0))
 		})
@@ -143,14 +143,14 @@ var _ = Describe("paired helpers", func() {
 	Describe("safeRemovalReplicasForRole", func() {
 		It("computes removable replicas from RoleSpare for a given role", func() {
 			// RoleSpare["prefill"]=20000, PRC_P=10000 → floor(20000/10000)=2
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)}
 			Expect(safeRemovalReplicasForRole(s, "pf", "prefill")).To(Equal(2))
 			// RoleSpare["decode"]=30000, PRC_D=10000 → floor(30000/10000)=3
 			Expect(safeRemovalReplicasForRole(s, "dc", "decode")).To(Equal(3))
 		})
 
 		It("returns 0 when RoleSpare for role is 0", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, 10000, 10000)}
 			Expect(safeRemovalReplicasForRole(s, "pf", "prefill")).To(Equal(0))
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("paired helpers", func() {
 	Describe("applyDeallocationForRole", func() {
 		It("decrements RoleSpare[role] by n×PRC", func() {
 			// RoleSpare["prefill"]=20000, PRC=10000, n=2 → 20000-20000=0
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)}
 			applyDeallocationForRole(s, "pf", "prefill", 2)
 			Expect(s[0].RoleSpare["prefill"]).To(Equal(0.0))
 			// decode spare unchanged
@@ -172,7 +172,7 @@ var _ = Describe("paired helpers", func() {
 		})
 
 		It("clamps RoleSpare to 0", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 5000, 0, 10000, 0, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 5000, 0, 10000, 0, 10000, 10000)}
 			applyDeallocationForRole(s, "pf", "prefill", 5) // would subtract 50000
 			Expect(s[0].RoleSpare["prefill"]).To(Equal(0.0))
 		})
@@ -180,13 +180,13 @@ var _ = Describe("paired helpers", func() {
 
 	Describe("needsScaleDownForRole", func() {
 		It("returns true when all analyzers have RoleSpare[role] > 0", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, 10000, 10000)}
 			Expect(needsScaleDownForRole(s, "prefill")).To(BeTrue())
 			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
 		})
 
 		It("returns false when any analyzer has RoleSpare[role] = 0", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, 10000, 10000)}
 			Expect(needsScaleDownForRole(s, "prefill")).To(BeFalse())
 			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
 		})
@@ -210,13 +210,19 @@ var _ = Describe("paired helpers", func() {
 			Expect(variantsForRole(vcs, "decode")[0].VariantName).To(Equal("dc"))
 		})
 
-		It("returns all variants for role 'both' or empty", func() {
+		It("matches 'both' query against both explicit 'both' and empty-role variants", func() {
 			vcs := []interfaces.VariantCapacity{
 				{VariantName: "pf", Role: "prefill"},
 				{VariantName: "dc", Role: "decode"},
+				{VariantName: "all", Role: "both"},
+				{VariantName: "also-both"}, // empty Role → canonicalized to "both" by variantsForRole
 			}
-			Expect(variantsForRole(vcs, "both")).To(HaveLen(2))
-			Expect(variantsForRole(vcs, "")).To(HaveLen(2))
+			result := variantsForRole(vcs, "both")
+			Expect(result).To(HaveLen(2))
+			names := []string{result[0].VariantName, result[1].VariantName}
+			Expect(names).To(ConsistOf("all", "also-both"))
+			// querying "" matches nothing (vc empty roles are canonicalized to "both", not "")
+			Expect(variantsForRole(vcs, "")).To(BeEmpty())
 		})
 	})
 

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -1,9 +1,6 @@
 package pipeline
 
 import (
-	"context"
-	"math"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -36,141 +33,6 @@ func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
 
 var _ = Describe("analyzer helpers", func() {
 
-	Describe("needsScaleUp", func() {
-		It("returns false for empty slice", func() {
-			Expect(needsScaleUp(nil)).To(BeFalse())
-		})
-
-		It("returns false when all RC = 0", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 100, "v", 10.0),
-				makeNamed("ta", 0, 50, "v", 10.0),
-			}
-			Expect(needsScaleUp(s)).To(BeFalse())
-		})
-
-		It("returns true when any analyzer has RC > 0 (any-up)", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 0, "v", 10.0),
-				makeNamed("ta", 20, 0, "v", 10.0),
-			}
-			Expect(needsScaleUp(s)).To(BeTrue())
-		})
-
-		It("skips nil results", func() {
-			s := []NamedAnalyzerResult{
-				{Name: "sat", Result: nil},
-			}
-			Expect(needsScaleUp(s)).To(BeFalse())
-		})
-	})
-
-	Describe("needsScaleDown", func() {
-		It("returns false for empty slice (no consensus)", func() {
-			Expect(needsScaleDown(nil)).To(BeFalse())
-		})
-
-		It("returns true when all analyzers have SC > 0 (all-down)", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 100, "v", 10.0),
-				makeNamed("ta", 0, 30, "v", 10.0),
-			}
-			Expect(needsScaleDown(s)).To(BeTrue())
-		})
-
-		It("returns false when any analyzer has SC = 0 (all-down blocked)", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 100, "v", 10.0),
-				makeNamed("ta", 0, 0, "v", 10.0),
-			}
-			Expect(needsScaleDown(s)).To(BeFalse())
-		})
-
-		It("returns false for nil result entry", func() {
-			s := []NamedAnalyzerResult{
-				{Name: "sat", Result: nil},
-			}
-			Expect(needsScaleDown(s)).To(BeFalse())
-		})
-	})
-
-	Describe("bottleneckReplicas", func() {
-		It("returns ceil(RC/PRC) for a single analyzer — pass-through", func() {
-			// RC=200, PRC=600 → ceil(200/600) = 1
-			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "v", 600.0)}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(1))
-		})
-
-		It("returns the max across analyzers when sat has larger signal", func() {
-			// sat: RC=200, PRC=600 → ceil(200/600)=1
-			// ta:  RC=5,   PRC=10  → ceil(5/10)=1
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 200, 0, "v", 600.0),
-				makeNamed("ta", 5, 0, "v", 10.0),
-			}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(1))
-		})
-
-		It("returns the max across analyzers when non-sat has larger signal", func() {
-			// sat: RC=50,  PRC=600 → ceil(50/600)=1
-			// ta:  RC=30,  PRC=10  → ceil(30/10)=3
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 50, 0, "v", 600.0),
-				makeNamed("ta", 30, 0, "v", 10.0),
-			}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(3))
-		})
-
-		It("returns 0 when PRC = 0 (cold-start guard)", func() {
-			s := []NamedAnalyzerResult{makeNamed("sat", 250, 0, "v", 0.0)}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(0))
-		})
-
-		It("returns 0 when variant is absent from all analyzers", func() {
-			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "other", 100.0)}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(0))
-		})
-
-		It("ignores nil result entries", func() {
-			s := []NamedAnalyzerResult{
-				{Name: "sat", Result: nil},
-				makeNamed("ta", 20, 0, "v", 10.0),
-			}
-			Expect(bottleneckReplicas(s, "v")).To(Equal(2))
-		})
-	})
-
-	Describe("safeRemovalReplicas", func() {
-		It("returns floor(SC/PRC) for a single analyzer — pass-through", func() {
-			// SC=150, PRC=100 → floor(150/100) = 1
-			s := []NamedAnalyzerResult{makeNamed("sat", 0, 150, "v", 100.0)}
-			Expect(safeRemovalReplicas(s, "v")).To(Equal(1))
-		})
-
-		It("returns the min when both analyzers agree on scale-down", func() {
-			// sat: SC=100, PRC=100 → floor=1
-			// ta:  SC=300, PRC=100 → floor=3; min=1
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 100, "v", 100.0),
-				makeNamed("ta", 0, 300, "v", 100.0),
-			}
-			Expect(safeRemovalReplicas(s, "v")).To(Equal(1))
-		})
-
-		It("returns 0 when any analyzer has SC = 0 (all-down blocked)", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 100, "v", 100.0),
-				makeNamed("ta", 0, 0, "v", 100.0),
-			}
-			Expect(safeRemovalReplicas(s, "v")).To(Equal(0))
-		})
-
-		It("returns 0 when variant is absent", func() {
-			s := []NamedAnalyzerResult{makeNamed("sat", 0, 100, "other", 100.0)}
-			Expect(safeRemovalReplicas(s, "v")).To(Equal(0))
-		})
-	})
-
 	Describe("applyAllocation", func() {
 		It("subtracts n×PRC from each analyzer's Remaining counter", func() {
 			// PRC=100, n=2 → subtract 200 from each Remaining
@@ -195,70 +57,6 @@ var _ = Describe("analyzer helpers", func() {
 			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "other", 100.0)}
 			applyAllocation(s, "v", 3)
 			Expect(s[0].Remaining).To(Equal(200.0))
-		})
-	})
-
-	Describe("applyDeallocation", func() {
-		It("subtracts n×PRC from each analyzer's Spare counter", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 0, 500, "v", 100.0),
-				makeNamed("ta", 0, 300, "v", 100.0),
-			}
-			applyDeallocation(s, "v", 2)
-			Expect(s[0].Spare).To(BeNumerically("~", 300.0, 1e-9))
-			Expect(s[1].Spare).To(BeNumerically("~", 100.0, 1e-9))
-			// Result.SpareCapacity is not mutated
-			Expect(s[0].Result.SpareCapacity).To(Equal(500.0))
-		})
-
-		It("clamps Spare to 0", func() {
-			s := []NamedAnalyzerResult{makeNamed("sat", 0, 50, "v", 100.0)}
-			applyDeallocation(s, "v", 2)
-			Expect(s[0].Spare).To(Equal(0.0))
-		})
-	})
-
-	Describe("allocateForModel", func() {
-		It("allocates until needsScaleUp is false", func() {
-			// Two variants: cheap (PRC=10) and expensive (PRC=20)
-			// RC=30 from saturation only
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 30, 0, "cheap", 10.0, "expensive", 20.0),
-			}
-			variants := []interfaces.VariantCapacity{
-				{VariantName: "cheap", PerReplicaCapacity: 10},
-				{VariantName: "expensive", PerReplicaCapacity: 20},
-			}
-			targets := map[string]int{"cheap": 1, "expensive": 1}
-
-			// Pick always returns "cheap" with unlimited cap
-			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
-				_ map[string]interfaces.VariantReplicaState,
-				_ map[string]int, _ map[string]int) (string, int) {
-				return "cheap", math.MaxInt
-			}
-			allocateForModel(context.Background(), s, variants, nil, nil, targets, pick)
-
-			// ceil(30/10) = 3 replicas should have been added to "cheap"
-			Expect(targets["cheap"]).To(Equal(4)) // 1 initial + 3 allocated
-			Expect(needsScaleUp(s)).To(BeFalse())
-		})
-
-		It("stops when pick returns empty string", func() {
-			s := []NamedAnalyzerResult{
-				makeNamed("sat", 100, 0, "v", 10.0),
-			}
-			targets := map[string]int{"v": 0}
-			calls := 0
-			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
-				_ map[string]interfaces.VariantReplicaState,
-				_ map[string]int, _ map[string]int) (string, int) {
-				calls++
-				return "", 0
-			}
-			allocateForModel(context.Background(), s, nil, nil, nil, targets, pick)
-			Expect(calls).To(Equal(1))
-			Expect(targets["v"]).To(Equal(0))
 		})
 	})
 
@@ -301,44 +99,6 @@ func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float
 
 var _ = Describe("paired helpers", func() {
 
-	Describe("isDisaggregated", func() {
-		It("returns true when any variant has a non-empty non-both role", func() {
-			vcs := []interfaces.VariantCapacity{
-				{VariantName: "pf", Role: "prefill"},
-				{VariantName: "dc", Role: "decode"},
-			}
-			Expect(isDisaggregated(vcs)).To(BeTrue())
-		})
-
-		It("returns false when all variants have no role", func() {
-			vcs := []interfaces.VariantCapacity{
-				{VariantName: "v1", Role: ""},
-				{VariantName: "v2", Role: "both"},
-			}
-			Expect(isDisaggregated(vcs)).To(BeFalse())
-		})
-
-		It("returns false for empty slice", func() {
-			Expect(isDisaggregated(nil)).To(BeFalse())
-		})
-	})
-
-	Describe("InitRolePairedState", func() {
-		It("initializes per-role demand from RoleCapacities.RequiredCapacity", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 0, 0, 15000, 5000, "pf", 10000, "dc", 10000)}
-			ps := InitRolePairedState(s)
-			Expect(ps[0]["prefill"]).To(BeNumerically("~", 15000.0, 1e-9))
-			Expect(ps[0]["decode"]).To(BeNumerically("~", 5000.0, 1e-9))
-		})
-
-		It("returns zero map for analyzer without RoleCapacities", func() {
-			s := []NamedAnalyzerResult{makeNamed("sat", 20000, 0, "v", 10.0)}
-			ps := InitRolePairedState(s)
-			Expect(ps[0]["prefill"]).To(Equal(0.0))
-			Expect(ps[0]["decode"]).To(Equal(0.0))
-		})
-	})
-
 	Describe("initRoleState", func() {
 		It("disaggregated: roles from RoleCapacities; picker-state from RC; RoleSpare from SC", func() {
 			s := []NamedAnalyzerResult{makeNamedPD("sat", 15000, 5000, 20000, 10000, 15000, 5000, "pf", 10000, "dc", 10000)}
@@ -367,7 +127,7 @@ var _ = Describe("paired helpers", func() {
 				makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000),
 				makeNamedPD("ta", 15000, 15000, 0, 0, 15000, 15000, "pf", 5000, "dc", 8000),
 			}
-			ps := InitRolePairedState(s)
+			_, ps := initRoleState(s)
 			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(3))
 			// decode: max(ceil(20000/8000)=3, ceil(15000/8000)=2) = 3
 			Expect(roleBottleneckReplicas(s, ps, "decode", "dc")).To(Equal(3))
@@ -375,22 +135,8 @@ var _ = Describe("paired helpers", func() {
 
 		It("returns 0 when PRC=0 (cold-start guard)", func() {
 			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 0, "dc", 0)}
-			ps := InitRolePairedState(s)
+			_, ps := initRoleState(s)
 			Expect(roleBottleneckReplicas(s, ps, "prefill", "pf")).To(Equal(0))
-		})
-	})
-
-	Describe("needsScaleUpPaired", func() {
-		It("returns true when any role has aggregate remaining demand", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 5000, 0, 0, 10000, 5000, "pf", 10000, "dc", 10000)}
-			ps := InitRolePairedState(s)
-			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeTrue())
-		})
-
-		It("returns false when all roles have zero remaining demand", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 0, 10000, 5000, "pf", 10000, "dc", 10000)}
-			ps := InitRolePairedState(s)
-			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeFalse())
 		})
 	})
 
@@ -474,72 +220,4 @@ var _ = Describe("paired helpers", func() {
 		})
 	})
 
-	Describe("allocateForModelPairedB2", func() {
-		// B2.1 — Joint-commit atomicity: one role exhausted.
-		It("B2.1: commits only what both roles can satisfy (decode exhausted → kP=0, kD=0)", func() {
-			// P-demand=10000, D-demand=0 (no decode demand) → decode drops from min (util=1).
-			// Reduced to single-role P allocation.
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 0, "pf", 5000, "dc", 8000)}
-			variants := []interfaces.VariantCapacity{
-				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: 5000},
-				{VariantName: "dc", Role: "decode", PerReplicaCapacity: 8000},
-			}
-			targets := map[string]int{"pf": 1, "dc": 3}
-			ps := InitRolePairedState(s)
-			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
-				_ map[string]interfaces.VariantReplicaState,
-				_ map[string]int, _ map[string]int) (string, string, int, int) {
-				return "pf", "dc", math.MaxInt, math.MaxInt
-			}
-			allocateForModelPairedB2(context.Background(), s, variants, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
-			// Only P has demand; decode drops from min → single-role P allocation
-			// demandP=10000, prcP=5000: nP=2, util_P=2*5000/10000=1.0, util_D=1.0 (demand=0)
-			// Δ_util=1.0, kP=floor(1.0*10000/5000)=2, kD=floor(1.0*0/8000)=0
-			Expect(targets["pf"]).To(Equal(3)) // 1 + 2
-			Expect(targets["dc"]).To(Equal(3)) // unchanged (kD=0)
-		})
-
-		// B2.2 — Util-bottleneck trim: ceil-rounded sizing over-allocates one role.
-		// Step 1: nP=4 (ceil(10000/3000)), nD=1 (ceil(10000/10000)).
-		//   util_P=1.2, util_D=1.0 → Δ_util=1.0 → kP=floor(3.33)=3 (trim!), kD=1.
-		//   After step 1: P-remaining=10000-9000=1000, D-remaining=0.
-		// Step 2: P still has demand; D has none → commits 1 more P replica.
-		//   Final: kP=4, kD=1. The trim in step 1 prevented over-committing D.
-		It("B2.2: util-bottleneck trim — each step advances both roles by same Δ_util", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 10000, 0, 0, 10000, 10000, "pf", 3000, "dc", 10000)}
-			variants := []interfaces.VariantCapacity{
-				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: 3000},
-				{VariantName: "dc", Role: "decode", PerReplicaCapacity: 10000},
-			}
-			targets := map[string]int{"pf": 0, "dc": 0}
-			ps := InitRolePairedState(s)
-			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
-				_ map[string]interfaces.VariantReplicaState,
-				_ map[string]int, _ map[string]int) (string, string, int, int) {
-				return "pf", "dc", math.MaxInt, math.MaxInt
-			}
-			allocateForModelPairedB2(context.Background(), s, variants, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
-			// Both roles fully served at end (no over-commitment beyond demand).
-			Expect(needsScaleUpPaired(s, ps, []string{"prefill", "decode"})).To(BeFalse())
-			// D satisfied in 1 replica (trim prevented committing decode beyond demand).
-			Expect(targets["dc"]).To(Equal(1))
-			// P served with ceil(10000/3000)=4 replicas (loop ran twice to cover residual).
-			Expect(targets["pf"]).To(Equal(4))
-		})
-
-		It("stops when pick returns empty pair", func() {
-			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 10000, 0, 0, 10000, 10000, "pf", 5000, "dc", 10000)}
-			ps := InitRolePairedState(s)
-			targets := map[string]int{"pf": 0, "dc": 0}
-			calls := 0
-			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
-				_ map[string]interfaces.VariantReplicaState,
-				_ map[string]int, _ map[string]int) (string, string, int, int) {
-				calls++
-				return "", "", 0, 0
-			}
-			allocateForModelPairedB2(context.Background(), s, nil, nil, nil, targets, pick, ps, []string{"prefill", "decode"})
-			Expect(calls).To(Equal(1))
-		})
-	})
 })

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -1,0 +1,280 @@
+package pipeline
+
+import (
+	"context"
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// makeNamed builds a NamedAnalyzerResult with the given RC, SC, and per-variant
+// (variantName, perReplicaCapacity) pairs.
+func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
+	var caps []interfaces.VariantCapacity
+	for i := 0; i+1 < len(vcs); i += 2 {
+		vName := vcs[i].(string)
+		prc := vcs[i+1].(float64)
+		caps = append(caps, interfaces.VariantCapacity{
+			VariantName:        vName,
+			PerReplicaCapacity: prc,
+		})
+	}
+	return NamedAnalyzerResult{
+		Name: name,
+		Result: &interfaces.AnalyzerResult{
+			RequiredCapacity:  RC,
+			SpareCapacity:     SC,
+			VariantCapacities: caps,
+		},
+		Remaining: RC,
+		Spare:     SC,
+	}
+}
+
+var _ = Describe("analyzer helpers", func() {
+
+	Describe("needsScaleUp", func() {
+		It("returns false for empty slice", func() {
+			Expect(needsScaleUp(nil)).To(BeFalse())
+		})
+
+		It("returns false when all RC = 0", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 100, "v", 10.0),
+				makeNamed("ta", 0, 50, "v", 10.0),
+			}
+			Expect(needsScaleUp(s)).To(BeFalse())
+		})
+
+		It("returns true when any analyzer has RC > 0 (any-up)", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 0, "v", 10.0),
+				makeNamed("ta", 20, 0, "v", 10.0),
+			}
+			Expect(needsScaleUp(s)).To(BeTrue())
+		})
+
+		It("skips nil results", func() {
+			s := []NamedAnalyzerResult{
+				{Name: "sat", Result: nil},
+			}
+			Expect(needsScaleUp(s)).To(BeFalse())
+		})
+	})
+
+	Describe("needsScaleDown", func() {
+		It("returns false for empty slice (no consensus)", func() {
+			Expect(needsScaleDown(nil)).To(BeFalse())
+		})
+
+		It("returns true when all analyzers have SC > 0 (all-down)", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 100, "v", 10.0),
+				makeNamed("ta", 0, 30, "v", 10.0),
+			}
+			Expect(needsScaleDown(s)).To(BeTrue())
+		})
+
+		It("returns false when any analyzer has SC = 0 (all-down blocked)", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 100, "v", 10.0),
+				makeNamed("ta", 0, 0, "v", 10.0),
+			}
+			Expect(needsScaleDown(s)).To(BeFalse())
+		})
+
+		It("returns false for nil result entry", func() {
+			s := []NamedAnalyzerResult{
+				{Name: "sat", Result: nil},
+			}
+			Expect(needsScaleDown(s)).To(BeFalse())
+		})
+	})
+
+	Describe("bottleneckReplicas", func() {
+		It("returns ceil(RC/PRC) for a single analyzer — pass-through", func() {
+			// RC=200, PRC=600 → ceil(200/600) = 1
+			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "v", 600.0)}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(1))
+		})
+
+		It("returns the max across analyzers when sat has larger signal", func() {
+			// sat: RC=200, PRC=600 → ceil(200/600)=1
+			// ta:  RC=5,   PRC=10  → ceil(5/10)=1
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 200, 0, "v", 600.0),
+				makeNamed("ta", 5, 0, "v", 10.0),
+			}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(1))
+		})
+
+		It("returns the max across analyzers when non-sat has larger signal", func() {
+			// sat: RC=50,  PRC=600 → ceil(50/600)=1
+			// ta:  RC=30,  PRC=10  → ceil(30/10)=3
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 50, 0, "v", 600.0),
+				makeNamed("ta", 30, 0, "v", 10.0),
+			}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(3))
+		})
+
+		It("returns 0 when PRC = 0 (cold-start guard)", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 250, 0, "v", 0.0)}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(0))
+		})
+
+		It("returns 0 when variant is absent from all analyzers", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "other", 100.0)}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(0))
+		})
+
+		It("ignores nil result entries", func() {
+			s := []NamedAnalyzerResult{
+				{Name: "sat", Result: nil},
+				makeNamed("ta", 20, 0, "v", 10.0),
+			}
+			Expect(bottleneckReplicas(s, "v")).To(Equal(2))
+		})
+	})
+
+	Describe("safeRemovalReplicas", func() {
+		It("returns floor(SC/PRC) for a single analyzer — pass-through", func() {
+			// SC=150, PRC=100 → floor(150/100) = 1
+			s := []NamedAnalyzerResult{makeNamed("sat", 0, 150, "v", 100.0)}
+			Expect(safeRemovalReplicas(s, "v")).To(Equal(1))
+		})
+
+		It("returns the min when both analyzers agree on scale-down", func() {
+			// sat: SC=100, PRC=100 → floor=1
+			// ta:  SC=300, PRC=100 → floor=3; min=1
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 100, "v", 100.0),
+				makeNamed("ta", 0, 300, "v", 100.0),
+			}
+			Expect(safeRemovalReplicas(s, "v")).To(Equal(1))
+		})
+
+		It("returns 0 when any analyzer has SC = 0 (all-down blocked)", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 100, "v", 100.0),
+				makeNamed("ta", 0, 0, "v", 100.0),
+			}
+			Expect(safeRemovalReplicas(s, "v")).To(Equal(0))
+		})
+
+		It("returns 0 when variant is absent", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 0, 100, "other", 100.0)}
+			Expect(safeRemovalReplicas(s, "v")).To(Equal(0))
+		})
+	})
+
+	Describe("applyAllocation", func() {
+		It("subtracts n×PRC from each analyzer's Remaining counter", func() {
+			// PRC=100, n=2 → subtract 200 from each Remaining
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 500, 0, "v", 100.0),
+				makeNamed("ta", 300, 0, "v", 100.0),
+			}
+			applyAllocation(s, "v", 2)
+			Expect(s[0].Remaining).To(BeNumerically("~", 300.0, 1e-9))
+			Expect(s[1].Remaining).To(BeNumerically("~", 100.0, 1e-9))
+			// Result.RequiredCapacity is not mutated
+			Expect(s[0].Result.RequiredCapacity).To(Equal(500.0))
+		})
+
+		It("clamps Remaining to 0", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 50, 0, "v", 100.0)}
+			applyAllocation(s, "v", 2) // would subtract 200 from 50
+			Expect(s[0].Remaining).To(Equal(0.0))
+		})
+
+		It("is a no-op for variants not in the result", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 200, 0, "other", 100.0)}
+			applyAllocation(s, "v", 3)
+			Expect(s[0].Remaining).To(Equal(200.0))
+		})
+	})
+
+	Describe("applyDeallocation", func() {
+		It("subtracts n×PRC from each analyzer's Spare counter", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 0, 500, "v", 100.0),
+				makeNamed("ta", 0, 300, "v", 100.0),
+			}
+			applyDeallocation(s, "v", 2)
+			Expect(s[0].Spare).To(BeNumerically("~", 300.0, 1e-9))
+			Expect(s[1].Spare).To(BeNumerically("~", 100.0, 1e-9))
+			// Result.SpareCapacity is not mutated
+			Expect(s[0].Result.SpareCapacity).To(Equal(500.0))
+		})
+
+		It("clamps Spare to 0", func() {
+			s := []NamedAnalyzerResult{makeNamed("sat", 0, 50, "v", 100.0)}
+			applyDeallocation(s, "v", 2)
+			Expect(s[0].Spare).To(Equal(0.0))
+		})
+	})
+
+	Describe("allocateForModel", func() {
+		It("allocates until needsScaleUp is false", func() {
+			// Two variants: cheap (PRC=10) and expensive (PRC=20)
+			// RC=30 from saturation only
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 30, 0, "cheap", 10.0, "expensive", 20.0),
+			}
+			variants := []interfaces.VariantCapacity{
+				{VariantName: "cheap", PerReplicaCapacity: 10},
+				{VariantName: "expensive", PerReplicaCapacity: 20},
+			}
+			targets := map[string]int{"cheap": 1, "expensive": 1}
+
+			// Pick always returns "cheap" with unlimited cap
+			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
+				_ map[string]interfaces.VariantReplicaState,
+				_ map[string]int, _ map[string]int) (string, int) {
+				return "cheap", math.MaxInt
+			}
+			allocateForModel(context.Background(), s, variants, nil, nil, targets, pick)
+
+			// ceil(30/10) = 3 replicas should have been added to "cheap"
+			Expect(targets["cheap"]).To(Equal(4)) // 1 initial + 3 allocated
+			Expect(needsScaleUp(s)).To(BeFalse())
+		})
+
+		It("stops when pick returns empty string", func() {
+			s := []NamedAnalyzerResult{
+				makeNamed("sat", 100, 0, "v", 10.0),
+			}
+			targets := map[string]int{"v": 0}
+			calls := 0
+			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
+				_ map[string]interfaces.VariantReplicaState,
+				_ map[string]int, _ map[string]int) (string, int) {
+				calls++
+				return "", 0
+			}
+			allocateForModel(context.Background(), s, nil, nil, nil, targets, pick)
+			Expect(calls).To(Equal(1))
+			Expect(targets["v"]).To(Equal(0))
+		})
+	})
+
+	Describe("saturationEntry", func() {
+		It("returns the saturation result from the slice", func() {
+			satResult := &interfaces.AnalyzerResult{RequiredCapacity: 42}
+			s := []NamedAnalyzerResult{
+				{Name: interfaces.SaturationAnalyzerName, Result: satResult},
+				makeNamed("ta", 10, 0),
+			}
+			Expect(saturationEntry(s)).To(BeIdenticalTo(satResult))
+		})
+
+		It("returns nil when saturation is absent", func() {
+			s := []NamedAnalyzerResult{makeNamed("ta", 10, 0)}
+			Expect(saturationEntry(s)).To(BeNil())
+		})
+	})
+})

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -29,6 +29,7 @@ func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
 			SpareCapacity:     SC,
 			VariantCapacities: caps,
 		},
+		Score:     1.0,
 		Remaining: RC,
 		Spare:     SC,
 	}
@@ -275,6 +276,278 @@ var _ = Describe("analyzer helpers", func() {
 		It("returns nil when saturation is absent", func() {
 			s := []NamedAnalyzerResult{makeNamed("ta", 10, 0)}
 			Expect(saturationEntry(s)).To(BeNil())
+		})
+	})
+})
+
+// makeNamedPD builds a NamedAnalyzerResult with RoleCapacities for P/D tests.
+// RoleSpare is initialized from pSC/dSC (as initDisaggregatedRemaining would do).
+func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float64, vPName string, vPPRC float64, vDName string, vDPRC float64) NamedAnalyzerResult {
+	return NamedAnalyzerResult{
+		Name: name,
+		Result: &interfaces.AnalyzerResult{
+			VariantCapacities: []interfaces.VariantCapacity{
+				{VariantName: vPName, Role: "prefill", PerReplicaCapacity: vPPRC},
+				{VariantName: vDName, Role: "decode", PerReplicaCapacity: vDPRC},
+			},
+			RoleCapacities: map[string]interfaces.RoleCapacity{
+				"prefill": {Role: "prefill", RequiredCapacity: pRC, SpareCapacity: pSC, TotalDemand: pDemand},
+				"decode":  {Role: "decode", RequiredCapacity: dRC, SpareCapacity: dSC, TotalDemand: dDemand},
+			},
+		},
+		Score:     1.0,
+		Remaining: pRC, // P-scope after initDisaggregatedRemaining
+		RoleSpare: map[string]float64{"prefill": pSC, "decode": dSC},
+	}
+}
+
+var _ = Describe("paired helpers", func() {
+
+	Describe("isDisaggregated", func() {
+		It("returns true when any variant has a non-empty non-both role", func() {
+			vcs := []interfaces.VariantCapacity{
+				{VariantName: "pf", Role: "prefill"},
+				{VariantName: "dc", Role: "decode"},
+			}
+			Expect(isDisaggregated(vcs)).To(BeTrue())
+		})
+
+		It("returns false when all variants have no role", func() {
+			vcs := []interfaces.VariantCapacity{
+				{VariantName: "v1", Role: ""},
+				{VariantName: "v2", Role: "both"},
+			}
+			Expect(isDisaggregated(vcs)).To(BeFalse())
+		})
+
+		It("returns false for empty slice", func() {
+			Expect(isDisaggregated(nil)).To(BeFalse())
+		})
+	})
+
+	Describe("analyzerAlpha", func() {
+		It("returns α=D/P and both-tracks when P>0, D>0", func() {
+			r := &interfaces.AnalyzerResult{
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {TotalDemand: 10000},
+					"decode":  {TotalDemand: 30000},
+				},
+			}
+			alpha, tracksP, tracksD := analyzerAlpha(r)
+			Expect(alpha).To(BeNumerically("~", 3.0, 1e-9))
+			Expect(tracksP).To(BeTrue())
+			Expect(tracksD).To(BeTrue())
+		})
+
+		It("returns P-only when D=0", func() {
+			r := &interfaces.AnalyzerResult{
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {TotalDemand: 10000},
+					"decode":  {TotalDemand: 0},
+				},
+			}
+			_, tracksP, tracksD := analyzerAlpha(r)
+			Expect(tracksP).To(BeTrue())
+			Expect(tracksD).To(BeFalse())
+		})
+
+		It("returns D-only with α=1 default when P=0, D>0", func() {
+			r := &interfaces.AnalyzerResult{
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {TotalDemand: 0},
+					"decode":  {TotalDemand: 5000},
+				},
+			}
+			alpha, tracksP, tracksD := analyzerAlpha(r)
+			Expect(alpha).To(Equal(1.0))
+			Expect(tracksP).To(BeFalse())
+			Expect(tracksD).To(BeTrue())
+		})
+
+		It("returns false for both when P=0, D=0", func() {
+			r := &interfaces.AnalyzerResult{
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {TotalDemand: 0},
+					"decode":  {TotalDemand: 0},
+				},
+			}
+			_, tracksP, tracksD := analyzerAlpha(r)
+			Expect(tracksP).To(BeFalse())
+			Expect(tracksD).To(BeFalse())
+		})
+
+		It("returns false for nil result", func() {
+			_, tracksP, tracksD := analyzerAlpha(nil)
+			Expect(tracksP).To(BeFalse())
+			Expect(tracksD).To(BeFalse())
+		})
+	})
+
+	Describe("bottleneckReplicasPaired", func() {
+		It("computes n_P and n_D from single analyzer with α=2", func() {
+			// P-Remaining=10000, PRC_P=5000 → n_P=ceil(10000/5000)=2
+			// D=α×P=20000, PRC_D=8000 → n_D=ceil(20000/8000)=3
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
+			Expect(nP).To(Equal(2))
+			Expect(nD).To(Equal(3))
+		})
+
+		It("takes max across analyzers", func() {
+			// analyzer1: P-Remaining=10000, PRC_P=5000 → nP=2; D=20000, PRC_D=8000 → nD=3
+			// analyzer2: P-Remaining=15000, PRC_P=5000 → nP=3; D=15000, PRC_D=8000 → nD=2
+			s := []NamedAnalyzerResult{
+				makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000),
+				makeNamedPD("ta", 15000, 15000, 0, 0, 15000, 15000, "pf", 5000, "dc", 8000),
+			}
+			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
+			Expect(nP).To(Equal(3)) // max(2,3)
+			Expect(nD).To(Equal(3)) // max(3,2)=3 for first, then second gives 2; max=3
+		})
+
+		It("returns (0,0) when PRC=0 (cold-start guard)", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 20000, 0, 0, 10000, 20000, "pf", 0, "dc", 0)}
+			nP, nD := bottleneckReplicasPaired(s, "pf", "dc")
+			Expect(nP).To(Equal(0))
+			Expect(nD).To(Equal(0))
+		})
+	})
+
+	Describe("safeRemovalReplicasForRole", func() {
+		It("computes removable replicas from RoleSpare for a given role", func() {
+			// RoleSpare["prefill"]=20000, PRC_P=10000 → floor(20000/10000)=2
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			Expect(safeRemovalReplicasForRole(s, "pf", "prefill")).To(Equal(2))
+			// RoleSpare["decode"]=30000, PRC_D=10000 → floor(30000/10000)=3
+			Expect(safeRemovalReplicasForRole(s, "dc", "decode")).To(Equal(3))
+		})
+
+		It("returns 0 when RoleSpare for role is 0", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			Expect(safeRemovalReplicasForRole(s, "pf", "prefill")).To(Equal(0))
+		})
+
+		It("returns 0 when RoleSpare is nil", func() {
+			e := makeNamed("sat", 0, 100, "v", 10.0)
+			e.RoleSpare = nil
+			Expect(safeRemovalReplicasForRole([]NamedAnalyzerResult{e}, "v", "prefill")).To(Equal(0))
+		})
+	})
+
+	Describe("applyDeallocationForRole", func() {
+		It("decrements RoleSpare[role] by n×PRC", func() {
+			// RoleSpare["prefill"]=20000, PRC=10000, n=2 → 20000-20000=0
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			applyDeallocationForRole(s, "pf", "prefill", 2)
+			Expect(s[0].RoleSpare["prefill"]).To(Equal(0.0))
+			// decode spare unchanged
+			Expect(s[0].RoleSpare["decode"]).To(BeNumerically("~", 30000.0, 1e-9))
+		})
+
+		It("clamps RoleSpare to 0", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 5000, 0, 10000, 0, "pf", 10000, "dc", 10000)}
+			applyDeallocationForRole(s, "pf", "prefill", 5) // would subtract 50000
+			Expect(s[0].RoleSpare["prefill"]).To(Equal(0.0))
+		})
+	})
+
+	Describe("needsScaleDownForRole", func() {
+		It("returns true when all analyzers have RoleSpare[role] > 0", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 20000, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeTrue())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
+		})
+
+		It("returns false when any analyzer has RoleSpare[role] = 0", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 0, 0, 0, 30000, 10000, 30000, "pf", 10000, "dc", 10000)}
+			Expect(needsScaleDownForRole(s, "prefill")).To(BeFalse())
+			Expect(needsScaleDownForRole(s, "decode")).To(BeTrue())
+		})
+
+		It("returns false for nil RoleSpare", func() {
+			e := makeNamed("sat", 0, 100, "v", 10.0)
+			e.RoleSpare = nil
+			Expect(needsScaleDownForRole([]NamedAnalyzerResult{e}, "prefill")).To(BeFalse())
+		})
+	})
+
+	Describe("variantsForRole", func() {
+		It("filters variants by exact role match", func() {
+			vcs := []interfaces.VariantCapacity{
+				{VariantName: "pf", Role: "prefill"},
+				{VariantName: "dc", Role: "decode"},
+				{VariantName: "both", Role: "both"},
+			}
+			Expect(variantsForRole(vcs, "prefill")).To(HaveLen(1))
+			Expect(variantsForRole(vcs, "prefill")[0].VariantName).To(Equal("pf"))
+			Expect(variantsForRole(vcs, "decode")[0].VariantName).To(Equal("dc"))
+		})
+
+		It("returns all variants for role 'both' or empty", func() {
+			vcs := []interfaces.VariantCapacity{
+				{VariantName: "pf", Role: "prefill"},
+				{VariantName: "dc", Role: "decode"},
+			}
+			Expect(variantsForRole(vcs, "both")).To(HaveLen(2))
+			Expect(variantsForRole(vcs, "")).To(HaveLen(2))
+		})
+	})
+
+	Describe("applyAllocationPaired", func() {
+		It("decrements Remaining by min(P-capacity, D-capacity-in-P-units)", func() {
+			// α=2 (D=2×P), PRC_P=5000, PRC_D=8000, nP=2, nD=3
+			// servedP = 2×5000=10000; servedD = 3×8000/2=12000; served=min=10000
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 20000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			applyAllocationPaired(s, "pf", 2, "dc", 3)
+			Expect(s[0].Remaining).To(BeNumerically("~", 10000.0, 1e-9))
+		})
+
+		It("clamps Remaining to 0 on over-allocation", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 5000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			applyAllocationPaired(s, "pf", 5, "dc", 5) // more than needed
+			Expect(s[0].Remaining).To(Equal(0.0))
+		})
+
+		It("does not mutate Result fields", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			applyAllocationPaired(s, "pf", 1, "dc", 2)
+			Expect(s[0].Result.RequiredCapacity).To(Equal(0.0)) // Result.RC unchanged (makeNamedPD sets 0)
+		})
+	})
+
+	Describe("allocateForModelPaired", func() {
+		It("allocates until needsScaleUp is false", func() {
+			// P-Remaining=10000, PRC_P=5000 → needs 2 prefill replicas
+			// D=α×P=20000, PRC_D=8000 → needs 3 decode replicas
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			variants := []interfaces.VariantCapacity{
+				{VariantName: "pf", Role: "prefill", PerReplicaCapacity: 5000},
+				{VariantName: "dc", Role: "decode", PerReplicaCapacity: 8000},
+			}
+			targets := map[string]int{"pf": 1, "dc": 1}
+			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
+				_ map[string]interfaces.VariantReplicaState,
+				_ map[string]int, _ map[string]int) (string, string, int, int) {
+				return "pf", "dc", math.MaxInt, math.MaxInt
+			}
+			allocateForModelPaired(context.Background(), s, variants, nil, nil, targets, pick)
+			Expect(targets["pf"]).To(Equal(3)) // 1 + 2
+			Expect(targets["dc"]).To(Equal(4)) // 1 + 3
+			Expect(needsScaleUp(s)).To(BeFalse())
+		})
+
+		It("stops when pick returns empty pair", func() {
+			s := []NamedAnalyzerResult{makeNamedPD("sat", 10000, 0, 0, 0, 10000, 20000, "pf", 5000, "dc", 8000)}
+			targets := map[string]int{"pf": 0, "dc": 0}
+			calls := 0
+			pick := func(_ []NamedAnalyzerResult, _ []interfaces.VariantCapacity,
+				_ map[string]interfaces.VariantReplicaState,
+				_ map[string]int, _ map[string]int) (string, string, int, int) {
+				calls++
+				return "", "", 0, 0
+			}
+			allocateForModelPaired(context.Background(), s, nil, nil, nil, targets, pick)
+			Expect(calls).To(Equal(1))
 		})
 	})
 })

--- a/internal/engines/pipeline/analyzer_helpers_test.go
+++ b/internal/engines/pipeline/analyzer_helpers_test.go
@@ -29,7 +29,6 @@ func makeNamed(name string, RC, SC float64, vcs ...any) NamedAnalyzerResult {
 			SpareCapacity:     SC,
 			VariantCapacities: caps,
 		},
-		Score:     1.0,
 		Remaining: RC,
 		Spare:     SC,
 	}
@@ -295,7 +294,6 @@ func makeNamedPD(name string, pRC, dRC, pSC, dSC float64, pDemand, dDemand float
 				"decode":  {Role: "decode", RequiredCapacity: dRC, SpareCapacity: dSC, TotalDemand: dDemand},
 			},
 		},
-		Score:     1.0,
 		Remaining: pRC, // P-scope after initDisaggregatedRemaining
 		RoleSpare: map[string]float64{"prefill": pSC, "decode": dSC},
 	}

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -54,9 +54,8 @@ func (o *CostAwareOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if isDisaggregated(satEntry.VariantCapacities) {
-			s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
-			copy(s, req.AnalyzerResults)
+		if req.Disaggregated {
+			s := req.AnalyzerResults // engine guarantees a fresh slice per cycle
 			initDisaggregatedRemaining(s)
 			if needsScaleUp(s) {
 				ps := InitRolePairedState(s)
@@ -378,8 +377,8 @@ func buildDecisionsWithOptimizer(
 	return decisions
 }
 
-// mergeConstraints combines constraints from multiple providers.
-// Currently unused in CostAwareOptimizer but available for limited mode.
+// mergeConstraints combines GPU budget constraints from multiple providers.
+// Used by GreedyByScoreOptimizer; lives here since CostAwareOptimizer owns the shared helpers.
 func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 	merged := make(map[string]int)
 	for _, c := range constraints {
@@ -455,19 +454,24 @@ func costAwareScaleDownRoleIterated(
 		states = stateMap[0]
 	}
 
-	// Collect distinct roles from the variant set.
-	roles := make(map[string]struct{})
+	// Collect distinct roles from the variant set. Sorted for determinism (N4).
+	rolesSet := make(map[string]struct{})
 	for _, vc := range variants {
 		role := vc.Role
 		if role == "" {
 			role = interfaces.RoleBoth
 		}
 		if role != interfaces.RoleBoth {
-			roles[role] = struct{}{}
+			rolesSet[role] = struct{}{}
 		}
 	}
+	roles := make([]string, 0, len(rolesSet))
+	for role := range rolesSet {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
 
-	for role := range roles {
+	for _, role := range roles {
 		roleVCs := variantsForRole(variants, role)
 		if len(roleVCs) == 0 {
 			continue

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -104,84 +104,83 @@ func costGreedyRolePick(
 	return "", 0
 }
 
-// scaleDownRoleIterated is the Phase-3 unified scale-down: iterates roles
-// independently and sheds against per-role spare. Arity-1 (roles=["both"])
-// handles non-disaggregated models via the single synthetic "both" role.
-func scaleDownRoleIterated(
-	ctx context.Context,
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	targets map[string]int,
-	stateMap ...map[string]interfaces.VariantReplicaState,
-) {
-	costAwareScaleDownRoleIterated(ctx, s, variants, targets, stateMap...)
-}
-
-// scaleDownVariantSet removes replicas from the given variant set, most-expensive
-// first, until `spare` capacity is shed or each variant's minReplicas floor is
-// reached. The cheapest variant — last in the cost-descending order — is protected
-// at one replica when it would otherwise be the last variant with replicas in the
-// set, preventing a scale-to-zero deadlock.
+// scaleDownVariantSet sheds replicas from sortedVariants (PRE-SORTED cost-desc,
+// cheapest last). minReplicas floor and cheapest-at-1 protection are enforced
+// here. maxRemovable returns how many replicas of vc the caller permits to remove;
+// onRemove is invoked after committing n so the caller can update its spare bookkeeping.
 func scaleDownVariantSet(
 	ctx context.Context,
-	variants []interfaces.VariantCapacity,
-	spare float64,
+	sortedVariants []interfaces.VariantCapacity,
 	targets map[string]int,
 	states map[string]interfaces.VariantReplicaState,
+	maxRemovable func(vc interfaces.VariantCapacity) int,
+	onRemove func(vc interfaces.VariantCapacity, n int),
 ) {
 	logger := ctrl.LoggerFrom(ctx)
-
-	sorted := sortByCostDesc(variants)
-	remaining := spare
-
-	for i, vc := range sorted {
-		if remaining <= 0 {
-			break
-		}
+	for i, vc := range sortedVariants {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
 		}
-
 		current := targets[vc.VariantName]
-
-		// Annotation floor caps removal.
 		minReplicas := 0
 		if states != nil {
-			if state, ok := states[vc.VariantName]; ok && state.MinReplicas != nil {
-				minReplicas = *state.MinReplicas
+			if st, ok := states[vc.VariantName]; ok && st.MinReplicas != nil {
+				minReplicas = *st.MinReplicas
 			}
 		}
 		removable := current - minReplicas
 		if removable <= 0 {
 			continue
 		}
-
-		toRemove := int(math.Floor(remaining / vc.PerReplicaCapacity))
-		if toRemove > removable {
-			toRemove = removable
+		n := maxRemovable(vc)
+		if n > removable {
+			n = removable
 		}
-
-		// Protect the cheapest variant (last in cost-descending order) at one
-		// replica when removing toRemove would drop it below one and no
-		// more-expensive variant still holds replicas — i.e. it is the last with
-		// replicas in the set. When minReplicas >= 1, removable <= current-1 so
-		// toRemove <= current-1 and current-toRemove >= 1 already, so this clause
-		// never triggers.
-		if i == len(sorted)-1 && current-toRemove < 1 && !anyHasReplicas(sorted[:i], targets) {
-			toRemove = current - 1
+		// cheapest-at-1: the last (cheapest) variant is protected at 1 only when no
+		// more-expensive variant still holds replicas (#1237's positional rule).
+		if i == len(sortedVariants)-1 && current-n < 1 && !anyHasReplicas(sortedVariants[:i], targets) {
+			n = current - 1
 		}
-		if toRemove <= 0 {
+		if n <= 0 {
 			continue
 		}
-
-		targets[vc.VariantName] = current - toRemove
-		remaining -= float64(toRemove) * vc.PerReplicaCapacity
-
-		logger.V(logging.DEBUG).Info("Scale-down allocation",
-			"variant", vc.VariantName,
-			"removed", toRemove,
-			"cost", vc.Cost)
+		targets[vc.VariantName] = current - n
+		onRemove(vc, n)
+		logger.V(logging.DEBUG).Info("scale-down: removed replicas",
+			"variant", vc.VariantName, "removed", n, "cost", vc.Cost)
 	}
+}
+
+// sortVariantsForScaleDown orders a role's variants for cost-greedy scale-down:
+//  1. Cost descending — shed the most expensive first.
+//  2. Tie: score-weighted per-replica capacity ascending — Σ_i Score_i·PRC_i[v].
+//  3. Tie: variant name ascending — full determinism.
+//
+// With a single analyzer (Score=1) this reduces to Cost-desc then PRC-asc, i.e.
+// #1237's existing tie-break.
+func sortVariantsForScaleDown(s []NamedAnalyzerResult, roleVCs []interfaces.VariantCapacity) []interfaces.VariantCapacity {
+	weighted := func(name string) float64 {
+		sum := 0.0
+		for _, e := range s {
+			if e.Result == nil {
+				continue
+			}
+			sum += e.Score * prcForVariant(e.Result, name)
+		}
+		return sum
+	}
+	out := append([]interfaces.VariantCapacity(nil), roleVCs...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cost != out[j].Cost {
+			return out[i].Cost > out[j].Cost
+		}
+		wi, wj := weighted(out[i].VariantName), weighted(out[j].VariantName)
+		if wi != wj {
+			return wi < wj
+		}
+		return out[i].VariantName < out[j].VariantName
+	})
+	return out
 }
 
 // anyHasReplicas reports whether any of the given variants has a positive target.
@@ -227,23 +226,6 @@ func sortByCostEfficiencyAsc(capacities []interfaces.VariantCapacity) []interfac
 	copy(sorted, capacities)
 	sort.Slice(sorted, func(i, j int) bool {
 		return costEfficiency(sorted[i]) < costEfficiency(sorted[j])
-	})
-	return sorted
-}
-
-// sortByCostDesc returns variants sorted by absolute cost descending. Equal-cost
-// variants are tie-broken by per-replica capacity ascending, so the highest-PRC
-// variant at the cheapest cost tier lands last — the deterministic slot the
-// scale-down protection keeps at one replica (prefer keeping the more capable
-// replica among equal-cost variants).
-func sortByCostDesc(capacities []interfaces.VariantCapacity) []interfaces.VariantCapacity {
-	sorted := make([]interfaces.VariantCapacity, len(capacities))
-	copy(sorted, capacities)
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Cost != sorted[j].Cost {
-			return sorted[i].Cost > sorted[j].Cost
-		}
-		return sorted[i].PerReplicaCapacity < sorted[j].PerReplicaCapacity
 	})
 	return sorted
 }
@@ -319,29 +301,20 @@ func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 	return merged
 }
 
-// costGreedyPickPaired selects the cheapest-by-cost-efficiency (vP, vD) pair for
-// costAwareScaleDownRoleIterated removes replicas from disaggregated models by
-// iterating each role independently. P and D scale-down are independent — trimming
-// one role's slack does not affect the other (each role's supply and demand are
-// distinct). Per role: remove from most expensive variant first; cheapest-variant
-// protection scoped to the role; minReplicas floor respected.
-func costAwareScaleDownRoleIterated(
+// scaleDownRoleIterated removes replicas role-by-role using the generalized
+// scaleDownVariantSet primitive. Roles are sorted for determinism.
+// Arity-1 (roles=["both"]) handles non-disaggregated models.
+func scaleDownRoleIterated(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
 	targets map[string]int,
 	stateMap ...map[string]interfaces.VariantReplicaState,
 ) {
-	logger := ctrl.LoggerFrom(ctx)
-
 	var states map[string]interfaces.VariantReplicaState
 	if len(stateMap) > 0 {
 		states = stateMap[0]
 	}
-
-	// Collect distinct roles from the variant set. Sorted for determinism (N4).
-	// "both" (non-disaggregated variants) is included so the unified path serves
-	// arity-1 models as well as multi-role disaggregated models.
 	rolesSet := make(map[string]struct{})
 	for _, vc := range variants {
 		role := vc.Role
@@ -357,51 +330,22 @@ func costAwareScaleDownRoleIterated(
 	sort.Strings(roles)
 
 	for _, role := range roles {
+		if !needsScaleDownForRole(s, role) {
+			continue
+		}
 		roleVCs := variantsForRole(variants, role)
 		if len(roleVCs) == 0 {
 			continue
 		}
-		sorted := sortByCostDesc(roleVCs)
-
-		for needsScaleDownForRole(s, role) {
-			removed := false
-			for i, vc := range sorted {
-				if !needsScaleDownForRole(s, role) {
-					break
-				}
-				if vc.PerReplicaCapacity <= 0 {
-					continue
-				}
-				current := targets[vc.VariantName]
-				minReplicas := 0
-				if states != nil {
-					if st, ok := states[vc.VariantName]; ok && st.MinReplicas != nil {
-						minReplicas = *st.MinReplicas
-					}
-				}
-				// Protect cheapest (last in cost-desc order) at 1 replica when
-				// it's the last variant with replicas in the role.
-				if i == len(sorted)-1 && !anyHasReplicas(sorted[:i], targets) && minReplicas < 1 {
-					minReplicas = 1
-				}
-				removable := current - minReplicas
-				if removable <= 0 {
-					continue
-				}
-				n := min(safeRemovalReplicasForRole(s, vc.VariantName, role), removable)
-				if n <= 0 {
-					continue
-				}
+		sorted := sortVariantsForScaleDown(s, roleVCs)
+		scaleDownVariantSet(ctx, sorted, targets, states,
+			func(vc interfaces.VariantCapacity) int {
+				return safeRemovalReplicasForRole(s, vc.VariantName, role)
+			},
+			func(vc interfaces.VariantCapacity, n int) {
 				applyDeallocationForRole(s, vc.VariantName, role, n)
-				targets[vc.VariantName] -= n
-				removed = true
-				logger.V(logging.DEBUG).Info("scale-down role-iterated: removed replicas",
-					"role", role, "variant", vc.VariantName, "removed", n, "cost", vc.Cost)
-			}
-			if !removed {
-				break
-			}
-		}
+			},
+		)
 	}
 }
 

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -59,7 +59,9 @@ func (o *CostAwareOptimizer) Optimize(
 			copy(s, req.AnalyzerResults)
 			initDisaggregatedRemaining(s)
 			if needsScaleUp(s) {
-				allocateForModelPaired(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets, costGreedyPickPaired)
+				ps := InitRolePairedState(s)
+				allocateForModelPairedB2(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets,
+					costGreedyPickPaired, ps, []string{"prefill", "decode"})
 			} else {
 				costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
 			}

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -54,22 +54,15 @@ func (o *CostAwareOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if req.Disaggregated {
-			s := req.AnalyzerResults // engine guarantees a fresh slice per cycle
-			initDisaggregatedRemaining(s)
-			if needsScaleUp(s) {
-				ps := InitRolePairedState(s)
-				allocateForModelPairedB2(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets,
-					costGreedyPickPaired, ps, []string{"prefill", "decode"})
-			} else {
-				costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
-			}
+		// Unified dispatch: one path for all models via (model, role) math.
+		// Non-disaggregated uses synthetic "both" role; disaggregated uses actual roles.
+		s := req.AnalyzerResults
+		roles, ps := initRoleState(s)
+		if anyRoleNeedsScaleUp(ps, roles) {
+			allocateForModelPaired(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets,
+				costGreedyRolePick, ps, roles)
 		} else {
-			if needsScaleUp(req.AnalyzerResults) {
-				costAwareScaleUp(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
-			} else if needsScaleDown(req.AnalyzerResults) {
-				costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
-			}
+			scaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
 		}
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "cost-aware")
@@ -82,30 +75,19 @@ func (o *CostAwareOptimizer) Optimize(
 	return allDecisions
 }
 
-// costAwareScaleUp adds replicas to the most cost-efficient variant using the
-// per-analyzer slice helpers. Delegates to allocateForModel with costGreedyPick.
-func costAwareScaleUp(
-	ctx context.Context,
-	s []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	targets map[string]int,
-	stateMap map[string]interfaces.VariantReplicaState,
-) {
-	allocateForModel(ctx, s, variants, stateMap, nil, targets, costGreedyPick)
-}
-
-// costGreedyPick returns the cheapest-by-cost-efficiency variant that still has
-// replica headroom. capN is the maxReplicas headroom (math.MaxInt when unlimited).
-// Returns ("", 0) when all variants are at their cap or have no capacity.
-func costGreedyPick(
+// costGreedyRolePick is a RolePickFn that picks the cheapest-by-cost-efficiency
+// variant in the given role. For "both" (non-disaggregated), all variants are
+// eligible. For role-tagged roles, only variants with a matching Role are picked.
+func costGreedyRolePick(
+	role string,
 	_ []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
 	stateMap map[string]interfaces.VariantReplicaState,
 	_ map[string]int,
 	targets map[string]int,
 ) (string, int) {
-	sorted := sortByCostEfficiencyAsc(variants)
-	for _, vc := range sorted {
+	roleVCs := variantsForRole(variants, role)
+	for _, vc := range sortByCostEfficiencyAsc(roleVCs) {
 		if vc.PerReplicaCapacity <= 0 {
 			continue
 		}
@@ -122,74 +104,17 @@ func costGreedyPick(
 	return "", 0
 }
 
-// costAwareScaleDown removes replicas from the most expensive variant using the
-// per-analyzer slice helpers. Iterates most-expensive-first while needsScaleDown
-// holds. Cheapest-variant protection and minReplicas floor are preserved.
-func costAwareScaleDown(
+// scaleDownRoleIterated is the Phase-3 unified scale-down: iterates roles
+// independently and sheds against per-role spare. Arity-1 (roles=["both"])
+// handles non-disaggregated models via the single synthetic "both" role.
+func scaleDownRoleIterated(
 	ctx context.Context,
 	s []NamedAnalyzerResult,
 	variants []interfaces.VariantCapacity,
 	targets map[string]int,
 	stateMap ...map[string]interfaces.VariantReplicaState,
 ) {
-	logger := ctrl.LoggerFrom(ctx)
-
-	sorted := sortByCostDesc(variants)
-
-	var states map[string]interfaces.VariantReplicaState
-	if len(stateMap) > 0 {
-		states = stateMap[0]
-	}
-
-	for needsScaleDown(s) {
-		// removed prevents an infinite loop: needsScaleDown can hold (some Spare_i > 0)
-		// while no variant has remaining capacity to give up (all at minReplicas, or
-		// PRC mismatched). Break when a full sweep makes no progress.
-		removed := false
-		for i, vc := range sorted {
-			if !needsScaleDown(s) {
-				break
-			}
-			if vc.PerReplicaCapacity <= 0 {
-				continue
-			}
-
-			current := targets[vc.VariantName]
-
-			// Determine minReplicas: annotation floor takes priority, then cheapest-variant logic.
-			minReplicas := 0
-			if states != nil {
-				if state, ok := states[vc.VariantName]; ok && state.MinReplicas != nil {
-					minReplicas = *state.MinReplicas
-				}
-			}
-			// Protect cheapest (last in cost-desc order) at 1 replica when it's
-			// the last variant with replicas in the set.
-			if i == len(sorted)-1 && !anyHasReplicas(sorted[:i], targets) && minReplicas < 1 {
-				minReplicas = 1
-			}
-
-			removable := current - minReplicas
-			if removable <= 0 {
-				continue
-			}
-
-			n := min(safeRemovalReplicas(s, vc.VariantName), removable)
-			if n <= 0 {
-				continue
-			}
-
-			applyDeallocation(s, vc.VariantName, n)
-			targets[vc.VariantName] = current - n
-			removed = true
-
-			logger.V(logging.DEBUG).Info("scale-down: removed replicas",
-				"variant", vc.VariantName, "removed", n, "cost", vc.Cost)
-		}
-		if !removed {
-			break
-		}
-	}
+	costAwareScaleDownRoleIterated(ctx, s, variants, targets, stateMap...)
 }
 
 // scaleDownVariantSet removes replicas from the given variant set, most-expensive
@@ -395,46 +320,6 @@ func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 }
 
 // costGreedyPickPaired selects the cheapest-by-cost-efficiency (vP, vD) pair for
-// disaggregated models. Returns the cheapest eligible prefill variant and cheapest
-// eligible decode variant independently, with their maxReplicas headroom as caps.
-func costGreedyPickPaired(
-	_ []NamedAnalyzerResult,
-	variants []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	_ map[string]int,
-	targets map[string]int,
-) (vP, vD string, capNP, capND int) {
-	var pVCs, dVCs []interfaces.VariantCapacity
-	for _, vc := range variants {
-		switch vc.Role {
-		case "prefill":
-			pVCs = append(pVCs, vc)
-		case "decode":
-			dVCs = append(dVCs, vc)
-		}
-	}
-	pick := func(vcs []interfaces.VariantCapacity) (string, int) {
-		for _, vc := range sortByCostEfficiencyAsc(vcs) {
-			if vc.PerReplicaCapacity <= 0 {
-				continue
-			}
-			state := stateMap[vc.VariantName]
-			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
-				headroom := *state.MaxReplicas - targets[vc.VariantName]
-				if headroom <= 0 {
-					continue
-				}
-				return vc.VariantName, headroom
-			}
-			return vc.VariantName, math.MaxInt
-		}
-		return "", 0
-	}
-	vP, capNP = pick(pVCs)
-	vD, capND = pick(dVCs)
-	return
-}
-
 // costAwareScaleDownRoleIterated removes replicas from disaggregated models by
 // iterating each role independently. P and D scale-down are independent — trimming
 // one role's slack does not affect the other (each role's supply and demand are
@@ -455,15 +340,15 @@ func costAwareScaleDownRoleIterated(
 	}
 
 	// Collect distinct roles from the variant set. Sorted for determinism (N4).
+	// "both" (non-disaggregated variants) is included so the unified path serves
+	// arity-1 models as well as multi-role disaggregated models.
 	rolesSet := make(map[string]struct{})
 	for _, vc := range variants {
 		role := vc.Role
 		if role == "" {
 			role = interfaces.RoleBoth
 		}
-		if role != interfaces.RoleBoth {
-			rolesSet[role] = struct{}{}
-		}
+		rolesSet[role] = struct{}{}
 	}
 	roles := make([]string, 0, len(rolesSet))
 	for role := range rolesSet {

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -50,18 +50,19 @@ func (o *CostAwareOptimizer) Optimize(
 	var allDecisions []interfaces.VariantDecision
 
 	for _, req := range requests {
-		if req.Result == nil {
+		satEntry := saturationEntry(req.AnalyzerResults)
+		if satEntry == nil {
 			continue
 		}
 
 		stateMap := buildStateMap(req.VariantStates)
-		vcMap := buildCapacityMap(req.Result.VariantCapacities)
+		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if req.Result.RequiredCapacity > 0 {
-			costAwareScaleUp(ctx, req.Result, targets, stateMap)
-		} else if req.Result.SpareCapacity > 0 {
-			costAwareScaleDown(ctx, req.Result, targets, stateMap)
+		if needsScaleUp(req.AnalyzerResults) {
+			costAwareScaleUp(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+		} else if needsScaleDown(req.AnalyzerResults) {
+			costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
 		}
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, CostAwareOptimizerName)
@@ -74,89 +75,111 @@ func (o *CostAwareOptimizer) Optimize(
 	return allDecisions
 }
 
-// costAwareScaleUp adds replicas to the most cost-efficient variant.
-// Sorts by cost-efficiency (cost/perReplicaCapacity) ascending, picks first eligible.
-// Respects maxReplicas per variant — if a variant hits its cap, remaining capacity
-// spills over to the next variant.
+// costAwareScaleUp adds replicas to the most cost-efficient variant using the
+// per-analyzer slice helpers. Delegates to allocateForModel with costGreedyPick.
 func costAwareScaleUp(
 	ctx context.Context,
-	result *interfaces.AnalyzerResult,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
 	targets map[string]int,
 	stateMap map[string]interfaces.VariantReplicaState,
 ) {
-	logger := ctrl.LoggerFrom(ctx)
+	allocateForModel(ctx, s, variants, stateMap, nil, targets, costGreedyPick)
+}
 
-	sorted := sortByCostEfficiencyAsc(result.VariantCapacities)
-	remaining := result.RequiredCapacity
-
+// costGreedyPick returns the cheapest-by-cost-efficiency variant that still has
+// replica headroom. capN is the maxReplicas headroom (math.MaxInt when unlimited).
+// Returns ("", 0) when all variants are at their cap or have no capacity.
+func costGreedyPick(
+	_ []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	_ map[string]int,
+	targets map[string]int,
+) (string, int) {
+	sorted := sortByCostEfficiencyAsc(variants)
 	for _, vc := range sorted {
-		if remaining <= 0 {
-			break
-		}
 		if vc.PerReplicaCapacity <= 0 {
 			continue
 		}
-
-		replicasNeeded := int(math.Ceil(remaining / vc.PerReplicaCapacity))
-
-		// Cap by maxReplicas if set
 		state := stateMap[vc.VariantName]
 		if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
-			maxAdd := *state.MaxReplicas - targets[vc.VariantName]
-			if maxAdd <= 0 {
-				continue // already at max
+			headroom := *state.MaxReplicas - targets[vc.VariantName]
+			if headroom <= 0 {
+				continue
 			}
-			if replicasNeeded > maxAdd {
-				replicasNeeded = maxAdd
-			}
+			return vc.VariantName, headroom
 		}
-
-		targets[vc.VariantName] += replicasNeeded
-		remaining -= float64(replicasNeeded) * vc.PerReplicaCapacity
-
-		logger.V(logging.DEBUG).Info("Scale-up allocation",
-			"variant", vc.VariantName,
-			"added", replicasNeeded,
-			"costEfficiency", costEfficiency(vc))
+		return vc.VariantName, math.MaxInt
 	}
+	return "", 0
 }
 
-// costAwareScaleDown removes replicas to shed spare capacity, most-expensive
-// variant first, respecting minReplicas.
-//
-// For disaggregated (prefill/decode) models it sheds each role independently
-// against that role's own spare. Prefill and decode capacity are not fungible, so
-// removing by the model-level SpareCapacity — which aggregates all roles — would
-// let a role with slack drive removal of replicas from a saturated role (e.g.
-// trimming prefill because decode has spare). RoleCapacities is non-nil only when
-// disaggregation is active; non-disaggregated models keep the model-level shed.
+// costAwareScaleDown removes replicas from the most expensive variant using the
+// per-analyzer slice helpers. Iterates most-expensive-first while needsScaleDown
+// holds. Cheapest-variant protection and minReplicas floor are preserved.
 func costAwareScaleDown(
 	ctx context.Context,
-	result *interfaces.AnalyzerResult,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
 	targets map[string]int,
 	stateMap ...map[string]interfaces.VariantReplicaState,
 ) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	sorted := sortByCostDesc(variants)
+
 	var states map[string]interfaces.VariantReplicaState
 	if len(stateMap) > 0 {
 		states = stateMap[0]
 	}
 
-	if len(result.RoleCapacities) > 0 {
-		// Each role owns a disjoint set of variants and sheds against its own
-		// spare, so the map's iteration order does not affect the outcome.
-		// Assumes RoleCapacities keys partition VariantCapacities by role
-		// (one role per variant; no overlap); mixed-role configurations would
-		// break disjointness.
-		for role, rc := range result.RoleCapacities {
-			if rc.SpareCapacity <= 0 {
-				continue // saturated or under-supplied role — never trim it
+	for needsScaleDown(s) {
+		removed := false
+		for i, vc := range sorted {
+			if !needsScaleDown(s) {
+				break
 			}
-			scaleDownVariantSet(ctx, variantsForRole(result.VariantCapacities, role), rc.SpareCapacity, targets, states)
-		}
-		return
-	}
+			if vc.PerReplicaCapacity <= 0 {
+				continue
+			}
 
-	scaleDownVariantSet(ctx, result.VariantCapacities, result.SpareCapacity, targets, states)
+			current := targets[vc.VariantName]
+
+			// Determine minReplicas: annotation floor takes priority, then cheapest-variant logic.
+			minReplicas := 0
+			if states != nil {
+				if state, ok := states[vc.VariantName]; ok && state.MinReplicas != nil {
+					minReplicas = *state.MinReplicas
+				}
+			}
+			// Protect cheapest (last in cost-desc order) at 1 replica when it's
+			// the last variant with replicas in the set.
+			if i == len(sorted)-1 && !anyHasReplicas(sorted[:i], targets) && minReplicas < 1 {
+				minReplicas = 1
+			}
+
+			removable := current - minReplicas
+			if removable <= 0 {
+				continue
+			}
+
+			n := min(safeRemovalReplicas(s, vc.VariantName), removable)
+			if n <= 0 {
+				continue
+			}
+
+			applyDeallocation(s, vc.VariantName, n)
+			targets[vc.VariantName] = current - n
+			removed = true
+
+			logger.V(logging.DEBUG).Info("scale-down: removed replicas",
+				"variant", vc.VariantName, "removed", n, "cost", vc.Cost)
+		}
+		if !removed {
+			break
+		}
+	}
 }
 
 // scaleDownVariantSet removes replicas from the given variant set, most-expensive
@@ -234,24 +257,6 @@ func anyHasReplicas(variants []interfaces.VariantCapacity, targets map[string]in
 		}
 	}
 	return false
-}
-
-// variantsForRole returns the capacities whose role matches exactly (an empty
-// role is treated as "both"). Unlike filterVariantCapacitiesByRole, which treats
-// "both" as a wildcard for scale-up allocation, this matches the role exactly so
-// per-role scale-down operates on disjoint variant sets.
-func variantsForRole(capacities []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
-	out := make([]interfaces.VariantCapacity, 0, len(capacities))
-	for _, vc := range capacities {
-		r := vc.Role
-		if r == "" {
-			r = interfaces.RoleBoth
-		}
-		if r == role {
-			out = append(out, vc)
-		}
-	}
-	return out
 }
 
 // buildStateMap creates a lookup map from variant name to VariantReplicaState.

--- a/internal/engines/pipeline/cost_aware_optimizer.go
+++ b/internal/engines/pipeline/cost_aware_optimizer.go
@@ -12,11 +12,6 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
-const (
-	// CostAwareOptimizerName is the identifier for the cost-aware optimizer
-	CostAwareOptimizerName = "cost-aware"
-)
-
 // CostAwareOptimizer is a per-model optimizer that minimizes total cost while
 // meeting capacity requirements. It processes each model independently:
 //
@@ -36,7 +31,7 @@ func NewCostAwareOptimizer() *CostAwareOptimizer {
 
 // Name returns the optimizer identifier.
 func (o *CostAwareOptimizer) Name() string {
-	return CostAwareOptimizerName
+	return "cost-aware"
 }
 
 // Optimize produces VariantDecisions for all models.
@@ -59,13 +54,24 @@ func (o *CostAwareOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if needsScaleUp(req.AnalyzerResults) {
-			costAwareScaleUp(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
-		} else if needsScaleDown(req.AnalyzerResults) {
-			costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+		if isDisaggregated(satEntry.VariantCapacities) {
+			s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
+			copy(s, req.AnalyzerResults)
+			initDisaggregatedRemaining(s)
+			if needsScaleUp(s) {
+				allocateForModelPaired(ctx, s, satEntry.VariantCapacities, stateMap, nil, targets, costGreedyPickPaired)
+			} else {
+				costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
+			}
+		} else {
+			if needsScaleUp(req.AnalyzerResults) {
+				costAwareScaleUp(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+			} else if needsScaleDown(req.AnalyzerResults) {
+				costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+			}
 		}
 
-		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, CostAwareOptimizerName)
+		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "cost-aware")
 		logger.V(logging.DEBUG).Info("Cost-aware optimizer decisions",
 			"modelID", req.ModelID,
 			"decisions", len(decisions))
@@ -135,6 +141,9 @@ func costAwareScaleDown(
 	}
 
 	for needsScaleDown(s) {
+		// removed prevents an infinite loop: needsScaleDown can hold (some Spare_i > 0)
+		// while no variant has remaining capacity to give up (all at minReplicas, or
+		// PRC mismatched). Break when a full sweep makes no progress.
 		removed := false
 		for i, vc := range sorted {
 			if !needsScaleDown(s) {
@@ -340,31 +349,28 @@ func buildDecisionsWithOptimizer(
 		switch {
 		case target > state.CurrentReplicas:
 			action = interfaces.ActionScaleUp
-			reason = fmt.Sprintf("V2 scale-up (optimizer: %s, required: %.0f)", optimizerName, req.Result.RequiredCapacity)
+			reason = fmt.Sprintf("V2 scale-up (optimizer: %s)", optimizerName)
 		case target < state.CurrentReplicas:
 			action = interfaces.ActionScaleDown
-			reason = fmt.Sprintf("V2 scale-down (optimizer: %s, spare: %.0f)", optimizerName, req.Result.SpareCapacity)
+			reason = fmt.Sprintf("V2 scale-down (optimizer: %s)", optimizerName)
 		default:
 			action = interfaces.ActionNoChange
 			reason = "V2 steady state"
 		}
 
 		decisions = append(decisions, interfaces.VariantDecision{
-			VariantName:      name,
-			ModelID:          req.ModelID,
-			Namespace:        req.Namespace,
-			AcceleratorName:  vc.AcceleratorName,
-			Cost:             vc.Cost,
-			Role:             state.Role,
-			CurrentReplicas:  state.CurrentReplicas,
-			TargetReplicas:   target,
-			Action:           action,
-			Reason:           reason,
-			MinReplicas:      state.MinReplicas,
-			MaxReplicas:      state.MaxReplicas,
-			Utilization:      vc.Utilization,
-			SpareCapacity:    1.0 - vc.Utilization,
-			RequiredCapacity: req.Result.RequiredCapacity,
+			VariantName:     name,
+			ModelID:         req.ModelID,
+			Namespace:       req.Namespace,
+			AcceleratorName: vc.AcceleratorName,
+			Cost:            vc.Cost,
+			Role:            state.Role,
+			CurrentReplicas: state.CurrentReplicas,
+			TargetReplicas:  target,
+			Action:          action,
+			Reason:          reason,
+			MinReplicas:     state.MinReplicas,
+			MaxReplicas:     state.MaxReplicas,
 		})
 	}
 	return decisions
@@ -385,6 +391,127 @@ func mergeConstraints(constraints []*ResourceConstraints) map[string]int {
 		}
 	}
 	return merged
+}
+
+// costGreedyPickPaired selects the cheapest-by-cost-efficiency (vP, vD) pair for
+// disaggregated models. Returns the cheapest eligible prefill variant and cheapest
+// eligible decode variant independently, with their maxReplicas headroom as caps.
+func costGreedyPickPaired(
+	_ []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	stateMap map[string]interfaces.VariantReplicaState,
+	_ map[string]int,
+	targets map[string]int,
+) (vP, vD string, capNP, capND int) {
+	var pVCs, dVCs []interfaces.VariantCapacity
+	for _, vc := range variants {
+		switch vc.Role {
+		case "prefill":
+			pVCs = append(pVCs, vc)
+		case "decode":
+			dVCs = append(dVCs, vc)
+		}
+	}
+	pick := func(vcs []interfaces.VariantCapacity) (string, int) {
+		for _, vc := range sortByCostEfficiencyAsc(vcs) {
+			if vc.PerReplicaCapacity <= 0 {
+				continue
+			}
+			state := stateMap[vc.VariantName]
+			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
+				headroom := *state.MaxReplicas - targets[vc.VariantName]
+				if headroom <= 0 {
+					continue
+				}
+				return vc.VariantName, headroom
+			}
+			return vc.VariantName, math.MaxInt
+		}
+		return "", 0
+	}
+	vP, capNP = pick(pVCs)
+	vD, capND = pick(dVCs)
+	return
+}
+
+// costAwareScaleDownRoleIterated removes replicas from disaggregated models by
+// iterating each role independently. P and D scale-down are independent — trimming
+// one role's slack does not affect the other (each role's supply and demand are
+// distinct). Per role: remove from most expensive variant first; cheapest-variant
+// protection scoped to the role; minReplicas floor respected.
+func costAwareScaleDownRoleIterated(
+	ctx context.Context,
+	s []NamedAnalyzerResult,
+	variants []interfaces.VariantCapacity,
+	targets map[string]int,
+	stateMap ...map[string]interfaces.VariantReplicaState,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	var states map[string]interfaces.VariantReplicaState
+	if len(stateMap) > 0 {
+		states = stateMap[0]
+	}
+
+	// Collect distinct roles from the variant set.
+	roles := make(map[string]struct{})
+	for _, vc := range variants {
+		role := vc.Role
+		if role == "" {
+			role = interfaces.RoleBoth
+		}
+		if role != interfaces.RoleBoth {
+			roles[role] = struct{}{}
+		}
+	}
+
+	for role := range roles {
+		roleVCs := variantsForRole(variants, role)
+		if len(roleVCs) == 0 {
+			continue
+		}
+		sorted := sortByCostDesc(roleVCs)
+
+		for needsScaleDownForRole(s, role) {
+			removed := false
+			for i, vc := range sorted {
+				if !needsScaleDownForRole(s, role) {
+					break
+				}
+				if vc.PerReplicaCapacity <= 0 {
+					continue
+				}
+				current := targets[vc.VariantName]
+				minReplicas := 0
+				if states != nil {
+					if st, ok := states[vc.VariantName]; ok && st.MinReplicas != nil {
+						minReplicas = *st.MinReplicas
+					}
+				}
+				// Protect cheapest (last in cost-desc order) at 1 replica when
+				// it's the last variant with replicas in the role.
+				if i == len(sorted)-1 && !anyHasReplicas(sorted[:i], targets) && minReplicas < 1 {
+					minReplicas = 1
+				}
+				removable := current - minReplicas
+				if removable <= 0 {
+					continue
+				}
+				n := min(safeRemovalReplicasForRole(s, vc.VariantName, role), removable)
+				if n <= 0 {
+					continue
+				}
+				applyDeallocationForRole(s, vc.VariantName, role, n)
+				targets[vc.VariantName] -= n
+				removed = true
+				logger.V(logging.DEBUG).Info("scale-down role-iterated: removed replicas",
+					"role", role, "variant", vc.VariantName, "removed", n, "cost", vc.Cost)
+			}
+			if !removed {
+				break
+			}
+		}
+	}
 }
 
 // Ensure CostAwareOptimizer implements ScalingOptimizer

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
+// withSatEntry adds a single-saturation AnalyzerResults to req, initialised from
+// req.Result. Used by test fixtures so CostAwareOptimizer can find the saturation entry.
+func withSatEntry(req ModelScalingRequest) ModelScalingRequest {
+	if req.Result != nil {
+		req.AnalyzerResults = []NamedAnalyzerResult{{
+			Name:      interfaces.SaturationAnalyzerName,
+			Result:    req.Result,
+			Remaining: req.Result.RequiredCapacity,
+			Spare:     req.Result.SpareCapacity,
+		}}
+	}
+	return req
+}
+
 var _ = Describe("CostAwareOptimizer", func() {
 
 	var (
@@ -30,7 +44,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should add replicas to most cost-efficient variant", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -47,7 +61,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 2},
 						{VariantName: "expensive", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -61,7 +75,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should not skip variants with pending replicas", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -75,7 +89,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -89,7 +103,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should skip variants with zero capacity", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -103,7 +117,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "zero-cap", CurrentReplicas: 0},
 						{VariantName: "normal", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -115,7 +129,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should spread across multiple variants when needed", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -129,7 +143,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -145,7 +159,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should remove from most expensive variant first", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -159,25 +173,21 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
-			// expensive is removed first: floor(15000/20000)=0 → can't remove full replica?
-			// Actually floor(15000/20000) = 0. Hmm. Let me reconsider.
-			// No wait: spare=15000, expensive.perReplica=20000 → floor(15000/20000)=0
-			// But expensive has minReplicas=0 (not cheapest), removable=2
-			// 0 replicas removed from expensive → try cheap: floor(15000/10000)=1, removable=3-0=3
-			// cheap goes from 3 to 2
+			// expensive: floor(15000/20000)=0 → can't remove full replica
+			// cheap: expensive still has replicas → not protected, floor(15000/10000)=1 → remove 1
 			Expect(dm["expensive"].TargetReplicas).To(Equal(2))
 			Expect(dm["cheap"].TargetReplicas).To(Equal(2))
 		})
 
 		It("should protect cheapest variant at 1 replica", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -191,7 +201,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -205,7 +215,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should remove cheap variant when expensive replica capacity exceeds spare", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -219,7 +229,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -233,7 +243,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should cascade scale-down across variants", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -249,16 +259,16 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "mid", CurrentReplicas: 2},
 						{VariantName: "cheap", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
 			// sorted by cost DESC: expensive(15), mid(10), cheap(5)
-			// expensive: floor(50000/20000)=2, removable=2 → remove 2. remaining=50000-40000=10000
+			// expensive: floor(50000/20000)=2, removable=2 → remove 2. spare=10000
 			// mid: floor(10000/15000)=0 → skip
-			// cheap: mid still has replicas → not protected, removable=2, floor(10000/10000)=1 → remove 1. remaining=0
+			// cheap: mid still has replicas → not protected, floor(10000/10000)=1 → remove 1. spare=0
 			Expect(dm["expensive"].TargetReplicas).To(Equal(0))
 			Expect(dm["mid"].TargetReplicas).To(Equal(2))
 			Expect(dm["cheap"].TargetReplicas).To(Equal(1))
@@ -416,7 +426,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should return no-change when no scaling signal", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -429,7 +439,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -439,9 +449,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(decisions[0].TargetReplicas).To(Equal(2))
 		})
 
-		It("should skip requests with nil result", func() {
+		It("should skip requests with no saturation entry", func() {
 			requests := []ModelScalingRequest{
-				{ModelID: "model-1", Namespace: "default", Result: nil},
+				{ModelID: "model-1", Namespace: "default"},
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -453,7 +463,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should process models independently", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -465,8 +475,8 @@ var _ = Describe("CostAwareOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "m1-v1", CurrentReplicas: 1},
 					},
-				},
-				{
+				}),
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-2",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -478,7 +488,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "m2-v1", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -495,7 +505,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should set model ID, namespace, and cost on decisions", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "ns-1",
 					Result: &interfaces.AnalyzerResult{
@@ -507,7 +517,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -525,7 +535,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should respect maxReplicas during scale-up (spillover to next variant)", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -539,22 +549,21 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 1, MaxReplicas: intPtr(3)},
 						{VariantName: "expensive", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
-			// cheap: ceil(30000/10000)=3, but current=1 so target=1+3=4, capped by max=3 → add 2
-			// remaining = 30000 - 2*10000 = 10000
-			// expensive: ceil(10000/20000)=1 → target=1+1=2
+			// cheap: ceil(30000/10000)=3, headroom=3-1=2 → add 2; remaining=10000
+			// expensive: ceil(10000/20000)=1 → add 1
 			Expect(dm["cheap"].TargetReplicas).To(Equal(3))
 			Expect(dm["expensive"].TargetReplicas).To(Equal(2))
 		})
 
 		It("should respect minReplicas during scale-down", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -568,14 +577,13 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "expensive", CurrentReplicas: 3, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
-			// expensive: cost DESC → tried first. min=2, removable=3-2=1. floor(50000/20000)=2 → capped to 1
-			// remaining = 50000-20000=30000
+			// expensive: min=2, removable=1. floor(50000/20000)=2 → capped to 1. spare=30000
 			// cheap: not last variant → min=0. removable=3. floor(30000/10000)=3 → remove 3
 			Expect(dm["expensive"].TargetReplicas).To(Equal(2))
 			Expect(dm["cheap"].TargetReplicas).To(Equal(0))
@@ -583,11 +591,11 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("should scale minReplicas=0 variant to zero while keeping minReplicas>0 sibling", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 80000, // enough to remove all
+						SpareCapacity: 80000,
 						VariantCapacities: []interfaces.VariantCapacity{
 							{VariantName: "keep-alive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
 							{VariantName: "expendable", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
@@ -597,21 +605,19 @@ var _ = Describe("CostAwareOptimizer", func() {
 						{VariantName: "keep-alive", CurrentReplicas: 2, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, MinReplicas: intPtr(0)},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
 			dm := decisionMap(decisions)
 
-			// keep-alive: minReplicas=1, so floor at 1
 			Expect(dm["keep-alive"].TargetReplicas).To(Equal(1))
-			// expendable: minReplicas=0 and other variant has replicas, so can go to 0
 			Expect(dm["expendable"].TargetReplicas).To(Equal(0))
 		})
 
 		It("should propagate MinReplicas/MaxReplicas to VariantDecision", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -624,7 +630,7 @@ var _ = Describe("CostAwareOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2, MinReplicas: intPtr(1), MaxReplicas: intPtr(10)},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -639,9 +645,9 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		It("sortByCostEfficiencyAsc should order by cost/capacity", func() {
 			capacities := []interfaces.VariantCapacity{
-				{VariantName: "expensive", Cost: 15.0, PerReplicaCapacity: 10000}, // 0.0015
-				{VariantName: "cheap", Cost: 5.0, PerReplicaCapacity: 10000},      // 0.0005
-				{VariantName: "mid", Cost: 10.0, PerReplicaCapacity: 10000},       // 0.001
+				{VariantName: "expensive", Cost: 15.0, PerReplicaCapacity: 10000},
+				{VariantName: "cheap", Cost: 5.0, PerReplicaCapacity: 10000},
+				{VariantName: "mid", Cost: 10.0, PerReplicaCapacity: 10000},
 			}
 
 			sorted := sortByCostEfficiencyAsc(capacities)

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -279,26 +279,26 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// decode has spare. Model-level SpareCapacity aggregates both roles, so a
 			// role-blind scale-down would trim the expensive prefill. Role-aware
 			// scale-down must leave the saturated prefill untouched and shed decode.
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 20000, // aggregate (decode's spare) — gates scale-down
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", SpareCapacity: 0},
+					"decode":  {Role: "decode", SpareCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 20000, // aggregate (decode's spare) — gates scale-down
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", SpareCapacity: 0},
-							"decode":  {Role: "decode", SpareCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -315,26 +315,26 @@ var _ = Describe("CostAwareOptimizer", func() {
 		It("should shed each role by its own spare when both have slack", func() {
 			// Both roles have spare, but different amounts. Each role must shed by
 			// its own per-role spare, not the aggregate.
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 30000, // aggregate — gates scale-down
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill", Role: "prefill", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", SpareCapacity: 10000}, // 1 replica
+					"decode":  {Role: "decode", SpareCapacity: 20000},  // 2 replicas
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 30000, // aggregate — gates scale-down
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill", Role: "prefill", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", SpareCapacity: 10000}, // 1 replica
-							"decode":  {Role: "decode", SpareCapacity: 20000},  // 2 replicas
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 3},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -350,25 +350,25 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// Only decode has a RoleCapacities entry (e.g. a prefill data-collection
 			// gap). The one-iteration path must shed decode against its own spare and
 			// keep the cheapest decode variant at one replica.
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "decode-exp", Role: "decode", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "decode-cheap", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"decode": {Role: "decode", SpareCapacity: 20000}, // 2 replicas
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "decode-exp", Role: "decode", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "decode-cheap", Role: "decode", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"decode": {Role: "decode", SpareCapacity: 20000}, // 2 replicas
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "decode-exp", Role: "decode", CurrentReplicas: 1},
 						{VariantName: "decode-cheap", Role: "decode", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -385,28 +385,28 @@ var _ = Describe("CostAwareOptimizer", func() {
 			// prefill/decode RoleCapacities map — so the per-role sheds never include it.
 			// The design assumes one role per variant; this pins the defensive behavior
 			// if that assumption is violated: the orphan is left as-is.
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+					{VariantName: "orphan", Role: "", Cost: 20.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", SpareCapacity: 0},
+					"decode":  {Role: "decode", SpareCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill", Role: "prefill", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "decode", Role: "decode", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-							{VariantName: "orphan", Role: "", Cost: 20.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", SpareCapacity: 0},
-							"decode":  {Role: "decode", SpareCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill", Role: "prefill", CurrentReplicas: 2},
 						{VariantName: "decode", Role: "decode", CurrentReplicas: 3},
 						{VariantName: "orphan", Role: "", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -646,10 +646,10 @@ var _ = Describe("CostAwareOptimizer", func() {
 		// withSatEntryPD builds a request with a disaggregated saturation result.
 		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 			if r != nil {
+				req.Disaggregated = true
 				req.AnalyzerResults = []NamedAnalyzerResult{{
 					Name:      interfaces.SaturationAnalyzerName,
 					Result:    r,
-					Score:     1.0,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
 				}}
@@ -734,10 +734,10 @@ var _ = Describe("CostAwareOptimizer", func() {
 
 		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
 			if r != nil {
+				req.Disaggregated = true
 				req.AnalyzerResults = []NamedAnalyzerResult{{
 					Name:      interfaces.SaturationAnalyzerName,
 					Result:    r,
-					Score:     1.0,
 					Remaining: r.RequiredCapacity,
 					Spare:     r.SpareCapacity,
 				}}

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -17,7 +17,6 @@ func withSatEntry(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelSc
 		req.AnalyzerResults = []NamedAnalyzerResult{{
 			Name:      interfaces.SaturationAnalyzerName,
 			Result:    r,
-			Score:     1.0,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
 		}}

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -730,6 +730,58 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 	})
 
+	// Phase 3 test: D-only scale-up (RC_P=0, RC_D>0).
+	// Before Phase 3, the model-level gate read Remaining (P-anchor=0) and routed
+	// the model to scale-down instead of allocating decode. The per-role gate
+	// (anyRoleNeedsScaleUp) correctly fires on decode demand.
+	Context("Disaggregated (P/D) D-only scale-up", func() {
+
+		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+			if r != nil {
+				req.Disaggregated = true
+				req.AnalyzerResults = []NamedAnalyzerResult{{
+					Name:      interfaces.SaturationAnalyzerName,
+					Result:    r,
+					Remaining: r.RequiredCapacity,
+					Spare:     r.SpareCapacity,
+				}}
+			}
+			return req
+		}
+
+		It("should scale up only decode when only D has demand (RC_P=0, RC_D>0)", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {RequiredCapacity: 0, TotalDemand: 0},
+					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntryPD(r, ModelScalingRequest{
+					ModelID:   "model-d-only",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "prefill-v", CurrentReplicas: 2},
+						{VariantName: "decode-v", CurrentReplicas: 1},
+					},
+				}),
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// prefill has no demand: unchanged.
+			Expect(dm["prefill-v"].TargetReplicas).To(Equal(2))
+			// decode has demand 10000 / PRC 10000 = 1 replica added.
+			Expect(dm["decode-v"].TargetReplicas).To(Equal(2))
+		})
+	})
+
 	Context("Disaggregated (P/D) Scale-Down", func() {
 
 		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -10,15 +10,16 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
-// withSatEntry adds a single-saturation AnalyzerResults to req, initialised from
-// req.Result. Used by test fixtures so CostAwareOptimizer can find the saturation entry.
-func withSatEntry(req ModelScalingRequest) ModelScalingRequest {
-	if req.Result != nil {
+// withSatEntry adds a single-saturation AnalyzerResults to req, initialised from r.
+// Used by test fixtures so CostAwareOptimizer can find the saturation entry.
+func withSatEntry(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+	if r != nil {
 		req.AnalyzerResults = []NamedAnalyzerResult{{
 			Name:      interfaces.SaturationAnalyzerName,
-			Result:    req.Result,
-			Remaining: req.Result.RequiredCapacity,
-			Spare:     req.Result.SpareCapacity,
+			Result:    r,
+			Score:     1.0,
+			Remaining: r.RequiredCapacity,
+			Spare:     r.SpareCapacity,
 		}}
 	}
 	return req
@@ -43,20 +44,20 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Scale-Up", func() {
 
 		It("should add replicas to most cost-efficient variant", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				AnalyzedAt:       time.Now(),
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						AnalyzedAt:       time.Now(),
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 2},
 						{VariantName: "expensive", CurrentReplicas: 1},
@@ -74,17 +75,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should not skip variants with pending replicas", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
@@ -102,17 +103,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should skip variants with zero capacity", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "zero-cap", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
+					{VariantName: "normal", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "zero-cap", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
-							{VariantName: "normal", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "zero-cap", CurrentReplicas: 0},
 						{VariantName: "normal", CurrentReplicas: 1},
@@ -128,17 +129,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should spread across multiple variants when needed", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 25000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 25000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1},
 						{VariantName: "mid", CurrentReplicas: 1},
@@ -158,17 +159,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Scale-Down", func() {
 
 		It("should remove from most expensive variant first", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 15000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 15000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
@@ -186,17 +187,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should protect cheapest variant at 1 replica", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
@@ -214,17 +215,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should remove cheap variant when expensive replica capacity exceeds spare", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 15000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 15000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 1},
 						{VariantName: "cheap", CurrentReplicas: 1},
@@ -242,18 +243,18 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should cascade scale-down across variants", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+					{VariantName: "mid", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 15000},
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-							{VariantName: "mid", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 15000},
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 2},
 						{VariantName: "mid", CurrentReplicas: 2},
@@ -425,17 +426,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Steady State", func() {
 
 		It("should return no-change when no scaling signal", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 0,
+				SpareCapacity:    0,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 0,
-						SpareCapacity:    0,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
@@ -462,29 +463,29 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Multi-Model", func() {
 
 		It("should process models independently", func() {
+			r1 := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "m1-v1", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			r2 := &interfaces.AnalyzerResult{
+				SpareCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "m2-v1", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r1, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "m1-v1", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "m1-v1", CurrentReplicas: 1},
 					},
 				}),
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r2, ModelScalingRequest{
 					ModelID:   "model-2",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "m2-v1", Cost: 10.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "m2-v1", CurrentReplicas: 2},
 					},
@@ -504,16 +505,16 @@ var _ = Describe("CostAwareOptimizer", func() {
 	Context("Decision Metadata", func() {
 
 		It("should set model ID, namespace, and cost on decisions", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "ns-1",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1},
 					},
@@ -534,17 +535,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		intPtr := func(n int) *int { return &n }
 
 		It("should respect maxReplicas during scale-up (spillover to next variant)", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, MaxReplicas: intPtr(3)},
 						{VariantName: "expensive", CurrentReplicas: 1},
@@ -562,17 +563,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should respect minReplicas during scale-down", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 3, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3},
@@ -590,17 +591,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should scale minReplicas=0 variant to zero while keeping minReplicas>0 sibling", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 80000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "keep-alive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+					{VariantName: "expendable", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 80000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "keep-alive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-							{VariantName: "expendable", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "keep-alive", CurrentReplicas: 2, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, MinReplicas: intPtr(0)},
@@ -616,17 +617,17 @@ var _ = Describe("CostAwareOptimizer", func() {
 		})
 
 		It("should propagate MinReplicas/MaxReplicas to VariantDecision", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 0,
+				SpareCapacity:    0,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 0,
-						SpareCapacity:    0,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2, MinReplicas: intPtr(1), MaxReplicas: intPtr(10)},
 					},
@@ -638,6 +639,147 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(decisions).To(HaveLen(1))
 			Expect(decisions[0].MinReplicas).To(Equal(intPtr(1)))
 			Expect(decisions[0].MaxReplicas).To(Equal(intPtr(10)))
+		})
+	})
+
+	Context("Disaggregated (P/D) Scale-Up", func() {
+
+		// withSatEntryPD builds a request with a disaggregated saturation result.
+		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+			if r != nil {
+				req.AnalyzerResults = []NamedAnalyzerResult{{
+					Name:      interfaces.SaturationAnalyzerName,
+					Result:    r,
+					Score:     1.0,
+					Remaining: r.RequiredCapacity,
+					Spare:     r.SpareCapacity,
+				}}
+			}
+			return req
+		}
+
+		It("should allocate paired (n_P, n_D) replicas for cheapest prefill + decode pair", func() {
+			// P-Remaining=20000, PRC_P=10000 → n_P=2
+			// D=α×P=20000 (α=1), PRC_D=10000 → n_D=2
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {RequiredCapacity: 20000, TotalDemand: 20000},
+					"decode":  {RequiredCapacity: 20000, TotalDemand: 20000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntryPD(r, ModelScalingRequest{
+					ModelID:   "model-pd",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "prefill-v", CurrentReplicas: 1},
+						{VariantName: "decode-v", CurrentReplicas: 1},
+					},
+				}),
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// α=20000/20000=1; n_P=ceil(20000/10000)=2; n_D=ceil(1×20000/10000)=2
+			Expect(dm["prefill-v"].TargetReplicas).To(Equal(3)) // 1 + 2
+			Expect(dm["decode-v"].TargetReplicas).To(Equal(3))  // 1 + 2
+		})
+
+		It("should pick cheapest prefill and decode variants independently", func() {
+			// Two prefill variants: cheap-p (cost 5) and expensive-p (cost 15)
+			// Two decode variants: cheap-d (cost 5) and expensive-d (cost 15)
+			// α=1; P-RC=10000, PRC=10000 → n_P=1 on cheap-p; n_D=1 on cheap-d
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap-p", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "expensive-p", Cost: 15.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "cheap-d", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
+					{VariantName: "expensive-d", Cost: 15.0, Role: "decode", PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {RequiredCapacity: 10000, TotalDemand: 10000},
+					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntryPD(r, ModelScalingRequest{
+					ModelID:   "model-pd",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "cheap-p", CurrentReplicas: 1},
+						{VariantName: "expensive-p", CurrentReplicas: 1},
+						{VariantName: "cheap-d", CurrentReplicas: 1},
+						{VariantName: "expensive-d", CurrentReplicas: 1},
+					},
+				}),
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			Expect(dm["cheap-p"].TargetReplicas).To(Equal(2))     // cheapest P gets +1
+			Expect(dm["expensive-p"].TargetReplicas).To(Equal(1)) // unchanged
+			Expect(dm["cheap-d"].TargetReplicas).To(Equal(2))     // cheapest D gets +1
+			Expect(dm["expensive-d"].TargetReplicas).To(Equal(1)) // unchanged
+		})
+	})
+
+	Context("Disaggregated (P/D) Scale-Down", func() {
+
+		withSatEntryPD := func(r *interfaces.AnalyzerResult, req ModelScalingRequest) ModelScalingRequest {
+			if r != nil {
+				req.AnalyzerResults = []NamedAnalyzerResult{{
+					Name:      interfaces.SaturationAnalyzerName,
+					Result:    r,
+					Score:     1.0,
+					Remaining: r.RequiredCapacity,
+					Spare:     r.SpareCapacity,
+				}}
+			}
+			return req
+		}
+
+		It("should remove from most expensive prefill and decode variants", func() {
+			// P-Spare=20000, PRC_P=10000 → n_P=2; D-Spare=10000, PRC_D=10000 → n_D=1
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 20000, // model-level (unused in disaggregated path)
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap-p", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "expensive-p", Cost: 15.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {SpareCapacity: 20000, TotalDemand: 10000},
+					"decode":  {SpareCapacity: 10000, TotalDemand: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				withSatEntryPD(r, ModelScalingRequest{
+					ModelID:   "model-pd",
+					Namespace: "default",
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "cheap-p", CurrentReplicas: 2},
+						{VariantName: "expensive-p", CurrentReplicas: 2},
+						{VariantName: "decode-v", CurrentReplicas: 3},
+					},
+				}),
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, nil)
+			dm := decisionMap(decisions)
+
+			// expensive-p removed first (cost 15 > 5); n_P=floor(20000/10000)=2 but capped by removable
+			Expect(dm["expensive-p"].TargetReplicas).To(Equal(0)) // -2
+			Expect(dm["cheap-p"].TargetReplicas).To(Equal(2))     // unchanged (protected as last P)
+			// decode-v: n_D=floor(10000/10000)=1
+			Expect(dm["decode-v"].TargetReplicas).To(Equal(2)) // -1
 		})
 	})
 

--- a/internal/engines/pipeline/cost_aware_optimizer_test.go
+++ b/internal/engines/pipeline/cost_aware_optimizer_test.go
@@ -850,33 +850,6 @@ var _ = Describe("CostAwareOptimizer", func() {
 			Expect(sorted[2].VariantName).To(Equal("expensive"))
 		})
 
-		It("sortByCostDesc should order by absolute cost descending", func() {
-			capacities := []interfaces.VariantCapacity{
-				{VariantName: "cheap", Cost: 5.0},
-				{VariantName: "expensive", Cost: 15.0},
-				{VariantName: "mid", Cost: 10.0},
-			}
-
-			sorted := sortByCostDesc(capacities)
-
-			Expect(sorted[0].VariantName).To(Equal("expensive"))
-			Expect(sorted[1].VariantName).To(Equal("mid"))
-			Expect(sorted[2].VariantName).To(Equal("cheap"))
-		})
-
-		It("sortByCostDesc should tie-break equal cost by per-replica capacity ascending", func() {
-			// Among equal-cost variants, the higher-PRC one must land last — the
-			// deterministic slot scale-down protects at one replica.
-			capacities := []interfaces.VariantCapacity{
-				{VariantName: "lo-prc", Cost: 5.0, PerReplicaCapacity: 1000},
-				{VariantName: "hi-prc", Cost: 5.0, PerReplicaCapacity: 9000},
-			}
-
-			sorted := sortByCostDesc(capacities)
-
-			Expect(sorted[len(sorted)-1].VariantName).To(Equal("hi-prc"))
-		})
-
 		It("mergeConstraints should take minimum available per type", func() {
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{"A100": {Limit: 10}, "H100": {Limit: 4}}},

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -44,28 +44,46 @@ type modelWork struct {
 	targets   map[string]int             // variant name → target replicas (ALL variants)
 }
 
-// fairShareValue computes the fair-share priority metric for one model from its
-// per-analyzer working slice. Returns priority × Σᵢ(Remainingᵢ × Scoreᵢ).
-// Falls back to max_i(Remainingᵢ) when the weighted result is zero (priority
-// unset or no score weights), matching the original fallback to RequiredCapacity.
-func fairShareValue(priority float64, s []NamedAnalyzerResult) float64 {
+// fairShareValue computes the fair-share priority metric for one model.
+// Phase 3: reads picker-local role-remaining (sum over roles × analyzer Score)
+// so the metric reflects actual per-role demand remaining rather than the
+// P-anchor model-level scalar.
+//
+//	fsv = priority × Σᵢ Score_i × Σ_role pickerState[i][role]
+//
+// Falls back to max remaining demand when the weighted result is zero.
+func fairShareValue(priority float64, s []NamedAnalyzerResult, ps RolePairedState, roles []string) float64 {
 	weighted := 0.0
-	for _, e := range s {
-		if e.Result != nil {
-			weighted += e.Remaining * e.Score
+	for i, e := range s {
+		if e.Result == nil {
+			continue
 		}
+		roleSum := 0.0
+		for _, role := range roles {
+			if i < len(ps) {
+				roleSum += ps[i][role]
+			}
+		}
+		weighted += roleSum * e.Score
 	}
 	if fsv := priority * weighted; fsv > 0 {
 		return fsv
 	}
-	// Fallback: bottleneck remaining without priority scaling.
-	maxRemaining := 0.0
-	for _, e := range s {
-		if e.Result != nil && e.Remaining > maxRemaining {
-			maxRemaining = e.Remaining
+	// Fallback: max remaining demand across roles when Score=0 or priority=0.
+	maxDemand := 0.0
+	for i, e := range s {
+		if e.Result == nil {
+			continue
+		}
+		if i < len(ps) {
+			for _, role := range roles {
+				if ps[i][role] > maxDemand {
+					maxDemand = ps[i][role]
+				}
+			}
 		}
 	}
-	return maxRemaining
+	return maxDemand
 }
 
 // Optimize produces VariantDecisions for all models, fair-sharing GPUs across
@@ -89,7 +107,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 
 		s := req.AnalyzerResults
 		roles, ps := initRoleState(s)
-		fsv := fairShareValue(req.Priority, s) // updated to role-sum in commit 3
+		fsv := fairShareValue(req.Priority, s, ps, roles)
 		if anyRoleNeedsScaleUp(ps, roles) || fsv > 0 {
 			w := o.buildScaleUpWork(req, satEntry, s, ps, roles, fsv)
 			if w != nil {
@@ -244,31 +262,15 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	allocateForModelPaired(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
 		w.targets, pick, ps, w.roles)
 
-	// Recompute w.remaining after allocation.
-	// - "both" single-role (non-disag): s[i].Remaining (P-anchor) is reliable
-	//   since applyAllocation tracks it; fairShareValue reads it correctly.
-	// - P/D multi-role: use role-sum from ps (capped→decremented), which correctly
-	//   reaches 0 when both roles are satisfied in one step.
-	// Commit 3 unifies both cases via fairShareValue reading ps.
+	// Recompute w.remaining for fair-share ordering.
+	// For "both" (non-disag): use fresh ps so applyAllocation-decremented
+	// s[i].Remaining is read (budget-capped ps is already 0).
+	// For P/D: use local capped ps which correctly reaches 0 when both roles served.
 	if len(w.roles) == 1 && w.roles[0] == interfaces.RoleBoth {
-		w.remaining = fairShareValue(w.req.Priority, w.s)
+		_, freshPs := initRoleState(w.s)
+		w.remaining = fairShareValue(w.req.Priority, w.s, freshPs, w.roles)
 	} else {
-		sum := 0.0
-		for i, m := range ps {
-			if w.s[i].Result != nil {
-				for _, demand := range m {
-					sum += demand * w.s[i].Score
-				}
-			}
-		}
-		if sum > 0 {
-			w.remaining = w.req.Priority * sum
-			if w.remaining <= 0 {
-				w.remaining = sum
-			}
-		} else {
-			w.remaining = 0
-		}
+		w.remaining = fairShareValue(w.req.Priority, w.s, ps, w.roles)
 	}
 	return w.remaining < oldRemaining
 }
@@ -277,24 +279,11 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 // Greedy's disaggregated scale-up now delegates to allocateForModelPairedB2.
 
 // fairShareRolePick returns a RolePickFn for the unified allocateForModelPaired loop.
-// Routes the fair-share budget per role: "both" → full target; "prefill" → full
-// target; "decode" → α-scaled target. α derivation is removed in commit 3.
+// Each role receives the same target fair-share budget. The joint Δ_util commit
+// inside allocateForModelPaired enforces P/D coupling — α is no longer needed.
 func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) RolePickFn {
-	// Derive α for D-side cap (commit 3 will drop this and use the joint min-util
-	// commit to enforce the P/D coupling instead).
-	alpha := 1.0
-	for _, e := range s {
-		if e.Result == nil || e.Result.RoleCapacities == nil {
-			continue
-		}
-		p := e.Result.RoleCapacities["prefill"].TotalDemand
-		d := e.Result.RoleCapacities["decode"].TotalDemand
-		if p > 0 && d > 0 {
-			alpha = d / p
-			break
-		}
-	}
-	_ = roles // roles available for future per-role scaling; currently uniform
+	_ = s     // slice available for future multi-analyzer demand inspection
+	_ = roles // roles available for future per-role budget splitting
 	return func(
 		role string,
 		_ []NamedAnalyzerResult,
@@ -304,10 +293,6 @@ func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) 
 		targets map[string]int,
 	) (string, int) {
 		roleVCs := variantsForRole(variants, role)
-		scale := 1.0
-		if role == "decode" {
-			scale = alpha
-		}
 		for _, vc := range sortByCostEfficiencyAsc(roleVCs) {
 			if vc.PerReplicaCapacity <= 0 {
 				continue
@@ -321,7 +306,7 @@ func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) 
 			if gpusAvail < gpusPR {
 				continue
 			}
-			fairShareCap := int(math.Ceil(target * scale / vc.PerReplicaCapacity))
+			fairShareCap := int(math.Ceil(target / vc.PerReplicaCapacity))
 			capN := min(fairShareCap, gpusAvail/gpusPR)
 			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
 				headroom := *state.MaxReplicas - targets[vc.VariantName]

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -233,8 +233,11 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	oldRemaining := w.remaining
 
 	if isDisaggregated(w.satEntry.VariantCapacities) {
+		ps := InitRolePairedState(w.s)
 		pick := fairSharePickPaired(target, w.s)
-		o.allocateToVariantsPaired(ctx, w, target, stateMap, available, pick)
+		allocateForModelPairedB2(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
+			w.targets, pick, ps, []string{"prefill", "decode"})
+		// GPU budget already decremented inside allocateForModelPairedB2.
 	} else {
 		pick := fairSharePick(target)
 		o.allocateToVariants(ctx, w, target, w.satEntry.VariantCapacities, stateMap, available, pick)
@@ -286,48 +289,8 @@ func (o *GreedyByScoreOptimizer) allocateToVariants(
 	}
 }
 
-// allocateToVariantsPaired allocates paired (n_P, n_D) replicas for disaggregated models.
-// Stops when the per-iteration target budget (in P-units) is consumed.
-func (o *GreedyByScoreOptimizer) allocateToVariantsPaired(
-	ctx context.Context,
-	w *modelWork,
-	target float64,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	pick PickPairFn,
-) {
-	logger := ctrl.LoggerFrom(ctx)
-	consumed := 0.0
-	for needsScaleUp(w.s) && consumed < target {
-		vP, vD, capNP, capND := pick(w.s, w.satEntry.VariantCapacities, stateMap, available, w.targets)
-		if vP == "" || vD == "" {
-			break
-		}
-		// Cap by remaining budget (P-units).
-		prcP := prcFromVCs(w.satEntry.VariantCapacities, vP)
-		if prcP > 0 {
-			budgetCap := int(math.Ceil((target - consumed) / prcP))
-			capNP = min(capNP, budgetCap)
-		}
-		nP, nD := bottleneckReplicasPaired(w.s, vP, vD)
-		nP = min(nP, capNP)
-		nD = min(nD, capND)
-		if nP <= 0 && nD <= 0 {
-			break
-		}
-		applyAllocationPaired(w.s, vP, nP, vD, nD)
-		w.targets[vP] += nP
-		w.targets[vD] += nD
-		consumed += float64(nP) * prcP
-		available[accFromVCs(w.satEntry.VariantCapacities, vP)] -= nP * gpusPerReplicaFromState(stateMap, vP)
-		available[accFromVCs(w.satEntry.VariantCapacities, vD)] -= nD * gpusPerReplicaFromState(stateMap, vD)
-		logger.V(logging.DEBUG).Info("scale-up paired: allocated replicas",
-			"model", w.req.ModelID,
-			"prefill-variant", vP, "prefill-replicas", nP,
-			"decode-variant", vD, "decode-replicas", nD,
-			"budgetConsumed", consumed, "budgetTarget", target)
-	}
-}
+// allocateToVariantsPaired was the old α-based paired loop; retired in B2.
+// Greedy's disaggregated scale-up now delegates to allocateForModelPairedB2.
 
 // fairSharePick returns a PickVariantFn that caps allocation by the fair-share
 // target and GPU budget. Cheapest-first within eligible variants.
@@ -370,17 +333,19 @@ func fairSharePick(target float64) PickVariantFn {
 }
 
 // fairSharePickPaired returns a PickPairFn for disaggregated models.
-// Caps each side by the fair-share target scaled by α.
+// Caps each side by the fair-share target scaled by α (D:P demand ratio).
+// α is derived inline from RoleCapacities[*].TotalDemand (workload invariant).
 func fairSharePickPaired(target float64, s []NamedAnalyzerResult) PickPairFn {
-	// Derive α from the slice (first analyzer tracking both sides).
+	// Derive α = D/P from the first analyzer that has both sides > 0.
 	alpha := 1.0
 	for _, e := range s {
-		if e.Result == nil {
+		if e.Result == nil || e.Result.RoleCapacities == nil {
 			continue
 		}
-		a, _, tracksD := analyzerAlpha(e.Result)
-		if tracksD {
-			alpha = a
+		p := e.Result.RoleCapacities["prefill"].TotalDemand
+		d := e.Result.RoleCapacities["decode"].TotalDemand
+		if p > 0 && d > 0 {
+			alpha = d / p
 			break
 		}
 	}

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -20,7 +20,7 @@ import (
 //   - Respects ResourceConstraints (GPU budgets per accelerator type)
 //   - Fair-shares GPUs across models (highest-priority model gets GPUs first)
 //   - Disaggregated models use paired (n_P, n_D) allocation via the paired helpers
-//   - Scale-down reuses costAwareScaleDown / costAwareScaleDownPaired
+//   - Scale-down uses scaleDownRoleIterated (role-iterated unified path)
 type GreedyByScoreOptimizer struct{}
 
 // NewGreedyByScoreOptimizer creates a new GreedyByScoreOptimizer.
@@ -38,6 +38,8 @@ type modelWork struct {
 	req       ModelScalingRequest
 	s         []NamedAnalyzerResult      // working slice; Remaining/Spare decremented in place
 	satEntry  *interfaces.AnalyzerResult // variant metadata keeper (Cost, AcceleratorName, Role)
+	ps        RolePairedState            // picker-local per-role demand (from initRoleState)
+	roles     []string                   // active roles for this model
 	remaining float64                    // fair-share priority metric (negative = fully satisfied)
 	targets   map[string]int             // variant name → target replicas (ALL variants)
 }
@@ -85,14 +87,11 @@ func (o *GreedyByScoreOptimizer) Optimize(
 			continue
 		}
 
-		s := req.AnalyzerResults // engine guarantees a fresh slice per cycle
-		if req.Disaggregated {
-			initDisaggregatedRemaining(s)
-		}
-
-		fsv := fairShareValue(req.Priority, s)
-		if needsScaleUp(s) || fsv > 0 {
-			w := o.buildScaleUpWork(req, satEntry, s, fsv)
+		s := req.AnalyzerResults
+		roles, ps := initRoleState(s)
+		fsv := fairShareValue(req.Priority, s) // updated to role-sum in commit 3
+		if anyRoleNeedsScaleUp(ps, roles) || fsv > 0 {
+			w := o.buildScaleUpWork(req, satEntry, s, ps, roles, fsv)
 			if w != nil {
 				scaleUpWork = append(scaleUpWork, w)
 			}
@@ -125,15 +124,10 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if req.Disaggregated {
-			s := req.AnalyzerResults
-			initDisaggregatedRemaining(s)
-			costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
-		} else {
-			if needsScaleDown(req.AnalyzerResults) {
-				costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
-			}
-		}
+		// Unified scale-down path via scaleDownRoleIterated.
+		s := req.AnalyzerResults
+		_, _ = initRoleState(s) // populates RoleSpare for all roles
+		scaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "greedy-by-score")
 		logger.V(logging.DEBUG).Info("Greedy-by-score optimizer decisions (other)",
@@ -146,7 +140,7 @@ func (o *GreedyByScoreOptimizer) Optimize(
 }
 
 // buildScaleUpWork creates a single work unit for a scale-up request.
-func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *interfaces.AnalyzerResult, s []NamedAnalyzerResult, fsv float64) *modelWork {
+func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *interfaces.AnalyzerResult, s []NamedAnalyzerResult, ps RolePairedState, roles []string, fsv float64) *modelWork {
 	if fsv <= 0 {
 		return nil
 	}
@@ -154,6 +148,8 @@ func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEn
 		req:       req,
 		s:         s,
 		satEntry:  satEntry,
+		ps:        ps,
+		roles:     roles,
 		remaining: fsv,
 		targets:   initTargets(req.VariantStates),
 	}
@@ -230,111 +226,62 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	stateMap := buildStateMap(w.req.VariantStates)
 	oldRemaining := w.remaining
 
-	if w.req.Disaggregated {
-		ps := InitRolePairedState(w.s)
-		pick := fairSharePickPaired(target, w.s)
-		allocateForModelPairedB2(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
-			w.targets, pick, ps, []string{"prefill", "decode"})
-		// GPU budget already decremented inside allocateForModelPairedB2.
+	// Re-initialize picker-state from current s[i].Remaining each call so
+	// multi-iteration fair-sharing sees the correct post-allocation demand.
+	// Cap at target so the loop exits when the fair-share budget is exhausted.
+	_, ps := initRoleState(w.s)
+	for i := range ps {
+		for _, role := range w.roles {
+			if ps[i][role] > target {
+				ps[i][role] = target
+			}
+		}
+	}
+
+	// Unified path: fairShareRolePick behind the RolePickFn interface.
+	// α logic removed in commit 3.
+	pick := fairShareRolePick(target, w.s, w.roles)
+	allocateForModelPaired(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
+		w.targets, pick, ps, w.roles)
+
+	// Recompute w.remaining after allocation.
+	// - "both" single-role (non-disag): s[i].Remaining (P-anchor) is reliable
+	//   since applyAllocation tracks it; fairShareValue reads it correctly.
+	// - P/D multi-role: use role-sum from ps (capped→decremented), which correctly
+	//   reaches 0 when both roles are satisfied in one step.
+	// Commit 3 unifies both cases via fairShareValue reading ps.
+	if len(w.roles) == 1 && w.roles[0] == interfaces.RoleBoth {
+		w.remaining = fairShareValue(w.req.Priority, w.s)
 	} else {
-		pick := fairSharePick(target)
-		o.allocateToVariants(ctx, w, target, w.satEntry.VariantCapacities, stateMap, available, pick)
+		sum := 0.0
+		for i, m := range ps {
+			if w.s[i].Result != nil {
+				for _, demand := range m {
+					sum += demand * w.s[i].Score
+				}
+			}
+		}
+		if sum > 0 {
+			w.remaining = w.req.Priority * sum
+			if w.remaining <= 0 {
+				w.remaining = sum
+			}
+		} else {
+			w.remaining = 0
+		}
 	}
-
-	// Recompute w.remaining from the slice state after allocation.
-	w.remaining = fairShareValue(w.req.Priority, w.s)
 	return w.remaining < oldRemaining
-}
-
-// allocateToVariants allocates replicas from the cheapest available variants,
-// capped by the fair-share pick function, GPU budget, and maxReplicas.
-// Stops when the per-iteration target budget is consumed or no more replicas
-// can be allocated. Updates the working slice via applyAllocation.
-func (o *GreedyByScoreOptimizer) allocateToVariants(
-	ctx context.Context,
-	w *modelWork,
-	target float64,
-	capacities []interfaces.VariantCapacity,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-	pick PickVariantFn,
-) {
-	logger := ctrl.LoggerFrom(ctx)
-	consumed := 0.0
-	for needsScaleUp(w.s) && consumed < target {
-		v, capN := pick(w.s, capacities, stateMap, available, w.targets)
-		if v == "" {
-			break
-		}
-		// Also cap by remaining budget for this iteration.
-		prc := prcFromVCs(capacities, v)
-		if prc > 0 {
-			budgetCap := int(math.Ceil((target - consumed) / prc))
-			capN = min(capN, budgetCap)
-		}
-		n := min(bottleneckReplicas(w.s, v), capN)
-		if n <= 0 {
-			break
-		}
-		capacityAdded := float64(n) * prc
-		applyAllocation(w.s, v, n)
-		w.targets[v] += n
-		consumed += capacityAdded
-		available[accFromVCs(capacities, v)] -= n * gpusPerReplicaFromState(stateMap, v)
-		logger.V(logging.DEBUG).Info("scale-up: allocated replicas",
-			"model", w.req.ModelID, "variant", v, "replicas", n,
-			"budgetConsumed", consumed, "budgetTarget", target)
-	}
 }
 
 // allocateToVariantsPaired was the old α-based paired loop; retired in B2.
 // Greedy's disaggregated scale-up now delegates to allocateForModelPairedB2.
 
-// fairSharePick returns a PickVariantFn that caps allocation by the fair-share
-// target and GPU budget. Cheapest-first within eligible variants.
-func fairSharePick(target float64) PickVariantFn {
-	return func(
-		_ []NamedAnalyzerResult,
-		variants []interfaces.VariantCapacity,
-		stateMap map[string]interfaces.VariantReplicaState,
-		available map[string]int,
-		targets map[string]int,
-	) (string, int) {
-		for _, vc := range sortByCostEfficiencyAsc(variants) {
-			if vc.PerReplicaCapacity <= 0 {
-				continue
-			}
-			state := stateMap[vc.VariantName]
-			gpusPerReplica := state.GPUsPerReplica
-			if gpusPerReplica <= 0 {
-				gpusPerReplica = 1
-			}
-			gpusAvail := available[vc.AcceleratorName]
-			if gpusAvail < gpusPerReplica {
-				continue
-			}
-			fairShareCap := int(math.Ceil(target / vc.PerReplicaCapacity))
-			capN := min(fairShareCap, gpusAvail/gpusPerReplica)
-			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
-				headroom := *state.MaxReplicas - targets[vc.VariantName]
-				if headroom <= 0 {
-					continue
-				}
-				capN = min(capN, headroom)
-			}
-			if capN > 0 {
-				return vc.VariantName, capN
-			}
-		}
-		return "", 0
-	}
-}
-
-// fairSharePickPaired returns a PickPairFn for disaggregated models.
-// Caps each side by the fair-share target scaled by α (D:P demand ratio).
-// α is derived inline from RoleCapacities[*].TotalDemand (workload invariant).
-func fairSharePickPaired(target float64, s []NamedAnalyzerResult) PickPairFn {
-	// Derive α = D/P from the first analyzer that has both sides > 0.
+// fairShareRolePick returns a RolePickFn for the unified allocateForModelPaired loop.
+// Routes the fair-share budget per role: "both" → full target; "prefill" → full
+// target; "decode" → α-scaled target. α derivation is removed in commit 3.
+func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) RolePickFn {
+	// Derive α for D-side cap (commit 3 will drop this and use the joint min-util
+	// commit to enforce the P/D coupling instead).
 	alpha := 1.0
 	for _, e := range s {
 		if e.Result == nil || e.Result.RoleCapacities == nil {
@@ -347,54 +294,47 @@ func fairSharePickPaired(target float64, s []NamedAnalyzerResult) PickPairFn {
 			break
 		}
 	}
+	_ = roles // roles available for future per-role scaling; currently uniform
 	return func(
+		role string,
 		_ []NamedAnalyzerResult,
 		variants []interfaces.VariantCapacity,
 		stateMap map[string]interfaces.VariantReplicaState,
 		available map[string]int,
 		targets map[string]int,
-	) (vP, vD string, capNP, capND int) {
-		var pVCs, dVCs []interfaces.VariantCapacity
-		for _, vc := range variants {
-			switch vc.Role {
-			case "prefill":
-				pVCs = append(pVCs, vc)
-			case "decode":
-				dVCs = append(dVCs, vc)
-			}
+	) (string, int) {
+		roleVCs := variantsForRole(variants, role)
+		scale := 1.0
+		if role == "decode" {
+			scale = alpha
 		}
-		pickSide := func(vcs []interfaces.VariantCapacity, scale float64) (string, int) {
-			for _, vc := range sortByCostEfficiencyAsc(vcs) {
-				if vc.PerReplicaCapacity <= 0 {
+		for _, vc := range sortByCostEfficiencyAsc(roleVCs) {
+			if vc.PerReplicaCapacity <= 0 {
+				continue
+			}
+			state := stateMap[vc.VariantName]
+			gpusPR := state.GPUsPerReplica
+			if gpusPR <= 0 {
+				gpusPR = 1
+			}
+			gpusAvail := available[vc.AcceleratorName]
+			if gpusAvail < gpusPR {
+				continue
+			}
+			fairShareCap := int(math.Ceil(target * scale / vc.PerReplicaCapacity))
+			capN := min(fairShareCap, gpusAvail/gpusPR)
+			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
+				headroom := *state.MaxReplicas - targets[vc.VariantName]
+				if headroom <= 0 {
 					continue
 				}
-				state := stateMap[vc.VariantName]
-				gpusPerReplica := state.GPUsPerReplica
-				if gpusPerReplica <= 0 {
-					gpusPerReplica = 1
-				}
-				gpusAvail := available[vc.AcceleratorName]
-				if gpusAvail < gpusPerReplica {
-					continue
-				}
-				fairShareCap := int(math.Ceil(target * scale / vc.PerReplicaCapacity))
-				capN := min(fairShareCap, gpusAvail/gpusPerReplica)
-				if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
-					headroom := *state.MaxReplicas - targets[vc.VariantName]
-					if headroom <= 0 {
-						continue
-					}
-					capN = min(capN, headroom)
-				}
-				if capN > 0 {
-					return vc.VariantName, capN
-				}
+				capN = min(capN, headroom)
 			}
-			return "", 0
+			if capN > 0 {
+				return vc.VariantName, capN
+			}
 		}
-		vP, capNP = pickSide(pVCs, 1.0)
-		vD, capND = pickSide(dVCs, alpha)
-		return
+		return "", 0
 	}
 }
 

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -275,9 +275,6 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	return w.remaining < oldRemaining
 }
 
-// allocateToVariantsPaired was the old α-based paired loop; retired in B2.
-// Greedy's disaggregated scale-up now delegates to allocateForModelPairedB2.
-
 // fairShareRolePick returns a RolePickFn for the unified allocateForModelPaired loop.
 // Each role receives the same target fair-share budget. The joint Δ_util commit
 // inside allocateForModelPaired enforces P/D coupling — α is no longer needed.

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -11,21 +11,16 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 )
 
-const (
-	// GreedyByScoreOptimizerName is the identifier for the greedy-by-score optimizer
-	GreedyByScoreOptimizerName = "greedy-by-score"
-)
-
 // GreedyByScoreOptimizer is a multi-model optimizer for GPU-constrained
 // environments. It uses iterative mean-based fair-sharing to distribute scarce
-// GPUs across competing models, ordered by composite score
-// (priority * sum(requiredCapacity_i * analyzerScore_i)).
+// GPUs across competing models, ordered by fair-share priority value
+// (priority × Σᵢ(Remainingᵢ × Scoreᵢ) across analyzers).
 //
 // Key differences from CostAwareOptimizer:
 //   - Respects ResourceConstraints (GPU budgets per accelerator type)
-//   - Fair-shares GPUs across models (highest-score model gets GPUs first)
-//   - Distributes replicas between P/D roles proportional to per-role demand
-//   - Scale-down is identical to CostAwareOptimizer (reuses costAwareScaleDown)
+//   - Fair-shares GPUs across models (highest-priority model gets GPUs first)
+//   - Disaggregated models use paired (n_P, n_D) allocation via the paired helpers
+//   - Scale-down reuses costAwareScaleDown / costAwareScaleDownPaired
 type GreedyByScoreOptimizer struct{}
 
 // NewGreedyByScoreOptimizer creates a new GreedyByScoreOptimizer.
@@ -35,15 +30,40 @@ func NewGreedyByScoreOptimizer() *GreedyByScoreOptimizer {
 
 // Name returns the optimizer identifier.
 func (o *GreedyByScoreOptimizer) Name() string {
-	return GreedyByScoreOptimizerName
+	return "greedy-by-score"
 }
 
 // modelWork tracks per-model allocation state during fair-share iteration.
 type modelWork struct {
-	req         ModelScalingRequest
-	remaining   float64            // remaining Score (negative = fully satisfied)
-	targets     map[string]int     // variant name → target replicas (ALL variants)
-	roleDemands map[string]float64 // role → demand fraction; nil for non-disaggregated
+	req       ModelScalingRequest
+	s         []NamedAnalyzerResult      // working slice; Remaining/Spare decremented in place
+	satEntry  *interfaces.AnalyzerResult // variant metadata keeper (Cost, AcceleratorName, Role)
+	remaining float64                    // fair-share priority metric (negative = fully satisfied)
+	targets   map[string]int             // variant name → target replicas (ALL variants)
+}
+
+// fairShareValue computes the fair-share priority metric for one model from its
+// per-analyzer working slice. Returns priority × Σᵢ(Remainingᵢ × Scoreᵢ).
+// Falls back to max_i(Remainingᵢ) when the weighted result is zero (priority
+// unset or no score weights), matching the original fallback to RequiredCapacity.
+func fairShareValue(priority float64, s []NamedAnalyzerResult) float64 {
+	weighted := 0.0
+	for _, e := range s {
+		if e.Result != nil {
+			weighted += e.Remaining * e.Score
+		}
+	}
+	if fsv := priority * weighted; fsv > 0 {
+		return fsv
+	}
+	// Fallback: bottleneck remaining without priority scaling.
+	maxRemaining := 0.0
+	for _, e := range s {
+		if e.Result != nil && e.Remaining > maxRemaining {
+			maxRemaining = e.Remaining
+		}
+	}
+	return maxRemaining
 }
 
 // Optimize produces VariantDecisions for all models, fair-sharing GPUs across
@@ -56,17 +76,24 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	logger := ctrl.LoggerFrom(ctx).WithName(o.Name())
 	available := mergeConstraints(constraints)
 
-	// Separate scale-up and scale-down/steady models
 	var scaleUpWork []*modelWork
 	var otherRequests []ModelScalingRequest
 
 	for _, req := range requests {
-		if req.Result == nil {
+		satEntry := saturationEntry(req.AnalyzerResults)
+		if satEntry == nil {
 			continue
 		}
 
-		if req.Result.RequiredCapacity > 0 || req.Result.Score > 0 {
-			w := o.buildScaleUpWork(req)
+		s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
+		copy(s, req.AnalyzerResults)
+		if isDisaggregated(satEntry.VariantCapacities) {
+			initDisaggregatedRemaining(s)
+		}
+
+		fsv := fairShareValue(req.Priority, s)
+		if needsScaleUp(s) || fsv > 0 {
+			w := o.buildScaleUpWork(req, satEntry, s, fsv)
 			if w != nil {
 				scaleUpWork = append(scaleUpWork, w)
 			}
@@ -75,16 +102,14 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		}
 	}
 
-	// Scale-up: iterative mean-based fair sharing
 	o.fairShareScaleUp(ctx, scaleUpWork, available)
 
-	// Build all decisions
 	allDecisions := make([]interfaces.VariantDecision, 0, len(scaleUpWork))
 
 	for _, w := range scaleUpWork {
 		stateMap := buildStateMap(w.req.VariantStates)
-		vcMap := buildCapacityMap(w.req.Result.VariantCapacities)
-		decisions := buildDecisionsWithOptimizer(w.req, stateMap, vcMap, w.targets, GreedyByScoreOptimizerName)
+		vcMap := buildCapacityMap(w.satEntry.VariantCapacities)
+		decisions := buildDecisionsWithOptimizer(w.req, stateMap, vcMap, w.targets, "greedy-by-score")
 		logger.V(logging.DEBUG).Info("Greedy-by-score optimizer decisions (scale-up)",
 			"modelID", w.req.ModelID,
 			"decisions", len(decisions))
@@ -101,11 +126,18 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if needsScaleDown(req.AnalyzerResults) {
-			costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+		if isDisaggregated(satEntry.VariantCapacities) {
+			s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
+			copy(s, req.AnalyzerResults)
+			initDisaggregatedRemaining(s)
+			costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
+		} else {
+			if needsScaleDown(req.AnalyzerResults) {
+				costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
+			}
 		}
 
-		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, GreedyByScoreOptimizerName)
+		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, "greedy-by-score")
 		logger.V(logging.DEBUG).Info("Greedy-by-score optimizer decisions (other)",
 			"modelID", req.ModelID,
 			"decisions", len(decisions))
@@ -116,47 +148,20 @@ func (o *GreedyByScoreOptimizer) Optimize(
 }
 
 // buildScaleUpWork creates a single work unit for a scale-up request.
-// For disaggregated models, computes demand fractions per role so that
-// allocateForModel distributes replicas proportional to per-role demand.
-func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest) *modelWork {
-	remaining := req.Result.Score
-	if remaining <= 0 {
-		remaining = req.Result.RequiredCapacity
-	}
-	if remaining <= 0 {
+func (o *GreedyByScoreOptimizer) buildScaleUpWork(req ModelScalingRequest, satEntry *interfaces.AnalyzerResult, s []NamedAnalyzerResult, fsv float64) *modelWork {
+	if fsv <= 0 {
 		return nil
 	}
-
-	w := &modelWork{
+	return &modelWork{
 		req:       req,
-		remaining: remaining,
+		s:         s,
+		satEntry:  satEntry,
+		remaining: fsv,
 		targets:   initTargets(req.VariantStates),
 	}
-
-	// For disaggregated models, compute demand fractions per role
-	if req.Disaggregated && req.Result.RoleCapacities != nil {
-		totalDemand := 0.0
-		for _, rc := range req.Result.RoleCapacities {
-			if rc.RequiredCapacity > 0 {
-				totalDemand += rc.RequiredCapacity
-			}
-		}
-		if totalDemand > 0 {
-			w.roleDemands = make(map[string]float64)
-			for role, rc := range req.Result.RoleCapacities {
-				if rc.RequiredCapacity > 0 {
-					w.roleDemands[role] = rc.RequiredCapacity / totalDemand
-				}
-			}
-		}
-	}
-
-	return w
 }
 
 // fairShareScaleUp implements the iterative mean-based fair-sharing algorithm.
-// Each iteration picks the most starved model and allocates enough replicas to
-// bring its remaining score below the current mean.
 func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 	ctx context.Context,
 	work []*modelWork,
@@ -165,13 +170,11 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 	logger := ctrl.LoggerFrom(ctx)
 
 	for {
-		// Filter active models (remaining > 0)
 		active := filterActive(work)
 		if len(active) == 0 {
 			break
 		}
 
-		// Check if any GPUs remain
 		totalGPUs := 0
 		for _, v := range available {
 			totalGPUs += v
@@ -181,18 +184,13 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 			break
 		}
 
-		// Compute mean remaining score
 		mean := computeMean(active)
 		logger.V(logging.DEBUG).Info("GreedyByScore: iteration",
 			"activeModels", len(active), "meanRemaining", mean)
 
-		// Sort by remaining DESC (most starved first)
 		sortByRemainingDesc(active)
-
-		// Pick the most starved model
 		w := active[0]
 
-		// Compute allocation target
 		allocationMean := mean
 		if len(active) == 1 {
 			allocationMean = 0
@@ -200,7 +198,6 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 			allocationMean = mean - (w.remaining / float64(len(active)))
 		}
 
-		// Allocate replicas
 		allocated := o.allocateForModel(ctx, w, allocationMean, available)
 
 		if !allocated {
@@ -218,9 +215,9 @@ func (o *GreedyByScoreOptimizer) fairShareScaleUp(
 	}
 }
 
-// allocateForModel allocates replicas to bring the model's remaining score
-// below the mean. For disaggregated models, distributes replicas between
-// roles proportional to their per-role demand.
+// allocateForModel allocates replicas to bring the model's remaining score below
+// the mean. Dispatches to the paired path for disaggregated models.
+// After allocation, w.remaining is recomputed from the working slice.
 func (o *GreedyByScoreOptimizer) allocateForModel(
 	ctx context.Context,
 	w *modelWork,
@@ -233,74 +230,25 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	}
 
 	stateMap := buildStateMap(w.req.VariantStates)
+	oldRemaining := w.remaining
 
-	if w.roleDemands != nil {
-		return o.allocateByRole(ctx, w, target, stateMap, available)
+	if isDisaggregated(w.satEntry.VariantCapacities) {
+		pick := fairSharePickPaired(target, w.s)
+		o.allocateToVariantsPaired(ctx, w, target, stateMap, available, pick)
+	} else {
+		pick := fairSharePick(target)
+		o.allocateToVariants(ctx, w, target, w.satEntry.VariantCapacities, stateMap, available, pick)
 	}
 
-	return o.allocateToVariants(ctx, w, target, w.req.Result.VariantCapacities, stateMap, available, interfaces.RoleBoth)
+	// Recompute w.remaining from the slice state after allocation.
+	w.remaining = fairShareValue(w.req.Priority, w.s)
+	return w.remaining < oldRemaining
 }
 
-// allocateByRole distributes replicas between roles proportional to their demand.
-// Higher-demand roles are allocated first. If a role cannot fully allocate
-// (e.g. accelerator exhausted), its unallocated portion is consumed from
-// remaining so it does not overflow to other roles in subsequent iterations.
-func (o *GreedyByScoreOptimizer) allocateByRole(
-	ctx context.Context,
-	w *modelWork,
-	totalTarget float64,
-	stateMap map[string]interfaces.VariantReplicaState,
-	available map[string]int,
-) bool {
-	logger := ctrl.LoggerFrom(ctx)
-
-	// Sort roles by demand fraction DESC to prioritize higher-demand roles
-	type roleFraction struct {
-		role     string
-		fraction float64
-	}
-	roles := make([]roleFraction, 0, len(w.roleDemands))
-	for role, fraction := range w.roleDemands {
-		roles = append(roles, roleFraction{role, fraction})
-	}
-	sort.Slice(roles, func(i, j int) bool {
-		return roles[i].fraction > roles[j].fraction
-	})
-
-	allocated := false
-	for _, rf := range roles {
-		roleTarget := totalTarget * rf.fraction
-		if roleTarget <= 0 {
-			continue
-		}
-
-		roleVariants := filterVariantCapacitiesByRole(w.req.Result.VariantCapacities, rf.role)
-		if len(roleVariants) == 0 {
-			// Role has no variants — consume its share so it doesn't overflow
-			w.remaining -= roleTarget
-			logger.V(logging.DEBUG).Info("GreedyByScore: no variants for role, consuming share",
-				"model", w.req.ModelID, "role", rf.role, "consumed", roleTarget)
-			continue
-		}
-
-		remainingBefore := w.remaining
-		if o.allocateToVariants(ctx, w, roleTarget, roleVariants, stateMap, available, rf.role) {
-			allocated = true
-		}
-		// Consume any unallocated portion so it doesn't overflow to other roles
-		capacityAllocated := remainingBefore - w.remaining
-		unallocated := roleTarget - capacityAllocated
-		if unallocated > 0 {
-			w.remaining -= unallocated
-			logger.V(logging.DEBUG).Info("GreedyByScore: role partially allocated, consuming remainder",
-				"model", w.req.ModelID, "role", rf.role, "allocated", capacityAllocated, "consumed", unallocated)
-		}
-	}
-	return allocated
-}
-
-// allocateToVariants allocates replicas from the cheapest available variants
-// within the given capacity set, up to the specified target.
+// allocateToVariants allocates replicas from the cheapest available variants,
+// capped by the fair-share pick function, GPU budget, and maxReplicas.
+// Stops when the per-iteration target budget is consumed or no more replicas
+// can be allocated. Updates the working slice via applyAllocation.
 func (o *GreedyByScoreOptimizer) allocateToVariants(
 	ctx context.Context,
 	w *modelWork,
@@ -308,67 +256,183 @@ func (o *GreedyByScoreOptimizer) allocateToVariants(
 	capacities []interfaces.VariantCapacity,
 	stateMap map[string]interfaces.VariantReplicaState,
 	available map[string]int,
-	role string,
-) bool {
+	pick PickVariantFn,
+) {
 	logger := ctrl.LoggerFrom(ctx)
-	sorted := sortByCostEfficiencyAsc(capacities)
-
-	allocated := false
-	for _, vc := range sorted {
-		if target <= 0 {
+	consumed := 0.0
+	for needsScaleUp(w.s) && consumed < target {
+		v, capN := pick(w.s, capacities, stateMap, available, w.targets)
+		if v == "" {
 			break
 		}
-		if vc.PerReplicaCapacity <= 0 {
-			continue
+		// Also cap by remaining budget for this iteration.
+		prc := prcFromVCs(capacities, v)
+		if prc > 0 {
+			budgetCap := int(math.Ceil((target - consumed) / prc))
+			capN = min(capN, budgetCap)
 		}
-
-		state := stateMap[vc.VariantName]
-		gpusPerReplica := state.GPUsPerReplica
-		if gpusPerReplica <= 0 {
-			gpusPerReplica = 1
-		}
-		gpusAvail := available[vc.AcceleratorName]
-		if gpusAvail < gpusPerReplica {
-			continue
-		}
-
-		n := int(math.Ceil(target / vc.PerReplicaCapacity))
-		maxByGPU := gpusAvail / gpusPerReplica
-		if n > maxByGPU {
-			n = maxByGPU
-		}
-
-		// Cap by maxReplicas if set
-		if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
-			maxAdd := *state.MaxReplicas - w.targets[vc.VariantName]
-			if maxAdd <= 0 {
-				continue // already at max
-			}
-			if n > maxAdd {
-				n = maxAdd
-			}
-		}
-
+		n := min(bottleneckReplicas(w.s, v), capN)
 		if n <= 0 {
+			break
+		}
+		capacityAdded := float64(n) * prc
+		applyAllocation(w.s, v, n)
+		w.targets[v] += n
+		consumed += capacityAdded
+		available[accFromVCs(capacities, v)] -= n * gpusPerReplicaFromState(stateMap, v)
+		logger.V(logging.DEBUG).Info("scale-up: allocated replicas",
+			"model", w.req.ModelID, "variant", v, "replicas", n,
+			"budgetConsumed", consumed, "budgetTarget", target)
+	}
+}
+
+// allocateToVariantsPaired allocates paired (n_P, n_D) replicas for disaggregated models.
+// Stops when the per-iteration target budget (in P-units) is consumed.
+func (o *GreedyByScoreOptimizer) allocateToVariantsPaired(
+	ctx context.Context,
+	w *modelWork,
+	target float64,
+	stateMap map[string]interfaces.VariantReplicaState,
+	available map[string]int,
+	pick PickPairFn,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+	consumed := 0.0
+	for needsScaleUp(w.s) && consumed < target {
+		vP, vD, capNP, capND := pick(w.s, w.satEntry.VariantCapacities, stateMap, available, w.targets)
+		if vP == "" || vD == "" {
+			break
+		}
+		// Cap by remaining budget (P-units).
+		prcP := prcFromVCs(w.satEntry.VariantCapacities, vP)
+		if prcP > 0 {
+			budgetCap := int(math.Ceil((target - consumed) / prcP))
+			capNP = min(capNP, budgetCap)
+		}
+		nP, nD := bottleneckReplicasPaired(w.s, vP, vD)
+		nP = min(nP, capNP)
+		nD = min(nD, capND)
+		if nP <= 0 && nD <= 0 {
+			break
+		}
+		applyAllocationPaired(w.s, vP, nP, vD, nD)
+		w.targets[vP] += nP
+		w.targets[vD] += nD
+		consumed += float64(nP) * prcP
+		available[accFromVCs(w.satEntry.VariantCapacities, vP)] -= nP * gpusPerReplicaFromState(stateMap, vP)
+		available[accFromVCs(w.satEntry.VariantCapacities, vD)] -= nD * gpusPerReplicaFromState(stateMap, vD)
+		logger.V(logging.DEBUG).Info("scale-up paired: allocated replicas",
+			"model", w.req.ModelID,
+			"prefill-variant", vP, "prefill-replicas", nP,
+			"decode-variant", vD, "decode-replicas", nD,
+			"budgetConsumed", consumed, "budgetTarget", target)
+	}
+}
+
+// fairSharePick returns a PickVariantFn that caps allocation by the fair-share
+// target and GPU budget. Cheapest-first within eligible variants.
+func fairSharePick(target float64) PickVariantFn {
+	return func(
+		_ []NamedAnalyzerResult,
+		variants []interfaces.VariantCapacity,
+		stateMap map[string]interfaces.VariantReplicaState,
+		available map[string]int,
+		targets map[string]int,
+	) (string, int) {
+		for _, vc := range sortByCostEfficiencyAsc(variants) {
+			if vc.PerReplicaCapacity <= 0 {
+				continue
+			}
+			state := stateMap[vc.VariantName]
+			gpusPerReplica := state.GPUsPerReplica
+			if gpusPerReplica <= 0 {
+				gpusPerReplica = 1
+			}
+			gpusAvail := available[vc.AcceleratorName]
+			if gpusAvail < gpusPerReplica {
+				continue
+			}
+			fairShareCap := int(math.Ceil(target / vc.PerReplicaCapacity))
+			capN := min(fairShareCap, gpusAvail/gpusPerReplica)
+			if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
+				headroom := *state.MaxReplicas - targets[vc.VariantName]
+				if headroom <= 0 {
+					continue
+				}
+				capN = min(capN, headroom)
+			}
+			if capN > 0 {
+				return vc.VariantName, capN
+			}
+		}
+		return "", 0
+	}
+}
+
+// fairSharePickPaired returns a PickPairFn for disaggregated models.
+// Caps each side by the fair-share target scaled by α.
+func fairSharePickPaired(target float64, s []NamedAnalyzerResult) PickPairFn {
+	// Derive α from the slice (first analyzer tracking both sides).
+	alpha := 1.0
+	for _, e := range s {
+		if e.Result == nil {
 			continue
 		}
-
-		w.targets[vc.VariantName] += n
-		capacityAdded := float64(n) * vc.PerReplicaCapacity
-		w.remaining -= capacityAdded
-		target -= capacityAdded
-		available[vc.AcceleratorName] -= n * gpusPerReplica
-
-		logger.V(logging.DEBUG).Info("GreedyByScore: allocated replicas",
-			"model", w.req.ModelID,
-			"role", role,
-			"variant", vc.VariantName,
-			"replicas", n,
-			"gpusUsed", n*gpusPerReplica,
-			"remainingScore", w.remaining)
-		allocated = true
+		a, _, tracksD := analyzerAlpha(e.Result)
+		if tracksD {
+			alpha = a
+			break
+		}
 	}
-	return allocated
+	return func(
+		_ []NamedAnalyzerResult,
+		variants []interfaces.VariantCapacity,
+		stateMap map[string]interfaces.VariantReplicaState,
+		available map[string]int,
+		targets map[string]int,
+	) (vP, vD string, capNP, capND int) {
+		var pVCs, dVCs []interfaces.VariantCapacity
+		for _, vc := range variants {
+			switch vc.Role {
+			case "prefill":
+				pVCs = append(pVCs, vc)
+			case "decode":
+				dVCs = append(dVCs, vc)
+			}
+		}
+		pickSide := func(vcs []interfaces.VariantCapacity, scale float64) (string, int) {
+			for _, vc := range sortByCostEfficiencyAsc(vcs) {
+				if vc.PerReplicaCapacity <= 0 {
+					continue
+				}
+				state := stateMap[vc.VariantName]
+				gpusPerReplica := state.GPUsPerReplica
+				if gpusPerReplica <= 0 {
+					gpusPerReplica = 1
+				}
+				gpusAvail := available[vc.AcceleratorName]
+				if gpusAvail < gpusPerReplica {
+					continue
+				}
+				fairShareCap := int(math.Ceil(target * scale / vc.PerReplicaCapacity))
+				capN := min(fairShareCap, gpusAvail/gpusPerReplica)
+				if state.MaxReplicas != nil && *state.MaxReplicas > 0 {
+					headroom := *state.MaxReplicas - targets[vc.VariantName]
+					if headroom <= 0 {
+						continue
+					}
+					capN = min(capN, headroom)
+				}
+				if capN > 0 {
+					return vc.VariantName, capN
+				}
+			}
+			return "", 0
+		}
+		vP, capNP = pickSide(pVCs, 1.0)
+		vD, capND = pickSide(dVCs, alpha)
+		return
+	}
 }
 
 // filterVariantCapacitiesByRole returns variant capacities matching the specified role.
@@ -418,6 +482,34 @@ func sortByRemainingDesc(active []*modelWork) {
 	sort.Slice(active, func(i, j int) bool {
 		return active[i].remaining > active[j].remaining
 	})
+}
+
+// prcFromVCs returns the PerReplicaCapacity for variant v from a slice of VCs.
+func prcFromVCs(vcs []interfaces.VariantCapacity, v string) float64 {
+	for _, vc := range vcs {
+		if vc.VariantName == v {
+			return vc.PerReplicaCapacity
+		}
+	}
+	return 0
+}
+
+// accFromVCs returns the AcceleratorName for variant v from a slice of VCs.
+func accFromVCs(vcs []interfaces.VariantCapacity, v string) string {
+	for _, vc := range vcs {
+		if vc.VariantName == v {
+			return vc.AcceleratorName
+		}
+	}
+	return ""
+}
+
+// gpusPerReplicaFromState returns GPUsPerReplica for variant v, defaulting to 1.
+func gpusPerReplicaFromState(stateMap map[string]interfaces.VariantReplicaState, v string) int {
+	if state, ok := stateMap[v]; ok && state.GPUsPerReplica > 0 {
+		return state.GPUsPerReplica
+	}
+	return 1
 }
 
 // Ensure GreedyByScoreOptimizer implements ScalingOptimizer

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -92,12 +92,17 @@ func (o *GreedyByScoreOptimizer) Optimize(
 	}
 
 	for _, req := range otherRequests {
+		satEntry := saturationEntry(req.AnalyzerResults)
+		if satEntry == nil {
+			continue
+		}
+
 		stateMap := buildStateMap(req.VariantStates)
-		vcMap := buildCapacityMap(req.Result.VariantCapacities)
+		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if req.Result.SpareCapacity > 0 {
-			costAwareScaleDown(ctx, req.Result, targets, stateMap)
+		if needsScaleDown(req.AnalyzerResults) {
+			costAwareScaleDown(ctx, req.AnalyzerResults, satEntry.VariantCapacities, targets, stateMap)
 		}
 
 		decisions := buildDecisionsWithOptimizer(req, stateMap, vcMap, targets, GreedyByScoreOptimizerName)

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -320,7 +320,6 @@ func fairShareRolePick(target float64, s []NamedAnalyzerResult, roles []string) 
 	}
 }
 
-
 // filterActive returns modelWork entries that still have remaining > 0.
 func filterActive(work []*modelWork) []*modelWork {
 	var active []*modelWork

--- a/internal/engines/pipeline/greedy_score_optimizer.go
+++ b/internal/engines/pipeline/greedy_score_optimizer.go
@@ -85,9 +85,8 @@ func (o *GreedyByScoreOptimizer) Optimize(
 			continue
 		}
 
-		s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
-		copy(s, req.AnalyzerResults)
-		if isDisaggregated(satEntry.VariantCapacities) {
+		s := req.AnalyzerResults // engine guarantees a fresh slice per cycle
+		if req.Disaggregated {
 			initDisaggregatedRemaining(s)
 		}
 
@@ -126,9 +125,8 @@ func (o *GreedyByScoreOptimizer) Optimize(
 		vcMap := buildCapacityMap(satEntry.VariantCapacities)
 		targets := initTargets(req.VariantStates)
 
-		if isDisaggregated(satEntry.VariantCapacities) {
-			s := make([]NamedAnalyzerResult, len(req.AnalyzerResults))
-			copy(s, req.AnalyzerResults)
+		if req.Disaggregated {
+			s := req.AnalyzerResults
 			initDisaggregatedRemaining(s)
 			costAwareScaleDownRoleIterated(ctx, s, satEntry.VariantCapacities, targets, stateMap)
 		} else {
@@ -232,7 +230,7 @@ func (o *GreedyByScoreOptimizer) allocateForModel(
 	stateMap := buildStateMap(w.req.VariantStates)
 	oldRemaining := w.remaining
 
-	if isDisaggregated(w.satEntry.VariantCapacities) {
+	if w.req.Disaggregated {
 		ps := InitRolePairedState(w.s)
 		pick := fairSharePickPaired(target, w.s)
 		allocateForModelPairedB2(ctx, w.s, w.satEntry.VariantCapacities, stateMap, available,
@@ -400,24 +398,6 @@ func fairSharePickPaired(target float64, s []NamedAnalyzerResult) PickPairFn {
 	}
 }
 
-// filterVariantCapacitiesByRole returns variant capacities matching the specified role.
-// For role RoleBoth or empty, returns all capacities.
-func filterVariantCapacitiesByRole(capacities []interfaces.VariantCapacity, role string) []interfaces.VariantCapacity {
-	if role == interfaces.RoleBoth || role == "" {
-		return capacities
-	}
-	var filtered []interfaces.VariantCapacity
-	for _, vc := range capacities {
-		vcRole := vc.Role
-		if vcRole == "" {
-			vcRole = interfaces.RoleBoth
-		}
-		if vcRole == role {
-			filtered = append(filtered, vc)
-		}
-	}
-	return filtered
-}
 
 // filterActive returns modelWork entries that still have remaining > 0.
 func filterActive(work []*modelWork) []*modelWork {

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -372,7 +372,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 	Context("Scale-Down", func() {
 
-		It("should reuse costAwareScaleDown for scale-down models", func() {
+		It("should apply role-iterated scale-down for scale-down models", func() {
 			r := &interfaces.AnalyzerResult{
 				SpareCapacity: 15000,
 				VariantCapacities: []interfaces.VariantCapacity{
@@ -1025,7 +1025,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(dm["cheap"].TargetReplicas).To(BeNumerically("<=", 3))
 		})
 
-		It("scale-down should respect minReplicas via costAwareScaleDown", func() {
+		It("scale-down should respect minReplicas via scaleDownRoleIterated", func() {
 			intPtr := func(n int) *int { return &n }
 
 			r := &interfaces.AnalyzerResult{

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -686,6 +686,80 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// High-score model (100000) should get GPU preference over low-score (20000)
 			Expect(dm["high-v"].TargetReplicas).To(BeNumerically(">=", 2))
 		})
+
+		// T1.3: multi-model fair-share priority integration test.
+		// Verifies that fairShareValue = priority × Σ(Remaining × Score) correctly
+		// orders models. This test explicitly sets Score on AnalyzerResults, mirroring
+		// what the engine populates from config.Analyzers[].Score after the B1 fix.
+		// Without B1 (Score=0), fairShareValue falls back to max_i(Remaining) = RC,
+		// making both models equal — this test would then produce non-deterministic
+		// results and the strict equality assertions would fail intermittently.
+		It("T1.3: priority × Score weighting drives fair-share ordering", func() {
+			// Model A: RC=20000, Score=1.0, Priority=1.0 → fsv=20000
+			// Model B: RC=20000, Score=1.0, Priority=5.0 → fsv=100000
+			// With 4 A100 GPUs (2 replicas each, 2 GPUs/replica):
+			// B (fsv=100000) should always get served first.
+			// Strict assertions require Score to be populated; Score=0 fallback
+			// produces equal fsv and non-deterministic ordering.
+			rA := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-A",
+					Namespace: "default",
+					Priority:  1.0,
+					AnalyzerResults: []NamedAnalyzerResult{{
+						Name:      interfaces.SaturationAnalyzerName,
+						Result:    rA,
+						Score:     1.0, // explicit: mirrors engine-populated value
+						Remaining: rA.RequiredCapacity,
+						Spare:     rA.SpareCapacity,
+					}},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+				{
+					ModelID:   "model-B",
+					Namespace: "default",
+					Priority:  5.0,
+					AnalyzerResults: []NamedAnalyzerResult{{
+						Name:      interfaces.SaturationAnalyzerName,
+						Result:    rB,
+						Score:     1.0, // explicit: mirrors engine-populated value
+						Remaining: rB.RequiredCapacity,
+						Spare:     rB.SpareCapacity,
+					}},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+			}
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{
+					"A100": {Limit: 4}, // 2 replicas worth
+				}},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			// fsv(A) = 1.0 * 20000 * 1.0 = 20000; fsv(B) = 5.0 * 20000 * 1.0 = 100000
+			// B is most starved (highest fsv), gets both available replicas.
+			// A gets nothing (GPU budget exhausted by B).
+			Expect(dm["b-v1"].TargetReplicas).To(Equal(3)) // 1 + 2 (all GPUs)
+			Expect(dm["a-v1"].TargetReplicas).To(Equal(1)) // unchanged
+		})
 	})
 
 	Context("Demand-Proportional P/D Distribution", func() {

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -374,7 +374,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should reuse costAwareScaleDown for scale-down models", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -388,7 +388,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -413,7 +413,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						{VariantName: "up-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
 				},
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-down",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -425,7 +425,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "down-v1", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -522,7 +522,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should handle steady state (no scaling needed)", func() {
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -535,7 +535,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -963,7 +963,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			intPtr := func(n int) *int { return &n }
 
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -980,7 +980,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						{VariantName: "expensive", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3, GPUsPerReplica: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -994,7 +994,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			intPtr := func(n int) *int { return &n }
 
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -1011,7 +1011,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 						{VariantName: "keep-alive", CurrentReplicas: 2, GPUsPerReplica: 1, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(0)},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -1101,29 +1101,6 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(active[2].req.ModelID).To(Equal("low"))
 		})
 
-		It("filterVariantCapacitiesByRole should filter by role", func() {
-			capacities := []interfaces.VariantCapacity{
-				{VariantName: "prefill-v", Role: "prefill"},
-				{VariantName: "decode-v", Role: "decode"},
-				{VariantName: "both-v", Role: "both"},
-				{VariantName: "empty-v", Role: ""},
-			}
-
-			prefill := filterVariantCapacitiesByRole(capacities, "prefill")
-			Expect(prefill).To(HaveLen(1))
-			Expect(prefill[0].VariantName).To(Equal("prefill-v"))
-
-			decode := filterVariantCapacitiesByRole(capacities, "decode")
-			Expect(decode).To(HaveLen(1))
-			Expect(decode[0].VariantName).To(Equal("decode-v"))
-
-			// "both" returns all
-			both := filterVariantCapacitiesByRole(capacities, "both")
-			Expect(both).To(HaveLen(4))
-
-			// empty returns all
-			empty := filterVariantCapacitiesByRole(capacities, "")
-			Expect(empty).To(HaveLen(4))
-		})
+		// filterVariantCapacitiesByRole removed (duplicate of variantsForRole in analyzer_helpers.go; N2 cleanup)
 	})
 })

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -29,25 +29,25 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Single-Model Scale-Up", func() {
 
 		It("should allocate replicas to cheapest variant within GPU budget", func() {
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				AnalyzedAt:       time.Now(),
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						AnalyzedAt:       time.Now(),
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "expensive", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -67,20 +67,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle GPU exhaustion with partial allocation", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -100,33 +100,33 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Multi-Model Fair-Share", func() {
 
 		It("should give GPUs to most starved model first", func() {
+			rA := &interfaces.AnalyzerResult{
+				RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-A",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				{
+				}),
+				withSatEntry(rB, ModelScalingRequest{
 					ModelID:   "model-B",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -143,46 +143,46 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should verify 3-model walkthrough from design doc", func() {
+			rA := &interfaces.AnalyzerResult{
+				RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				RequiredCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
+			rC := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "c-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-A",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				{
+				}),
+				withSatEntry(rB, ModelScalingRequest{
 					ModelID:   "model-B",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				{
+				}),
+				withSatEntry(rC, ModelScalingRequest{
 					ModelID:   "model-C",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "c-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "c-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -199,33 +199,33 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should distribute evenly with equal RequiredCapacity", func() {
+			rX := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "x-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rY := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "y-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rX, ModelScalingRequest{
 					ModelID:   "model-X",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "x-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "x-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				{
+				}),
+				withSatEntry(rY, ModelScalingRequest{
 					ModelID:   "model-Y",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "y-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "y-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -244,33 +244,33 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("GPU Constraints", func() {
 
 		It("should respect per-accelerator-type limits", func() {
+			rH := &interfaces.AnalyzerResult{
+				RequiredCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
+			rA := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rH, ModelScalingRequest{
 					ModelID:   "model-h100",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "h100-v", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
-				},
-				{
+				}),
+				withSatEntry(rA, ModelScalingRequest{
 					ModelID:   "model-a100",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "a100-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -287,22 +287,22 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle mixed accelerator types across variants", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-mixed",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "a100-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "h100-v", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "a100-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "h100-v", CurrentReplicas: 1, GPUsPerReplica: 4},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -319,20 +319,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should not allocate when zero GPU budget", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -347,20 +347,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should not allocate when nil constraints", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -373,17 +373,17 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Scale-Down", func() {
 
 		It("should reuse costAwareScaleDown for scale-down models", func() {
+			r := &interfaces.AnalyzerResult{
+				SpareCapacity: 15000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 15000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 3},
 						{VariantName: "expensive", CurrentReplicas: 2},
@@ -399,29 +399,29 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle mixed scale-up and scale-down models", func() {
+			rUp := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "up-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rDown := &interfaces.AnalyzerResult{
+				SpareCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "down-v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rUp, ModelScalingRequest{
 					ModelID:   "model-up",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "up-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "up-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				withSatEntry(ModelScalingRequest{
+				}),
+				withSatEntry(rDown, ModelScalingRequest{
 					ModelID:   "model-down",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						SpareCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "down-v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "down-v1", CurrentReplicas: 2},
 					},
@@ -447,22 +447,22 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Pending Replicas", func() {
 
 		It("should allocate to most cost-efficient variant regardless of pending replicas", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap-pending", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "expensive-ready", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap-pending", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "expensive-ready", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap-pending", CurrentReplicas: 2, PendingReplicas: 1, GPUsPerReplica: 2},
 						{VariantName: "expensive-ready", CurrentReplicas: 1, PendingReplicas: 0, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -482,7 +482,7 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should skip requests with nil result", func() {
 			requests := []ModelScalingRequest{
-				{ModelID: "model-1", Namespace: "default", Result: nil},
+				withSatEntry(nil, ModelScalingRequest{ModelID: "model-1", Namespace: "default"}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, nil)
@@ -490,22 +490,22 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should skip variants with zero capacity", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "zero-cap", AcceleratorName: "A100", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
+					{VariantName: "normal", AcceleratorName: "A100", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "zero-cap", AcceleratorName: "A100", Cost: 1.0, ReplicaCount: 0, PerReplicaCapacity: 0},
-							{VariantName: "normal", AcceleratorName: "A100", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "zero-cap", CurrentReplicas: 0, GPUsPerReplica: 2},
 						{VariantName: "normal", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -521,17 +521,17 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should handle steady state (no scaling needed)", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 0,
+				SpareCapacity:    0,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 0,
-						SpareCapacity:    0,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 2},
 					},
@@ -551,20 +551,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should default GPUsPerReplica to 1 when not specified", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 0},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -582,20 +582,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Decision Metadata", func() {
 
 		It("should set correct model ID, namespace, and cost on decisions", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "ns-1",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -613,20 +613,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should contain greedy-by-score in reason strings", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -644,37 +644,35 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 	Context("Score-Based Priority", func() {
 
 		It("should give GPUs to higher-score model first", func() {
+			rLow := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "low-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rHigh := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "high-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(rLow, ModelScalingRequest{
 					ModelID:   "low-priority",
 					Namespace: "default",
 					Priority:  1.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						Score:            20000, // 1.0 * 20000
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "low-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "low-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
-				{
+				}),
+				withSatEntry(rHigh, ModelScalingRequest{
 					ModelID:   "high-priority",
 					Namespace: "default",
 					Priority:  5.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						Score:            100000, // 5.0 * 20000
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "high-v", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "high-v", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -696,29 +694,28 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			// Prefill RequiredCapacity=15000 (75%), Decode RequiredCapacity=5000 (25%)
 			// Total model RequiredCapacity=20000, Score=20000
 			// With 10 A100 GPUs available, each variant uses 2 GPUs/replica
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 15000, TotalDemand: 15000},
+					"decode":  {Role: "decode", RequiredCapacity: 5000, TotalDemand: 5000},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:       "model-pd",
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						Score:            20000,
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", RequiredCapacity: 15000},
-							"decode":  {Role: "decode", RequiredCapacity: 5000},
-						},
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 3, GPUsPerReplica: 2, Role: "decode"},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -737,29 +734,28 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		})
 
 		It("should distribute equally when roles have equal demand", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
+					"decode":  {Role: "decode", RequiredCapacity: 10000, TotalDemand: 10000},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:       "model-equal",
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						Score:            20000,
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", RequiredCapacity: 10000},
-							"decode":  {Role: "decode", RequiredCapacity: 10000},
-						},
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "decode"},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -777,29 +773,28 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should only allocate to the role that needs scale-up", func() {
 			// Only prefill needs scale-up; decode has 0 RequiredCapacity
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
+					"decode":  {Role: "decode", RequiredCapacity: 0, TotalDemand: 0},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:       "model-prefill-only",
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						Score:            10000,
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", RequiredCapacity: 10000},
-							"decode":  {Role: "decode", RequiredCapacity: 0},
-						},
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill-v", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 3, GPUsPerReplica: 2, Role: "decode"},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -818,29 +813,28 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		It("should handle GPU exhaustion for one role without affecting the other", func() {
 			// Prefill uses H100s (exhausted), decode uses A100s (available)
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {Role: "prefill", RequiredCapacity: 10000, TotalDemand: 10000},
+					"decode":  {Role: "decode", RequiredCapacity: 10000, TotalDemand: 10000},
+				},
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "prefill-v", AcceleratorName: "H100", Cost: 15.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 20000},
+					{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:       "model-mixed-gpu",
 					Namespace:     "default",
 					Disaggregated: true,
 					Priority:      1.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 20000,
-						Score:            20000,
-						RoleCapacities: map[string]interfaces.RoleCapacity{
-							"prefill": {Role: "prefill", RequiredCapacity: 10000},
-							"decode":  {Role: "decode", RequiredCapacity: 10000},
-						},
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "prefill-v", AcceleratorName: "H100", Cost: 15.0, Role: "prefill", ReplicaCount: 1, PerReplicaCapacity: 20000},
-							{VariantName: "decode-v", AcceleratorName: "A100", Cost: 5.0, Role: "decode", ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "prefill-v", CurrentReplicas: 1, GPUsPerReplica: 4, Role: "prefill"},
 						{VariantName: "decode-v", CurrentReplicas: 1, GPUsPerReplica: 2, Role: "decode"},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -852,31 +846,28 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			decisions := optimizer.Optimize(ctx, requests, constraints)
 			dm := decisionMap(decisions)
 
-			// Prefill can't scale (no H100 GPUs) — its share is consumed, not overflowed
+			// Paired allocation: if P-side (H100) is exhausted, the pair cannot commit.
+			// Both prefill and decode stay at their current replicas.
 			Expect(dm["prefill-v"].TargetReplicas).To(Equal(1))
-			// Decode gets only its proportional share (50% of demand)
-			// roleTarget = 10000 (50% of 20000) → +1 replica
-			// Prefill's 10000 is consumed (not absorbed by decode)
-			Expect(dm["decode-v"].TargetReplicas).To(Equal(2)) // 1 + 1
+			Expect(dm["decode-v"].TargetReplicas).To(Equal(1))
 		})
 
 		It("should handle non-disaggregated model with Score", func() {
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Priority:  2.0,
-					Result: &interfaces.AnalyzerResult{
-						RequiredCapacity: 10000,
-						Score:            20000, // 2.0 * 10000
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "v1", CurrentReplicas: 1, GPUsPerReplica: 2},
 					},
-				},
+				}),
 			}
 			constraints := []*ResourceConstraints{
 				{Pools: map[string]ResourcePool{
@@ -887,8 +878,9 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			decisions := optimizer.Optimize(ctx, requests, constraints)
 			dm := decisionMap(decisions)
 
-			// Should allocate based on Score (20000), which maps to 2 replicas
-			Expect(dm["v1"].TargetReplicas).To(Equal(3)) // 1 + ceil(20000/10000)=2
+			// Score inflates the fair-share ordering priority but not the allocation size.
+			// Allocation is demand-driven: RC=10000, PRC=10000 → 1 replica added.
+			Expect(dm["v1"].TargetReplicas).To(Equal(2)) // 1 + 1
 		})
 	})
 
@@ -930,25 +922,25 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 				{Pools: map[string]ResourcePool{"A100": {Limit: 20}}},
 			}
 
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				AnalyzedAt:       time.Now(),
+				RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						AnalyzedAt:       time.Now(),
-						RequiredCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-							{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 1, MaxReplicas: intPtr(3)},
 						{VariantName: "expensive", CurrentReplicas: 1, GPUsPerReplica: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(ctx, requests, constraints)
@@ -962,20 +954,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		It("scale-down should respect minReplicas via costAwareScaleDown", func() {
 			intPtr := func(n int) *int { return &n }
 
+			r := &interfaces.AnalyzerResult{
+				ModelID:       "model-1",
+				Namespace:     "default",
+				AnalyzedAt:    time.Now(),
+				SpareCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:       "model-1",
-						Namespace:     "default",
-						AnalyzedAt:    time.Now(),
-						SpareCapacity: 50000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "expensive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 3, PerReplicaCapacity: 20000},
-							{VariantName: "cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "expensive", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(2)},
 						{VariantName: "cheap", CurrentReplicas: 3, GPUsPerReplica: 1},
@@ -993,20 +985,20 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 		It("scale-down should zero minReplicas=0 variant while keeping minReplicas>0 sibling", func() {
 			intPtr := func(n int) *int { return &n }
 
+			r := &interfaces.AnalyzerResult{
+				ModelID:       "model-1",
+				Namespace:     "default",
+				AnalyzedAt:    time.Now(),
+				SpareCapacity: 80000, // enough to remove all
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "keep-alive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+					{VariantName: "expendable", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []ModelScalingRequest{
-				withSatEntry(ModelScalingRequest{
+				withSatEntry(r, ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:       "model-1",
-						Namespace:     "default",
-						AnalyzedAt:    time.Now(),
-						SpareCapacity: 80000, // enough to remove all
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "keep-alive", AcceleratorName: "A100", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-							{VariantName: "expendable", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "keep-alive", CurrentReplicas: 2, GPUsPerReplica: 1, MinReplicas: intPtr(1)},
 						{VariantName: "expendable", CurrentReplicas: 3, GPUsPerReplica: 1, MinReplicas: intPtr(0)},

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -1103,4 +1103,102 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 
 		// filterVariantCapacitiesByRole removed (duplicate of variantsForRole in analyzer_helpers.go; N2 cleanup)
 	})
+
+	// Phase 3 test: D-only scale-up via the per-role gate.
+	Context("Disaggregated D-only scale-up (Phase 3)", func() {
+		It("should scale up only decode when RC_P=0 and RC_D>0", func() {
+			// Pre-Phase-3 the model-level gate (Remaining=0 from P-anchor) would
+			// route the model to scale-down. anyRoleNeedsScaleUp fires on D demand.
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 0,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "pf", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "dc", AcceleratorName: "A100", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {RequiredCapacity: 0, TotalDemand: 0},
+					"decode":  {RequiredCapacity: 10000, TotalDemand: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				{
+					ModelID:       "d-only",
+					Namespace:     "default",
+					Disaggregated: true,
+					Priority:      1.0,
+					AnalyzerResults: []NamedAnalyzerResult{{
+						Name:      interfaces.SaturationAnalyzerName,
+						Result:    r,
+						Score:     1.0,
+						Remaining: r.RequiredCapacity,
+						Spare:     r.SpareCapacity,
+					}},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "pf", CurrentReplicas: 2, GPUsPerReplica: 2},
+						{VariantName: "dc", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+			}
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: 4}}},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			Expect(dm["pf"].TargetReplicas).To(Equal(2)) // no P demand
+			Expect(dm["dc"].TargetReplicas).To(Equal(2)) // +1 decode
+		})
+	})
+
+	// Phase 3 test: min-util coupling without α.
+	Context("Disaggregated min-util coupling (Phase 3)", func() {
+		It("should advance P and D by matched util (not fixed α ratio)", func() {
+			// P-demand=10000, D-demand=30000, PRC=10000 each.
+			// Without α: P and D are sized independently and joint-committed by Δ_util.
+			// n_P=1 (ceil(10000/10000)), n_D=3 (ceil(30000/10000)).
+			// util_P=1.0, util_D=3.0 → Δ_util=1.0 → k_P=1, k_D=3.
+			// Result: prefill+1, decode+3 — same Δ_util=1.0 for both.
+			r := &interfaces.AnalyzerResult{
+				RequiredCapacity: 10000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "pf", AcceleratorName: "A100", Cost: 5.0, Role: "prefill", PerReplicaCapacity: 10000},
+					{VariantName: "dc", AcceleratorName: "A100", Cost: 5.0, Role: "decode", PerReplicaCapacity: 10000},
+				},
+				RoleCapacities: map[string]interfaces.RoleCapacity{
+					"prefill": {RequiredCapacity: 10000, TotalDemand: 10000},
+					"decode":  {RequiredCapacity: 30000, TotalDemand: 30000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				{
+					ModelID:       "pd-min-util",
+					Namespace:     "default",
+					Disaggregated: true,
+					Priority:      1.0,
+					AnalyzerResults: []NamedAnalyzerResult{{
+						Name:      interfaces.SaturationAnalyzerName,
+						Result:    r,
+						Score:     1.0,
+						Remaining: r.RequiredCapacity,
+						Spare:     r.SpareCapacity,
+					}},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "pf", CurrentReplicas: 1, GPUsPerReplica: 2},
+						{VariantName: "dc", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+			}
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{"A100": {Limit: 12}}},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			// Both roles committed by the same Δ_util=1.0.
+			Expect(dm["pf"].TargetReplicas).To(Equal(2)) // 1+1
+			Expect(dm["dc"].TargetReplicas).To(Equal(4)) // 1+3
+		})
+	})
 })

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -6,15 +6,33 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
 
+// NamedAnalyzerResult pairs an analyzer's name with its result and mutable
+// working counters for the optimizer's allocation loop.
+// It is the per-entry type of ModelScalingRequest.AnalyzerResults and is
+// only used inside the engine→optimizer contract; it is not a general-purpose
+// interfaces type.
+//
+// Remaining and Spare are initialised from Result.RequiredCapacity and
+// Result.SpareCapacity by the engine and decremented in place by applyAllocation /
+// applyDeallocation as the optimizer allocates replicas. The original Result
+// values are never mutated and remain available for reason strings and metrics.
+type NamedAnalyzerResult struct {
+	Name      string
+	Result    *interfaces.AnalyzerResult
+	Remaining float64 // mutable remaining required capacity; decremented during scale-up
+	Spare     float64 // mutable remaining spare capacity; decremented during scale-down
+}
+
 // ModelScalingRequest bundles the analyzer result with variant state for one model.
 // The optimizer receives a slice of these — one per model — and produces decisions.
 type ModelScalingRequest struct {
-	ModelID       string
-	Namespace     string
-	Result        *interfaces.AnalyzerResult
-	VariantStates []interfaces.VariantReplicaState
-	Priority      float64 // Model priority (default 1.0)
-	Disaggregated bool    // true when model has prefill+decode variants
+	ModelID         string
+	Namespace       string
+	Result          *interfaces.AnalyzerResult // combined result (legacy; will be removed when combine is deleted)
+	AnalyzerResults []NamedAnalyzerResult      // per-analyzer slice; saturation entry is always first
+	VariantStates   []interfaces.VariantReplicaState
+	Priority        float64 // Model priority (default 1.0)
+	Disaggregated   bool    // true when model has prefill+decode variants
 }
 
 // ScalingOptimizer makes final scaling decisions for all models.

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -13,14 +13,18 @@ import (
 // interfaces type.
 //
 // Remaining and Spare are initialised from Result.RequiredCapacity and
-// Result.SpareCapacity by the engine and decremented in place by applyAllocation /
-// applyDeallocation as the optimizer allocates replicas. The original Result
-// values are never mutated and remain available for reason strings and metrics.
+// Result.SpareCapacity by the engine (model scope) and decremented in place by
+// applyAllocation / applyDeallocation as the optimizer allocates replicas.
+// For disaggregated (P/D) models, the optimizer calls initDisaggregatedRemaining
+// to re-initialize Remaining to P-scope and populate RoleSpare per role.
+// The original Result values are never mutated.
 type NamedAnalyzerResult struct {
 	Name      string
 	Result    *interfaces.AnalyzerResult
-	Remaining float64 // mutable remaining required capacity; decremented during scale-up
-	Spare     float64 // mutable remaining spare capacity; decremented during scale-down
+	Score     float64            // per-analyzer weight from AnalyzerScoreConfig; used for fair-share priority
+	Remaining float64            // mutable remaining required capacity; P-scope for disaggregated, model-scope otherwise
+	Spare     float64            // mutable remaining spare capacity; model-scope (non-disaggregated only)
+	RoleSpare map[string]float64 // per-role mutable spare; set by initDisaggregatedRemaining; nil for non-disaggregated
 }
 
 // ModelScalingRequest bundles the analyzer result with variant state for one model.
@@ -28,8 +32,7 @@ type NamedAnalyzerResult struct {
 type ModelScalingRequest struct {
 	ModelID         string
 	Namespace       string
-	Result          *interfaces.AnalyzerResult // combined result (legacy; will be removed when combine is deleted)
-	AnalyzerResults []NamedAnalyzerResult      // per-analyzer slice; saturation entry is always first
+	AnalyzerResults []NamedAnalyzerResult // per-analyzer slice; saturation entry is always first
 	VariantStates   []interfaces.VariantReplicaState
 	Priority        float64 // Model priority (default 1.0)
 	Disaggregated   bool    // true when model has prefill+decode variants

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -15,8 +15,8 @@ import (
 // Remaining and Spare are initialised from Result.RequiredCapacity and
 // Result.SpareCapacity by the engine (model scope) and decremented in place by
 // applyAllocation / applyDeallocation as the optimizer allocates replicas.
-// For disaggregated (P/D) models, the optimizer calls initDisaggregatedRemaining
-// to re-initialize Remaining to P-scope and populate RoleSpare per role.
+// For disaggregated (P/D) models, the optimizer calls initRoleState
+// to populate RoleSpare per role and initialize picker-local demand.
 // The original Result values are never mutated.
 type NamedAnalyzerResult struct {
 	Name      string
@@ -24,7 +24,7 @@ type NamedAnalyzerResult struct {
 	Score     float64            // per-analyzer weight from AnalyzerScoreConfig; used for fair-share priority
 	Remaining float64            // mutable remaining required capacity; P-scope for disaggregated, model-scope otherwise
 	Spare     float64            // mutable remaining spare capacity; model-scope (non-disaggregated only)
-	RoleSpare map[string]float64 // per-role mutable spare; set by initDisaggregatedRemaining; nil for non-disaggregated
+	RoleSpare map[string]float64 // per-role mutable spare; set by initRoleState; nil for non-disaggregated
 }
 
 // ModelScalingRequest bundles the analyzer result with variant state for one model.

--- a/internal/engines/pipeline/optimizer_interfaces.go
+++ b/internal/engines/pipeline/optimizer_interfaces.go
@@ -14,7 +14,7 @@ import (
 //
 // Remaining and Spare are initialised from Result.RequiredCapacity and
 // Result.SpareCapacity by the engine (model scope) and decremented in place by
-// applyAllocation / applyDeallocation as the optimizer allocates replicas.
+// applyAllocation as the optimizer allocates replicas.
 // For disaggregated (P/D) models, the optimizer calls initRoleState
 // to populate RoleSpare per role and initialize picker-local demand.
 // The original Result values are never mutated.

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -717,7 +717,7 @@ func (e *Engine) optimizeV2(
 
 		req, err := e.collectV2ModelRequest(ctx, modelID, namespace,
 			data.replicaMetrics, saturationConfig, data.variantStates,
-			data.scaleTargets, data.variantAutoscalings)
+			data.scaleTargets, data.variantAutoscalings, data.schedulerQueue)
 		if err != nil {
 			logger.Error(err, "V2 analysis failed", "modelID", modelID)
 			e.emitSafetyNetMetrics(ctx, modelVAs, currentAllocations, data.scaleTargets)
@@ -1119,6 +1119,7 @@ type modelData struct {
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling
 	variantCosts        map[string]float64
 	variantStates       []interfaces.VariantReplicaState
+	schedulerQueue      *interfaces.SchedulerQueueMetrics
 }
 
 // prepareModelData collects metrics and builds lookup maps for a model's VAs.
@@ -1192,6 +1193,7 @@ func (e *Engine) prepareModelData(
 	}
 
 	variantStates := e.BuildVariantStates(ctx, modelVAs, scaleTargets, k8sClient)
+	schedulerQueue := e.ReplicaMetricsCollector.CollectSchedulerQueueMetrics(ctx, modelID)
 
 	return &modelData{
 		modelID:             modelID,
@@ -1201,6 +1203,7 @@ func (e *Engine) prepareModelData(
 		variantAutoscalings: variantAutoscalings,
 		variantCosts:        variantCosts,
 		variantStates:       variantStates,
+		schedulerQueue:      schedulerQueue,
 	}, nil
 }
 

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -290,10 +290,7 @@ func (e *Engine) StartOptimizeLoop(ctx context.Context) {
 
 func (e *Engine) recordActiveOptimizer() {
 	// Record metrics for which optimizer is active
-	optimizerNames := []string{
-		pipeline.GreedyByScoreOptimizerName,
-		pipeline.CostAwareOptimizerName,
-	}
+	optimizerNames := []string{"greedy-by-score", "cost-aware"}
 	for _, name := range optimizerNames {
 		isActive := false // default is false
 		if name == e.optimizer.Name() {

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -69,9 +69,14 @@ func (e *Engine) optimizeQueueingModel(
 		}
 
 		requests = append(requests, pipeline.ModelScalingRequest{
-			ModelID:       modelID,
-			Namespace:     namespace,
-			Result:        result,
+			ModelID:   modelID,
+			Namespace: namespace,
+			AnalyzerResults: []pipeline.NamedAnalyzerResult{{
+				Name:      interfaces.SaturationAnalyzerName,
+				Result:    result,
+				Remaining: result.RequiredCapacity,
+				Spare:     result.SpareCapacity,
+			}},
 			VariantStates: data.variantStates,
 		})
 	}

--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -74,6 +74,7 @@ func (e *Engine) optimizeQueueingModel(
 			AnalyzerResults: []pipeline.NamedAnalyzerResult{{
 				Name:      interfaces.SaturationAnalyzerName,
 				Result:    result,
+				Score:     1.0, // QM path: single analyzer, no per-entry score config
 				Remaining: result.RequiredCapacity,
 				Spare:     result.SpareCapacity,
 			}},

--- a/internal/engines/saturation/engine_test.go
+++ b/internal/engines/saturation/engine_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source/prometheus"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
-	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
 	interfaces "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
 	utils "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
@@ -574,7 +573,7 @@ var _ = Describe("Saturation Engine", func() {
 			By("Running optimize() with EnableLimiter=false")
 			err := engine.optimize(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(engine.optimizer.Name()).To(Equal(pipeline.CostAwareOptimizerName),
+			Expect(engine.optimizer.Name()).To(Equal("cost-aware"),
 				"Expected CostAwareOptimizer when EnableLimiter=false")
 
 			By("Updating config to EnableLimiter=true")
@@ -588,7 +587,7 @@ var _ = Describe("Saturation Engine", func() {
 			By("Running optimize() with EnableLimiter=true")
 			err = engine.optimize(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(engine.optimizer.Name()).To(Equal(pipeline.GreedyByScoreOptimizerName),
+			Expect(engine.optimizer.Name()).To(Equal("greedy-by-score"),
 				"Expected GreedyByScoreOptimizer when EnableLimiter=true")
 
 			By("Updating config back to EnableLimiter=false")
@@ -602,7 +601,7 @@ var _ = Describe("Saturation Engine", func() {
 			By("Running optimize() with EnableLimiter=false again")
 			err = engine.optimize(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(engine.optimizer.Name()).To(Equal(pipeline.CostAwareOptimizerName),
+			Expect(engine.optimizer.Name()).To(Equal("cost-aware"),
 				"Expected CostAwareOptimizer when EnableLimiter=false (second toggle)")
 		})
 	})

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -27,6 +27,7 @@ func (e *Engine) runV2AnalysisOnly(
 	variantStates []interfaces.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	schedulerQueue *interfaces.SchedulerQueueMetrics,
 ) (*interfaces.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -54,7 +55,7 @@ func (e *Engine) runV2AnalysisOnly(
 		ReplicaMetrics: replicaMetrics,
 		VariantStates:  variantStates,
 		Config:         &config,
-		// TODO: populate SchedulerQueue when flow control metrics are collected
+		SchedulerQueue: schedulerQueue,
 	}
 
 	// 3. Run V2 analyzer
@@ -79,13 +80,11 @@ func (e *Engine) runV2AnalysisOnly(
 // overrides where set), and computes the weighted composite score from
 // saturation's signal and the model's priority.
 //
-// The engine applies applyUniversalThreshold to every analyzer — saturation and
-// all registered non-saturation analyzers. Per-analyzer ScaleUpThreshold /
-// ScaleDownBoundary overrides from AnalyzerScoreConfig are resolved and used for
-// each analyzer's calibration call. Non-saturation results are calibrated but
-// intentionally discarded on this branch; the optimizer only receives saturation's
-// result. Combine semantics and per-analyzer score consumption land in a follow-up
-// PR (multi-analyzer-optimizer).
+// The engine applies applyUniversalThreshold to every analyzer (saturation and
+// all registered non-saturation analyzers) and collects the calibrated results
+// into a per-analyzer slice returned to the optimizer. Saturation is always the
+// first entry; it is the keeper of per-variant metadata (Cost, AcceleratorName,
+// Role) until a future pre-analysis-extraction PR separates that concern.
 func (e *Engine) runAnalyzersAndScore(
 	ctx context.Context,
 	modelID, namespace string,
@@ -94,14 +93,15 @@ func (e *Engine) runAnalyzersAndScore(
 	variantStates []interfaces.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
-) (*interfaces.AnalyzerResult, error) {
+	schedulerQueue *interfaces.SchedulerQueueMetrics,
+) ([]pipeline.NamedAnalyzerResult, *interfaces.AnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Run saturation analyzer (always needed for PerReplicaCapacity).
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
-		variantStates, scaleTargets, variantAutoscalings)
+		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Universal threshold post-step for saturation: recalibrate RC/SC using the
@@ -122,41 +122,38 @@ func (e *Engine) runAnalyzersAndScore(
 		ReplicaMetrics: replicaMetrics,
 		VariantStates:  variantStates,
 		Config:         &config,
-		// SchedulerQueue: nil — wired in a later PR
+		SchedulerQueue: schedulerQueue,
 	}
 
-	// Iterate every registered non-saturation analyzer. Each result is
-	// calibrated with the universal threshold post-step (using per-analyzer
-	// config overrides where set), then discarded on this branch — combine /
-	// per-analyzer-result consumption lands in follow-up PRs.
-	e.runRegisteredAnalyzers(ctx, logger, modelID, input, config)
-
-	// Compute weighted score from enabled analyzers.
-	// On this branch only saturation drives the score; non-saturation results
-	// are not yet consumed by the optimizer (see multi-analyzer-optimizer PR).
-	totalWeighted := 0.0
-	for _, aw := range config.Analyzers {
-		if aw.Enabled != nil && !*aw.Enabled {
+	// Collect per-analyzer results. Saturation is first; each non-saturation
+	// analyzer is run, calibrated with its resolved thresholds, and appended.
+	namedResults := []pipeline.NamedAnalyzerResult{{
+		Name:      interfaces.SaturationAnalyzerName,
+		Result:    baseResult,
+		Remaining: baseResult.RequiredCapacity,
+		Spare:     baseResult.SpareCapacity,
+	}}
+	for _, entry := range e.analyzersSnapshot {
+		if entry.name == interfaces.SaturationAnalyzerName {
 			continue
 		}
-		if aw.Name == interfaces.SaturationAnalyzerName {
-			totalWeighted += baseResult.RequiredCapacity * aw.Score
-			// future: add "throughput", "slo" cases
+		result := runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
+		if result == nil {
+			continue
 		}
+		up, down := resolveThresholds(entry.name, config)
+		applyUniversalThreshold(result, up, down)
+		namedResults = append(namedResults, pipeline.NamedAnalyzerResult{
+			Name:      entry.name,
+			Result:    result,
+			Remaining: result.RequiredCapacity,
+			Spare:     result.SpareCapacity,
+		})
 	}
-
-	// Score = priority * weighted sum; used by GreedyByScoreOptimizer for
-	// fair-share ordering across models. Computed from saturation's calibrated
-	// RC only; will be recomputed per-analyzer in the multi-analyzer-optimizer PR.
-	baseResult.Score = config.Priority * totalWeighted
-	return baseResult, nil
+	// satResult used as the transitional model-level Result pointer until 1.6.
+	return namedResults, baseResult, nil
 }
 
-// resolveThresholds returns the effective scaleUp and scaleDown threshold values
-// for the named analyzer. If config.Analyzers contains an entry for that name,
-// its per-entry overrides (ScaleUpThreshold / ScaleDownBoundary) take precedence
-// over the model-level globals. Falls back to the global values when no matching
-// entry exists or the override fields are nil.
 func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) (scaleUp, scaleDown float64) {
 	for _, aw := range cfg.Analyzers {
 		if aw.Name == analyzerName {
@@ -316,9 +313,10 @@ func (e *Engine) collectV2ModelRequest(
 	variantStates []interfaces.VariantReplicaState,
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	schedulerQueue *interfaces.SchedulerQueueMetrics,
 ) (*pipeline.ModelScalingRequest, error) {
-	result, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
-		variantStates, scaleTargets, variantAutoscalings)
+	namedResults, result, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
+		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
 		return nil, fmt.Errorf("collecting V2 model request for %s/%s: %w", namespace, modelID, err)
 	}
@@ -333,11 +331,12 @@ func (e *Engine) collectV2ModelRequest(
 	}
 
 	return &pipeline.ModelScalingRequest{
-		ModelID:       modelID,
-		Namespace:     namespace,
-		Result:        result,
-		VariantStates: variantStates,
-		Priority:      config.Priority,
-		Disaggregated: disaggregated,
+		ModelID:         modelID,
+		Namespace:       namespace,
+		Result:          result,
+		AnalyzerResults: namedResults,
+		VariantStates:   variantStates,
+		Priority:        config.Priority,
+		Disaggregated:   disaggregated,
 	}, nil
 }

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -94,14 +94,14 @@ func (e *Engine) runAnalyzersAndScore(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *interfaces.SchedulerQueueMetrics,
-) ([]pipeline.NamedAnalyzerResult, *interfaces.AnalyzerResult, error) {
+) ([]pipeline.NamedAnalyzerResult, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	// Run saturation analyzer (always needed for PerReplicaCapacity).
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Universal threshold post-step for saturation: recalibrate RC/SC using the
@@ -152,8 +152,7 @@ func (e *Engine) runAnalyzersAndScore(
 			Spare:     result.SpareCapacity,
 		})
 	}
-	// satResult used as the transitional model-level Result pointer until 1.6.
-	return namedResults, baseResult, nil
+	return namedResults, nil
 }
 
 // scoreForAnalyzer returns the AnalyzerScoreConfig.Score for the named analyzer,
@@ -340,7 +339,7 @@ func (e *Engine) collectV2ModelRequest(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *interfaces.SchedulerQueueMetrics,
 ) (*pipeline.ModelScalingRequest, error) {
-	namedResults, _, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
+	namedResults, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
 		return nil, fmt.Errorf("collecting V2 model request for %s/%s: %w", namespace, modelID, err)

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -101,7 +101,7 @@ func (e *Engine) runAnalyzersAndScore(
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Universal threshold post-step for saturation: recalibrate RC/SC using the
@@ -284,14 +284,21 @@ func applyUniversalThreshold(r *interfaces.AnalyzerResult, scaleUp, scaleDown fl
 func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]int {
 	usage := make(map[string]int)
 	for _, req := range requests {
-		if req.Result == nil {
+		var satEntry *interfaces.AnalyzerResult
+		for _, e := range req.AnalyzerResults {
+			if e.Name == interfaces.SaturationAnalyzerName {
+				satEntry = e.Result
+				break
+			}
+		}
+		if satEntry == nil {
 			continue
 		}
 		stateMap := make(map[string]interfaces.VariantReplicaState, len(req.VariantStates))
 		for _, s := range req.VariantStates {
 			stateMap[s.VariantName] = s
 		}
-		for _, vc := range req.Result.VariantCapacities {
+		for _, vc := range satEntry.VariantCapacities {
 			state := stateMap[vc.VariantName]
 			gpusPerReplica := state.GPUsPerReplica
 			if gpusPerReplica <= 0 {
@@ -333,7 +340,6 @@ func (e *Engine) collectV2ModelRequest(
 	return &pipeline.ModelScalingRequest{
 		ModelID:         modelID,
 		Namespace:       namespace,
-		Result:          result,
 		AnalyzerResults: namedResults,
 		VariantStates:   variantStates,
 		Priority:        config.Priority,

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -130,6 +130,7 @@ func (e *Engine) runAnalyzersAndScore(
 	namedResults := []pipeline.NamedAnalyzerResult{{
 		Name:      interfaces.SaturationAnalyzerName,
 		Result:    baseResult,
+		Score:     scoreForAnalyzer(interfaces.SaturationAnalyzerName, config),
 		Remaining: baseResult.RequiredCapacity,
 		Spare:     baseResult.SpareCapacity,
 	}}
@@ -146,12 +147,29 @@ func (e *Engine) runAnalyzersAndScore(
 		namedResults = append(namedResults, pipeline.NamedAnalyzerResult{
 			Name:      entry.name,
 			Result:    result,
+			Score:     scoreForAnalyzer(entry.name, config),
 			Remaining: result.RequiredCapacity,
 			Spare:     result.SpareCapacity,
 		})
 	}
 	// satResult used as the transitional model-level Result pointer until 1.6.
 	return namedResults, baseResult, nil
+}
+
+// scoreForAnalyzer returns the AnalyzerScoreConfig.Score for the named analyzer,
+// defaulting to 1.0 when the analyzer has no explicit entry in cfg.Analyzers.
+// This value is the per-analyzer weight used by GreedyByScoreOptimizer for
+// fair-share priority ordering across models.
+func scoreForAnalyzer(analyzerName string, cfg config.SaturationScalingConfig) float64 {
+	for _, aw := range cfg.Analyzers {
+		if aw.Name == analyzerName {
+			if aw.Score > 0 {
+				return aw.Score
+			}
+			return 1.0
+		}
+	}
+	return 1.0
 }
 
 func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) (scaleUp, scaleDown float64) {

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -101,7 +101,7 @@ func (e *Engine) runAnalyzersAndScore(
 	baseResult, err := e.runV2AnalysisOnly(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Universal threshold post-step for saturation: recalibrate RC/SC using the
@@ -322,7 +322,7 @@ func (e *Engine) collectV2ModelRequest(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	schedulerQueue *interfaces.SchedulerQueueMetrics,
 ) (*pipeline.ModelScalingRequest, error) {
-	namedResults, result, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
+	namedResults, _, err := e.runAnalyzersAndScore(ctx, modelID, namespace, replicaMetrics, config,
 		variantStates, scaleTargets, variantAutoscalings, schedulerQueue)
 	if err != nil {
 		return nil, fmt.Errorf("collecting V2 model request for %s/%s: %w", namespace, modelID, err)

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -1,0 +1,47 @@
+package saturation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+)
+
+var _ = Describe("Engine config-population helpers", func() {
+
+	Describe("scoreForAnalyzer", func() {
+		It("returns the configured score when the analyzer is present with a positive score", func() {
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "saturation", Score: 2.5},
+					{Name: "throughput", Score: 0.5},
+				},
+			}
+			Expect(scoreForAnalyzer("saturation", cfg)).To(Equal(2.5))
+			Expect(scoreForAnalyzer("throughput", cfg)).To(Equal(0.5))
+		})
+
+		It("returns 1.0 when the analyzer is absent from config", func() {
+			Expect(scoreForAnalyzer("unknown", config.SaturationScalingConfig{})).To(Equal(1.0))
+		})
+
+		It("returns 1.0 when the analyzer's Score is zero (field not set in config)", func() {
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "saturation", Score: 0},
+				},
+			}
+			Expect(scoreForAnalyzer("saturation", cfg)).To(Equal(1.0))
+		})
+
+		It("returns the first matching score when multiple entries share a name", func() {
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "sat", Score: 3.0},
+					{Name: "sat", Score: 7.0}, // duplicate — first wins
+				},
+			}
+			Expect(scoreForAnalyzer("sat", cfg)).To(Equal(3.0))
+		})
+	})
+})

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
+// withSatEntryV2 adds a single-saturation AnalyzerResults to req from req.Result.
+// Mirrors the helper in cost_aware_optimizer_test.go for use in the saturation package.
+func withSatEntryV2(req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
+	if req.Result != nil {
+		req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
+			Name:      interfaces.SaturationAnalyzerName,
+			Result:    req.Result,
+			Remaining: req.Result.RequiredCapacity,
+			Spare:     req.Result.SpareCapacity,
+		}}
+	}
+	return req
+}
+
 var _ = Describe("V2 Engine Integration", func() {
 
 	Context("CostAwareOptimizer via engine path", func() {
@@ -21,7 +35,7 @@ var _ = Describe("V2 Engine Integration", func() {
 		It("should scale up cheapest variant by cost-efficiency", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
 			requests := []pipeline.ModelScalingRequest{
-				{
+				withSatEntryV2(pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -37,7 +51,7 @@ var _ = Describe("V2 Engine Integration", func() {
 						{VariantName: "variant-cheap", CurrentReplicas: 2},
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(context.Background(), requests, nil)
@@ -52,7 +66,7 @@ var _ = Describe("V2 Engine Integration", func() {
 		It("should scale down most expensive variant", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
 			requests := []pipeline.ModelScalingRequest{
-				{
+				withSatEntryV2(pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -68,7 +82,7 @@ var _ = Describe("V2 Engine Integration", func() {
 						{VariantName: "variant-cheap", CurrentReplicas: 3},
 						{VariantName: "variant-expensive", CurrentReplicas: 2},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(context.Background(), requests, nil)
@@ -81,7 +95,7 @@ var _ = Describe("V2 Engine Integration", func() {
 		It("should protect cheapest variant at 1 during scale-down", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
 			requests := []pipeline.ModelScalingRequest{
-				{
+				withSatEntryV2(pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -97,7 +111,7 @@ var _ = Describe("V2 Engine Integration", func() {
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
 						{VariantName: "variant-cheap", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(context.Background(), requests, nil)
@@ -110,7 +124,7 @@ var _ = Describe("V2 Engine Integration", func() {
 		It("should not skip variants with pending replicas", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
 			requests := []pipeline.ModelScalingRequest{
-				{
+				withSatEntryV2(pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
 					Result: &interfaces.AnalyzerResult{
@@ -126,7 +140,7 @@ var _ = Describe("V2 Engine Integration", func() {
 						{VariantName: "variant-cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "variant-mid", CurrentReplicas: 1},
 					},
-				},
+				}),
 			}
 
 			decisions := optimizer.Optimize(context.Background(), requests, nil)

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -21,7 +21,6 @@ func withSatEntryV2(r *interfaces.AnalyzerResult, req pipeline.ModelScalingReque
 		req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
 			Name:      interfaces.SaturationAnalyzerName,
 			Result:    r,
-			Score:     1.0,
 			Remaining: r.RequiredCapacity,
 			Spare:     r.SpareCapacity,
 		}}

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -14,15 +14,16 @@ import (
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
-// withSatEntryV2 adds a single-saturation AnalyzerResults to req from req.Result.
+// withSatEntryV2 adds a single-saturation AnalyzerResults to req from r.
 // Mirrors the helper in cost_aware_optimizer_test.go for use in the saturation package.
-func withSatEntryV2(req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
-	if req.Result != nil {
+func withSatEntryV2(r *interfaces.AnalyzerResult, req pipeline.ModelScalingRequest) pipeline.ModelScalingRequest {
+	if r != nil {
 		req.AnalyzerResults = []pipeline.NamedAnalyzerResult{{
 			Name:      interfaces.SaturationAnalyzerName,
-			Result:    req.Result,
-			Remaining: req.Result.RequiredCapacity,
-			Spare:     req.Result.SpareCapacity,
+			Result:    r,
+			Score:     1.0,
+			Remaining: r.RequiredCapacity,
+			Spare:     r.SpareCapacity,
 		}}
 	}
 	return req
@@ -34,19 +35,19 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should scale up cheapest variant by cost-efficiency", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "variant-cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "variant-expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []pipeline.ModelScalingRequest{
-				withSatEntryV2(pipeline.ModelScalingRequest{
+				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "variant-cheap", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "variant-expensive", AcceleratorName: "H100", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 2},
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
@@ -65,19 +66,19 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should scale down most expensive variant", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
+			r := &interfaces.AnalyzerResult{
+				ModelID:       "model-1",
+				Namespace:     "default",
+				SpareCapacity: 25000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
+					{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
+				},
+			}
 			requests := []pipeline.ModelScalingRequest{
-				withSatEntryV2(pipeline.ModelScalingRequest{
+				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:       "model-1",
-						Namespace:     "default",
-						SpareCapacity: 25000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 3, PerReplicaCapacity: 10000},
-							{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 2, PerReplicaCapacity: 20000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 3},
 						{VariantName: "variant-expensive", CurrentReplicas: 2},
@@ -94,19 +95,19 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should protect cheapest variant at 1 during scale-down", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
+			r := &interfaces.AnalyzerResult{
+				ModelID:       "model-1",
+				Namespace:     "default",
+				SpareCapacity: 30000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
+					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
 			requests := []pipeline.ModelScalingRequest{
-				withSatEntryV2(pipeline.ModelScalingRequest{
+				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:       "model-1",
-						Namespace:     "default",
-						SpareCapacity: 30000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "variant-expensive", Cost: 15.0, ReplicaCount: 1, PerReplicaCapacity: 20000},
-							{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "variant-expensive", CurrentReplicas: 1},
 						{VariantName: "variant-cheap", CurrentReplicas: 1},
@@ -123,19 +124,19 @@ var _ = Describe("V2 Engine Integration", func() {
 
 		It("should not skip variants with pending replicas", func() {
 			optimizer := pipeline.NewCostAwareOptimizer()
+			r := &interfaces.AnalyzerResult{
+				ModelID:          "model-1",
+				Namespace:        "default",
+				RequiredCapacity: 5000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
+					{VariantName: "variant-mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
+				},
+			}
 			requests := []pipeline.ModelScalingRequest{
-				withSatEntryV2(pipeline.ModelScalingRequest{
+				withSatEntryV2(r, pipeline.ModelScalingRequest{
 					ModelID:   "model-1",
 					Namespace: "default",
-					Result: &interfaces.AnalyzerResult{
-						ModelID:          "model-1",
-						Namespace:        "default",
-						RequiredCapacity: 5000,
-						VariantCapacities: []interfaces.VariantCapacity{
-							{VariantName: "variant-cheap", Cost: 5.0, ReplicaCount: 2, PerReplicaCapacity: 10000},
-							{VariantName: "variant-mid", Cost: 10.0, ReplicaCount: 1, PerReplicaCapacity: 15000},
-						},
-					},
 					VariantStates: []interfaces.VariantReplicaState{
 						{VariantName: "variant-cheap", CurrentReplicas: 2, PendingReplicas: 1},
 						{VariantName: "variant-mid", CurrentReplicas: 1},

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -117,11 +117,6 @@ type AnalyzerResult struct {
 	RequiredCapacity float64 // >0 means scale-up needed
 	SpareCapacity    float64 // >0 means scale-down possible
 
-	// Score is the composite priority score for this model.
-	// Computed as: priority * sum(requiredCapacity_i * analyzerScore_i)
-	// Used by GreedyByScoreOptimizer for fair-share ordering.
-	Score float64
-
 	// RoleCapacities holds per-role capacity aggregation for P/D disaggregated models.
 	// nil when no disaggregation is active (all variants are role "both").
 	RoleCapacities map[string]RoleCapacity


### PR DESCRIPTION
## Summary

Completes the multi-analyzer engine rework: the engine no longer combines
analyzer results into a single scalar pair before optimizing. Instead it passes
a **per-analyzer slice** (`[]NamedAnalyzerResult`) straight to the optimizers,
which make scaling decisions over it via shared helpers. This is the third and
final piece of the split out of the original combine-based PR #1113, after
#1225 (race-safe analyzer registry) and #1228 (universal threshold post-step),
both merged.

## Why

The previous engine combined N analyzers into one `RequiredCapacity` /
`SpareCapacity` via dimensionless normalization, then handed that scalar to the
optimizer. But the optimizer fundamentally needs per-analyzer, per-variant data
(each analyzer's `PerReplicaCapacity` per variant) for its bottleneck math —
combining threw that away. This PR deletes the combine and gives the optimizer
the full per-analyzer slice.

## What changed

- **Slice contract** (`pipeline/optimizer_interfaces.go`): `ModelScalingRequest`
  carries `AnalyzerResults []NamedAnalyzerResult`. Each entry pairs an analyzer's
  result with mutable working counters the allocation loop decrements; the
  underlying `AnalyzerResult` is never mutated.
- **Shared helpers** (`pipeline/analyzer_helpers.go`): any-up / all-down gates,
  per-variant bottleneck sizing, and allocation/deallocation — implemented as
  free functions over the slice. The old combine's any-up/all-down semantics are
  preserved as slice predicates (scale up if *any* analyzer needs it; scale down
  only if *all* analyzers permit it).
- **Both optimizers migrated** to the slice: `CostAwareOptimizer` (cost-minimizing,
  unlimited) and `GreedyByScoreOptimizer` (fair-share, GPU-limited).
- **Unified (model, role) path**: a model is decomposed into per-role units —
  non-disaggregated is the single `"both"` role; disaggregated is `{prefill,
  decode}`. One scale-up path (role-generic joint allocation with a
  min-utilization joint commit so P and D advance together) and one
  role-iterated scale-down path serve both cases; the non-disaggregated case is
  the arity-1 reduction. No `if disaggregated` branching in dispatch.
- **`AnalyzerResult.Score` removed** from the interface; the fair-share priority
  metric is computed on demand from per-analyzer `Score` config weights.
- Saturation runs first and remains the keeper of per-variant metadata (Cost,
  AcceleratorName, Role) the optimizer reads — a transitional arrangement noted
  for future extraction.

## Behavior notes for reviewers

- For GPU-limited (`GreedyByScore`) disaggregated models, exhausting one role's
  accelerator budget stalls the joint scale-up for that model: the
  min-utilization joint commit advances both roles together, so a one-role cap
  pins the model at its current size.
- Fair-share `Score` affects model *ordering*, not per-model replica sizing.

## Testing

`make test` and `go test -race ./internal/engines/...` pass. New specs cover the
slice helpers, paired (P/D) scale-up and role-iterated scale-down, decode-only
scale-up, the min-utilization joint commit, and engine population of per-analyzer
config (scores, thresholds).

## Follow-ups (out of scope, tracked separately)

- Fold the queueing-model engine onto the same multi-analyzer slice path.
- Cost picker is efficiency-greedy; under integer rounding it can over-pick a
  high-capacity variant when required capacity is small — refine to rank by
  actual rounded allocation cost.
- Expand the multi-analyzer developer-guide (currently a stub) once the pipeline
  is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
