### PR TITLE
Fix usage of Intel extended k8s resource and label names

### DIFF
--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -91,7 +91,7 @@ make create-kind-cluster
 
 # With custom configuration
 make create-kind-cluster KIND_ARGS="-t mix -n 4 -g 2"
-# -t: vendor type (nvidia, amd, intel, mix)
+# -t: vendor type (nvidia, amd, intel-gaudi, intel-i915, intel-xe, mix)
 # -n: number of nodes
 # -g: GPUs per node
 ```
@@ -122,7 +122,7 @@ Creates Kind cluster with emulated GPU support.
 
 **Options:**
 
-- `-t`: Vendor type (nvidia|amd|intel|mix) - default: mix
+- `-t`: Vendor type - default: mix (nvidia|amd|intel-gaudi|intel-i915|intel-xe|mix|nvidia-mix|amd-mix)
 - `-n`: Number of nodes - default: 3
 - `-g`: GPUs per node - default: 2
 
@@ -158,7 +158,9 @@ GPUs are emulated using extended resources:
 
 - `nvidia.com/gpu`
 - `amd.com/gpu`
-- `intel.com/gpu`
+- `habana.ai/gaudi`
+- `gpu.intel.com/i915`
+- `gpu.intel.com/xe`
 
 ## Testing Locally
 
@@ -266,7 +268,7 @@ kubectl get clusterrole,clusterrolebinding -l app=workload-variant-autoscaler
 # Verify GPU labels on nodes
 kubectl get nodes -o json | jq '.items[].status.capacity'
 
-# Should see nvidia.com/gpu, amd.com/gpu, or intel.com/gpu
+# Should see nvidia.com/gpu, amd.com/gpu, habana.ai/gaudi, gpu.intel.com/i915 or gpu.intel.com/xe
 ```
 
 ### Port-Forward Issues

--- a/deploy/kind-emulator/setup.sh
+++ b/deploy/kind-emulator/setup.sh
@@ -44,7 +44,7 @@ Options:
     -c CLUSTER_NAME    Cluster name (default: $DEFAULT_CLUSTER_NAME)
     -n NODES           Number of nodes (default: $DEFAULT_NODES)
     -g GPUS            GPUs per node (default: $DEFAULT_GPUS_PER_NODE)
-    -t TYPE            GPU type: nvidia, amd, intel, mix, nvidia-mix, amd-mix (default: $DEFAULT_GPU_TYPE)
+    -t TYPE            GPU type: nvidia, amd, intel-gaudi, intel-i915, intel-xe, mix, nvidia-mix, amd-mix (default: $DEFAULT_GPU_TYPE)
                        - nvidia-mix: H100, A100, MI300X heterogeneous (for limiter tests)
                        - amd-mix: MI300X, MI250, A100 heterogeneous (for limiter tests)
     -d MODEL           GPU model (default: $DEFAULT_GPU_MODEL)
@@ -59,9 +59,9 @@ EOF
 
 validate_gpu_type() {
     case "$1" in
-        nvidia|amd|intel|mix|nvidia-mix|amd-mix) return 0 ;;
+        nvidia|amd|intel-gaudi|intel-i915|intel-xe|mix|nvidia-mix|amd-mix) return 0 ;;
         *)
-            echo "Error: Invalid GPU type '$1'. Valid: nvidia, amd, intel, mix, nvidia-mix, amd-mix"
+            echo "Error: Invalid GPU type '$1'. Valid: nvidia, amd, intel-gaudi, intel-i915, intel-xe, mix, nvidia-mix, amd-mix"
             exit 1
             ;;
     esac
@@ -148,13 +148,29 @@ patch_node_gpu() {
     local gpu_count="$3"
     local gpu_product="$4"
     local gpu_memory="$5"
+    # NVIDIA defaults
+    local domain="${gpu_type}.com"
+    local count_label="gpu.count"
+    local memory_label="gpu.memory"
+    local product_label="gpu.product"
+
+    case "$gpu_type" in
+        "amd")
+            product_label="gpu.product-name" ;;
+        "intel-gaudi")
+            domain="habana.ai"; count_label="device.count"; memory_label="device.memory"; product_label="product.name" ;;
+        "intel-i915"|"intel-xe")
+            domain="gpu.intel.com"; count_label="device.count"; memory_label="memory"; product_label="product" ;;
+        "nvidia"|*)
+            ;;
+    esac
 
     kubectl patch node "${node_name}" --type merge --patch "
 metadata:
   labels:
-    ${gpu_type}.com/gpu.count: \"${gpu_count}\"
-    ${gpu_type}.com/gpu.product: \"${gpu_product}\"
-    ${gpu_type}.com/gpu.memory: \"${gpu_memory}\"
+    ${domain}/${count_label}: \"${gpu_count}\"
+    ${domain}/${memory_label}: \"${gpu_memory}\"
+    ${domain}/${product_label}: \"${gpu_product}\"
 "
 }
 
@@ -167,6 +183,8 @@ patch_node_custom_label() {
 }
 
 nodes_list=$(kubectl get nodes --no-headers -o custom-columns=":metadata.name")
+# K8s node names do not contain spaces
+# shellcheck disable=SC2206
 node_array=($nodes_list)
 
 for i in "${!node_array[@]}"; do
@@ -197,11 +215,13 @@ for i in "${!node_array[@]}"; do
             esac
             ;;
         "mix")
-            # Original mixed: nvidia, amd, intel
-            case $((i % 3)) in
-                0) current_type="nvidia"; current_model="NVIDIA-A100-PCIE-80GB"; current_memory=81920 ;;
-                1) current_type="amd";    current_model="AMD-MI300X-192G";       current_memory=196608 ;;
-                2) current_type="intel";  current_model="Intel-Gaudi-2-96GB";    current_memory=98304 ;;
+            # Mix of everything supported
+            case $((i % 5)) in
+                0) current_type="nvidia"; current_model="NVIDIA-A100-PCIE-80GB";   current_memory=81920 ;;
+                1) current_type="amd";    current_model="AMD-MI300X-192G";         current_memory=196608 ;;
+                2) current_type="intel-gaudi"; current_model="Intel-Gaudi-2-96GB"; current_memory=98304 ;;
+                3) current_type="intel-i915";  current_model="Max_1100";           current_memory=49152 ;;
+                4) current_type="intel-xe";    current_model="Pro-B60-Graphics";   current_memory=24576 ;;
             esac
             ;;
         *)
@@ -241,10 +261,12 @@ for i in "${!node_array[@]}"; do
             esac
             ;;
         "mix")
-            case $((i % 3)) in
+            case $((i % 5)) in
                 0) current_type="nvidia" ;;
                 1) current_type="amd" ;;
-                2) current_type="intel" ;;
+                2) current_type="intel-gaudi" ;;
+                3) current_type="intel-i915" ;;
+                4) current_type="intel-xe" ;;
             esac
             ;;
         *)
@@ -252,13 +274,22 @@ for i in "${!node_array[@]}"; do
             ;;
     esac
 
-    resource_name="${current_type}.com~1gpu"
+    case "$current_type" in
+        "intel-gaudi")
+            resource_name="habana.ai~1gaudi" ;;
+        "intel-i915")
+            resource_name="gpu.intel.com~1i915" ;;
+        "intel-xe")
+            resource_name="gpu.intel.com~1xe" ;;
+        *)
+            resource_name="${current_type}.com~1gpu" ;;
+    esac
 
     # Use kubectl patch with --subresource=status to directly update node status
     # This avoids the need for kubectl proxy and raw curl requests
     kubectl patch node "${node_name}" --subresource=status --type=json -p '[
-        {"op":"add","path":"/status/capacity/'${resource_name}'","value":"'${gpus_per_node}'"},
-        {"op":"add","path":"/status/allocatable/'${resource_name}'","value":"'${gpus_per_node}'"}
+        {"op":"add","path":"/status/capacity/'"${resource_name}"'","value":"'"${gpus_per_node}"'"},
+        {"op":"add","path":"/status/allocatable/'"${resource_name}"'","value":"'"${gpus_per_node}"'"}
     ]'
 done
 
@@ -272,12 +303,20 @@ echo "--------------------------------------------------------------------------
 
 for node in "${node_array[@]}"; do
   node_json=$(kubectl get node "$node" -o json)
-  for resource in "nvidia.com/gpu" "amd.com/gpu" "intel.com/gpu"; do
+  for resource in "nvidia.com/gpu" "amd.com/gpu" "habana.ai/gaudi" "gpu.intel.com/i915" "gpu.intel.com/xe"; do
     cap=$(echo "$node_json" | jq -r ".status.capacity[\"$resource\"] // empty")
     alloc=$(echo "$node_json" | jq -r ".status.allocatable[\"$resource\"] // empty")
     if [[ -n "$cap" || -n "$alloc" ]]; then
-      product=$(echo "$node_json" | jq -r ".metadata.labels[\"${resource}.product\"] // \"-\"")
-      memory=$(echo "$node_json" | jq -r ".metadata.labels[\"${resource}.memory\"] // \"-\"")
+      case ${resource} in
+        "nvidia.com/gpu")   prod_label="nvidia.com/gpu.product";   mem_label="nvidia.com/gpu.memory" ;;
+        "amd.com/gpu")      prod_label="amd.com/gpu.product-name"; mem_label="amd.com/gpu.memory" ;;
+        "habana.ai/gaudi")  prod_label="habana.ai/product.name";   mem_label="habana.ai/device.memory" ;;
+        "gpu.intel.com/i915"|"gpu.intel.com/xe")
+                            prod_label="gpu.intel.com/product";    mem_label="gpu.intel.com/memory" ;;
+        *)                  echo "ERROR: resource '$resource' mismatch!"; exit 1 ;;
+      esac
+      product=$(echo "$node_json" | jq -r ".metadata.labels[\"${prod_label}\"] // \"-\"")
+      memory=$(echo "$node_json" | jq -r ".metadata.labels[\"${mem_label}\"] // \"-\"")
       printf "%-40s %-20s %-10s %-10s %-30s %-10s\n" "$node" "$resource" "$cap" "$alloc" "$product" "$memory"
     fi
   done

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -41,23 +41,51 @@ var (
 	}
 )
 
-var (
-	// GpuResources lists extended resource names provided by K8s GPU device vendor plugins
-	GpuResources = []string{
-		"nvidia.com/gpu",
-		"amd.com/gpu",
-		"habana.ai/gaudi",
-		"gpu.intel.com/i915",
-		"gpu.intel.com/xe",
-	}
+type GpuInfo struct {
+	Vendor              string
+	ResourceName        string
+	ProductLabel        string
+	ProductLabelAliases []string
+	MemoryLabel         string
+}
 
-	// GpuProductKeys are the node selector/affinity keys used to identify GPU products
-	GpuProductKeys = []string{
-		"nvidia.com/gpu.product",
-		"amd.com/gpu.product-name",
-		"cloud.google.com/gke-accelerator",
-		"habana.ai/product.name",
-		"gpu.intel.com/product",
+var (
+	// vendorResources lists each supported GPU resource and its discovery labels.
+	VendorResources = []GpuInfo{
+		{
+			Vendor:              "NVIDIA",
+			ResourceName:        "nvidia.com/gpu",
+			ProductLabel:        "nvidia.com/gpu.product",
+			ProductLabelAliases: []string{"cloud.google.com/gke-accelerator"},
+			MemoryLabel:         "nvidia.com/gpu.memory",
+		},
+		{
+			Vendor:       "AMD",
+			ResourceName: "amd.com/gpu",
+			ProductLabel: "amd.com/gpu.product-name",
+			MemoryLabel:  "amd.com/gpu.memory",
+		},
+		// NOTE: Node labeling rules installed for Node Feature Discovery (NFD) by Intel GPU operator,
+		// provide product labels only for Data Center products. Current Intel Gaudi / GPU operators
+		// do not label nodes with device memory information, that info needs to be labeled separately.
+		{
+			Vendor:       "Intel",
+			ResourceName: "habana.ai/gaudi",
+			ProductLabel: "habana.ai/product.name",
+			MemoryLabel:  "habana.ai/device.memory",
+		},
+		{
+			Vendor:       "Intel",
+			ResourceName: "gpu.intel.com/i915",
+			ProductLabel: "gpu.intel.com/product",
+			MemoryLabel:  "gpu.intel.com/memory",
+		},
+		{
+			Vendor:       "Intel",
+			ResourceName: "gpu.intel.com/xe",
+			ProductLabel: "gpu.intel.com/product",
+			MemoryLabel:  "gpu.intel.com/memory",
+		},
 	}
 
 	SpecReplicasFallback int32 = 1 // in case Spec.Replicas is nil

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -42,14 +42,22 @@ var (
 )
 
 var (
-	// gpuVendors lists the resource name prefixes for GPU vendors
-	GpuVendors = []string{"nvidia.com", "amd.com", "intel.com"}
+	// GpuResources lists extended resource names provided by K8s GPU device vendor plugins
+	GpuResources = []string{
+		"nvidia.com/gpu",
+		"amd.com/gpu",
+		"habana.ai/gaudi",
+		"gpu.intel.com/i915",
+		"gpu.intel.com/xe",
+	}
 
 	// GpuProductKeys are the node selector/affinity keys used to identify GPU products
 	GpuProductKeys = []string{
 		"nvidia.com/gpu.product",
 		"amd.com/gpu.product-name",
 		"cloud.google.com/gke-accelerator",
+		"habana.ai/product.name",
+		"gpu.intel.com/product",
 	}
 
 	SpecReplicasFallback int32 = 1 // in case Spec.Replicas is nil

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -13,11 +13,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type gpuInfo struct {
+	vendor       string
+	resourceName string
+	productLabel string
+	memoryLabel  string
+}
+
 // vendors list for GPU vendors
-var vendors = []string{
-	"nvidia.com",
-	"amd.com",
-	"intel.com",
+var vendors = []gpuInfo{
+	{"NVIDIA", "nvidia.com/gpu", "nvidia.com/gpu.product", "nvidia.com/gpu.memory"},
+	{"AMD", "amd.com/gpu", "amd.com/gpu.product-name", "amd.com/gpu.memory"},
+	// NOTE: Node labeling rules installed for Node Feature Discovery (NFD) by Intel GPU operator,
+	// provide product labels only for Data Center products. Current Intel Gaudi / GPU operators
+	// do not label nodes with device memory information, that info needs to be labeled separately.
+	{"Intel", "habana.ai/gaudi", "habana.ai/product.name", "habana.ai/device.memory"},
+	{"Intel", "gpu.intel.com/i915", "gpu.intel.com/product", "gpu.intel.com/memory"},
+	{"Intel", "gpu.intel.com/xe", "gpu.intel.com/product", "gpu.intel.com/memory"},
 }
 
 // K8sWithGpuOperator implements CapacityDiscovery for Kubernetes clusters with GPU Operator
@@ -57,9 +69,10 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 
 	// Query nodes for each GPU vendor separately.
 	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd).
-	for _, vendor := range vendors {
-		prodKey := vendor + "/gpu.product"
-		memKey := vendor + "/gpu.memory"
+	for _, gpuInfo := range vendors {
+		vendor := gpuInfo.vendor
+		memKey := gpuInfo.memoryLabel
+		prodKey := gpuInfo.productLabel
 
 		req, err := labels.NewRequirement(prodKey, selection.Exists, nil)
 		if err != nil {
@@ -86,7 +99,7 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 			}
 
 			count := 0
-			if cap, ok := node.Status.Allocatable[corev1.ResourceName(vendor+"/gpu")]; ok {
+			if cap, ok := node.Status.Allocatable[corev1.ResourceName(gpuInfo.resourceName)]; ok {
 				count = int(cap.Value())
 			}
 
@@ -196,8 +209,7 @@ func (d *K8sWithGpuOperator) DiscoverUsage(ctx context.Context) (map[string]int,
 
 // discoverNodeGPUTypes returns a map of node name to GPU type (model name).
 // For multi-vendor nodes (nodes labeled for more than one GPU vendor), the model
-// from the LAST matching vendor in `vendors` wins (order: nvidia.com, amd.com,
-// intel.com → intel wins if present, else amd, else nvidia).
+// from the LAST vendor with matching gpuInfo.productLabel wins.
 //
 // This preserves the pre-refactor behavior: the original implementation iterated
 // vendors in order and assigned `nodeGPUType[node] = model` on each match,
@@ -215,11 +227,11 @@ func (d *K8sWithGpuOperator) discoverNodeGPUTypes(ctx context.Context) (map[stri
 	out := make(map[string]string, len(nodes))
 	for name, n := range nodes {
 		// Iterate vendors in REVERSE order and break on first match so the
-		// last vendor in `vendors` wins (intel > amd > nvidia). Relies on the
+		// last item in `vendors` wins (Intel > AMD > NVIDIA). Relies on the
 		// listGPUNodes invariant that n.Accelerators[model] exists whenever
-		// n.Labels[vendor+"/gpu.product"] == model.
+		// n.Labels[gpuInfo.productLabel] == model.
 		for i := len(vendors) - 1; i >= 0; i-- {
-			prodKey := vendors[i] + "/gpu.product"
+			prodKey := vendors[i].productLabel
 			if model, ok := n.Labels[prodKey]; ok {
 				out[name] = model
 				break
@@ -238,8 +250,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	// Sum GPU requests from regular containers (run concurrently)
 	regularTotal := 0
 	for _, container := range pod.Spec.Containers {
-		for _, vendor := range vendors {
-			resName := corev1.ResourceName(vendor + "/gpu")
+		for _, gpuInfo := range vendors {
+			resName := corev1.ResourceName(gpuInfo.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				regularTotal += int(qty.Value())
 			}
@@ -250,8 +262,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	initMax := 0
 	for _, container := range pod.Spec.InitContainers {
 		containerGPUs := 0
-		for _, vendor := range vendors {
-			resName := corev1.ResourceName(vendor + "/gpu")
+		for _, gpuInfo := range vendors {
+			resName := corev1.ResourceName(gpuInfo.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				containerGPUs += int(qty.Value())
 			}

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -69,10 +69,10 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 
 	// Query nodes for each GPU vendor separately.
 	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd).
-	for _, gpuInfo := range vendorResources {
-		vendor := gpuInfo.vendor
-		memKey := gpuInfo.memoryLabel
-		prodKey := gpuInfo.productLabel
+	for _, res := range vendorResources {
+		vendor := res.vendor
+		memKey := res.memoryLabel
+		prodKey := res.productLabel
 
 		req, err := labels.NewRequirement(prodKey, selection.Exists, nil)
 		if err != nil {
@@ -99,7 +99,7 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 			}
 
 			count := 0
-			if cap, ok := node.Status.Allocatable[corev1.ResourceName(gpuInfo.resourceName)]; ok {
+			if cap, ok := node.Status.Allocatable[corev1.ResourceName(res.resourceName)]; ok {
 				count = int(cap.Value())
 			}
 
@@ -219,7 +219,7 @@ func (d *K8sWithGpuOperator) DiscoverUsage(ctx context.Context) (map[string]int,
 
 // discoverNodeGPUTypes returns a map of node name to GPU type (model name).
 // For multi-vendor nodes (nodes labeled for more than one GPU vendor), the model
-// from the LAST resource with matching gpuInfo.productLabel wins.
+// from the LAST resource with matching productLabel wins.
 //
 // This preserves the pre-refactor behavior: the original implementation iterated
 // vendorResources in order and assigned `nodeGPUType[node] = model` on each match,
@@ -239,7 +239,7 @@ func (d *K8sWithGpuOperator) discoverNodeGPUTypes(ctx context.Context) (map[stri
 		// Iterate vendor resources in REVERSE order and break on first match so
 		// the last item in `vendorResources` wins (Intel > AMD > NVIDIA).
 		// Relies on the listGPUNodes invariant that n.Accelerators[model]
-		// exists whenever n.Labels[gpuInfo.productLabel] == model.
+		// exists whenever n.Labels[productLabel] == model.
 		for i := len(vendorResources) - 1; i >= 0; i-- {
 			prodKey := vendorResources[i].productLabel
 			if model, ok := n.Labels[prodKey]; ok {
@@ -260,8 +260,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	// Sum GPU requests from regular containers (run concurrently)
 	regularTotal := 0
 	for _, container := range pod.Spec.Containers {
-		for _, gpuInfo := range vendorResources {
-			resName := corev1.ResourceName(gpuInfo.resourceName)
+		for _, res := range vendorResources {
+			resName := corev1.ResourceName(res.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				regularTotal += int(qty.Value())
 			}
@@ -272,8 +272,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	initMax := 0
 	for _, container := range pod.Spec.InitContainers {
 		containerGPUs := 0
-		for _, gpuInfo := range vendorResources {
-			resName := corev1.ResourceName(gpuInfo.resourceName)
+		for _, res := range vendorResources {
+			resName := corev1.ResourceName(res.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				containerGPUs += int(qty.Value())
 			}

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -20,8 +20,8 @@ type gpuInfo struct {
 	memoryLabel  string
 }
 
-// vendors list for GPU vendors
-var vendors = []gpuInfo{
+// vendorResources lists each supported GPU resource and its discovery labels.
+var vendorResources = []gpuInfo{
 	{"NVIDIA", "nvidia.com/gpu", "nvidia.com/gpu.product", "nvidia.com/gpu.memory"},
 	{"AMD", "amd.com/gpu", "amd.com/gpu.product-name", "amd.com/gpu.memory"},
 	// NOTE: Node labeling rules installed for Node Feature Discovery (NFD) by Intel GPU operator,
@@ -69,7 +69,7 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 
 	// Query nodes for each GPU vendor separately.
 	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd).
-	for _, gpuInfo := range vendors {
+	for _, gpuInfo := range vendorResources {
 		vendor := gpuInfo.vendor
 		memKey := gpuInfo.memoryLabel
 		prodKey := gpuInfo.productLabel
@@ -111,16 +111,15 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 					Accelerators: make(map[string]AcceleratorModelInfo),
 				}
 			}
-			// i915 and xe share the product label gpu.intel.com/product, so an
-			// i915 node is also selected during the xe iteration (and vice versa).
-			// In the non-matching iteration this resource has no allocatable, so
-			// count is 0 (and memKey resolves to the wrong vendor's label). Don't
-			// let that zero overwrite a non-zero count/memory already recorded for
-			// the same model in an earlier iteration.
+			// i915 and xe share the product label gpu.intel.com/product, so a node
+			// can be selected once for the matching resource and once for the
+			// sibling resource that has no allocatable entry. Preserve labeled
+			// nodes with no allocatable resource, but skip the duplicate zero-count
+			// pass when this node/model was already recorded.
 			memory := node.Labels[memKey]
-			if prev, seen := ni.Accelerators[model]; seen && count == 0 {
-				count = prev.Count
-				memory = prev.Memory
+			if _, seen := ni.Accelerators[model]; seen && count == 0 {
+				nodes[node.Name] = ni
+				continue
 			}
 			ni.Accelerators[model] = AcceleratorModelInfo{
 				Count:  count,
@@ -220,10 +219,10 @@ func (d *K8sWithGpuOperator) DiscoverUsage(ctx context.Context) (map[string]int,
 
 // discoverNodeGPUTypes returns a map of node name to GPU type (model name).
 // For multi-vendor nodes (nodes labeled for more than one GPU vendor), the model
-// from the LAST vendor with matching gpuInfo.productLabel wins.
+// from the LAST resource with matching gpuInfo.productLabel wins.
 //
 // This preserves the pre-refactor behavior: the original implementation iterated
-// vendors in order and assigned `nodeGPUType[node] = model` on each match,
+// vendorResources in order and assigned `nodeGPUType[node] = model` on each match,
 // causing later assignments to overwrite earlier ones. Changing this would
 // silently affect usage attribution for multi-vendor nodes, so the refactor
 // keeps the exact same tie-break semantics.
@@ -237,12 +236,12 @@ func (d *K8sWithGpuOperator) discoverNodeGPUTypes(ctx context.Context) (map[stri
 
 	out := make(map[string]string, len(nodes))
 	for name, n := range nodes {
-		// Iterate vendors in REVERSE order and break on first match so the
-		// last item in `vendors` wins (Intel > AMD > NVIDIA). Relies on the
-		// listGPUNodes invariant that n.Accelerators[model] exists whenever
-		// n.Labels[gpuInfo.productLabel] == model.
-		for i := len(vendors) - 1; i >= 0; i-- {
-			prodKey := vendors[i].productLabel
+		// Iterate vendor resources in REVERSE order and break on first match so
+		// the last item in `vendorResources` wins (Intel > AMD > NVIDIA).
+		// Relies on the listGPUNodes invariant that n.Accelerators[model]
+		// exists whenever n.Labels[gpuInfo.productLabel] == model.
+		for i := len(vendorResources) - 1; i >= 0; i-- {
+			prodKey := vendorResources[i].productLabel
 			if model, ok := n.Labels[prodKey]; ok {
 				out[name] = model
 				break
@@ -261,7 +260,7 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	// Sum GPU requests from regular containers (run concurrently)
 	regularTotal := 0
 	for _, container := range pod.Spec.Containers {
-		for _, gpuInfo := range vendors {
+		for _, gpuInfo := range vendorResources {
 			resName := corev1.ResourceName(gpuInfo.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				regularTotal += int(qty.Value())
@@ -273,7 +272,7 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	initMax := 0
 	for _, container := range pod.Spec.InitContainers {
 		containerGPUs := 0
-		for _, gpuInfo := range vendors {
+		for _, gpuInfo := range vendorResources {
 			resName := corev1.ResourceName(gpuInfo.resourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				containerGPUs += int(qty.Value())

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -111,9 +111,20 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 					Accelerators: make(map[string]AcceleratorModelInfo),
 				}
 			}
+			// i915 and xe share the product label gpu.intel.com/product, so an
+			// i915 node is also selected during the xe iteration (and vice versa).
+			// In the non-matching iteration this resource has no allocatable, so
+			// count is 0 (and memKey resolves to the wrong vendor's label). Don't
+			// let that zero overwrite a non-zero count/memory already recorded for
+			// the same model in an earlier iteration.
+			memory := node.Labels[memKey]
+			if prev, seen := ni.Accelerators[model]; seen && count == 0 {
+				count = prev.Count
+				memory = prev.Memory
+			}
 			ni.Accelerators[model] = AcceleratorModelInfo{
 				Count:  count,
-				Memory: node.Labels[memKey],
+				Memory: memory,
 			}
 			nodes[node.Name] = ni
 			accelerators[model] += count

--- a/internal/discovery/k8s_with_gpu_operator.go
+++ b/internal/discovery/k8s_with_gpu_operator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -12,25 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-type gpuInfo struct {
-	vendor       string
-	resourceName string
-	productLabel string
-	memoryLabel  string
-}
-
-// vendorResources lists each supported GPU resource and its discovery labels.
-var vendorResources = []gpuInfo{
-	{"NVIDIA", "nvidia.com/gpu", "nvidia.com/gpu.product", "nvidia.com/gpu.memory"},
-	{"AMD", "amd.com/gpu", "amd.com/gpu.product-name", "amd.com/gpu.memory"},
-	// NOTE: Node labeling rules installed for Node Feature Discovery (NFD) by Intel GPU operator,
-	// provide product labels only for Data Center products. Current Intel Gaudi / GPU operators
-	// do not label nodes with device memory information, that info needs to be labeled separately.
-	{"Intel", "habana.ai/gaudi", "habana.ai/product.name", "habana.ai/device.memory"},
-	{"Intel", "gpu.intel.com/i915", "gpu.intel.com/product", "gpu.intel.com/memory"},
-	{"Intel", "gpu.intel.com/xe", "gpu.intel.com/product", "gpu.intel.com/memory"},
-}
 
 // K8sWithGpuOperator implements CapacityDiscovery for Kubernetes clusters with GPU Operator
 type K8sWithGpuOperator struct {
@@ -69,10 +51,11 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 
 	// Query nodes for each GPU vendor separately.
 	// K8s LabelSelectors don't support OR logic across different keys (e.g. nvidia OR amd).
-	for _, res := range vendorResources {
-		vendor := res.vendor
-		memKey := res.memoryLabel
-		prodKey := res.productLabel
+	for _, res := range constants.VendorResources {
+		vendor := res.Vendor
+		memKey := res.MemoryLabel
+		prodKey := res.ProductLabel
+		resName := corev1.ResourceName(res.ResourceName)
 
 		req, err := labels.NewRequirement(prodKey, selection.Exists, nil)
 		if err != nil {
@@ -99,7 +82,7 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 			}
 
 			count := 0
-			if cap, ok := node.Status.Allocatable[corev1.ResourceName(res.resourceName)]; ok {
+			if cap, ok := node.Status.Allocatable[resName]; ok {
 				count = int(cap.Value())
 			}
 
@@ -111,19 +94,18 @@ func (d *K8sWithGpuOperator) listGPUNodes(ctx context.Context) (map[string]NodeI
 					Accelerators: make(map[string]AcceleratorModelInfo),
 				}
 			}
-			// i915 and xe share the product label gpu.intel.com/product, so a node
-			// can be selected once for the matching resource and once for the
+			// i915 and xe resources use the same gpu.intel.com/product label, so
+			// a node can be selected once for the matching resource and once for the
 			// sibling resource that has no allocatable entry. Preserve labeled
 			// nodes with no allocatable resource, but skip the duplicate zero-count
 			// pass when this node/model was already recorded.
-			memory := node.Labels[memKey]
 			if _, seen := ni.Accelerators[model]; seen && count == 0 {
 				nodes[node.Name] = ni
 				continue
 			}
 			ni.Accelerators[model] = AcceleratorModelInfo{
 				Count:  count,
-				Memory: memory,
+				Memory: node.Labels[memKey],
 			}
 			nodes[node.Name] = ni
 			accelerators[model] += count
@@ -222,7 +204,7 @@ func (d *K8sWithGpuOperator) DiscoverUsage(ctx context.Context) (map[string]int,
 // from the LAST resource with matching productLabel wins.
 //
 // This preserves the pre-refactor behavior: the original implementation iterated
-// vendorResources in order and assigned `nodeGPUType[node] = model` on each match,
+// VendorResources in order and assigned `nodeGPUType[node] = model` on each match,
 // causing later assignments to overwrite earlier ones. Changing this would
 // silently affect usage attribution for multi-vendor nodes, so the refactor
 // keeps the exact same tie-break semantics.
@@ -237,11 +219,11 @@ func (d *K8sWithGpuOperator) discoverNodeGPUTypes(ctx context.Context) (map[stri
 	out := make(map[string]string, len(nodes))
 	for name, n := range nodes {
 		// Iterate vendor resources in REVERSE order and break on first match so
-		// the last item in `vendorResources` wins (Intel > AMD > NVIDIA).
+		// the last item in `VendorResources` wins (Intel > AMD > NVIDIA).
 		// Relies on the listGPUNodes invariant that n.Accelerators[model]
 		// exists whenever n.Labels[productLabel] == model.
-		for i := len(vendorResources) - 1; i >= 0; i-- {
-			prodKey := vendorResources[i].productLabel
+		for i := len(constants.VendorResources) - 1; i >= 0; i-- {
+			prodKey := constants.VendorResources[i].ProductLabel
 			if model, ok := n.Labels[prodKey]; ok {
 				out[name] = model
 				break
@@ -260,8 +242,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	// Sum GPU requests from regular containers (run concurrently)
 	regularTotal := 0
 	for _, container := range pod.Spec.Containers {
-		for _, res := range vendorResources {
-			resName := corev1.ResourceName(res.resourceName)
+		for _, res := range constants.VendorResources {
+			resName := corev1.ResourceName(res.ResourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				regularTotal += int(qty.Value())
 			}
@@ -272,8 +254,8 @@ func getPodGPURequests(pod *corev1.Pod) int {
 	initMax := 0
 	for _, container := range pod.Spec.InitContainers {
 		containerGPUs := 0
-		for _, res := range vendorResources {
-			resName := corev1.ResourceName(res.resourceName)
+		for _, res := range constants.VendorResources {
+			resName := corev1.ResourceName(res.ResourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				containerGPUs += int(qty.Value())
 			}

--- a/internal/discovery/k8s_with_gpu_operator_test.go
+++ b/internal/discovery/k8s_with_gpu_operator_test.go
@@ -174,7 +174,7 @@ func TestDiscover_MixedVendors(t *testing.T) {
 				Name: "node-intel-gaudi",
 				Labels: map[string]string{
 					"habana.ai/product.name":  "Intel-Gaudi-2-96GB",
-					"habana.ai/device.memory": "98304", // manually set label
+					"habana.ai/device.memory": "98304",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -188,7 +188,7 @@ func TestDiscover_MixedVendors(t *testing.T) {
 				Name: "node-intel-i915",
 				Labels: map[string]string{
 					"gpu.intel.com/product": "Max_1100",
-					"gpu.intel.com/memory":  "49152", // manually set label
+					"gpu.intel.com/memory":  "49152",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -202,7 +202,7 @@ func TestDiscover_MixedVendors(t *testing.T) {
 				Name: "node-intel-xe",
 				Labels: map[string]string{
 					"gpu.intel.com/product": "Pro-B60-Graphics",
-					"gpu.intel.com/memory":  "24576", // manually set label
+					"gpu.intel.com/memory":  "24576",
 				},
 			},
 			Status: corev1.NodeStatus{

--- a/internal/discovery/k8s_with_gpu_operator_test.go
+++ b/internal/discovery/k8s_with_gpu_operator_test.go
@@ -93,8 +93,8 @@ func TestDiscover_AMDOnly(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-amd-1",
 				Labels: map[string]string{
-					"amd.com/gpu.product": "AMD-MI300X-192G",
-					"amd.com/gpu.memory":  "196608",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
+					"amd.com/gpu.memory":       "196608",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -107,8 +107,8 @@ func TestDiscover_AMDOnly(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-amd-2",
 				Labels: map[string]string{
-					"amd.com/gpu.product": "AMD-MI250-128G",
-					"amd.com/gpu.memory":  "131072",
+					"amd.com/gpu.product-name": "AMD-MI250-128G",
+					"amd.com/gpu.memory":       "131072",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -159,8 +159,8 @@ func TestDiscover_MixedVendors(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-amd",
 				Labels: map[string]string{
-					"amd.com/gpu.product": "AMD-MI300X-192G",
-					"amd.com/gpu.memory":  "196608",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
+					"amd.com/gpu.memory":       "196608",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -171,15 +171,43 @@ func TestDiscover_MixedVendors(t *testing.T) {
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-intel",
+				Name: "node-intel-gaudi",
 				Labels: map[string]string{
-					"intel.com/gpu.product": "Intel-Gaudi-2-96GB",
-					"intel.com/gpu.memory":  "98304",
+					"habana.ai/product.name":  "Intel-Gaudi-2-96GB",
+					"habana.ai/device.memory": "98304", // manually set label
 				},
 			},
 			Status: corev1.NodeStatus{
 				Allocatable: corev1.ResourceList{
-					"intel.com/gpu": resource.MustParse("8"),
+					"habana.ai/gaudi": resource.MustParse("8"),
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-intel-i915",
+				Labels: map[string]string{
+					"gpu.intel.com/product": "Max_1100",
+					"gpu.intel.com/memory":  "49152", // manually set label
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"gpu.intel.com/i915": resource.MustParse("4"),
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-intel-xe",
+				Labels: map[string]string{
+					"gpu.intel.com/product": "Pro-B60-Graphics",
+					"gpu.intel.com/memory":  "24576", // manually set label
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					"gpu.intel.com/xe": resource.MustParse("2"),
 				},
 			},
 		},
@@ -191,16 +219,20 @@ func TestDiscover_MixedVendors(t *testing.T) {
 	result, err := discoverer.Discover(context.Background())
 	require.NoError(t, err)
 
-	// Should find all 3 nodes from different vendors
-	assert.Len(t, result, 3)
+	// Should find all 5 nodes from different vendors
+	assert.Len(t, result, 5)
 	assert.Contains(t, result, "node-nvidia")
 	assert.Contains(t, result, "node-amd")
-	assert.Contains(t, result, "node-intel")
+	assert.Contains(t, result, "node-intel-gaudi")
+	assert.Contains(t, result, "node-intel-i915")
+	assert.Contains(t, result, "node-intel-xe")
 
 	// Verify each vendor's GPU details
 	assert.Equal(t, 4, result["node-nvidia"]["NVIDIA-H100-SXM5-80GB"].Count)
 	assert.Equal(t, 8, result["node-amd"]["AMD-MI300X-192G"].Count)
-	assert.Equal(t, 8, result["node-intel"]["Intel-Gaudi-2-96GB"].Count)
+	assert.Equal(t, 8, result["node-intel-gaudi"]["Intel-Gaudi-2-96GB"].Count)
+	assert.Equal(t, 4, result["node-intel-i915"]["Max_1100"].Count)
+	assert.Equal(t, 2, result["node-intel-xe"]["Pro-B60-Graphics"].Count)
 }
 
 func TestDiscover_WithNodeSelector(t *testing.T) {
@@ -274,7 +306,7 @@ func TestDiscoverUsage_MixedVendors(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-amd",
 				Labels: map[string]string{
-					"amd.com/gpu.product": "AMD-MI300X-192G",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -365,15 +397,31 @@ func TestDiscoverNodeGPUTypes_MixedVendors(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-amd",
 				Labels: map[string]string{
-					"amd.com/gpu.product": "AMD-MI300X-192G",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
 				},
 			},
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-intel",
+				Name: "node-intel-gaudi",
 				Labels: map[string]string{
-					"intel.com/gpu.product": "Intel-Gaudi-2-96GB",
+					"habana.ai/product.name": "Intel-Gaudi-2-96GB",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-intel-i915",
+				Labels: map[string]string{
+					"gpu.intel.com/product": "Max_1100",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-intel-xe",
+				Labels: map[string]string{
+					"gpu.intel.com/product": "Pro-B60-Graphics",
 				},
 			},
 		},
@@ -385,10 +433,12 @@ func TestDiscoverNodeGPUTypes_MixedVendors(t *testing.T) {
 	result, err := discoverer.discoverNodeGPUTypes(context.Background())
 	require.NoError(t, err)
 
-	assert.Len(t, result, 3)
+	assert.Len(t, result, 5)
 	assert.Equal(t, "NVIDIA-H100-SXM5-80GB", result["node-nvidia"])
 	assert.Equal(t, "AMD-MI300X-192G", result["node-amd"])
-	assert.Equal(t, "Intel-Gaudi-2-96GB", result["node-intel"])
+	assert.Equal(t, "Intel-Gaudi-2-96GB", result["node-intel-gaudi"])
+	assert.Equal(t, "Max_1100", result["node-intel-i915"])
+	assert.Equal(t, "Pro-B60-Graphics", result["node-intel-xe"])
 }
 
 func TestGetPodGPURequests_MixedVendors(t *testing.T) {
@@ -474,8 +524,8 @@ func TestDiscoverNodeGPUTypes_MultiVendorNode_LastWins(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-nvidia-amd",
 				Labels: map[string]string{
-					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
-					"amd.com/gpu.product":    "AMD-MI300X-192G",
+					"nvidia.com/gpu.product":   "NVIDIA-A100-PCIE-80GB",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -490,13 +540,13 @@ func TestDiscoverNodeGPUTypes_MultiVendorNode_LastWins(t *testing.T) {
 				Name: "node-nvidia-intel",
 				Labels: map[string]string{
 					"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB",
-					"intel.com/gpu.product":  "Intel-Gaudi-2-96GB",
+					"habana.ai/product.name": "Intel-Gaudi-2-96GB",
 				},
 			},
 			Status: corev1.NodeStatus{
 				Allocatable: corev1.ResourceList{
-					"nvidia.com/gpu": resource.MustParse("2"),
-					"intel.com/gpu":  resource.MustParse("8"),
+					"nvidia.com/gpu":  resource.MustParse("2"),
+					"habana.ai/gaudi": resource.MustParse("8"),
 				},
 			},
 		},
@@ -570,10 +620,10 @@ func TestDiscoverNodes_MultiVendorNode(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-multi",
 				Labels: map[string]string{
-					"nvidia.com/gpu.product": "NVIDIA-A100-PCIE-80GB",
-					"nvidia.com/gpu.memory":  "81920",
-					"amd.com/gpu.product":    "AMD-MI300X-192G",
-					"amd.com/gpu.memory":     "196608",
+					"nvidia.com/gpu.product":   "NVIDIA-A100-PCIE-80GB",
+					"nvidia.com/gpu.memory":    "81920",
+					"amd.com/gpu.product-name": "AMD-MI300X-192G",
+					"amd.com/gpu.memory":       "196608",
 				},
 			},
 			Status: corev1.NodeStatus{

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -34,8 +34,8 @@ import (
 func GetContainersGPUs(containers []corev1.Container) int {
 	total := 0
 	for _, container := range containers {
-		for _, vendor := range constants.GpuVendors {
-			resName := corev1.ResourceName(vendor + "/gpu")
+		for _, resource := range constants.GpuResources {
+			resName := corev1.ResourceName(resource)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				total += int(qty.Value())
 			}

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -34,8 +34,8 @@ import (
 func GetContainersGPUs(containers []corev1.Container) int {
 	total := 0
 	for _, container := range containers {
-		for _, resource := range constants.GpuResources {
-			resName := corev1.ResourceName(resource)
+		for _, resource := range constants.VendorResources {
+			resName := corev1.ResourceName(resource.ResourceName)
 			if qty, ok := container.Resources.Requests[resName]; ok {
 				total += int(qty.Value())
 			}

--- a/internal/utils/scaletarget/deployment_test.go
+++ b/internal/utils/scaletarget/deployment_test.go
@@ -165,7 +165,7 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 		expected   int
 	}{
 		{
-			name: "single container with nvidia GPU",
+			name: "single container with NVIDIA GPUs",
 			deployment: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -187,7 +187,7 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 			expected: 2,
 		},
 		{
-			name: "single container with amd GPU",
+			name: "single container with AMD GPUs",
 			deployment: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -209,7 +209,7 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 			expected: 4,
 		},
 		{
-			name: "single container with intel GPU",
+			name: "single container with Intel GPUs",
 			deployment: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -219,7 +219,7 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 									Name: "main",
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											"intel.com/gpu": resource.MustParse("1"),
+											"gpu.intel.com/xe": resource.MustParse("3"),
 										},
 									},
 								},
@@ -228,7 +228,7 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 					},
 				},
 			},
-			expected: 1,
+			expected: 3,
 		},
 		{
 			name: "multiple containers with GPUs",
@@ -283,12 +283,20 @@ func TestDeploymentAccessor_GetTotalGPUsPerReplica(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "intel-container",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"gpu.intel.com/xe": resource.MustParse("1"),
+										},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
-			expected: 3,
+			expected: 4,
 		},
 		{
 			name: "no GPU resources defaults to 1",

--- a/internal/utils/scaletarget/fetch_test.go
+++ b/internal/utils/scaletarget/fetch_test.go
@@ -486,7 +486,7 @@ func TestGetContainersGPUs(t *testing.T) {
 		expected   int
 	}{
 		{
-			name: "single container with nvidia GPUs",
+			name: "single container with NVIDIA GPUs",
 			containers: []corev1.Container{
 				{
 					Name: "main",
@@ -500,7 +500,7 @@ func TestGetContainersGPUs(t *testing.T) {
 			expected: 4,
 		},
 		{
-			name: "single container with amd GPUs",
+			name: "single container with AMD GPUs",
 			containers: []corev1.Container{
 				{
 					Name: "main",
@@ -514,13 +514,13 @@ func TestGetContainersGPUs(t *testing.T) {
 			expected: 2,
 		},
 		{
-			name: "single container with intel GPUs",
+			name: "single container with Intel GPUs",
 			containers: []corev1.Container{
 				{
 					Name: "main",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"intel.com/gpu": resource.MustParse("1"),
+							"gpu.intel.com/xe": resource.MustParse("1"),
 						},
 					},
 				},
@@ -572,7 +572,7 @@ func TestGetContainersGPUs(t *testing.T) {
 					Name: "intel-container",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"intel.com/gpu": resource.MustParse("1"),
+							"gpu.intel.com/xe": resource.MustParse("1"),
 						},
 					},
 				},

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -361,10 +361,7 @@ func ValidatePrometheusAPI(ctx context.Context, promAPI promv1.API) error {
 }
 
 // GetAcceleratorNameFromScaleTarget extracts GPU product information from a scale target's nodeSelector or nodeAffinity.
-// It checks for the following keys in order:
-// - nvidia.com/gpu.product
-// - amd.com/gpu.product-name
-// - cloud.google.com/gke-accelerator
+// GPU product information is checked against keys listed in constants.GpuProductKeys.
 // If not found in nodeSelector or nodeAffinity, falls back to the AcceleratorNameLabel on the VariantAutoscaling.
 // Returns the first matching value found, or constants.DefaultAcceleratorName ("unknown") if none are found.
 // The sentinel allows callers to proceed without hard-stopping; the GPU limiter resolves

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -360,8 +362,20 @@ func ValidatePrometheusAPI(ctx context.Context, promAPI promv1.API) error {
 	return ValidatePrometheusAPIWithBackoff(ctx, promAPI, constants.PrometheusValidationBackoff)
 }
 
+// GetProductKeys returns unique vendor product (node label) keys, in stable (sorted) order
+func GetProductKeys() []string {
+	labels := make(map[string]bool, len(constants.VendorResources))
+	for _, res := range constants.VendorResources {
+		labels[res.ProductLabel] = true
+		for _, label := range res.ProductLabelAliases {
+			labels[label] = true
+		}
+	}
+	return slices.Sorted(maps.Keys(labels))
+}
+
 // GetAcceleratorNameFromScaleTarget extracts GPU product information from a scale target's nodeSelector or nodeAffinity.
-// GPU product information is checked against keys listed in constants.GpuProductKeys.
+// GPU product information is checked against keys listed in constants.VendorResources.
 // If not found in nodeSelector or nodeAffinity, falls back to the AcceleratorNameLabel on the VariantAutoscaling.
 // Returns the first matching value found, or constants.DefaultAcceleratorName ("unknown") if none are found.
 // The sentinel allows callers to proceed without hard-stopping; the GPU limiter resolves
@@ -371,9 +385,11 @@ func GetAcceleratorNameFromScaleTarget(va *llmdVariantAutoscalingV1alpha1.Varian
 	if scaleTarget != nil {
 		podTemplateSpec := scaleTarget.GetLeaderPodTemplateSpec()
 		if podTemplateSpec != nil {
+			prodKeys := GetProductKeys()
+
 			// Check nodeSelector first
 			if podTemplateSpec.Spec.NodeSelector != nil {
-				for _, key := range constants.GpuProductKeys {
+				for _, key := range prodKeys {
 					if val, ok := podTemplateSpec.Spec.NodeSelector[key]; ok {
 						return val
 					}
@@ -382,7 +398,7 @@ func GetAcceleratorNameFromScaleTarget(va *llmdVariantAutoscalingV1alpha1.Varian
 
 			// Check nodeAffinity
 			if podTemplateSpec.Spec.Affinity != nil && podTemplateSpec.Spec.Affinity.NodeAffinity != nil {
-				if val := extractGPUFromNodeAffinity(podTemplateSpec.Spec.Affinity.NodeAffinity, constants.GpuProductKeys); val != "" {
+				if val := extractGPUFromNodeAffinity(podTemplateSpec.Spec.Affinity.NodeAffinity, prodKeys); val != "" {
 					return val
 				}
 			}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -149,6 +149,38 @@ func TestGetAcceleratorNameFromScaleTarget(t *testing.T) {
 			expected: "nvidia-tesla-v100",
 		},
 		{
+			name: "intel_gaudi_from_nodeSelector",
+			va:   &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{},
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"habana.ai/product.name": "Intel-Gaudi-2-96GB",
+							},
+						},
+					},
+				},
+			},
+			expected: "Intel-Gaudi-2-96GB",
+		},
+		{
+			name: "intel_gpu_from_nodeSelector",
+			va:   &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{},
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"gpu.intel.com/product": "Max_1100",
+							},
+						},
+					},
+				},
+			},
+			expected: "Max_1100",
+		},
+		{
 			name: "nvidia_gpu_from_required_nodeAffinity",
 			va:   &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{},
 			deployment: &appsv1.Deployment{

--- a/test/testconfig/config.go
+++ b/test/testconfig/config.go
@@ -20,7 +20,7 @@ type SharedConfig struct {
 
 	// Infrastructure mode
 	UseSimulator bool   // true for emulated GPUs, false for real vLLM
-	GPUType      string // "nvidia-mix", "amd-mix", "real"
+	GPUType      string // "nvidia-mix", "amd-mix", "real"...
 
 	// Scaler backend: "prometheus-adapter" (HPA) or "keda" (ScaledObject)
 	ScalerBackend string

--- a/test/utils/resources/llmdsim.go
+++ b/test/utils/resources/llmdsim.go
@@ -15,6 +15,11 @@ import (
 
 const SimulatorImage = "ghcr.io/llm-d/llm-d-inference-sim:v0.9.0"
 
+const (
+	// gpuResourceDefault is the extended K8s resource type requested when none is specified.
+	gpuResourceDefault = "nvidia.com/gpu"
+)
+
 // creates a llm-d-sim deployment with the specified configuration
 func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port string, avgTTFT, avgITL int, replicas int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -91,13 +96,13 @@ func CreateLlmdSimDeployment(namespace, deployName, modelName, appLabel, port st
 
 // CreateLlmdSimDeploymentWithGPU creates a llm-d-sim deployment with GPU resource requests.
 // gpusPerReplica specifies the number of GPUs to request per replica.
-// gpuType specifies the GPU vendor: "nvidia", "amd", or "intel" (defaults to "nvidia" if empty).
+// gpuResource specifies the GPU (vendor specific) extended K8s resource type to request.
 // If gpusPerReplica is 0, no GPU resources are requested (same as CreateLlmdSimDeployment).
-func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, port string, avgTTFT, avgITL int, replicas int32, gpusPerReplica int, gpuType string) *appsv1.Deployment {
-	if gpuType == "" {
-		gpuType = "nvidia"
+func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, port string, avgTTFT, avgITL int, replicas int32, gpusPerReplica int, gpuResource string) *appsv1.Deployment {
+	if gpuResource == "" {
+		gpuResource = gpuResourceDefault
 	}
-	gpuResourceName := corev1.ResourceName(gpuType + ".com/gpu")
+	gpuResourceName := corev1.ResourceName(gpuResource)
 
 	container := corev1.Container{
 		Name:            appLabel,
@@ -190,12 +195,12 @@ func CreateLlmdSimDeploymentWithGPU(namespace, deployName, modelName, appLabel, 
 func CreateLlmdSimDeploymentWithGPUAndNodeSelector(
 	namespace, deployName, modelName, appLabel, port string,
 	avgTTFT, avgITL int, replicas int32,
-	gpusPerReplica int, gpuType string,
+	gpusPerReplica int, gpuResource string,
 	nodeSelector map[string]string,
 ) *appsv1.Deployment {
 	deployment := CreateLlmdSimDeploymentWithGPU(
 		namespace, deployName, modelName, appLabel, port,
-		avgTTFT, avgITL, replicas, gpusPerReplica, gpuType,
+		avgTTFT, avgITL, replicas, gpusPerReplica, gpuResource,
 	)
 
 	if len(nodeSelector) > 0 {
@@ -224,13 +229,13 @@ func CreateLlmdSimDeploymentWithGPUAndNodeSelector(
 func CreateLlmdSimDeploymentWithGPUAndLabels(
 	namespace, deployName, modelName, appLabel, port string,
 	avgTTFT, avgITL int, replicas int32,
-	gpusPerReplica int, gpuType string,
+	gpusPerReplica int, gpuResource string,
 	nodeSelector map[string]string,
 	extraLabels map[string]string,
 ) *appsv1.Deployment {
 	deployment := CreateLlmdSimDeploymentWithGPUAndNodeSelector(
 		namespace, deployName, modelName, appLabel, port,
-		avgTTFT, avgITL, replicas, gpusPerReplica, gpuType,
+		avgTTFT, avgITL, replicas, gpusPerReplica, gpuResource,
 		nodeSelector,
 	)
 

--- a/test/utils/resources/llmdsim.go
+++ b/test/utils/resources/llmdsim.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const SimulatorImage = "ghcr.io/llm-d/llm-d-inference-sim:v0.9.0"
-
 const (
+	SimulatorImage = "ghcr.io/llm-d/llm-d-inference-sim:v0.9.0"
+
 	// gpuResourceDefault is the extended K8s resource type requested when none is specified.
 	gpuResourceDefault = "nvidia.com/gpu"
 )


### PR DESCRIPTION
Supersedes #1105 and fixes #1104, adopting @eero-t's groundwork. Adds the missing discovery fix so i915/xe GPU counts are no longer zeroed out when Intel variants share the `gpu.intel.com/product` label. Opened as draft for review.