### PR TITLE
fix(saturation_v2): include gpuCount in k2 history key to prevent cross-variant contamination

### DIFF
--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -20,7 +20,8 @@ type SaturationAnalyzer struct {
 	// mu protects computeCapacityHistory from concurrent access.
 	mu sync.Mutex
 	// computeCapacityHistory stores rolling averages of observed k2 values,
-	// keyed by "modelID|accelerator|outputBucket".
+	// keyed by "modelID|accelerator|gpuCount|outputBucket".
+	// TODO: check if we need to use other model parameters as key in the future.
 	computeCapacityHistory map[string]*rollingAverage
 	capacityStore          *CapacityKnowledgeStore
 }
@@ -169,6 +170,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	}
 	k2 := a.computeK2(
 		modelID, rm.AcceleratorName,
+		gpuCount,
 		rm.QueueLength, rm.TokensInUse,
 		rm.AvgOutputTokens, rm.AvgInputTokens,
 		config.QueueLengthThreshold,
@@ -270,6 +272,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 // 4. Fallback → k1 (memory-bound only)
 func (a *SaturationAnalyzer) computeK2(
 	modelID, accelerator string,
+	gpuCount int,
 	queueLen int, tokensInUse int64,
 	avgOutput, avgInput float64,
 	queueThreshold float64,
@@ -277,7 +280,7 @@ func (a *SaturationAnalyzer) computeK2(
 	k1 int64,
 ) int64 {
 	outputBucket := classifyOutputLength(avgOutput)
-	historyKey := fmt.Sprintf("%s|%s|%s", modelID, accelerator, outputBucket)
+	historyKey := fmt.Sprintf("%s|%s|%d|%s", modelID, accelerator, gpuCount, outputBucket)
 
 	// Priority 1: Observed (queue saturated)
 	if queueLen >= int(queueThreshold) && tokensInUse > 0 {

--- a/internal/engines/analyzers/saturation_v2/analyzer_test.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer_test.go
@@ -102,7 +102,7 @@ var _ = Describe("SaturationAnalyzer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify k2 was stored in history
-			histKey := "test-model|H100|short"
+			histKey := "test-model|H100|1|short"
 			ra, ok := analyzer.computeCapacityHistory[histKey]
 			Expect(ok).To(BeTrue())
 			Expect(ra.Average()).To(Equal(float64(8000)))


### PR DESCRIPTION
## Summary

- The `computeK2` rolling-average history key was `"modelID|accelerator|outputBucket"`, causing TP=1 and TP=2 variants of the same model to share k2 observations
- Add `gpuCount` to the key so each tensor-parallel width maintains an independent history
- Update the test to use the new key format

Fixes #1254

## Test plan

- [ ] `make test` passes — existing k2 history test updated to use `"modelID|accelerator|gpuCount|outputBucket"` key format
- [ ] Empirically validated on pokprod001 with two-variant Llama-3.1-8B (primary TP=2, v2 TP=1): with fix, per-replica capacity estimates are stable and consistent with hardware expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)