### PR TITLE
feat(collector): derive pod → VariantAutoscaling mapping per cycle

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -454,6 +454,9 @@ func main() {
 			sourceRegistry,
 			cfg, // Pass unified Config to engine
 		)
+		// Use the uncached API reader for the per-cycle pod LIST in pod→VA derivation,
+		// so it does not start a cluster-wide Pod informer/cache.
+		engine.APIReader = mgr.GetAPIReader()
 		go engine.StartOptimizeLoop(ctx)
 		return nil
 	}))

--- a/docs/design/controller-behavior.md
+++ b/docs/design/controller-behavior.md
@@ -243,14 +243,16 @@ This periodic reconciliation is why many Update and Delete events can be safely 
 
 ## Prerequisites
 
-### `llm-d.ai/variant` Label on the Scale Target
+### `llm-d.ai/variant` Label on the Scale Target (optional override)
 
-WVA identifies which pods belong to a given `VariantAutoscaling` resource by reading the `llm-d.ai/variant` label from Prometheus metrics. Two things must be true for this to work:
+By default WVA derives which pods belong to a `VariantAutoscaling` itself, once per optimization cycle, by listing the pods behind the scale target's selector (`scaleTargetRef` → Deployment/LeaderWorkerSet) and attributing each to that VA. **For the standard kinds (Deployment, LeaderWorkerSet) no pod-template label or ServiceMonitor relabeling rule is required** — pointing a `VariantAutoscaling` at a running workload is sufficient, with no rolling restart to adopt.
+
+The `llm-d.ai/variant` label remains supported as a **higher-precedence override**, for workloads the selector can't resolve (custom kinds or non-standard owner chains) and for back-compat with existing installs. When the label is present on a pod it takes precedence over the derived mapping. To use it, two things must be true:
 
 1. The `llm-d.ai/variant` label must be present on the **pod template** of the scale target (Deployment or LeaderWorkerSet), with a value equal to the name of the corresponding `VariantAutoscaling` resource.
 2. The `ServiceMonitor` or `PodMonitor` that Prometheus uses to scrape those pods must include a target relabeling rule that propagates the pod label into the scraped metrics as `llm_d_ai_variant`.
 
-**Both are your responsibility.** WVA does not configure either automatically.
+WVA reads the label but never writes it; both steps below are your responsibility only if you opt into the override.
 
 #### 1. Set the pod template label
 
@@ -315,15 +317,15 @@ spec:
 
 > **Important**: This rule must live under `relabelings` (target relabeling), **not** `metricRelabelings` (metric relabeling). The `__meta_kubernetes_pod_label_*` labels are only available during target relabeling and are stripped before metric relabeling runs.
 
-WVA uses the `llm_d_ai_variant` metric label to associate per-pod metrics with the correct `VariantAutoscaling` resource.
+WVA uses the `llm_d_ai_variant` metric label, when present, to associate per-pod metrics with the correct `VariantAutoscaling` resource, taking precedence over the derived mapping.
 
-If the pod label or the relabeling rule is absent, WVA will not collect metrics for the affected pods and scaling decisions for that variant will not be made.
+If the override label or relabeling rule is absent, WVA falls back to per-cycle selector derivation (the default). A pod that resolves to no scale target — and carries no override label — is skipped and counted in the `wva_pod_mapping_miss_total{reason="unresolved"}` metric; a pod matched by multiple overlapping selectors that the owner-reference tiebreak cannot disambiguate is counted with `reason="ambiguous"`.
 
 ## Best Practices
 
 ### For Operators
 
-1. **Set `llm-d.ai/variant` before creating the VA**: Ensure the pod template label is present on the scale target before creating the `VariantAutoscaling` resource. WVA begins collecting metrics on the first reconciliation and will miss pods that don't yet carry the label.
+1. **Adopt without touching the workload**: For Deployment/LeaderWorkerSet scale targets, no pod-template label is needed — create the `VariantAutoscaling` pointing at the running workload and WVA derives the pod mapping from the selector. Only reach for the `llm-d.ai/variant` override (and its relabeling rule) for custom kinds or non-standard owner chains; setting it requires a rolling restart of the workload, so prefer derivation where it works.
 
 2. **Create VAs after deployments are ready**: While the controller handles the race condition, creating VAs after deployments are fully initialized avoids unnecessary early reconciliation cycles.
 

--- a/internal/collector/build_instance_key_test.go
+++ b/internal/collector/build_instance_key_test.go
@@ -137,6 +137,7 @@ func TestBuildInstanceKey_VANameExtraction(t *testing.T) {
 				make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 				nil,
 				make(map[string]float64),
+				nil,
 			)
 			if err != nil {
 				t.Fatalf("CollectReplicaMetrics: %v", err)

--- a/internal/collector/podvamap/podvamap.go
+++ b/internal/collector/podvamap/podvamap.go
@@ -1,0 +1,199 @@
+// Package podvamap derives, once per optimization cycle, a mapping from pod
+// identity to the VariantAutoscaling whose scale target owns the pod.
+//
+// It replaces the tenant-authored llm-d.ai/variant pod-template label as the
+// default attribution path: for each managed VariantAutoscaling, WVA lists the
+// pods behind its scale target's selector and attributes them to that VA. Pods
+// matched by more than one workload selector are disambiguated by walking the
+// owner chain (Pod -> ReplicaSet/StatefulSet -> Deployment/LeaderWorkerSet ->
+// VA); if still ambiguous they are left unmapped and surface as a mapping miss.
+//
+// The map is read-only on the metrics hot path: callers resolve a pod with a
+// single Lookup, with no Kubernetes calls.
+package podvamap
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/logging"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+// Map holds a per-cycle "<namespace>/<pod-name>" -> VariantAutoscaling-name mapping.
+// A nil *Map is safe to Lookup against (it resolves nothing).
+type Map struct {
+	byPod map[string]string
+}
+
+// Lookup returns the VariantAutoscaling name a pod was attributed to, and whether
+// the pod was resolved. Pods are keyed by namespace and name (pod names are not
+// unique across namespaces).
+func (m *Map) Lookup(namespace, podName string) (string, bool) {
+	if m == nil || m.byPod == nil {
+		return "", false
+	}
+	va, ok := m.byPod[namespace+"/"+podName]
+	return va, ok
+}
+
+// Len returns the number of resolved pods. Used mainly in tests.
+func (m *Map) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.byPod)
+}
+
+// Build derives the pod -> VariantAutoscaling map for a set of managed VAs.
+//
+//   - reader is an uncached read interface (mgr.GetAPIReader()): a direct, bounded
+//     API LIST/GET per cycle that does NOT start a cluster-wide Pod informer/cache.
+//   - scaleTargets is keyed by "<namespace>/<scaleTargetName>" and provides the
+//     workload (Deployment/LWS) backing each VA's scaleTargetRef.
+//   - variantAutoscalings is keyed by "<namespace>/<vaName>".
+//
+// For each VA, the pods behind its scale target's selector are listed and attributed
+// to that VA. Overlapping-selector collisions are resolved by owner reference;
+// unresolved collisions increment the pod-mapping miss counter and are omitted.
+func Build(
+	ctx context.Context,
+	reader client.Reader,
+	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
+	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+) *Map {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// candidates: "<namespace>/<podName>" -> set of VA names whose selector matched it.
+	candidates := make(map[string]map[string]struct{})
+	// podObjs: same key -> Pod, retained only for collisions needing owner-ref tiebreak.
+	podObjs := make(map[string]*corev1.Pod)
+
+	// TODO: this issues one selector-scoped List per VA (O(VAs) API calls per cycle).
+	// Acceptable at realistic VA counts; if it grows, switch to one List per namespace
+	// plus in-memory selector matching.
+	for vaKey, va := range variantAutoscalings {
+		if va == nil {
+			continue
+		}
+		accessor, ok := scaleTargets[va.Namespace+"/"+va.GetScaleTargetName()]
+		if !ok || accessor == nil {
+			logger.V(logging.DEBUG).Info("pod-VA derivation: no scale target for VA", "va", vaKey)
+			continue
+		}
+
+		podList := &corev1.PodList{}
+		if err := reader.List(ctx, podList,
+			client.InNamespace(va.Namespace),
+			client.MatchingLabelsSelector{Selector: accessor.GetPodSelector()},
+		); err != nil {
+			logger.V(logging.DEBUG).Info("pod-VA derivation: failed to list pods", "va", vaKey, "error", err)
+			continue
+		}
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			key := pod.Namespace + "/" + pod.Name
+			if candidates[key] == nil {
+				candidates[key] = make(map[string]struct{})
+				podObjs[key] = pod
+			}
+			candidates[key][va.Name] = struct{}{}
+		}
+	}
+
+	byPod := make(map[string]string, len(candidates))
+	for key, vaSet := range candidates {
+		if len(vaSet) == 1 {
+			for vaName := range vaSet {
+				byPod[key] = vaName
+			}
+			continue
+		}
+
+		// Overlapping selectors: disambiguate via the owner chain.
+		pod := podObjs[key]
+		if vaName := resolveByOwnerRef(ctx, reader, pod, variantAutoscalings); vaName != "" {
+			if _, matched := vaSet[vaName]; matched {
+				byPod[key] = vaName
+				continue
+			}
+		}
+		// Still ambiguous: leave unmapped and record a miss. variant_name is empty
+		// because the pod could not be attributed to a single VA — that is the signal.
+		ns, name := "", key
+		if pod != nil {
+			ns, name = pod.Namespace, pod.Name
+		}
+		metrics.IncPodMappingMiss("", ns, constants.PodMappingMissAmbiguous)
+		logger.V(logging.DEBUG).Info("pod-VA derivation: pod matched multiple workloads, owner-ref tiebreak failed",
+			"pod", name, "namespace", ns)
+	}
+
+	return &Map{byPod: byPod}
+}
+
+// resolveByOwnerRef walks Pod -> ReplicaSet/StatefulSet -> Deployment/LeaderWorkerSet
+// and resolves the owning VariantAutoscaling by matching the top-level workload against
+// the in-memory variantAutoscalings (by scaleTargetRef), so it needs no field-index cache.
+// It returns the VA name, or "" if the chain cannot be resolved. Used only to break
+// overlapping-selector ties, so its per-pod reads are off the common path.
+func resolveByOwnerRef(
+	ctx context.Context,
+	reader client.Reader,
+	pod *corev1.Pod,
+	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+) string {
+	if pod == nil {
+		return ""
+	}
+	logger := ctrl.LoggerFrom(ctx)
+	ns := pod.Namespace
+
+	owner := metav1.GetControllerOf(pod)
+	if owner == nil {
+		return ""
+	}
+
+	var controllee metav1.Object
+	switch owner.Kind {
+	case constants.ReplicaSetKind:
+		rs := &appsv1.ReplicaSet{}
+		if err := reader.Get(ctx, client.ObjectKey{Namespace: ns, Name: owner.Name}, rs); err != nil {
+			logger.V(logging.DEBUG).Info("pod-VA derivation: failed to get ReplicaSet", "replicaset", owner.Name, "error", err)
+			return ""
+		}
+		controllee = rs
+	case constants.StatefulSetKind:
+		ss := &appsv1.StatefulSet{}
+		if err := reader.Get(ctx, client.ObjectKey{Namespace: ns, Name: owner.Name}, ss); err != nil {
+			logger.V(logging.DEBUG).Info("pod-VA derivation: failed to get StatefulSet", "statefulset", owner.Name, "error", err)
+			return ""
+		}
+		controllee = ss
+	default:
+		return ""
+	}
+
+	top := metav1.GetControllerOf(controllee)
+	if top == nil {
+		return ""
+	}
+
+	// Match the top-level workload against the managed VAs already in memory.
+	for _, va := range variantAutoscalings {
+		if va != nil && va.Namespace == ns &&
+			va.GetScaleTargetKind() == top.Kind && va.GetScaleTargetName() == top.Name {
+			return va.Name
+		}
+	}
+	return ""
+}

--- a/internal/collector/podvamap/podvamap_test.go
+++ b/internal/collector/podvamap/podvamap_test.go
@@ -1,0 +1,145 @@
+package podvamap
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
+)
+
+const testNS = "ns"
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1: %v", err)
+	}
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add llmd v1alpha1: %v", err)
+	}
+	return scheme
+}
+
+func deployment(name string, selector map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: selector},
+		},
+	}
+}
+
+func va(name, scaleTargetName string) *llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
+	return &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: scaleTargetName},
+			ModelID:        "model",
+		},
+	}
+}
+
+func pod(name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS, Labels: labels}}
+}
+
+func TestBuild(t *testing.T) {
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	t.Run("resolves pods that match the scale-target selector", func(t *testing.T) {
+		deploy := deployment("deploy-a", map[string]string{"app": "a"})
+		p1 := pod("pod-a-1", map[string]string{"app": "a"})
+		p2 := pod("pod-a-2", map[string]string{"app": "a"})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, p1, p2).Build()
+
+		scaleTargets := map[string]scaletarget.ScaleTargetAccessor{
+			"ns/deploy-a": scaletarget.NewDeploymentAccessor(deploy),
+		}
+		vas := map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+			"ns/va-a": va("va-a", "deploy-a"),
+		}
+
+		m := Build(ctx, c, scaleTargets, vas)
+		for _, name := range []string{"pod-a-1", "pod-a-2"} {
+			got, ok := m.Lookup(testNS, name)
+			if !ok || got != "va-a" {
+				t.Errorf("Lookup(%q) = (%q, %v), want (va-a, true)", name, got, ok)
+			}
+		}
+		if m.Len() != 2 {
+			t.Errorf("Len() = %d, want 2", m.Len())
+		}
+	})
+
+	t.Run("pods that match no selector are not resolved", func(t *testing.T) {
+		deploy := deployment("deploy-a", map[string]string{"app": "a"})
+		stray := pod("stray", map[string]string{"app": "other"})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, stray).Build()
+
+		m := Build(ctx, c,
+			map[string]scaletarget.ScaleTargetAccessor{"ns/deploy-a": scaletarget.NewDeploymentAccessor(deploy)},
+			map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{"ns/va-a": va("va-a", "deploy-a")},
+		)
+		if _, ok := m.Lookup(testNS, "stray"); ok {
+			t.Errorf("Lookup(stray) resolved unexpectedly")
+		}
+	})
+
+	t.Run("VA without a known scale target is skipped", func(t *testing.T) {
+		p1 := pod("pod-a-1", map[string]string{"app": "a"})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p1).Build()
+
+		// scaleTargets is empty: the VA's scale target is not present.
+		m := Build(ctx, c,
+			map[string]scaletarget.ScaleTargetAccessor{},
+			map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{"ns/va-a": va("va-a", "deploy-a")},
+		)
+		if m.Len() != 0 {
+			t.Errorf("Len() = %d, want 0 (no scale target → nothing resolved)", m.Len())
+		}
+	})
+
+	t.Run("overlapping selectors with no owner chain are left unresolved", func(t *testing.T) {
+		deployA := deployment("deploy-a", map[string]string{"app": "shared"})
+		deployB := deployment("deploy-b", map[string]string{"app": "shared"})
+		shared := pod("shared-pod", map[string]string{"app": "shared"})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployA, deployB, shared).Build()
+
+		scaleTargets := map[string]scaletarget.ScaleTargetAccessor{
+			"ns/deploy-a": scaletarget.NewDeploymentAccessor(deployA),
+			"ns/deploy-b": scaletarget.NewDeploymentAccessor(deployB),
+		}
+		vas := map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+			"ns/va-a": va("va-a", "deploy-a"),
+			"ns/va-b": va("va-b", "deploy-b"),
+		}
+
+		// The pod matches both selectors and has no owner reference, so the owner-ref
+		// tiebreak fails and the pod is left unresolved (a mapping miss) rather than
+		// being misattributed to an arbitrary VA.
+		m := Build(ctx, c, scaleTargets, vas)
+		if _, ok := m.Lookup(testNS, "shared-pod"); ok {
+			t.Errorf("Lookup(shared-pod) resolved despite ambiguous selectors")
+		}
+	})
+
+	t.Run("nil map Lookup is safe", func(t *testing.T) {
+		var m *Map
+		if _, ok := m.Lookup(testNS, "anything"); ok {
+			t.Errorf("nil Map.Lookup resolved unexpectedly")
+		}
+	})
+}

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/podvamap"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
@@ -129,6 +130,9 @@ func (c *ReplicaMetricsCollector) recordMetricsUnavailableEvent(
 //   - scaleTargets: Map of Deployment/LWS namespace/name to Deployment/LWS
 //   - variantAutoscalings: Map of VariantAutoscaling namespace/name to VariantAutoscaling object
 //   - variantCosts: Map of VariantAutoscaling namespace/name to cost value
+//   - podMap: Per-cycle pod→VA mapping derived from scale-target selectors; used to attribute
+//     a pod to its VariantAutoscaling when the llm-d.ai/variant override label is absent.
+//     May be nil, in which case attribution falls back to the label only.
 //
 // Returns:
 //   - []interfaces.ReplicaMetrics: Per-pod metrics for saturation and queueing model analysis
@@ -141,8 +145,9 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	vaEventTracker map[string]bool,
 	variantCosts map[string]float64,
+	podMap *podvamap.Map,
 ) ([]interfaces.ReplicaMetrics, error) {
-	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts)
+	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts, podMap)
 
 	// Determine if metrics are available in this cycle
 	metricsAvailable := err == nil && len(replicaMetrics) > 0
@@ -184,6 +189,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	variantCosts map[string]float64,
+	podMap *podvamap.Map,
 ) ([]interfaces.ReplicaMetrics, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -315,8 +321,15 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			podName = labels["pod_name"]
 		}
 
-		// Extract VA name from llm_d_ai_variant label (propagated by ServiceMonitor)
+		// Extract VA name from llm_d_ai_variant label (propagated by ServiceMonitor).
+		// The label is a higher-precedence override; when absent, fall back to the
+		// per-cycle pod→VA map derived from scale-target selectors.
 		vaName := labels[constants.VariantLabelPrometheusKey]
+		if vaName == "" && podMap != nil {
+			if derived, ok := podMap.Lookup(namespace, podName); ok {
+				vaName = derived
+			}
+		}
 
 		// Try to extract port from instance label (IP:port format)
 		instance := labels["instance"]
@@ -752,6 +765,9 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 
 		if vaName == "" {
+			// Neither the override label nor per-cycle derivation attributed this pod to
+			// a VA. variant_name is empty because the pod is unattributed — that is the signal.
+			metrics.IncPodMappingMiss("", namespace, constants.PodMappingMissUnresolved)
 			logger.Info("Skipping pod that doesn't match any scale target",
 				"pod", podName,
 				"instance", instanceKey,

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -186,7 +186,7 @@ func TestCollectReplicaMetrics_ErrorRecordsEvent(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call with error: no event (first observation, unknown previous state)
-	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.Error(t, err, "Should return error when refresh fails")
 	require.Nil(t, metrics, "Should return nil metrics on error")
 
@@ -198,7 +198,7 @@ func TestCollectReplicaMetrics_ErrorRecordsEvent(t *testing.T) {
 	}
 
 	// Second call: metrics still fail, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.Error(t, err, "Should still return error")
 
 	select {
@@ -244,7 +244,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call: no metrics, should NOT emit event (first observation, unknown previous state)
-	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error when no metrics available")
 	require.Empty(t, metrics, "Should return empty metrics slice")
 
@@ -256,7 +256,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	}
 
 	// Second call: still no metrics, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error")
 
 	select {
@@ -267,7 +267,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	}
 
 	// Third call: still no metrics, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error")
 
 	select {
@@ -319,7 +319,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call: metrics unavailable, should NOT emit event (first observation, unknown previous state)
-	_, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -330,7 +330,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	}
 
 	// Second call: metrics still unavailable, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -341,7 +341,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	}
 
 	// Third call: still unavailable, should NOT emit event
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -388,6 +388,7 @@ func TestCollectReplicaMetrics_MetricsObservation(t *testing.T) {
 		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 		nil,
 		make(map[string]float64),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CollectReplicaMetrics failed: %v", err)
@@ -499,6 +500,7 @@ func TestCollectReplicaMetrics_ErrorMetrics(t *testing.T) {
 		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 		nil,
 		make(map[string]float64),
+		nil,
 	)
 	if err == nil {
 		t.Fatal("Expected error but got nil")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -62,6 +62,11 @@ const (
 	LeaderWorkerSetKind       = "LeaderWorkerSet"
 	LeaderWorkerSetAPIVersion = "leaderworkerset.x-k8s.io/v1"
 
+	// Intermediate owner kinds traversed when resolving a pod to its scale target
+	// (Pod → ReplicaSet → Deployment, Pod → StatefulSet → LeaderWorkerSet).
+	ReplicaSetKind  = "ReplicaSet"
+	StatefulSetKind = "StatefulSet"
+
 	// K8s Events
 	K8SEventScaledUp                  = "ScaledUp"
 	K8SEventScaledDown                = "ScaledDown"

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -185,6 +185,21 @@ const (
 	// WVAKvCacheTokensCapacity is a gauge that tracks total KV cache token capacity per variant.
 	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
+
+	// WVAPodMappingMissTotal is a counter that tracks pods that could not be attributed
+	// to a VariantAutoscaling during per-cycle derivation from the scaleTargetRef selector.
+	// Labels: variant_name, namespace, reason
+	WVAPodMappingMissTotal = "wva_pod_mapping_miss_total"
+)
+
+// Pod-mapping miss reasons (values for the `reason` label of WVAPodMappingMissTotal).
+const (
+	// PodMappingMissUnresolved indicates a scraped pod matched no managed workload selector
+	// and carried no llm-d.ai/variant override label.
+	PodMappingMissUnresolved = "unresolved"
+	// PodMappingMissAmbiguous indicates a pod matched more than one workload selector and the
+	// owner-reference tiebreak could not attribute it to a single VariantAutoscaling.
+	PodMappingMissAmbiguous = "ambiguous"
 )
 
 // Metric Label Names

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -35,6 +35,7 @@ import (
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	actuator "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/actuator"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/podvamap"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
@@ -119,6 +120,12 @@ type Engine struct {
 	client   client.Client
 	scheme   *runtime.Scheme
 	executor executor.Executor
+
+	// APIReader is an uncached reader (mgr.GetAPIReader()) used for the per-cycle pod
+	// LIST in pod→VariantAutoscaling derivation, so listing pods does not start a
+	// cluster-wide Pod informer/cache. Falls back to the cached client when nil
+	// (e.g. in unit tests that construct the Engine directly).
+	APIReader client.Reader
 
 	// Recorder - use wrapper function recordEvent to limit number of events per va in an optimization cycle
 	Recorder record.EventRecorder
@@ -1248,10 +1255,21 @@ func (e *Engine) prepareModelData(
 		variantCosts[variantKey] = cost
 	}
 
+	// Derive the pod→VariantAutoscaling map for this cycle from each VA's scale-target
+	// selector, so the collector no longer depends on the tenant-authored
+	// llm-d.ai/variant pod label (which remains a higher-precedence override).
+	// Use the uncached APIReader so the per-cycle pod LIST does not start a
+	// cluster-wide Pod informer; fall back to the cached client when unset.
+	var podListReader client.Reader = k8sClient
+	if e.APIReader != nil {
+		podListReader = e.APIReader
+	}
+	podMap := podvamap.Build(ctx, podListReader, scaleTargets, variantAutoscalings)
+
 	logger.V(logging.DEBUG).Info("Using source infrastructure for replica metrics",
 		"modelID", modelID,
 		"namespace", namespace)
-	replicaMetrics, err := e.ReplicaMetricsCollector.CollectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, e.vaEventTracker, variantCosts)
+	replicaMetrics, err := e.ReplicaMetricsCollector.CollectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, e.vaEventTracker, variantCosts, podMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect Saturation metrics for model %s: %w", modelID, err)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -38,6 +38,7 @@ var (
 	metricsCollectionErrors             *prometheus.CounterVec
 	metricsPodsDiscovered               *prometheus.GaugeVec
 	metricsFreshnessStatus              *prometheus.GaugeVec
+	podMappingMissTotal                 *prometheus.CounterVec
 
 	// Saturation and capacity metrics
 	saturationUtilization *prometheus.GaugeVec
@@ -321,6 +322,18 @@ func InitMetrics(registry prometheus.Registerer) error {
 		metricsFreshnessStatusLabels,
 	)
 
+	podMappingMissLabels := []string{constants.LabelVariantName, constants.LabelNamespace, constants.LabelReason}
+	if controllerInstance != "" {
+		podMappingMissLabels = append(podMappingMissLabels, constants.LabelControllerInstance)
+	}
+	podMappingMissTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: constants.WVAPodMappingMissTotal,
+			Help: "Total number of pods that could not be attributed to a VariantAutoscaling during per-cycle derivation",
+		},
+		podMappingMissLabels,
+	)
+
 	// Register metrics with the registry
 	if err := registry.Register(replicaScalingTotal); err != nil {
 		return fmt.Errorf("failed to register replicaScalingTotal metric: %w", err)
@@ -378,6 +391,9 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(metricsFreshnessStatus); err != nil {
 		return fmt.Errorf("failed to register metricsFreshnessStatus metric: %w", err)
+	}
+	if err := registry.Register(podMappingMissTotal); err != nil {
+		return fmt.Errorf("failed to register podMappingMissTotal metric: %w", err)
 	}
 	if err := registry.Register(saturationUtilization); err != nil {
 		return fmt.Errorf("failed to register saturationUtilization metric: %w", err)
@@ -675,6 +691,22 @@ func IncMetricsCollectionErrors(queryType, reason string) {
 		labels[constants.LabelControllerInstance] = controllerInstance
 	}
 	metricsCollectionErrors.With(labels).Inc()
+}
+
+// IncPodMappingMiss increments the pod-to-VariantAutoscaling mapping miss counter.
+func IncPodMappingMiss(variantName, namespace, reason string) {
+	if podMappingMissTotal == nil {
+		return
+	}
+	labels := prometheus.Labels{
+		constants.LabelVariantName: variantName,
+		constants.LabelNamespace:   namespace,
+		constants.LabelReason:      reason,
+	}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	podMappingMissTotal.With(labels).Inc()
 }
 
 // SetMetricsPodsDiscovered sets the number of pods discovered in a namespace.

--- a/internal/utils/scaletarget/accessor.go
+++ b/internal/utils/scaletarget/accessor.go
@@ -3,6 +3,7 @@ package scaletarget
 import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // ScaleTargetAccessor provides a uniform interface to extract scaling-relevant
@@ -44,4 +45,10 @@ type ScaleTargetAccessor interface {
 	// For Deployment: always 1.
 	// For LWS: spec.leaderWorkerTemplate.size (1 leader + N-1 workers).
 	GetGroupSize() int32
+
+	// GetPodSelector returns a label selector matching the pods that belong to this
+	// scale target, used to derive the pod→VariantAutoscaling mapping per cycle.
+	// For Deployment: spec.selector.
+	// For LWS: the leaderworkerset.sigs.k8s.io/name label the LWS stamps on its pods.
+	GetPodSelector() labels.Selector
 }

--- a/internal/utils/scaletarget/deployment.go
+++ b/internal/utils/scaletarget/deployment.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/resources"
 )
@@ -64,6 +65,16 @@ func (r *deploymentAccessor) GetWorkerPodTemplateSpec() *corev1.PodTemplateSpec 
 
 func (r *deploymentAccessor) GetGroupSize() int32 {
 	return 1
+}
+
+func (r *deploymentAccessor) GetPodSelector() labels.Selector {
+	// r.deployment is always not nil; spec.selector is a required field on Deployment.
+	selector, err := v1.LabelSelectorAsSelector(r.deployment.Spec.Selector)
+	if err != nil || selector == nil {
+		// A malformed/absent selector matches nothing rather than everything.
+		return labels.Nothing()
+	}
+	return selector
 }
 
 func (r *deploymentAccessor) GetName() string {

--- a/internal/utils/scaletarget/lws.go
+++ b/internal/utils/scaletarget/lws.go
@@ -3,10 +3,15 @@ package scaletarget
 import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/resources"
 )
+
+// lwsNameLabelKey is the well-known label the LeaderWorkerSet controller stamps on
+// every pod it manages, set to the LWS name. It is the reliable selector for a LWS's pods.
+const lwsNameLabelKey = "leaderworkerset.sigs.k8s.io/name"
 
 type lwsAccessor struct {
 	lws *lwsv1.LeaderWorkerSet
@@ -82,6 +87,12 @@ func (r *lwsAccessor) GetGroupSize() int32 {
 		return 1
 	}
 	return *r.lws.Spec.LeaderWorkerTemplate.Size
+}
+
+func (r *lwsAccessor) GetPodSelector() labels.Selector {
+	// r.lws is always not nil. The LWS controller labels every managed pod with
+	// leaderworkerset.sigs.k8s.io/name=<lws name>.
+	return labels.SelectorFromSet(labels.Set{lwsNameLabelKey: r.lws.Name})
 }
 
 func (r *lwsAccessor) GetName() string {


### PR DESCRIPTION
## What

Replaces the tenant-authored `llm-d.ai/variant` pod-template label as the **default** path for attributing a pod's metrics to its `VariantAutoscaling`. WVA now derives the mapping itself, once per optimization cycle, from each VA's `scaleTargetRef` selector. Pointing a `VariantAutoscaling` at a running `Deployment`/`LeaderWorkerSet` is sufficient — **no required pod-template label, no rolling restart to adopt, no ServiceMonitor relabel rule.**

Implements the design in [`docs/proposals/design-pod-va-mapping.md`](docs/proposals/design-pod-va-mapping.md) (#1210).

## Why

Today the collector reads the VA name from the `llm-d.ai/variant` label that the tenant must stamp on the workload's **pod template** (twice for LWS) and propagate via a `ServiceMonitor` relabel rule. That's wrong for an autoscaler:

- **It blocks in-place adoption.** Adding the label to a running workload's pod template is a rolling restart of the whole fleet — forced purely to *start* autoscaling.
- **It fails silently.** A wrong label key/value, a missing relabel rule, or a half-templated LWS yields zero matching metrics and a "working" but wrong scaling decision, with no signal.
- **The anchor is being deprecated.** The label's value must equal the `VariantAutoscaling` name — the CRD that's being deprecated.

HPA/KEDA/VPA attach via a target reference and read the target; none edit the pod template. This change brings WVA in line with that norm.

## How

- **New package `internal/collector/podvamap`** — builds a per-cycle `"<namespace>/<pod>" → VariantAutoscaling` map: for each managed VA it lists the pods behind its scale target's selector and attributes each to that VA. `Lookup(namespace, pod)` is O(1) on the metrics hot path.
- **Uncached reads — no new watch.** The per-cycle pod LIST uses `mgr.GetAPIReader()` (a direct, bounded, selector-scoped API LIST per scale target), so it starts **no cluster-wide Pod informer/cache**. The engine gains an `APIReader` field (set in `cmd/main.go`), falling back to the cached client when unset (tests).
- **Ownership / overlapping selectors.** A pod is attributed by selector + namespace match; pods matched by more than one workload selector are disambiguated by an in-memory owner-reference walk (`Pod → ReplicaSet → Deployment`, `Pod → StatefulSet → LeaderWorkerSet`), with the workload→VA match resolved against the in-memory VA set (no field-index cache). Unresolved collisions are left unmapped rather than misattributed.
- **`ScaleTargetAccessor.GetPodSelector()`** — added for Deployment (`spec.selector`) and LeaderWorkerSet (the `leaderworkerset.sigs.k8s.io/name` label).
- **Label stays as a higher-precedence override.** `llm-d.ai/variant` (and its relabel rule) remain supported for custom kinds / non-standard owner chains and for back-compat; when present on a pod's metrics it wins over the derived mapping. The override's value names the same autoscaling object the derived path resolves to (deprecation-proof, not a frozen VA name).

## Observability

- **`wva_pod_mapping_miss_total{reason}`** — counts pods that couldn't be attributed: `reason="unresolved"` (matched no managed workload selector and no override label) or `reason="ambiguous"` (overlapping selectors, owner-ref tiebreak failed). Surfaces the previously-silent wrong-capacity fallback.
- **No VA status condition** is added: the `VariantAutoscaling` CRD is being deprecated, so the durable miss signal lives in Prometheus rather than on the object.

## Back-compat & RBAC

- Existing installs that keep the `llm-d.ai/variant` label + ServiceMonitor relabel rule keep working unchanged (the label is a higher-precedence override).
- `docs/design/controller-behavior.md` updated: the label/relabel rule are now documented as an **optional override**, with the new default and the miss-metric semantics.
- No RBAC change needed — the manager ClusterRole already grants `pods` list and `replicasets`/`statefulsets` get.

## Out of scope / follow-ups

- Migration steps, implementation phasing, and the full discovery mechanism after VA-CRD deprecation are tracked separately in the proposal.
- Optimization noted in code (`TODO`): collapsing the per-scale-target LIST to one LIST per namespace with in-memory selector matching, if the per-cycle API-call count grows.
- This change also unblocks dropping `llm_d_ai_variant` from the per-pod PromQL queries (e.g. the throughput analyzer) once derivation is the sole path.