### PR TITLE
engines/saturation: multi-analyzer addendum — disabled-analyzer fix, test gaps, pipeline dev guide

### DIFF
--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -11,6 +11,94 @@ over it via shared free functions in `internal/engines/pipeline/`.
 
 ---
 
+## Architecture
+
+### Data flow per optimize cycle
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Config (SaturationScalingConfig per model/namespace)     │
+│   Priority, Analyzers[]:                                 │
+│     name, enabled, Score,                                │
+│     ScaleUpThreshold, ScaleDownBoundary                  │
+└──────────────────────────┬───────────────────────────────┘
+                           │ engine reads per cycle
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│ Engine: per-model preparation                            │
+│   • BuildVariantStates (GPUsPerReplica per variant       │
+│     from ScaleTarget / VA labels)                        │
+│   • CollectSchedulerQueueMetrics (shared across          │
+│     analyzers)                                           │
+│   • resolveThresholds(name, cfg) per analyzer            │
+│     (per-analyzer override over model-level globals)     │
+└──────────────────────────┬───────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│ Engine: run analyzers, build per-analyzer slice          │
+│ Saturation V2 (always first), then each registered       │
+│ non-saturation analyzer in registration order:           │
+│   • skip if Enabled:false                                │
+│   • Analyze(ctx, input) → *AnalyzerResult                │
+│   • applyUniversalThreshold(result, scaleUp, scaleDown)  │
+│     → writes RC/SC at model scope + each role scope      │
+│   • append NamedAnalyzerResult{                          │
+│       Name, Result,                                      │
+│       Score     ← config.Analyzers[name].Score,          │
+│       Remaining ← RC,   Spare ← SC,                      │
+│     } to []NamedAnalyzerResult                           │
+└──────────────────────────┬───────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│ Engine: build ModelScalingRequest                        │
+│   AnalyzerResults  ← per-analyzer slice (above)          │
+│   VariantStates    ← prepared above                      │
+│   Priority         ← config.Priority                     │
+│   Disaggregated    ← any variant has a non-"both" Role   │
+└──────────────────────────┬───────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│ Optimizer (CostAware or GreedyByScore)                   │
+│   • initRoleState → RolePairedState + RoleSpare          │
+│   • Scale-up: allocateForModelPaired                     │
+│       pick(role) → variant; joint Δ_util commit          │
+│       applyAllocation → decrement Remaining              │
+│   • Scale-down: scaleDownRoleIterated                    │
+│       needsScaleDownForRole → veto gate (ALL must agree) │
+│       safeRemovalReplicasForRole → min across analyzers  │
+│       applyDeallocationForRole → decrement RoleSpare     │
+└──────────────────────────┬───────────────────────────────┘
+                           │
+                           ▼
+                       VariantDecisions
+```
+
+### Key concepts
+
+| Concept | Definition |
+|---|---|
+| **Analyzer** | Implementation of `interfaces.Analyzer`. Examples: saturation V2 (kv-token capacity), throughput (RPS/ITL-derived), queueing-model. |
+| **`VariantCapacity`** | Per-variant primitives: `ReplicaCount`, `PendingReplicas`, `PerReplicaCapacity` (analyzer-specific units), `Cost`, `AcceleratorName`, `Role`, `TotalDemand`. |
+| **`AnalyzerResult`** | Per-(model, analyzer) output: `VariantCapacities[]`, model-level `Total*`, `RoleCapacities[role]` (P/D only), `RequiredCapacity` / `SpareCapacity` (engine-written by post-step; analyzers must not populate these). |
+| **`RoleCapacity`** | Per-role aggregate within an `AnalyzerResult`: `TotalSupply`, `TotalDemand`, `TotalAnticipatedSupply`, `RequiredCapacity` / `SpareCapacity` (engine-written). Used for P/D disaggregated models only. |
+| **`NamedAnalyzerResult`** | Optimizer-side wrapper: `{Name, Result, Score, Remaining, Spare, RoleSpare}`. Working `Remaining`/`Spare`/`RoleSpare` are decremented by helpers during allocation; `Result` is never mutated. |
+| **Linearity invariant** | Adding *n* replicas of variant *v* reduces analyzer *i*'s working `Remaining` by exactly *n × PRC_i[v]*. Holds at model scope (non-disaggregated) and at role scope (disaggregated). |
+
+### Responsibility table
+
+| Field | Written by | Read by |
+|---|---|---|
+| Per-variant `ReplicaCount`, `PendingReplicas`, `PerReplicaCapacity`, `Cost`, `Role`, `AcceleratorName` | Analyzer | Optimizer (picker + scaling math) |
+| Model-level `TotalSupply`, `TotalAnticipatedSupply`, `TotalDemand` | Analyzer (via aggregation helpers) | Engine post-step |
+| Per-role `RoleCapacities[role].Total*` | Analyzer (via aggregation helpers) | Engine post-step |
+| `RequiredCapacity`, `SpareCapacity` (model + role scope) | **Engine post-step only** — analyzer-written values are overwritten | Optimizer |
+| `NamedAnalyzerResult.Remaining`, `Spare`, `RoleSpare` | Optimizer helpers (`applyAllocation`, `applyDeallocationForRole`) | Optimizer allocation loop |
+
+---
+
 ## Components
 
 - **Registration** — `internal/engines/saturation/engine.go`:
@@ -152,6 +240,117 @@ The saturation entry in the slice is also the keeper of per-variant metadata
 (`Cost`, `AcceleratorName`, `Role`) that the optimizer reads from
 `VariantCapacities`. Future work will extract per-variant metadata collection
 out of the saturation result so each analyzer owns only its own signals.
+
+---
+
+## Data model: AnalyzerResult → NamedAnalyzerResult
+
+Understanding what transforms where prevents the most common mistake: treating
+`Result.*` counters as live state during allocation.
+
+**`interfaces.AnalyzerResult`** is the immutable record an analyzer returns.
+The engine owns its calibration:
+
+1. The analyzer populates `VariantCapacities[]`, `TotalSupply`, `TotalDemand`,
+   `TotalAnticipatedSupply` (and `RoleCapacities` for P/D models). It must NOT
+   populate `RequiredCapacity` or `SpareCapacity`.
+2. `applyUniversalThreshold` overwrites `RequiredCapacity` / `SpareCapacity` at
+   model scope, and each `RoleCapacities[role].RequiredCapacity` /
+   `SpareCapacity`. The analyzer's view of supply and demand is fixed here.
+3. The engine wraps the calibrated result in a `NamedAnalyzerResult` and never
+   mutates `Result` again. `Result.*` values are stable read-only data for the
+   rest of the cycle.
+
+**`pipeline.NamedAnalyzerResult`** is the working unit the optimizer operates on.
+Its fields fall into three categories:
+
+| Field | Category | Description |
+|---|---|---|
+| `Name`, `Score`, `Result` | Immutable | Set by engine; never written by optimizer |
+| `Remaining`, `Spare` | Mutable scalars | Model-scope working counters; decremented by `applyAllocation` during scale-up |
+| `RoleSpare` | Mutable per-role map | Populated by `initRoleState`; decremented by `applyDeallocationForRole` during scale-down |
+
+`Remaining` and `Spare` are seeded from `Result.RequiredCapacity` and
+`Result.SpareCapacity`. `RoleSpare` is seeded from
+`Result.RoleCapacities[role].SpareCapacity`. None of this flows back into
+`Result`.
+
+**`RolePairedState`** (`[]map[string]float64`, indexed as
+`[analyzer-index][role]`) is picker-local demand created per call to
+`initRoleState`. It holds per-role required capacity for the scale-up loop and
+is decremented by the joint-commit step inside `allocateForModelPaired`. It is
+not stored on `NamedAnalyzerResult` and is discarded after each model's
+allocation pass.
+
+---
+
+## Optimizer internals and helper composition
+
+Both optimizers share the same allocation and scale-down primitives from
+`internal/engines/pipeline/analyzer_helpers.go` and
+`internal/engines/pipeline/cost_aware_optimizer.go`. The optimizers own the
+*when* and *which model*; the helpers own the *how*.
+
+### Scale-up path
+
+All scale-up goes through `allocateForModelPaired`:
+
+```
+initRoleState(s)               → roles, RolePairedState (per-role demand + RoleSpare)
+anyRoleNeedsScaleUp(ps, roles) → loop gate: any role still has demand?
+  pick(role, ...)              → (variant, capN): optimizer-specific variant selector
+  roleBottleneckReplicas       → max_i ceil(state[i][role] / PRC_i[v]): cross-analyzer replica sizing
+  roleAggRemaining             → max demand across analyzers for this role
+  Δ_util = min_role util_role  → joint commit bound: trim to the least-served role
+  applyAllocation(s, v, k)     → decrement Remaining on all NamedAnalyzerResults
+```
+
+`pick` is a `RolePickFn` — the only part that differs between optimizers:
+
+- `costGreedyRolePick`: picks the cheapest cost-efficient variant; no GPU budget
+  cap (unlimited mode).
+- `fairShareRolePick`: picks the cheapest variant within available GPU budget;
+  caps `capN` to the fair-share target (limited mode).
+
+For non-disaggregated models, `initRoleState` synthesizes a single `"both"` role
+from the model-level scalars, so `allocateForModelPaired` handles both the
+disaggregated and non-disaggregated cases through the same loop.
+
+### Scale-down path
+
+Both optimizers call `scaleDownRoleIterated`, which handles both disaggregated
+and non-disaggregated models through the same role loop (`"both"` is the
+synthetic role for non-disaggregated):
+
+```
+for each role (sorted for determinism):
+  needsScaleDownForRole(s, role)           → gate: ALL analyzers have RoleSpare > 0
+  sortVariantsForScaleDown(s, vcs)         → cost-desc; tie-break: Score-weighted PRC asc
+  scaleDownVariantSet(...)
+    safeRemovalReplicasForRole(s, v, role) → min_i floor(RoleSpare[i][role] / PRC_i[v])
+    applyDeallocationForRole(s, v, role, n)→ decrement RoleSpare on all entries
+```
+
+`sortVariantsForScaleDown` uses a Score-weighted PRC tie-break. With a single
+analyzer (Score=1) this reduces to plain cost-descending / PRC-ascending order.
+
+### Fair-share iteration (GreedyByScoreOptimizer only)
+
+`fairShareScaleUp` uses iterative mean equalization rather than fixed fractions:
+
+1. Compute `mean` = average `remaining` (fair-share priority value) across active
+   models.
+2. Sort by `remaining` descending; take the highest.
+3. Call `allocateForModel` with budget `target = remaining − mean`: allocates
+   replicas via `allocateForModelPaired` until the model's priority value drops
+   to or below `mean`.
+4. Recompute `remaining = fairShareValue(priority, s, ps, roles)` from the
+   post-allocation working state.
+5. Repeat until no active models remain or no GPUs are left.
+
+`fairShareValue = priority × Σᵢ Score_i × Σ_role pickerState[i][role]`.
+A higher `Score` on a high-demand analyzer increases a model's priority value
+and therefore how many GPUs it attracts in a constrained environment.
 
 ---
 

--- a/docs/developer-guide/multi-analyzer-pipeline.md
+++ b/docs/developer-guide/multi-analyzer-pipeline.md
@@ -1,11 +1,5 @@
 # Multi-Analyzer Pipeline (developer reference)
 
-> **Status: STUB.** This doc summarises the multi-analyzer pipeline at a
-> high level and points to the design doc for detailed architecture,
-> alternatives considered, and future direction. Full developer-guide
-> content covering all three multi-analyzer PRs (registration, threshold,
-> optimizer) will be added post-review.
-
 The Workload Variant Autoscaler's scaling engine runs multiple **analyzers**
 in series each cycle. Each analyzer consumes the same per-replica metrics
 and produces an `*interfaces.AnalyzerResult` carrying per-variant capacity,
@@ -15,36 +9,169 @@ every scope using a uniform threshold formula. The optimizer reads a
 per-analyzer slice (`[]NamedAnalyzerResult`) and decides scaling actions
 over it via shared free functions in `internal/engines/pipeline/`.
 
+---
+
 ## Components
 
 - **Registration** — `internal/engines/saturation/engine.go`:
   `RegisterAnalyzer(name, analyzer) error`. `cmd/main.go` registers external
   analyzers (e.g., throughput) before `StartOptimizeLoop`. Saturation V2 is
-  pre-registered. Registry is snapshotted at Start; late registration
-  returns an error.
+  pre-registered at slot 0. The registry is snapshotted at `StartOptimizeLoop`;
+  late registration returns an error.
 - **Engine post-step** — `internal/engines/saturation/engine_v2.go`:
-  `applyUniversalThreshold(*AnalyzerResult, scaleUp, scaleDown)` applies a
-  pure formula `RC = max(0, TD/scaleUp − Anticipated)` /
-  `SC = max(0, TS − TD/scaleDown)` at model scope and every role.
+  `applyUniversalThreshold(*AnalyzerResult, scaleUp, scaleDown)` applies the
+  formula `RC = max(0, TotalDemand/scaleUp − TotalAnticipatedSupply)` /
+  `SC = max(0, TotalSupply − TotalDemand/scaleDown)` at model scope and
+  each role in `RoleCapacities`.
 - **Aggregation helpers** — `internal/engines/aggregation/`:
   `SumTotalSupply`, `SumTotalAnticipatedSupply`, `SumTotalDemand`,
   `AggregateByRole` over `[]VariantCapacity`. Analyzer authors use these to
-  populate per-scope `Total*` fields.
+  populate per-scope `Total*` fields without reimplementing the math.
 - **Optimizer slice flow** — `internal/engines/pipeline/`:
-  `NamedAnalyzerResult` slice carries each analyzer's result + working
-  scratch state for allocation. `CostAwareOptimizer` and
+  `NamedAnalyzerResult` slice carries each analyzer's calibrated result plus
+  working scratch state for the allocation loop. `CostAwareOptimizer` and
   `GreedyByScoreOptimizer` consume the slice via shared free functions
-  (single-variant + paired + role-iterated helpers).
+  (single-variant, paired P/D, and role-iterated helpers).
 
-## Detailed design
+---
 
-For full architecture (per-variant canonical model; linearity invariant;
-α coupling for P/D; paired scale-up + role-iterated scale-down;
-alternatives considered including the rejected combine-in-engine
-algorithm; future direction), see the design doc:
+## User configuration
 
-https://github.com/deanlorenz/llm-d-workload-variant-autoscaler/blob/plans/planning/multi-analyzer-design.md
+Analyzers are configured via `SaturationScalingConfig.Analyzers` (YAML key
+`analyzers`). Each entry is an `AnalyzerScoreConfig` struct
+(`internal/config/saturation_scaling.go`):
 
-This is the Type-1 design doc for the multi-analyzer mission. It will be
-folded into this developer-guide post-review across all three multi-analyzer
-PRs (#1225 registration, #1228 threshold, optimizer pending).
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `name` | string | required | Must match the name returned by `Analyzer.Name()` |
+| `enabled` | bool | true | Set false to disable without removing the analyzer |
+| `score` | float64 | 1.0 | Weight in the fair-share priority formula |
+| `scaleUpThreshold` | float64 | global | Overrides the model-level `scaleUpThreshold` for this analyzer |
+| `scaleDownBoundary` | float64 | global | Overrides the model-level `scaleDownBoundary` for this analyzer |
+
+Minimal YAML example:
+
+```yaml
+analyzers:
+  - name: saturation
+    score: 1.0
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
+  - name: throughput
+    enabled: false   # disable without removing
+    score: 2.0
+```
+
+When `enabled` is false the analyzer is neither called nor included in the
+result slice, so it cannot veto scale-down decisions.
+
+---
+
+## Analyzer implementor guide
+
+Implement `interfaces.Analyzer` (`internal/interfaces/analyzer.go`):
+
+```go
+type Analyzer interface {
+    Name() string
+    Analyze(ctx context.Context, input AnalyzerInput) (*AnalyzerResult, error)
+}
+```
+
+### Input
+
+Key `AnalyzerInput` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `ModelID` | string | Model being analyzed |
+| `Namespace` | string | Kubernetes namespace |
+| `ReplicaMetrics` | `[]ReplicaMetrics` | Per-replica metric snapshots |
+| `VariantStates` | `[]VariantReplicaState` | Current/desired/pending replica counts per variant |
+| `Config` | `AnalyzerConfig` | Resolved config (cast to your config type as needed) |
+| `SchedulerQueue` | `*SchedulerQueueMetrics` | Scheduler queue metrics; nil when flow control is off |
+
+### Output invariants
+
+The **linearity invariant**: `TotalSupply = Σ_v PerReplicaCapacity × ReplicaCount`
+across all entries in `VariantCapacities`. Use the aggregation helpers to
+populate `VariantCapacities[]`, then call:
+
+```go
+result.TotalSupply             = aggregation.SumTotalSupply(result.VariantCapacities)
+result.TotalDemand             = aggregation.SumTotalDemand(result.VariantCapacities)
+result.TotalAnticipatedSupply  = aggregation.SumTotalAnticipatedSupply(result.VariantCapacities)
+```
+
+For P/D disaggregated models, also populate `RoleCapacities` using
+`aggregation.AggregateByRole(result.VariantCapacities)`. The engine applies
+`applyUniversalThreshold` to every role entry.
+
+**Do NOT populate `RequiredCapacity` or `SpareCapacity`** in the returned
+`AnalyzerResult`. The engine overwrites both fields in the post-step; any
+analyzer-written values are discarded.
+
+---
+
+## Pipeline flow
+
+1. `cmd/main.go` calls `engine.RegisterAnalyzer(name, a)` for each external
+   analyzer before `StartOptimizeLoop`. Saturation V2 is pre-registered at
+   slot 0.
+2. `StartOptimizeLoop` snapshots the registry into `analyzersSnapshot`
+   (frozen, race-safe). The snapshot is the ordered set of analyzers that
+   every optimize cycle iterates.
+3. Per cycle, for each model: `runAnalyzersAndScore` runs the saturation V2
+   analyzer unconditionally (it drives variant metadata), then iterates
+   `analyzersSnapshot` in registration order for non-saturation analyzers.
+4. Analyzers with `Enabled: false` are skipped entirely — neither called nor
+   appended to the result slice.
+5. For each analyzer that runs, `applyUniversalThreshold` is applied to its
+   result using resolved thresholds (per-analyzer override beats global):
+   `RC = max(0, TotalDemand/scaleUp − TotalAnticipatedSupply)`,
+   `SC = max(0, TotalSupply − TotalDemand/scaleDown)`.
+6. Each result is wrapped in a `NamedAnalyzerResult{Name, Result, Score,
+   Remaining, Spare}` and appended to the `[]NamedAnalyzerResult` slice.
+   `Remaining = RC` and `Spare = SC` after the post-step.
+7. Saturation is always first. Its `VariantCapacities` entries carry `Cost`,
+   `AcceleratorName`, and `Role` used downstream by the optimizer and
+   enforcer.
+
+---
+
+## How results combine
+
+**Scale-down gate** (`needsScaleDownForRole`): ALL non-disabled analyzers in
+the slice must have `Spare > 0` for a role to scale down. One analyzer with
+`RequiredCapacity > 0` (i.e., `Spare == 0`) blocks scale-down for that role.
+
+**Scale-up gate** (`anyRoleNeedsScaleUp`): ANY analyzer having `Remaining > 0`
+triggers scale-up for the corresponding role.
+
+The saturation entry in the slice is also the keeper of per-variant metadata
+(`Cost`, `AcceleratorName`, `Role`) that the optimizer reads from
+`VariantCapacities`. Future work will extract per-variant metadata collection
+out of the saturation result so each analyzer owns only its own signals.
+
+---
+
+## Optimizer consumption
+
+The `[]NamedAnalyzerResult` slice is passed to one of two optimizers depending
+on the `enableLimiter` flag in `SaturationScalingConfig`:
+
+- **`CostAwareOptimizer`** (unlimited mode, `enableLimiter: false`): operates
+  on the saturation entry's `VariantCapacities` for cost and role data; scales
+  up the cheapest variant that covers the required capacity, scales down the
+  most expensive variant with spare capacity.
+- **`GreedyByScoreOptimizer`** (limited mode, `enableLimiter: true`): respects
+  `ResourceConstraints` (GPU budgets per accelerator type). Models are ordered
+  by fair-share priority value:
+  `fsv = Priority × Σᵢ Score_i × Σ_role pickerState[i][role]`,
+  where the sum over `i` runs across all `NamedAnalyzerResult` entries and
+  `pickerState` is seeded from each entry's `Remaining`. Higher `Score` on a
+  high-demand analyzer increases a model's allocation priority in constrained
+  environments.
+
+Both optimizers are stateless and selected per-cycle from the engine's
+`optimizer` field.

--- a/internal/engines/pipeline/greedy_score_optimizer_test.go
+++ b/internal/engines/pipeline/greedy_score_optimizer_test.go
@@ -760,6 +760,82 @@ var _ = Describe("GreedyByScoreOptimizer", func() {
 			Expect(dm["b-v1"].TargetReplicas).To(Equal(3)) // 1 + 2 (all GPUs)
 			Expect(dm["a-v1"].TargetReplicas).To(Equal(1)) // unchanged
 		})
+
+		It("T1.4: non-uniform Score across two analyzers drives fair-share ordering", func() {
+			// Model A has two AnalyzerResults:
+			//   saturation: Score=1.0, RC=20000
+			//   throughput: Score=2.0, RC=20000
+			//   fsv(A) = 1.0 × (20000×1.0 + 20000×2.0) = 60000
+			// Model B has one AnalyzerResult:
+			//   saturation: Score=1.0, RC=20000
+			//   fsv(B) = 1.0 × (20000×1.0) = 20000
+			// With 4 A100 GPUs (2 GPUs/replica): A (higher fsv) gets both
+			// available replicas; B gets none.
+			rA := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "a-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			rB := &interfaces.AnalyzerResult{
+				RequiredCapacity: 20000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "b-v1", AcceleratorName: "A100", Cost: 5.0, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			requests := []ModelScalingRequest{
+				{
+					ModelID:   "model-A",
+					Namespace: "default",
+					Priority:  1.0,
+					AnalyzerResults: []NamedAnalyzerResult{
+						{
+							Name:      "saturation",
+							Result:    rA,
+							Score:     1.0,
+							Remaining: rA.RequiredCapacity,
+						},
+						{
+							Name:  "throughput",
+							Score: 2.0,
+							// throughput shares rA's variant capacity for simplicity;
+							// its RC signal adds to the fair-share weight.
+							Result:    &interfaces.AnalyzerResult{RequiredCapacity: 20000},
+							Remaining: 20000,
+						},
+					},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "a-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+				{
+					ModelID:   "model-B",
+					Namespace: "default",
+					Priority:  1.0,
+					AnalyzerResults: []NamedAnalyzerResult{{
+						Name:      "saturation",
+						Result:    rB,
+						Score:     1.0,
+						Remaining: rB.RequiredCapacity,
+					}},
+					VariantStates: []interfaces.VariantReplicaState{
+						{VariantName: "b-v1", CurrentReplicas: 1, GPUsPerReplica: 2},
+					},
+				},
+			}
+			constraints := []*ResourceConstraints{
+				{Pools: map[string]ResourcePool{
+					"A100": {Limit: 4}, // 2 replicas worth
+				}},
+			}
+
+			decisions := optimizer.Optimize(ctx, requests, constraints)
+			dm := decisionMap(decisions)
+
+			// fsv(A)=60000 > fsv(B)=20000: A wins the GPU budget.
+			Expect(dm["a-v1"].TargetReplicas).To(Equal(3)) // 1 + 2 (all 4 GPUs)
+			Expect(dm["b-v1"].TargetReplicas).To(Equal(1)) // unchanged
+		})
 	})
 
 	Context("Demand-Proportional P/D Distribution", func() {

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -146,7 +146,8 @@ type Engine struct {
 
 	// saturationV2Analyzer is the V2 token-based saturation analyzer (initialized once).
 	// Also pre-registered in analyzers under interfaces.SaturationAnalyzerName.
-	saturationV2Analyzer *saturation_v2.SaturationAnalyzer
+	// Typed as interfaces.Analyzer to allow injection in tests.
+	saturationV2Analyzer interfaces.Analyzer
 
 	// queueingModelAnalyzer is the queueing model-based analyzer (initialized once).
 	// Selected via analyzerName: "queueing-model" in SaturationScalingConfig.

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Engine analyzer registry", func() {
 
 			Expect(engine.analyzers).To(HaveLen(1))
 			Expect(engine.analyzers[0].name).To(Equal(interfaces.SaturationAnalyzerName))
-			Expect(engine.analyzers[0].analyzer).To(BeIdenticalTo(interfaces.Analyzer(engine.saturationV2Analyzer)))
+			Expect(engine.analyzers[0].analyzer).To(BeIdenticalTo(engine.saturationV2Analyzer))
 		})
 	})
 

--- a/internal/engines/saturation/engine_register_test.go
+++ b/internal/engines/saturation/engine_register_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Engine analyzer registry", func() {
 		})
 	})
 
-	Describe("runRegisteredAnalyzers", func() {
+	Describe("runRegisteredAnalyzer", func() {
 
 		var (
 			testCtx    context.Context
@@ -196,66 +196,24 @@ var _ = Describe("Engine analyzer registry", func() {
 			testLogger = logf.Log
 		})
 
-		It("calls Analyze on every registered non-saturation analyzer exactly once, in registration order", func() {
-			sat := &spyAnalyzer{name: interfaces.SaturationAnalyzerName}
-			ta := &spyAnalyzer{name: "throughput"}
-			slo := &spyAnalyzer{name: "slo"}
-			// runRegisteredAnalyzers iterates analyzersSnapshot (built by
-			// StartOptimizeLoop). Construct it directly to match.
-			snapshot := []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: sat},
-				{name: "throughput", analyzer: ta},
-				{name: "slo", analyzer: slo},
-			}
-			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
-
-			e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
-
-			// Saturation entry is skipped — engine runs saturation via
-			// runV2AnalysisOnly with full args. When a future PR unifies
-			// saturation into the loop, this expectation flips and the
-			// surrounding test description should be revised.
-			Expect(sat.callCount).To(Equal(0))
-			Expect(ta.callCount).To(Equal(1))
-			Expect(slo.callCount).To(Equal(1))
+		It("returns nil and does not panic when the analyzer returns an error", func() {
+			spy := &spyAnalyzer{name: "throughput", err: errors.New("boom")}
+			entry := analyzerEntry{name: "throughput", analyzer: spy}
+			result := runRegisteredAnalyzer(testCtx, testLogger, entry, "model-1",
+				interfaces.AnalyzerInput{ModelID: "model-1"})
+			Expect(result).To(BeNil())
+			Expect(spy.callCount).To(Equal(1))
 		})
 
-		It("logs and continues when a registered analyzer returns an error", func() {
-			ta := &spyAnalyzer{name: "throughput", err: errors.New("boom")}
-			slo := &spyAnalyzer{name: "slo"}
-			snapshot := []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
-				{name: "throughput", analyzer: ta},
-				{name: "slo", analyzer: slo},
-			}
-			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
-
+		It("recovers from a panicking analyzer and returns nil", func() {
+			spy := &spyAnalyzer{name: "throughput", panicMsg: "boom"}
+			entry := analyzerEntry{name: "throughput", analyzer: spy}
+			var result *interfaces.AnalyzerResult
 			Expect(func() {
-				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
+				result = runRegisteredAnalyzer(testCtx, testLogger, entry, "model-1",
+					interfaces.AnalyzerInput{ModelID: "model-1"})
 			}).NotTo(Panic())
-
-			// Both analyzers are still called even though throughput erred.
-			Expect(ta.callCount).To(Equal(1))
-			Expect(slo.callCount).To(Equal(1))
-		})
-
-		It("recovers from a panicking analyzer and continues with the rest", func() {
-			ta := &spyAnalyzer{name: "throughput", panicMsg: "boom"}
-			slo := &spyAnalyzer{name: "slo"}
-			snapshot := []analyzerEntry{
-				{name: interfaces.SaturationAnalyzerName, analyzer: &spyAnalyzer{name: interfaces.SaturationAnalyzerName}},
-				{name: "throughput", analyzer: ta},
-				{name: "slo", analyzer: slo},
-			}
-			e := &Engine{analyzers: snapshot, analyzersSnapshot: snapshot, started: true}
-
-			Expect(func() {
-				e.runRegisteredAnalyzers(testCtx, testLogger, "model-1", interfaces.AnalyzerInput{ModelID: "model-1"}, config.SaturationScalingConfig{})
-			}).NotTo(Panic())
-
-			// throughput panicked but was recovered; slo still ran.
-			Expect(ta.callCount).To(Equal(1))
-			Expect(slo.callCount).To(Equal(1))
+			Expect(result).To(BeNil())
 		})
 	})
 })

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -199,32 +199,6 @@ func effectiveEnabled(analyzerName string, cfg config.SaturationScalingConfig) b
 	return true
 }
 
-// runRegisteredAnalyzers invokes Analyze on every registered non-saturation
-// analyzer in registration order, reading from the frozen analyzersSnapshot
-// built by StartOptimizeLoop. For each result the universal threshold post-step
-// is applied using per-analyzer config overrides where set (falling back to the
-// model-level globals). Results are discarded on this branch — combine logic
-// lands in follow-up PRs. Saturation is skipped; it runs via runV2AnalysisOnly.
-func (e *Engine) runRegisteredAnalyzers(
-	ctx context.Context,
-	logger logr.Logger,
-	modelID string,
-	input interfaces.AnalyzerInput,
-	cfg config.SaturationScalingConfig,
-) {
-	for _, entry := range e.analyzersSnapshot {
-		if entry.name == interfaces.SaturationAnalyzerName {
-			continue
-		}
-		result := runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
-		if result != nil {
-			up, down := resolveThresholds(entry.name, cfg)
-			applyUniversalThreshold(result, up, down)
-		}
-		// result discarded: optimizer receives only saturation on this branch
-	}
-}
-
 // runRegisteredAnalyzer invokes a single non-saturation analyzer's Analyze
 // method, isolating the call from the rest of the cycle. Errors are logged
 // and nil is returned; panics are recovered and logged. Returns the result

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -138,6 +138,9 @@ func (e *Engine) runAnalyzersAndScore(
 		if entry.name == interfaces.SaturationAnalyzerName {
 			continue
 		}
+		if !effectiveEnabled(entry.name, config) {
+			continue
+		}
 		result := runRegisteredAnalyzer(ctx, logger, entry, modelID, input)
 		if result == nil {
 			continue
@@ -179,6 +182,21 @@ func resolveThresholds(analyzerName string, cfg config.SaturationScalingConfig) 
 		}
 	}
 	return cfg.ScaleUpThreshold, cfg.ScaleDownBoundary
+}
+
+// effectiveEnabled returns false only when the analyzer has an explicit
+// Enabled:false entry in cfg.Analyzers. Absent entries and nil Enabled
+// pointers default to true (consistent with ApplyDefaults).
+func effectiveEnabled(analyzerName string, cfg config.SaturationScalingConfig) bool {
+	for _, aw := range cfg.Analyzers {
+		if aw.Name == analyzerName {
+			if aw.Enabled != nil {
+				return *aw.Enabled
+			}
+			return true
+		}
+	}
+	return true
 }
 
 // runRegisteredAnalyzers invokes Analyze on every registered non-saturation

--- a/internal/engines/saturation/engine_v2_population_test.go
+++ b/internal/engines/saturation/engine_v2_population_test.go
@@ -1,11 +1,28 @@
 package saturation
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
 )
+
+// fakeAnalyzerWithResult is a minimal interfaces.Analyzer whose Analyze result
+// is set at construction time. Used to inject controlled saturation/spy output
+// into runAnalyzersAndScore without needing a real SaturationAnalyzer.
+type fakeAnalyzerWithResult struct {
+	analyzerName string
+	result       *interfaces.AnalyzerResult
+}
+
+func (f *fakeAnalyzerWithResult) Name() string { return f.analyzerName }
+func (f *fakeAnalyzerWithResult) Analyze(_ context.Context, _ interfaces.AnalyzerInput) (*interfaces.AnalyzerResult, error) {
+	return f.result, nil
+}
 
 var _ = Describe("Engine config-population helpers", func() {
 
@@ -44,4 +61,149 @@ var _ = Describe("Engine config-population helpers", func() {
 			Expect(scoreForAnalyzer("sat", cfg)).To(Equal(3.0))
 		})
 	})
+
+	Describe("effectiveEnabled", func() {
+		It("returns true when the analyzer is absent from config", func() {
+			Expect(effectiveEnabled("throughput", config.SaturationScalingConfig{})).To(BeTrue())
+		})
+
+		It("returns true when Enabled is nil for the matching entry", func() {
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "throughput"}, // Enabled nil → default true
+				},
+			}
+			Expect(effectiveEnabled("throughput", cfg)).To(BeTrue())
+		})
+
+		It("returns false when Enabled is explicitly false", func() {
+			f := false
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "throughput", Enabled: &f},
+				},
+			}
+			Expect(effectiveEnabled("throughput", cfg)).To(BeFalse())
+		})
+
+		It("returns true when Enabled is explicitly true", func() {
+			t := true
+			cfg := config.SaturationScalingConfig{
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "throughput", Enabled: &t},
+				},
+			}
+			Expect(effectiveEnabled("throughput", cfg)).To(BeTrue())
+		})
+	})
+
+	Describe("runAnalyzersAndScore config-bridge", func() {
+
+		// minEngine builds a minimal Engine suitable for calling runAnalyzersAndScore.
+		// satFake is used as saturationV2Analyzer; spies is the additional snapshot.
+		minEngine := func(satFake interfaces.Analyzer, spies ...analyzerEntry) *Engine {
+			snapshot := append(
+				[]analyzerEntry{{name: interfaces.SaturationAnalyzerName, analyzer: satFake}},
+				spies...,
+			)
+			return &Engine{
+				saturationV2Analyzer: satFake,
+				analyzersSnapshot:    snapshot,
+				started:              true,
+			}
+		}
+
+		zeroSat := &fakeAnalyzerWithResult{
+			analyzerName: interfaces.SaturationAnalyzerName,
+			result:       &interfaces.AnalyzerResult{},
+		}
+
+		It("populates Score from AnalyzerScoreConfig.Score into the returned slice", func() {
+			spy := &fakeAnalyzerWithResult{
+				analyzerName: "spy",
+				result:       &interfaces.AnalyzerResult{},
+			}
+			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
+			cfg := config.SaturationScalingConfig{
+				ScaleUpThreshold:  0.85,
+				ScaleDownBoundary: 0.70,
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: interfaces.SaturationAnalyzerName, Score: 2.0},
+					{Name: "spy", Score: 0.5},
+				},
+			}
+
+			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(2))
+
+			byName := namedByName(results)
+			Expect(byName[interfaces.SaturationAnalyzerName].Score).To(Equal(2.0))
+			Expect(byName["spy"].Score).To(Equal(0.5))
+		})
+
+		It("defaults Score to 1.0 when the analyzer has no Analyzers entry", func() {
+			spy := &fakeAnalyzerWithResult{
+				analyzerName: "spy",
+				result:       &interfaces.AnalyzerResult{},
+			}
+			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
+			cfg := config.SaturationScalingConfig{
+				ScaleUpThreshold:  0.85,
+				ScaleDownBoundary: 0.70,
+				// No Analyzers entries — both default to 1.0.
+			}
+
+			results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(2))
+
+			byName := namedByName(results)
+			Expect(byName[interfaces.SaturationAnalyzerName].Score).To(Equal(1.0))
+			Expect(byName["spy"].Score).To(Equal(1.0))
+		})
+
+		It("applies per-analyzer ScaleUpThreshold override into RequiredCapacity", func() {
+			// spy returns TotalDemand=100, everything else zero.
+			spy := &fakeAnalyzerWithResult{
+				analyzerName: "spy",
+				result:       &interfaces.AnalyzerResult{TotalDemand: 100},
+			}
+			e := minEngine(zeroSat, analyzerEntry{name: "spy", analyzer: spy})
+
+			// Global ScaleUpThreshold=0.85 → RC = 100/0.85 ≈ 117.6
+			cfgGlobal := config.SaturationScalingConfig{
+				ScaleUpThreshold:  0.85,
+				ScaleDownBoundary: 0.70,
+			}
+			resultsGlobal, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgGlobal, nil, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Per-analyzer ScaleUpThreshold=1.10 → RC = 100/1.10 ≈ 90.9
+			overrideThreshold := 1.10
+			cfgOverride := config.SaturationScalingConfig{
+				ScaleUpThreshold:  0.85,
+				ScaleDownBoundary: 0.70,
+				Analyzers: []config.AnalyzerScoreConfig{
+					{Name: "spy", ScaleUpThreshold: &overrideThreshold},
+				},
+			}
+			resultsOverride, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfgOverride, nil, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			rcGlobal := namedByName(resultsGlobal)["spy"].Remaining
+			rcOverride := namedByName(resultsOverride)["spy"].Remaining
+			Expect(rcGlobal).To(BeNumerically(">", rcOverride),
+				"global threshold (0.85) should yield higher RC than override (1.10)")
+		})
+	})
 })
+
+// namedByName indexes a NamedAnalyzerResult slice by Name for easy lookup in tests.
+func namedByName(results []pipeline.NamedAnalyzerResult) map[string]pipeline.NamedAnalyzerResult {
+	m := make(map[string]pipeline.NamedAnalyzerResult, len(results))
+	for _, r := range results {
+		m[r.Name] = r
+	}
+	return m
+}

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -280,9 +280,9 @@ var _ = Describe("resolveSaturationConfig", func() {
 	})
 })
 
-var _ = Describe("runAnalyzersAndScore enabled gate (MA-F7)", func() {
+var _ = Describe("runAnalyzersAndScore disabled-analyzer gate", func() {
 
-	It("MA-F7: disabled analyzer is not appended and its Analyze is never called", func() {
+	It("disabled analyzer is not appended and its Analyze is never called", func() {
 		fakeSat := &fakeAnalyzerWithResult{
 			analyzerName: interfaces.SaturationAnalyzerName,
 			result:       &interfaces.AnalyzerResult{SpareCapacity: 1000},
@@ -313,7 +313,7 @@ var _ = Describe("runAnalyzersAndScore enabled gate (MA-F7)", func() {
 	})
 })
 
-var _ = Describe("collectV2ModelRequest Disaggregated flag (MA-H-1)", func() {
+var _ = Describe("collectV2ModelRequest Disaggregated flag", func() {
 
 	It("sets Disaggregated=true when any variant has a non-both role", func() {
 		fakeSat := &fakeAnalyzerWithResult{

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -280,6 +280,94 @@ var _ = Describe("resolveSaturationConfig", func() {
 	})
 })
 
+var _ = Describe("runAnalyzersAndScore enabled gate (MA-F7)", func() {
+
+	It("MA-F7: disabled analyzer is not appended and its Analyze is never called", func() {
+		fakeSat := &fakeAnalyzerWithResult{
+			analyzerName: interfaces.SaturationAnalyzerName,
+			result:       &interfaces.AnalyzerResult{SpareCapacity: 1000},
+		}
+		spy := &spyAnalyzer{name: "spy"}
+		e := &Engine{
+			saturationV2Analyzer: fakeSat,
+			analyzersSnapshot: []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: "spy", analyzer: spy},
+			},
+			started: true,
+		}
+		f := false
+		cfg := config.SaturationScalingConfig{
+			ScaleUpThreshold:  0.85,
+			ScaleDownBoundary: 0.70,
+			Analyzers: []config.AnalyzerScoreConfig{
+				{Name: "spy", Enabled: &f},
+			},
+		}
+
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1), "only saturation entry — disabled spy must not be appended")
+		Expect(results[0].Name).To(Equal(interfaces.SaturationAnalyzerName))
+		Expect(spy.callCount).To(Equal(0), "Analyze must not be called for a disabled analyzer")
+	})
+})
+
+var _ = Describe("collectV2ModelRequest Disaggregated flag (MA-H-1)", func() {
+
+	It("sets Disaggregated=true when any variant has a non-both role", func() {
+		fakeSat := &fakeAnalyzerWithResult{
+			analyzerName: interfaces.SaturationAnalyzerName,
+			result:       &interfaces.AnalyzerResult{},
+		}
+		e := &Engine{
+			saturationV2Analyzer: fakeSat,
+			analyzersSnapshot: []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+			},
+			started: true,
+		}
+		cfg := config.SaturationScalingConfig{
+			ScaleUpThreshold:  0.85,
+			ScaleDownBoundary: 0.70,
+		}
+		variantStates := []interfaces.VariantReplicaState{
+			{VariantName: "prefill-v1", Role: "prefill"},
+			{VariantName: "decode-v1", Role: "decode"},
+		}
+
+		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Disaggregated).To(BeTrue())
+	})
+
+	It("sets Disaggregated=false when all variants have role 'both' or empty", func() {
+		fakeSat := &fakeAnalyzerWithResult{
+			analyzerName: interfaces.SaturationAnalyzerName,
+			result:       &interfaces.AnalyzerResult{},
+		}
+		e := &Engine{
+			saturationV2Analyzer: fakeSat,
+			analyzersSnapshot: []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+			},
+			started: true,
+		}
+		cfg := config.SaturationScalingConfig{
+			ScaleUpThreshold:  0.85,
+			ScaleDownBoundary: 0.70,
+		}
+		variantStates := []interfaces.VariantReplicaState{
+			{VariantName: "v1", Role: interfaces.RoleBoth},
+			{VariantName: "v2", Role: ""},
+		}
+
+		req, err := e.collectV2ModelRequest(context.Background(), "m", "ns", nil, cfg, variantStates, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Disaggregated).To(BeFalse())
+	})
+})
+
 func decisionsByVariant(decisions []interfaces.VariantDecision) map[string]interfaces.VariantDecision {
 	m := make(map[string]interfaces.VariantDecision, len(decisions))
 	for _, d := range decisions {

--- a/internal/engines/saturation/engine_v2_test.go
+++ b/internal/engines/saturation/engine_v2_test.go
@@ -280,6 +280,41 @@ var _ = Describe("resolveSaturationConfig", func() {
 	})
 })
 
+var _ = Describe("runAnalyzersAndScore call ordering", func() {
+
+	It("calls each enabled non-saturation analyzer exactly once in registration order", func() {
+		fakeSat := &fakeAnalyzerWithResult{
+			analyzerName: interfaces.SaturationAnalyzerName,
+			result:       &interfaces.AnalyzerResult{},
+		}
+		ta := &spyAnalyzer{name: "throughput"}
+		slo := &spyAnalyzer{name: "slo"}
+		e := &Engine{
+			saturationV2Analyzer: fakeSat,
+			analyzersSnapshot: []analyzerEntry{
+				{name: interfaces.SaturationAnalyzerName, analyzer: fakeSat},
+				{name: "throughput", analyzer: ta},
+				{name: "slo", analyzer: slo},
+			},
+			started: true,
+		}
+		cfg := config.SaturationScalingConfig{
+			ScaleUpThreshold:  0.85,
+			ScaleDownBoundary: 0.70,
+		}
+
+		results, err := e.runAnalyzersAndScore(context.Background(), "m", "ns", nil, cfg, nil, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		// saturation + throughput + slo all appended
+		Expect(results).To(HaveLen(3))
+		Expect(ta.callCount).To(Equal(1))
+		Expect(slo.callCount).To(Equal(1))
+		// saturationV2Analyzer is called via runV2AnalysisOnly, not the loop;
+		// the snapshot entry for saturation is skipped by the name guard.
+		Expect(fakeSat.Name()).To(Equal(interfaces.SaturationAnalyzerName)) // sanity
+	})
+})
+
 var _ = Describe("runAnalyzersAndScore disabled-analyzer gate", func() {
 
 	It("disabled analyzer is not appended and its Analyze is never called", func() {


### PR DESCRIPTION
## Summary

Addendum to #1246 (per-analyzer slice optimizer). Addresses four items
that did not fit inside the three-PR multi-analyzer stack (#1225/#1228/#1246):

- **Bug fix**: disabled analyzer still vetoed scale-down (runtime bug,
  `Enabled:false` was parsed but not checked at runtime).
- **Test gaps**: no spec asserted config-bridge population (Score, threshold
  overrides) or non-uniform Score driving fair-share ordering.
- **Developer guide**: `multi-analyzer-pipeline.md` was a stub pointing to a
  private fork URL; replaced with a self-contained reference doc.

## What changed

**`engines/saturation: skip disabled analyzers in runAnalyzersAndScore`**
`runAnalyzersAndScore` iterated `analyzersSnapshot` unconditionally. A disabled
analyzer (`Enabled:false`) returned zero `SpareCapacity`, vetoing scale-down.
Fix: add `effectiveEnabled(name, cfg)` helper (consistent with `ApplyDefaults`
nil-pointer handling) and skip both the `Analyze` call and the append.
`saturationV2Analyzer` field widened to `interfaces.Analyzer` to allow test
injection (one-line change to `engine.go`).

**`engines/saturation: add config-bridge population and non-uniform Score tests`**
- `engine_v2_population_test.go`: `effectiveEnabled` unit specs (4 cases);
  `runAnalyzersAndScore` config-bridge specs asserting Score population,
  Score default=1.0, and per-analyzer ScaleUpThreshold override.
- `engine_v2_test.go`: disabled-analyzer integration spec (not appended + not
  called); `collectV2ModelRequest` Disaggregated true/false specs.
- `greedy_score_optimizer_test.go`: T1.4 non-uniform Score spec — two analyzers
  with Score=1.0 and Score=2.0 drive fair-share ordering as expected.

**`docs: expand multi-analyzer pipeline developer guide`**
Full rewrite of `docs/developer-guide/multi-analyzer-pipeline.md`. The stub
and private fork URL are gone. The doc is now self-contained for a code
reviewer reading only the PR diff:
- Architecture section: ASCII data-flow diagram (Config → Engine prep → run
  analyzers + post-step → ModelScalingRequest → Optimizer → VariantDecisions),
  key concepts table, responsibility table (who writes / reads each field).
- User configuration, analyzer implementor guide (interface, input, output
  invariants, linearity invariant, do-not-populate RC/SC rule).
- Pipeline flow (numbered steps), how results combine (veto semantics).
- Data model section: AnalyzerResult immutability, NamedAnalyzerResult
  mutable/immutable field split, RolePairedState lifecycle.
- Optimizer internals: scale-up path (allocateForModelPaired, RolePickFn),
  scale-down path (scaleDownRoleIterated — same loop for both disaggregated
  and non-disaggregated via synthetic "both" role), fair-share iteration
  algorithm.

## Testing

`make test`, `make lint`, `gofmt`, `go build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)