### PR TITLE
feat(collector): resolve VA attribution behind an Attributor seam

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -455,6 +455,9 @@ func main() {
 			sourceRegistry,
 			cfg, // Pass unified Config to engine
 		)
+		// Uncached reader for the per-cycle variant-label pod LIST used by VA
+		// attribution, so no Pod informer/cache is started for it.
+		engine.APIReader = mgr.GetAPIReader()
 		go engine.StartOptimizeLoop(ctx)
 		return nil
 	}))

--- a/docs/design/controller-behavior.md
+++ b/docs/design/controller-behavior.md
@@ -245,12 +245,13 @@ This periodic reconciliation is why many Update and Delete events can be safely 
 
 ### `llm-d.ai/variant` Label on the Scale Target
 
-WVA identifies which pods belong to a given `VariantAutoscaling` resource by reading the `llm-d.ai/variant` label from Prometheus metrics. Two things must be true for this to work:
+WVA identifies which pods belong to a given `VariantAutoscaling` resource by reading the `llm-d.ai/variant` label **directly from the pod objects**. Once per optimization cycle WVA lists the variant-labeled pods in the namespace and maps each pod to its `VariantAutoscaling` by the label value. Per-replica metrics are collected keyed by replica identity (`instance`, `pod`) and attributed to a VA in this separate step — attribution is not carried in the metric labels.
+
+For this to work:
 
 1. The `llm-d.ai/variant` label must be present on the **pod template** of the scale target (Deployment or LeaderWorkerSet), with a value equal to the name of the corresponding `VariantAutoscaling` resource.
-2. The `ServiceMonitor` or `PodMonitor` that Prometheus uses to scrape those pods must include a target relabeling rule that propagates the pod label into the scraped metrics as `llm_d_ai_variant`.
 
-**Both are your responsibility.** WVA does not configure either automatically.
+**This is your responsibility.** WVA does not configure it automatically. The `ServiceMonitor`/`PodMonitor` relabeling rule that propagates the label into the metric series (described below) is **no longer required for attribution**; it is optional and only useful if you want to filter your own metric queries or dashboards by variant.
 
 #### 1. Set the pod template label
 
@@ -289,9 +290,11 @@ spec:
           llm-d.ai/variant: llama-70b-autoscaler   # must match the VariantAutoscaling name
 ```
 
-#### 2. Patch the ServiceMonitor or PodMonitor to propagate the label
+#### 2. (Optional) Propagate the label into metric series
 
-The `llm-d.ai/variant` pod label must flow through Prometheus target relabeling into the scraped metric series as `llm_d_ai_variant`. Add the following relabeling rule to the `endpoints[].relabelings` section of your `ServiceMonitor`, or to the `podMetricsEndpoints[].relabelings` section of your `PodMonitor`:
+> This step is **not required for WVA attribution** — WVA reads the `llm-d.ai/variant` label from the pod object, not from the metric series. Apply it only if you want the `llm_d_ai_variant` label on the scraped metric series for your own PromQL queries or dashboards.
+
+To make the `llm-d.ai/variant` pod label flow through Prometheus target relabeling into the scraped metric series as `llm_d_ai_variant`, add the following relabeling rule to the `endpoints[].relabelings` section of your `ServiceMonitor`, or to the `podMetricsEndpoints[].relabelings` section of your `PodMonitor`:
 
 ```yaml
 # ServiceMonitor patch
@@ -315,9 +318,7 @@ spec:
 
 > **Important**: This rule must live under `relabelings` (target relabeling), **not** `metricRelabelings` (metric relabeling). The `__meta_kubernetes_pod_label_*` labels are only available during target relabeling and are stripped before metric relabeling runs.
 
-WVA uses the `llm_d_ai_variant` metric label to associate per-pod metrics with the correct `VariantAutoscaling` resource.
-
-If the pod label or the relabeling rule is absent, WVA will not collect metrics for the affected pods and scaling decisions for that variant will not be made.
+If the `llm-d.ai/variant` pod label is absent (or carries the wrong value), WVA cannot attribute the affected pods to a `VariantAutoscaling` and scaling decisions for that variant will not be made.
 
 ## Best Practices
 
@@ -363,12 +364,16 @@ kubectl logs -n workload-variant-autoscaler-system deployment/controller-manager
 
 **Symptom**: WVA is running and the VA exists, but no scaling decisions are produced for a specific variant (e.g., `wva_desired_replicas` has no series for that variant).
 
-**Likely causes**:
-- The `llm-d.ai/variant` pod label is missing or has the wrong value on the scale target's pod template.
-- The ServiceMonitor or PodMonitor that scrapes those pods is missing the relabeling rule that propagates `llm-d.ai/variant` → `llm_d_ai_variant`.
+**Likely cause**:
+- The `llm-d.ai/variant` pod label is missing or has the wrong value on the scale target's pod template (it must equal the `VariantAutoscaling` resource name). WVA attributes pods to a VA by reading this label from the pod object, so without it no metrics are attributed to the variant.
+
+**Quick signal**: WVA emits a `Warning` event with reason `UnattributedReadyPods` on the VA when the scale target has Ready pods but none are attributed. Run `kubectl describe va <name>` to surface it directly.
 
 **Diagnosis**:
 ```bash
+# Check the VA events for UnattributedReadyPods
+kubectl describe va <va-name> -n <namespace> | grep -A3 UnattributedReadyPods
+
 # Verify the label is present on live pods
 kubectl get pods -n <namespace> -l llm-d.ai/variant=<va-name>
 
@@ -380,35 +385,18 @@ kubectl get deployment <name> -n <namespace> \
 kubectl get lws <name> -n <namespace> \
   -o jsonpath='{.spec.leaderWorkerTemplate.workerTemplate.metadata.labels.llm-d\.ai/variant}'
 
-# Confirm the label flows through to Prometheus metrics
-# (replace <va-name> with the VariantAutoscaling resource name)
+# Confirm the per-replica vLLM metrics are scraped for those pods
+# (attribution is by pod label, so the metric series need not carry llm_d_ai_variant)
 curl -G 'http://<prometheus>/api/v1/query' \
-  --data-urlencode 'query=vllm:num_requests_running{llm_d_ai_variant="<va-name>"}'
-
-# If the query returns no results, check the ServiceMonitor for the relabeling rule
-kubectl get servicemonitor <name> -n <monitoring-namespace> -o yaml | grep -A5 relabeling
+  --data-urlencode 'query=vllm:num_requests_running{namespace="<namespace>"}'
 ```
 
-**Solution 1 — missing pod label**: Add the label to the pod template and roll out the workload.
+**Solution — missing pod label**: Add the label to the pod template and roll out the workload.
 
 ```bash
 kubectl patch deployment <name> -n <namespace> \
   --type=merge \
   -p '{"spec":{"template":{"metadata":{"labels":{"llm-d.ai/variant":"<va-name>"}}}}}'
-```
-
-**Solution 2 — missing relabeling rule**: Patch the ServiceMonitor (or PodMonitor) to add the rule that propagates the pod label into Prometheus metrics.
-
-```bash
-# For a ServiceMonitor — patch the first endpoint's relabelings
-kubectl patch servicemonitor <name> -n <monitoring-namespace> \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/endpoints/0/relabelings/-","value":{"sourceLabels":["__meta_kubernetes_pod_label_llm_d_ai_variant"],"targetLabel":"llm_d_ai_variant","action":"replace"}}]'
-
-# For a PodMonitor — patch the first podMetricsEndpoint's relabelings
-kubectl patch podmonitor <name> -n <monitoring-namespace> \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/podMetricsEndpoints/0/relabelings/-","value":{"sourceLabels":["__meta_kubernetes_pod_label_llm_d_ai_variant"],"targetLabel":"llm_d_ai_variant","action":"replace"}}]'
 ```
 
 ### Metrics Not Available

--- a/docs/developer-guide/variant-attribution.md
+++ b/docs/developer-guide/variant-attribution.md
@@ -1,0 +1,62 @@
+# Variant Attribution
+
+This document describes how the metrics collector associates per-replica metrics
+with the `VariantAutoscaling` (VA) that owns each replica, and the seam that keeps
+that association decoupled from the Prometheus queries.
+
+## Two separate concerns
+
+Collecting per-replica metrics and deciding which VA a replica belongs to are
+deliberately kept apart:
+
+1. **Per-replica queries carry replica identity only.** Every per-replica PromQL
+   template (saturation, queueing-model, and throughput-analyzer queries under
+   `internal/collector/registration/`) selects by `{namespace, model_name}` and
+   groups by `(instance, pod)`. They do **not** carry a `llm_d_ai_variant` label.
+   `buildInstanceKey` (in `replica_metrics.go`) turns those labels into a single
+   replica identity key (`pod:port`, falling back to `instance`), and nothing
+   else.
+
+2. **VA attribution is resolved once per pod, after the query**, through the
+   `Attributor` seam.
+
+This separation means a per-pod metric for the same replica from any query
+(KV-cache usage, generation-token rate, …) merges into a single
+`ReplicaMetrics` entry keyed by replica identity, and the question "which VA owns
+this pod?" is answered in exactly one place.
+
+## The `Attributor` seam
+
+`internal/collector/attribution` defines:
+
+```go
+type Attributor interface {
+    VAForPod(namespace, podName string) (vaName string, ok bool)
+}
+```
+
+An `Attributor` is built once per optimization cycle and queried `O(1)` for each
+pod on the metrics-assembly path. `CollectReplicaMetrics` takes an `Attributor`
+and, for each discovered replica, sets `VariantName` from `VAForPod`; replicas
+that resolve to no VA are skipped (same behavior as before, different source).
+
+### Default implementation: the label attributor
+
+`BuildLabelAttributor` is the default. It performs one bounded, labeled `List`
+per namespace — `client.HasLabels{"llm-d.ai/variant"}` — via an **uncached API
+reader** (`mgr.GetAPIReader()`), so it starts no Pod informer/cache. It maps each
+labeled pod to the VA named by its `llm-d.ai/variant` label value. The
+`ServiceMonitor`/`PodMonitor` relabeling rule that used to copy the pod label
+into the metric series is **no longer required for attribution** — the label is
+read from the pod object directly.
+
+The engine wires the reader in `prepareModelData`: it uses
+`Engine.APIReader` when set (production, from `mgr.GetAPIReader()`) and falls back
+to the cached client when nil (unit tests).
+
+## Adding a new attribution mechanism
+
+Alternative resolution strategies (for example, an owner-reference walk from pod
+to its controlling workload to the VA) become additional `Attributor`
+implementations in this package. They plug in behind the same interface — the
+queries, the collector hot path, and every analyzer are untouched.

--- a/internal/collector/attribution/attribution.go
+++ b/internal/collector/attribution/attribution.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package attribution resolves which VariantAutoscaling owns a given pod.
+//
+// VA attribution is deliberately decoupled from the per-replica Prometheus
+// queries: the queries carry replica identity only (instance, pod), and the
+// owning VariantAutoscaling is resolved once per pod, after the query, through
+// the Attributor seam. Alternative resolution mechanisms (e.g. an owner-walk
+// pod locator) plug in as additional Attributor implementations without
+// touching the queries, the collector hot path, or any analyzer.
+package attribution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+// Attributor resolves a pod (namespace + name) to the VariantAutoscaling that
+// owns it. Implementations are built once per optimization cycle and queried
+// O(1) on the metrics assembly path.
+type Attributor interface {
+	VAForPod(namespace, podName string) (vaName string, ok bool)
+}
+
+// labelAttributor resolves via the llm-d.ai/variant label stamped on the pod.
+type labelAttributor struct {
+	byPod map[string]string // "<ns>/<pod>" -> VA name
+}
+
+func (a labelAttributor) VAForPod(ns, pod string) (string, bool) {
+	if a.byPod == nil {
+		return "", false
+	}
+	v, ok := a.byPod[ns+"/"+pod]
+	return v, ok
+}
+
+// BuildLabelAttributor lists pods carrying the variant label — one bounded
+// labeled LIST per namespace via the uncached reader — and maps them to their
+// VA name. reader should be mgr.GetAPIReader() so no Pod informer is started.
+//
+// On a List failure it keeps the entries from namespaces that succeeded and
+// returns the partial attributor together with a joined error, so the caller
+// can surface the degradation (warn once per cycle) while still using whatever
+// resolved. A nil error means every namespace listed cleanly.
+//
+// No factory for now: construction is specific to this label strategy, and a
+// free constructor is sufficient while the label attributor is the only impl.
+// A future second mechanism (e.g. the owner-walk locator) gets its own builder;
+// if more than one ever needs to coexist behind engine config, introduce a
+// builder/factory interface at that point.
+func BuildLabelAttributor(ctx context.Context, reader client.Reader, namespaces []string) (Attributor, error) {
+	byPod := make(map[string]string)
+	var errs []error
+	for _, ns := range namespaces {
+		pods := &corev1.PodList{}
+		if err := reader.List(ctx, pods,
+			client.InNamespace(ns),
+			client.HasLabels{constants.VariantLabelKey},
+		); err != nil {
+			errs = append(errs, fmt.Errorf("listing variant-labeled pods in namespace %q: %w", ns, err))
+			continue
+		}
+		for i := range pods.Items {
+			p := &pods.Items[i]
+			if v := p.Labels[constants.VariantLabelKey]; v != "" {
+				byPod[p.Namespace+"/"+p.Name] = v
+			}
+		}
+	}
+	return labelAttributor{byPod: byPod}, errors.Join(errs...)
+}

--- a/internal/collector/attribution/attribution_test.go
+++ b/internal/collector/attribution/attribution_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attribution
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+func pod(ns, name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+	}
+}
+
+func corev1Scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestBuildLabelAttributor(t *testing.T) {
+	const ns = "team-a"
+
+	c := fake.NewClientBuilder().WithScheme(corev1Scheme(t)).WithObjects(
+		pod(ns, "labeled-1", map[string]string{constants.VariantLabelKey: "va-one"}),
+		pod(ns, "labeled-2", map[string]string{constants.VariantLabelKey: "va-two"}),
+		// Unlabeled pod: must not be attributed.
+		pod(ns, "unlabeled", map[string]string{"app": "vllm"}),
+		// Empty label value: treated as no attribution.
+		pod(ns, "empty-label", map[string]string{constants.VariantLabelKey: ""}),
+		// Different namespace: must not leak into ns's attributor.
+		pod("other-ns", "elsewhere", map[string]string{constants.VariantLabelKey: "va-elsewhere"}),
+	).Build()
+
+	a, err := BuildLabelAttributor(context.Background(), c, []string{ns})
+	if err != nil {
+		t.Fatalf("BuildLabelAttributor: unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		podName    string
+		wantVAName string
+		wantOK     bool
+	}{
+		{"labeled pod resolves", "labeled-1", "va-one", true},
+		{"second labeled pod resolves", "labeled-2", "va-two", true},
+		{"unlabeled pod not attributed", "unlabeled", "", false},
+		{"empty label value not attributed", "empty-label", "", false},
+		{"unknown pod not attributed", "ghost", "", false},
+		{"pod from another namespace not attributed", "elsewhere", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVA, gotOK := a.VAForPod(ns, tc.podName)
+			if gotOK != tc.wantOK || gotVA != tc.wantVAName {
+				t.Errorf("VAForPod(%q,%q) = (%q,%v), want (%q,%v)",
+					ns, tc.podName, gotVA, gotOK, tc.wantVAName, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestLabelAttributor_NilSafe asserts a zero-value / nil-map attributor never
+// panics and always reports "not found".
+func TestLabelAttributor_NilSafe(t *testing.T) {
+	var a labelAttributor // byPod is nil
+	if v, ok := a.VAForPod("ns", "pod"); ok || v != "" {
+		t.Errorf("nil-map VAForPod = (%q,%v), want (\"\",false)", v, ok)
+	}
+}
+
+// TestBuildLabelAttributor_EmptyNamespaces builds an attributor over no
+// namespaces; every lookup reports "not found" without listing anything.
+func TestBuildLabelAttributor_EmptyNamespaces(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(corev1Scheme(t)).Build()
+
+	a, err := BuildLabelAttributor(context.Background(), c, nil)
+	if err != nil {
+		t.Fatalf("BuildLabelAttributor: unexpected error: %v", err)
+	}
+	if v, ok := a.VAForPod("ns", "pod"); ok || v != "" {
+		t.Errorf("empty-namespaces VAForPod = (%q,%v), want (\"\",false)", v, ok)
+	}
+}
+
+// TestBuildLabelAttributor_ListError verifies the partial-success contract:
+// when a List fails for one namespace the builder returns a non-nil error but
+// also a non-nil, query-safe (empty) Attributor so the caller can proceed.
+// With multiple namespaces, entries from the namespaces that succeeded must
+// still be present in the returned attributor.
+func TestBuildLabelAttributor_ListError(t *testing.T) {
+	t.Run("single namespace fails – error returned, attributor safe", func(t *testing.T) {
+		listErr := errors.New("injected list failure")
+		ic := interceptor.NewClient(
+			fake.NewClientBuilder().WithScheme(corev1Scheme(t)).Build(),
+			interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return listErr
+				},
+			},
+		)
+
+		a, err := BuildLabelAttributor(context.Background(), ic, []string{"ns-a"})
+		if err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+		if a == nil {
+			t.Fatal("expected non-nil Attributor even on error, got nil")
+		}
+		// The attributor must be safe to query (no panic, returns ok=false).
+		if v, ok := a.VAForPod("ns-a", "any-pod"); ok || v != "" {
+			t.Errorf("VAForPod on error attributor = (%q,%v), want (\"\",false)", v, ok)
+		}
+	})
+
+	t.Run("second namespace fails – first namespace entries still resolved", func(t *testing.T) {
+		scheme := corev1Scheme(t)
+		goodClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			pod("ns-good", "pod-ok", map[string]string{constants.VariantLabelKey: "va-ok"}),
+		).Build()
+
+		var callCount int
+		ic := interceptor.NewClient(goodClient, interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				callCount++
+				if callCount == 2 {
+					return errors.New("injected failure on second namespace")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		})
+
+		a, err := BuildLabelAttributor(context.Background(), ic, []string{"ns-good", "ns-bad"})
+		if err == nil {
+			t.Fatal("expected non-nil error, got nil")
+		}
+		// ns-good succeeded on the first call — its pod must still resolve.
+		if v, ok := a.VAForPod("ns-good", "pod-ok"); !ok || v != "va-ok" {
+			t.Errorf("VAForPod(ns-good, pod-ok) = (%q,%v), want (\"va-ok\",true)", v, ok)
+		}
+	})
+}

--- a/internal/collector/build_instance_key_test.go
+++ b/internal/collector/build_instance_key_test.go
@@ -22,95 +22,130 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/attribution"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
-// buildInstanceKeyTestCase drives a single call through CollectReplicaMetrics with
-// a source that returns exactly one KV-cache sample, then checks that the resulting
-// ReplicaMetrics carries the expected vaName (or none when the label is absent).
-type buildInstanceKeyTestCase struct {
-	name        string
-	labels      map[string]string
-	wantVAName  string
-	wantSkipped bool // true when buildInstanceKey returns ("","","") → no entry produced
+const attribTestNS = "test-ns"
+
+// labeledPod builds a pod carrying the llm-d.ai/variant label — the source the
+// default Attributor reads VA attribution from.
+func labeledPod(name, vaName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: attribTestNS,
+			Name:      name,
+			Labels:    map[string]string{constants.VariantLabelKey: vaName},
+		},
+	}
 }
 
-var buildInstanceKeyTestCases = []buildInstanceKeyTestCase{
+// attributorWithPods builds a fake client seeded with the given pods and the
+// default label Attributor over attribTestNS. The same client is returned so
+// callers can hand it to NewReplicaMetricsCollector.
+func attributorWithPods(t *testing.T, pods ...*corev1.Pod) (attribution.Attributor, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme (VA): %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme (corev1): %v", err)
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, p := range pods {
+		builder = builder.WithObjects(p)
+	}
+	c := builder.Build()
+	a, err := attribution.BuildLabelAttributor(context.Background(), c, []string{attribTestNS})
+	if err != nil {
+		t.Fatalf("BuildLabelAttributor: %v", err)
+	}
+	return a, c
+}
+
+// attribTestCase drives a single KV-cache sample (replica identity only — the
+// metric carries no variant label) through CollectReplicaMetrics together with
+// an Attributor built from the seeded pods, then checks the resulting
+// ReplicaMetrics carries the expected VariantName (or that the pod is skipped
+// when attribution fails).
+type attribTestCase struct {
+	name        string
+	labels      map[string]string // identity labels on the metric sample
+	pods        []*corev1.Pod     // pods seeding the label attributor
+	wantVAName  string
+	wantSkipped bool
+}
+
+var attribTestCases = []attribTestCase{
 	{
-		name: "pod label present – vaName propagated",
+		name: "pod label present, pod attributed – VariantName from attributor",
 		labels: map[string]string{
-			"pod":                               "pod-abc",
-			"instance":                          "10.0.0.1:8000",
-			constants.VariantLabelPrometheusKey: "my-va",
+			"pod":      "pod-abc",
+			"instance": "10.0.0.1:8000",
 		},
+		pods:       []*corev1.Pod{labeledPod("pod-abc", "my-va")},
 		wantVAName: "my-va",
 	},
 	{
-		name: "pod_name fallback – vaName propagated",
+		name: "pod_name fallback, pod attributed – VariantName from attributor",
 		labels: map[string]string{
-			"pod_name":                          "pod-xyz",
-			"instance":                          "10.0.0.2:8000",
-			constants.VariantLabelPrometheusKey: "other-va",
+			"pod_name": "pod-xyz",
+			"instance": "10.0.0.2:8000",
 		},
+		pods:       []*corev1.Pod{labeledPod("pod-xyz", "other-va")},
 		wantVAName: "other-va",
 	},
 	{
-		// Pods without llm_d_ai_variant are skipped at line 669 of replica_metrics.go
-		// ("Skipping pod that doesn't match any scale target"), so no ReplicaMetrics is produced.
-		name: "llm_d_ai_variant label absent – pod skipped, no result",
+		// The metric resolves to a replica identity, but no pod with the variant
+		// label backs it, so attribution yields nothing and the pod is skipped.
+		name: "pod identity present but not attributed – pod skipped",
 		labels: map[string]string{
-			"pod":      "pod-no-variant",
+			"pod":      "pod-unmapped",
 			"instance": "10.0.0.3:8000",
 		},
+		pods:        nil,
 		wantSkipped: true,
 	},
 	{
-		// Same: empty string is treated the same as missing.
-		name: "llm_d_ai_variant label empty string – pod skipped, no result",
+		name: "no pod identity labels – entry skipped before attribution",
 		labels: map[string]string{
-			"pod":                               "pod-empty-variant",
-			"instance":                          "10.0.0.4:8000",
-			constants.VariantLabelPrometheusKey: "",
+			"foo": "bar",
 		},
+		pods:        []*corev1.Pod{labeledPod("pod-abc", "my-va")},
 		wantSkipped: true,
 	},
 	{
-		name: "no pod identity labels – entry skipped entirely",
+		// instance-only metrics carry no pod name, so there is no pod identity to
+		// attribute against — the pod is skipped even though a labeled pod exists.
+		name: "instance-only (no pod name) – not attributable, skipped",
 		labels: map[string]string{
-			constants.VariantLabelPrometheusKey: "irrelevant",
+			"instance": "10.0.0.5:8000",
 		},
+		pods:        []*corev1.Pod{labeledPod("pod-abc", "my-va")},
 		wantSkipped: true,
-	},
-	{
-		name: "instance-only (no pod name) – instance used as key, vaName propagated",
-		labels: map[string]string{
-			"instance":                          "10.0.0.5:8000",
-			constants.VariantLabelPrometheusKey: "instance-va",
-		},
-		wantVAName: "instance-va",
 	},
 }
 
-func TestBuildInstanceKey_VANameExtraction(t *testing.T) {
-	for _, tc := range buildInstanceKeyTestCases {
+func TestCollectReplicaMetrics_Attribution(t *testing.T) {
+	for _, tc := range attribTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			if err := metrics.InitMetrics(registry); err != nil {
 				t.Fatalf("InitMetrics: %v", err)
 			}
 
-			scheme := runtime.NewScheme()
-			if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
-				t.Fatalf("AddToScheme: %v", err)
-			}
-			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			attributor, k8sClient := attributorWithPods(t, tc.pods...)
 
 			mockSource := &mockMetricsSource{
 				refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
@@ -132,11 +167,12 @@ func TestBuildInstanceKey_VANameExtraction(t *testing.T) {
 			results, err := collector.CollectReplicaMetrics(
 				context.Background(),
 				"test-model",
-				"test-ns",
+				attribTestNS,
 				make(map[string]scaletarget.ScaleTargetAccessor),
 				make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 				nil,
 				make(map[string]float64),
+				attributor,
 			)
 			if err != nil {
 				t.Fatalf("CollectReplicaMetrics: %v", err)

--- a/internal/collector/registration/queueing_model.go
+++ b/internal/collector/registration/queueing_model.go
@@ -49,11 +49,13 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// Average time-to-first-token per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed TTFT for Kalman filter updates.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgTTFT,
 		Type:     source.QueryTypePromQL,
-		Template: `max by (instance, pod, llm_d_ai_variant) (rate(vllm:time_to_first_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:time_to_first_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template: `max by (instance, pod) (rate(vllm:time_to_first_token_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:time_to_first_token_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:   []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average time-to-first-token per instance (seconds), " +
 			"used by queueing model tuner for parameter learning",
@@ -62,11 +64,13 @@ func RegisterQueueingModelQueries(sourceRegistry *source.SourceRegistry) {
 	// Average inter-token latency per instance (seconds).
 	// Uses histogram rate(sum[1m]) / rate(count[1m]) over a 1m sliding window.
 	// Used by queueing model tuner as the observed ITL for Kalman filter updates.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:     QueryAvgITL,
 		Type:     source.QueryTypePromQL,
-		Template: `max by (instance, pod, llm_d_ai_variant) (rate(vllm:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template: `max by (instance, pod) (rate(vllm:inter_token_latency_seconds_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]) / rate(vllm:inter_token_latency_seconds_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:   []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average inter-token latency per instance (seconds), " +
 			"used by queueing model tuner for parameter learning",

--- a/internal/collector/registration/saturation.go
+++ b/internal/collector/registration/saturation.go
@@ -27,22 +27,26 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 
 	// KV cache usage per instance (peak over last minute)
 	// Uses max_over_time to catch saturation events between scrapes
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryKvCacheUsage,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (max_over_time(vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `max by (instance, pod) (max_over_time(vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Peak KV cache utilization per instance (0.0-1.0) over last minute",
 	})
 
 	// Queue length per instance (peak over last minute)
 	// Uses max_over_time to catch burst traffic
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryQueueLength,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (max_over_time(vllm:num_requests_waiting{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `max by (instance, pod) (max_over_time(vllm:num_requests_waiting{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Peak queue length per instance over last minute",
 	})
@@ -52,7 +56,9 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	// Cache config info per instance (static labels with block size and GPU blocks count)
 	// Uses max to deduplicate when multiple series exist per instance with different label combinations
 	// Used by Saturation Analyzer V2 for token capacity computation
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), llm_d_ai_variant (for direct pod-to-VA mapping), and config labels
+	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and config labels.
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	//
 	// NOTE: vllm:cache_config_info is an info-style metric. Unlike vLLM's regular
 	// gauges/counters, it is NOT labeled with model_name — its label set is derived
@@ -65,29 +71,33 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryCacheConfigInfo,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}"})`,
+		Template:    `max by (instance, pod, num_gpu_blocks, block_size) (vllm:cache_config_info{namespace="{{.namespace}}"})`,
 		Params:      []string{source.ParamNamespace},
 		Description: "KV cache configuration info per instance (num_gpu_blocks and block_size as labels)",
 	})
 
 	// Average output (generation) tokens per completed request
 	// Used for output-length-dependent k2 estimation
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgOutputTokens,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average output tokens per completed request (5m rate)",
 	})
 
 	// Average input (prompt) tokens per completed request
 	// Used in k2 derivation formula: k2 = N_max × (I + O/2)
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryAvgInputTokens,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(vllm:request_prompt_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_prompt_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:request_prompt_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:request_prompt_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Average input tokens per completed request (5m rate)",
 	})
@@ -95,11 +105,13 @@ func RegisterSaturationQueries(sourceRegistry *source.SourceRegistry) {
 	// Prefix cache hit rate per instance (5m rate)
 	// Used to reduce estimated input token demand for scheduler-queued requests.
 	// Returns 0..1 where 1 means all prefix lookups were cache hits.
-	// Preserves instance (IP:port for multi-vLLM pods), pod (for pod lookup), and llm_d_ai_variant (for direct pod-to-VA mapping)
+	// Preserves instance (IP:port for multi-vLLM pods) and pod (for pod lookup).
+	// VA attribution is resolved at the collector layer after the query (via the
+	// Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryPrefixCacheHitRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (instance, pod, llm_d_ai_variant) (rate(vllm:prefix_cache_hits{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
+		Template:    `max by (instance, pod) (rate(vllm:prefix_cache_hits{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]) / rate(vllm:prefix_cache_queries{namespace="{{.namespace}}",model_name="{{.modelID}}"}[5m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Prefix cache hit rate per instance (0.0-1.0, 5m rate)",
 	})

--- a/internal/collector/registration/throughput_analyzer.go
+++ b/internal/collector/registration/throughput_analyzer.go
@@ -100,26 +100,30 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 
 	// Per-pod observed generation (decode) token rate (tokens/sec).
 	// Computed as the rate of the _sum histogram counter over 1m.
-	// Uses sum by (pod, llm_d_ai_variant) because request_generation_tokens_sum is an additive
+	// Uses sum by (instance, pod) because request_generation_tokens_sum is an additive
 	// counter — multiple histogram buckets per pod must be summed.
-	// Preserves llm_d_ai_variant for direct pod-to-VA mapping.
+	// Groups by (instance, pod) to match the per-replica keying of the saturation
+	// and queueing-model queries. VA attribution is resolved at the collector layer
+	// after the query (via the Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryGenerationTokenRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `sum by (pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `sum by (instance, pod) (rate(vllm:request_generation_tokens_sum{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Observed generation (decode) token rate per pod (tokens/sec), proxy for μ_dec^obs",
 	})
 
 	// Per-pod instantaneous KV cache utilization (0.0–1.0).
-	// Uses max by (pod, llm_d_ai_variant) to consolidate any duplicate series to a single per-pod value.
+	// Uses max by (instance, pod) to consolidate any duplicate series to a single per-pod value.
 	// Does NOT use max_over_time: the throughput analyzer needs the current
 	// operating point k*, not the worst-case peak used by the saturation analyzer.
-	// Preserves llm_d_ai_variant for direct pod-to-VA mapping.
+	// Groups by (instance, pod) to match the per-replica keying of the saturation
+	// and queueing-model queries. VA attribution is resolved at the collector layer
+	// after the query (via the Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryKvUsageInstant,
 		Type:        source.QueryTypePromQL,
-		Template:    `max by (pod, llm_d_ai_variant) (vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
+		Template:    `max by (instance, pod) (vllm:kv_cache_usage_perc{namespace="{{.namespace}}",model_name="{{.modelID}}"})`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "Instantaneous KV cache utilization per pod (0.0–1.0), used as k* in the ITL model",
 	})
@@ -129,11 +133,13 @@ func RegisterThroughputAnalyzerQueries(sourceRegistry *source.SourceRegistry) {
 	// completed request). Used as a fallback for λ_dec when EPP/scheduler metrics
 	// are unavailable; per variant V, the analyzer falls back to:
 	//   λ_dec_vllm = Σ_{r∈V}(VLLMRequestRate_r × AvgOutputTokens_r)
-	// Preserves llm_d_ai_variant for direct pod-to-VA mapping.
+	// Groups by (instance, pod) to match the per-replica keying of the saturation
+	// and queueing-model queries. VA attribution is resolved at the collector layer
+	// after the query (via the Attributor seam), not carried in the metric labels.
 	registry.MustRegister(source.QueryTemplate{
 		Name:        QueryVLLMRequestRate,
 		Type:        source.QueryTypePromQL,
-		Template:    `sum by (pod, llm_d_ai_variant) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
+		Template:    `sum by (instance, pod) (rate(vllm:request_generation_tokens_count{namespace="{{.namespace}}",model_name="{{.modelID}}"}[1m]))`,
 		Params:      []string{source.ParamNamespace, source.ParamModelID},
 		Description: "vLLM request completion rate per pod (req/s); fallback for λ_dec when EPP metrics are unavailable",
 	})

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/attribution"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
@@ -141,8 +142,10 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	vaEventTracker map[string]bool,
 	variantCosts map[string]float64,
+	attributor attribution.Attributor,
 ) ([]interfaces.ReplicaMetrics, error) {
-	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts)
+	logger := ctrl.LoggerFrom(ctx)
+	replicaMetrics, err := c.collectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, variantCosts, attributor)
 
 	// Determine if metrics are available in this cycle
 	metricsAvailable := err == nil && len(replicaMetrics) > 0
@@ -170,10 +173,57 @@ func (c *ReplicaMetricsCollector) CollectReplicaMetrics(
 		c.metricsAvailableState[key] = metricsAvailable
 	}
 
+	// Warn when a VA has Ready pods but none are attributed to it this cycle.
+	// Only runs when the model produced at least one attributed replica — model-wide
+	// emptiness is the availability path above; the scrape-lag gate keeps quiet there.
+	if err == nil && len(replicaMetrics) > 0 {
+		attributed := make(map[string]int, len(variantAutoscalings))
+		for i := range replicaMetrics {
+			attributed[replicaMetrics[i].VariantName]++
+		}
+		for _, va := range variantAutoscalings {
+			if attributed[va.Name] > 0 {
+				continue
+			}
+			stKey := utils.GetNamespacedKey(va.Namespace, va.GetScaleTargetName())
+			st, ok := scaleTargets[stKey]
+			if !ok || st == nil {
+				continue
+			}
+			if ready := st.GetStatusReadyReplicas(); ready > 0 {
+				logger.V(logging.DEBUG).Info("VA has ready pods but none attributed",
+					"va", va.Name, "namespace", va.Namespace, "readyReplicas", ready)
+				c.recordUnattributedReadyPodsEvent(va, ready, vaEventTracker)
+			}
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 	return replicaMetrics, nil
+}
+
+func (c *ReplicaMetricsCollector) recordUnattributedReadyPodsEvent(
+	va *llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
+	readyCount int32,
+	vaEventTracker map[string]bool,
+) {
+	if c.recorder == nil {
+		return
+	}
+	key := utils.GetNamespacedKey(va.Namespace, va.Name)
+	if vaEventTracker != nil {
+		if _, ok := vaEventTracker[key]; ok { // one event per VA per cycle
+			return
+		}
+	}
+	c.recorder.Event(va, corev1.EventTypeWarning, constants.K8SEventUnattributedReadyPods,
+		fmt.Sprintf("%s has %d ready pod(s) but none attributed; "+
+			"verify the llm-d.ai/variant pod label on the scale target equals %q", va.Name, readyCount, va.Name))
+	if vaEventTracker != nil {
+		vaEventTracker[key] = true
+	}
 }
 
 // collectReplicaMetrics is the internal implementation that collects per-replica metrics.
@@ -184,6 +234,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	scaleTargets map[string]scaletarget.ScaleTargetAccessor,
 	variantAutoscalings map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling,
 	variantCosts map[string]float64,
+	attributor attribution.Attributor,
 ) ([]interfaces.ReplicaMetrics, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -234,7 +285,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	// podMetricData holds per-pod metric values and timestamps
 	type podMetricData struct {
 		podName        string // Actual pod name for K8s API lookups
-		vaName         string // VariantAutoscaling name extracted from llm_d_ai_variant label
 		kvUsage        float64
 		kvTimestamp    time.Time
 		hasKv          bool
@@ -305,18 +355,16 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		trackTimestamp(data.avgITLTimestamp)
 	}
 
-	// Helper function to build consistent instance key from labels and extract VA name
-	// Prefers pod_name:port format for consistency with scheduler metrics
-	// Falls back to instance (IP:port) if pod_name is not available
-	// Also extracts the VariantAutoscaling name from the llm_d_ai_variant label
-	buildInstanceKey := func(labels map[string]string) (string, string, string) {
+	// Helper function to build a consistent replica identity key from labels.
+	// Prefers pod_name:port format for consistency with scheduler metrics;
+	// falls back to instance (IP:port) if pod_name is not available.
+	// VA attribution is resolved separately via the Attributor seam — this key
+	// carries replica identity only.
+	buildInstanceKey := func(labels map[string]string) (string, string) {
 		podName := labels["pod"]
 		if podName == "" {
 			podName = labels["pod_name"]
 		}
-
-		// Extract VA name from llm_d_ai_variant label (propagated by ServiceMonitor)
-		vaName := labels[constants.VariantLabelPrometheusKey]
 
 		// Try to extract port from instance label (IP:port format)
 		instance := labels["instance"]
@@ -340,10 +388,10 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			// Fallback to just pod name if no port available
 			instanceKey = podName
 		default:
-			return "", "", ""
+			return "", ""
 		}
 
-		return instanceKey, podName, vaName
+		return instanceKey, podName
 	}
 
 	// Extract per-pod metrics from results
@@ -355,7 +403,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			return nil, fmt.Errorf("KV cache query failed: %w", result.Error)
 		}
 		for _, value := range result.Values {
-			instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+			instanceKey, podName := buildInstanceKey(value.Labels)
 			if instanceKey == "" {
 				continue
 			}
@@ -363,7 +411,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			if podData[instanceKey] == nil {
 				podData[instanceKey] = &podMetricData{
 					podName: podName,
-					vaName:  vaName,
 				}
 			}
 			podData[instanceKey].kvUsage = value.Value
@@ -384,7 +431,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			return nil, fmt.Errorf("queue length query failed: %w", result.Error)
 		}
 		for _, value := range result.Values {
-			instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+			instanceKey, podName := buildInstanceKey(value.Labels)
 			if instanceKey == "" {
 				continue
 			}
@@ -392,7 +439,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			if podData[instanceKey] == nil {
 				podData[instanceKey] = &podMetricData{
 					podName: podName,
-					vaName:  vaName,
 				}
 			}
 			podData[instanceKey].queueLen = int(value.Value)
@@ -417,7 +463,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryCacheConfigInfo]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, _ := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -458,7 +504,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryAvgOutputTokens]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -466,7 +512,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				if podData[instanceKey] == nil {
 					podData[instanceKey] = &podMetricData{
 						podName: podName,
-						vaName:  vaName,
 					}
 				}
 				// NaN check: rate division by zero produces NaN
@@ -482,7 +527,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryAvgInputTokens]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -490,7 +535,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				if podData[instanceKey] == nil {
 					podData[instanceKey] = &podMetricData{
 						podName: podName,
-						vaName:  vaName,
 					}
 				}
 				// NaN check: rate division by zero produces NaN
@@ -506,7 +550,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryPrefixCacheHitRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -514,7 +558,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				if podData[instanceKey] == nil {
 					podData[instanceKey] = &podMetricData{
 						podName: podName,
-						vaName:  vaName,
 					}
 				}
 				// NaN check: rate division by zero produces NaN when no prefix cache queries
@@ -577,7 +620,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryAvgTTFT]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -585,7 +628,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				if podData[instanceKey] == nil {
 					podData[instanceKey] = &podMetricData{
 						podName: podName,
-						vaName:  vaName,
 					}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value > 0 {
@@ -605,7 +647,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryAvgITL]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				instanceKey, podName, vaName := buildInstanceKey(value.Labels)
+				instanceKey, podName := buildInstanceKey(value.Labels)
 				if instanceKey == "" {
 					continue
 				}
@@ -613,7 +655,6 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 				if podData[instanceKey] == nil {
 					podData[instanceKey] = &podMetricData{
 						podName: podName,
-						vaName:  vaName,
 					}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value > 0 {
@@ -633,18 +674,15 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryGenerationTokenRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{podName: podName}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
-					podData[podName].generationTokenRate = value.Value
+					podData[instanceKey].generationTokenRate = value.Value
 				}
 			}
 		}
@@ -654,18 +692,15 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryKvUsageInstant]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{podName: podName}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 && value.Value <= 1 {
-					podData[podName].kvUsageInstant = value.Value
+					podData[instanceKey].kvUsageInstant = value.Value
 				}
 			}
 		}
@@ -675,18 +710,15 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 	if result := results[registration.QueryVLLMRequestRate]; result != nil {
 		if !result.HasError() {
 			for _, value := range result.Values {
-				podName := value.Labels["pod"]
-				if podName == "" {
-					podName = value.Labels["pod_name"]
-				}
-				if podName == "" {
+				instanceKey, podName := buildInstanceKey(value.Labels)
+				if instanceKey == "" {
 					continue
 				}
-				if podData[podName] == nil {
-					podData[podName] = &podMetricData{}
+				if podData[instanceKey] == nil {
+					podData[instanceKey] = &podMetricData{podName: podName}
 				}
 				if !math.IsNaN(value.Value) && !math.IsInf(value.Value, 0) && value.Value >= 0 {
-					podData[podName].vllmRequestRate = value.Value
+					podData[instanceKey].vllmRequestRate = value.Value
 				}
 			}
 		}
@@ -719,9 +751,16 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 			podName = instanceKey
 		}
 
-		// Extract VA name directly from metrics (llm_d_ai_variant label)
-		// This replaces the previous ownership traversal approach
-		vaName := data.vaName
+		// Resolve the owning VariantAutoscaling for this pod via the Attributor
+		// seam (default: the llm-d.ai/variant label read from the pod object).
+		// Attribution is decoupled from the metric labels — the queries carry
+		// replica identity only.
+		vaName := ""
+		if attributor != nil {
+			if v, ok := attributor.VAForPod(namespace, data.podName); ok {
+				vaName = v
+			}
+		}
 
 		// Track freshness for metrics in this pod for this variant right away
 		trackMetricFreshness(vaName, data, collectedAt, vaMetricsFreshnessStatus)
@@ -752,7 +791,7 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 
 		if vaName == "" {
-			logger.Info("Skipping pod that doesn't match any scale target",
+			logger.V(logging.DEBUG).Info("Skipping pod with no variant attribution (not managed by any VariantAutoscaling)",
 				"pod", podName,
 				"instance", instanceKey,
 				"scale targets", getScaleTargetNames(scaleTargets))

--- a/internal/collector/replica_metrics_test.go
+++ b/internal/collector/replica_metrics_test.go
@@ -19,12 +19,14 @@ package collector
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,9 +34,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/metrics"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/scaletarget"
 )
 
@@ -186,7 +190,7 @@ func TestCollectReplicaMetrics_ErrorRecordsEvent(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call with error: no event (first observation, unknown previous state)
-	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.Error(t, err, "Should return error when refresh fails")
 	require.Nil(t, metrics, "Should return nil metrics on error")
 
@@ -198,7 +202,7 @@ func TestCollectReplicaMetrics_ErrorRecordsEvent(t *testing.T) {
 	}
 
 	// Second call: metrics still fail, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.Error(t, err, "Should still return error")
 
 	select {
@@ -244,7 +248,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call: no metrics, should NOT emit event (first observation, unknown previous state)
-	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	metrics, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error when no metrics available")
 	require.Empty(t, metrics, "Should return empty metrics slice")
 
@@ -256,7 +260,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	}
 
 	// Second call: still no metrics, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error")
 
 	select {
@@ -267,7 +271,7 @@ func TestCollectReplicaMetrics_NoMetricsRecordsEvent(t *testing.T) {
 	}
 
 	// Third call: still no metrics, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err, "Should not return error")
 
 	select {
@@ -319,7 +323,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	collector := NewReplicaMetricsCollector(mockSource, nil, fakeRecorder)
 
 	// First call: metrics unavailable, should NOT emit event (first observation, unknown previous state)
-	_, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err := collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -330,7 +334,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	}
 
 	// Second call: metrics still unavailable, should NOT emit event (no state transition)
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -341,7 +345,7 @@ func TestCollectReplicaMetrics_EdgeTriggeredEvents(t *testing.T) {
 	}
 
 	// Third call: still unavailable, should NOT emit event
-	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts)
+	_, err = collector.CollectReplicaMetrics(ctx, "test-model", "default", scaleTargets, variantAutoscalings, nil, variantCosts, nil)
 	require.NoError(t, err)
 
 	select {
@@ -388,6 +392,7 @@ func TestCollectReplicaMetrics_MetricsObservation(t *testing.T) {
 		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 		nil,
 		make(map[string]float64),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CollectReplicaMetrics failed: %v", err)
@@ -499,6 +504,7 @@ func TestCollectReplicaMetrics_ErrorMetrics(t *testing.T) {
 		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
 		nil,
 		make(map[string]float64),
+		nil,
 	)
 	if err == nil {
 		t.Fatal("Expected error but got nil")
@@ -558,4 +564,249 @@ func TestCollectReplicaMetrics_ErrorMetrics(t *testing.T) {
 			t.Errorf("Expected error metric for query_type=%s but was not found", queryType)
 		}
 	}
+}
+
+// TestCollectReplicaMetrics_ThroughputKeyMerge is the regression guard for the
+// latent key-mismatch where the throughput-analyzer loops keyed podData by the
+// bare pod name while every other query keyed by the instance key (pod:port).
+// A KV-cache sample and a generation-token-rate sample for the same replica
+// (same instance + pod labels) must now merge into a single ReplicaMetrics
+// entry carrying both KvCacheUsage and GenerationTokenRate.
+func TestCollectReplicaMetrics_ThroughputKeyMerge(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	// Same replica identity on both samples → same instance key (pod-merge:8000).
+	identity := map[string]string{
+		"pod":      "pod-merge",
+		"instance": "10.0.0.7:8000",
+	}
+
+	attributor, k8sClient := attributorWithPods(t, labeledPod("pod-merge", "merge-va"))
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				registration.QueryKvCacheUsage: {
+					Values: []source.MetricValue{
+						{Labels: identity, Value: 0.42, Timestamp: time.Now()},
+					},
+				},
+				registration.QueryGenerationTokenRate: {
+					Values: []source.MetricValue{
+						{Labels: identity, Value: 123.0, Timestamp: time.Now()},
+					},
+				},
+			}, nil
+		},
+	}
+
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, nil)
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		attribTestNS,
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+		attributor,
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+
+	require.Len(t, results, 1, "KV and generation-token-rate samples for the same replica must merge into one entry")
+	got := results[0]
+	assert.Equal(t, "merge-va", got.VariantName)
+	assert.Greater(t, got.KvCacheUsage, 0.0, "KvCacheUsage should be populated from the KV sample")
+	assert.Equal(t, 123.0, got.GenerationTokenRate, "GenerationTokenRate should be populated from the throughput sample on the merged entry")
+}
+
+// deploymentWithReady builds a minimal Deployment accessor with the given
+// ReadyReplicas count — sufficient for GetStatusReadyReplicas() in tests.
+func deploymentWithReady(name string, ready int32) scaletarget.ScaleTargetAccessor {
+	return scaletarget.NewDeploymentAccessor(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: attribTestNS},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: ready},
+	})
+}
+
+// vaWithDeployment builds a minimal VariantAutoscaling pointing at the named
+// Deployment in attribTestNS.
+func vaWithDeployment(vaName, deployName string) *llmdVariantAutoscalingV1alpha1.VariantAutoscaling {
+	return &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{Name: vaName, Namespace: attribTestNS},
+		Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: deployName},
+			ModelID:        "test-model",
+		},
+	}
+}
+
+// TestCollectReplicaMetrics_UnattributedReadyPods verifies the R2 warning path:
+// when a VA has Ready pods but none are attributed to it this cycle (while
+// another VA did get attributed replicas), a K8s Warning Event with reason
+// UnattributedReadyPods is emitted for the unattributed VA and not for the
+// attributed one.
+func TestCollectReplicaMetrics_UnattributedReadyPods(t *testing.T) {
+	const (
+		ns          = attribTestNS
+		vaAName     = "va-a"
+		vaBName     = "va-b"
+		deployAName = "deploy-a"
+		deployBName = "deploy-b"
+	)
+
+	registry := prometheus.NewRegistry()
+	require.NoError(t, metrics.InitMetrics(registry))
+
+	// VA-A has a ready pod that IS attributed (pod-a labeled with va-a).
+	// VA-B has a ready pod that is NOT attributed (no pod carries va-b label).
+	vaA := vaWithDeployment(vaAName, deployAName)
+	vaB := vaWithDeployment(vaBName, deployBName)
+
+	variantAutoscalings := map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		utils.GetNamespacedKey(ns, vaAName): vaA,
+		utils.GetNamespacedKey(ns, vaBName): vaB,
+	}
+	scaleTargets := map[string]scaletarget.ScaleTargetAccessor{
+		utils.GetNamespacedKey(ns, deployAName): deploymentWithReady(deployAName, 1),
+		utils.GetNamespacedKey(ns, deployBName): deploymentWithReady(deployBName, 1),
+	}
+
+	// Source returns a KV-cache sample attributed to VA-A only.
+	attributor, k8sClient := attributorWithPods(t, labeledPod("pod-a", vaAName))
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				registration.QueryKvCacheUsage: {
+					Values: []source.MetricValue{
+						{
+							Labels:    map[string]string{"pod": "pod-a", "instance": "10.0.0.1:8000"},
+							Value:     0.5,
+							Timestamp: time.Now(),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	fakeRecorder := record.NewFakeRecorder(10)
+	collector := NewReplicaMetricsCollector(mockSource, k8sClient, fakeRecorder)
+
+	results, err := collector.CollectReplicaMetrics(
+		context.Background(), "test-model", ns,
+		scaleTargets, variantAutoscalings, make(map[string]bool),
+		make(map[string]float64), attributor,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "expected at least one attributed replica")
+
+	// Drain the event channel and look for UnattributedReadyPods events.
+	var gotEvents []string
+	for {
+		select {
+		case e := <-fakeRecorder.Events:
+			gotEvents = append(gotEvents, e)
+		default:
+			goto done
+		}
+	}
+done:
+
+	var unattribEvents []string
+	for _, e := range gotEvents {
+		if strings.Contains(e, constants.K8SEventUnattributedReadyPods) {
+			unattribEvents = append(unattribEvents, e)
+		}
+	}
+	require.Len(t, unattribEvents, 1, "expected exactly one UnattributedReadyPods event (for VA-B)")
+	assert.Contains(t, unattribEvents[0], vaBName, "event should name VA-B")
+	for _, e := range gotEvents {
+		if strings.Contains(e, constants.K8SEventUnattributedReadyPods) {
+			assert.NotContains(t, e, vaAName, "no UnattributedReadyPods event expected for attributed VA-A")
+		}
+	}
+}
+
+// TestCollectReplicaMetrics_UnattributedReadyPods_Negatives covers the two
+// gate conditions that suppress the event.
+func TestCollectReplicaMetrics_UnattributedReadyPods_Negatives(t *testing.T) {
+	const (
+		ns          = attribTestNS
+		vaBName     = "va-b"
+		deployBName = "deploy-b"
+	)
+
+	vaB := vaWithDeployment(vaBName, deployBName)
+	variantAutoscalings := map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		utils.GetNamespacedKey(ns, vaBName): vaB,
+	}
+
+	t.Run("ready==0, no event", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		require.NoError(t, metrics.InitMetrics(registry))
+
+		// VA-A attributed so len(replicaMetrics)>0, but VA-B has ready=0.
+		vaA := vaWithDeployment("va-a", "deploy-a")
+		vas := map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+			utils.GetNamespacedKey(ns, "va-a"):  vaA,
+			utils.GetNamespacedKey(ns, vaBName): vaB,
+		}
+		sts := map[string]scaletarget.ScaleTargetAccessor{
+			utils.GetNamespacedKey(ns, "deploy-a"):  deploymentWithReady("deploy-a", 1),
+			utils.GetNamespacedKey(ns, deployBName): deploymentWithReady(deployBName, 0), // ready=0
+		}
+		attributor, k8sClient := attributorWithPods(t, labeledPod("pod-a", "va-a"))
+		mockSource := &mockMetricsSource{
+			refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+				return map[string]*source.MetricResult{
+					registration.QueryKvCacheUsage: {Values: []source.MetricValue{
+						{Labels: map[string]string{"pod": "pod-a", "instance": "10.0.0.1:8000"}, Value: 0.5, Timestamp: time.Now()},
+					}},
+				}, nil
+			},
+		}
+		fakeRecorder := record.NewFakeRecorder(10)
+		col := NewReplicaMetricsCollector(mockSource, k8sClient, fakeRecorder)
+		_, err := col.CollectReplicaMetrics(context.Background(), "test-model", ns,
+			sts, vas, make(map[string]bool), make(map[string]float64), attributor)
+		require.NoError(t, err)
+		select {
+		case e := <-fakeRecorder.Events:
+			assert.NotContains(t, e, constants.K8SEventUnattributedReadyPods,
+				"ready=0 must not emit UnattributedReadyPods")
+		default:
+		}
+	})
+
+	t.Run("model-wide no metrics, no event", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		require.NoError(t, metrics.InitMetrics(registry))
+
+		sts := map[string]scaletarget.ScaleTargetAccessor{
+			utils.GetNamespacedKey(ns, deployBName): deploymentWithReady(deployBName, 2),
+		}
+		attributor, k8sClient := attributorWithPods(t) // no pods → no attributions
+		mockSource := &mockMetricsSource{
+			refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+				return make(map[string]*source.MetricResult), nil // empty → len==0
+			},
+		}
+		fakeRecorder := record.NewFakeRecorder(10)
+		col := NewReplicaMetricsCollector(mockSource, k8sClient, fakeRecorder)
+		_, err := col.CollectReplicaMetrics(context.Background(), "test-model", ns,
+			sts, variantAutoscalings, make(map[string]bool), make(map[string]float64), attributor)
+		require.NoError(t, err)
+		select {
+		case e := <-fakeRecorder.Events:
+			assert.NotContains(t, e, constants.K8SEventUnattributedReadyPods,
+				"model-wide empty metrics must not emit UnattributedReadyPods")
+		default:
+		}
+	})
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -69,6 +69,7 @@ const (
 	K8SEventMetricsUnavailable        = "MetricsUnavailable"
 	K8SEventScaledToZero              = "ScaledToZero"
 	K8SEventOptimizationFailed        = "OptimizationFailed"
+	K8SEventUnattributedReadyPods     = "UnattributedReadyPods"
 	EnforcerPolicyTypeScaleToZero     = "scale_to_zero"
 	EnforcerPolicyTypeMinimumReplicas = "minimum_replicas"
 

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -36,6 +36,7 @@ import (
 	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	actuator "github.com/llm-d/llm-d-workload-variant-autoscaler/internal/actuator"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/attribution"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/registration"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/collector/source"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/config"
@@ -132,6 +133,11 @@ type Engine struct {
 
 	// ReplicaMetricsCollector is the collector for replica metrics using the source infrastructure
 	ReplicaMetricsCollector *collector.ReplicaMetricsCollector
+
+	// APIReader is an uncached reader (mgr.GetAPIReader()) used for the per-cycle
+	// variant-label pod LIST in attribution, so it starts no Pod informer/cache.
+	// Falls back to the cached client when nil (unit tests).
+	APIReader client.Reader
 
 	// ScaleToZeroEnforcer applies scale-to-zero and minimum replica enforcement
 	ScaleToZeroEnforcer *pipeline.Enforcer
@@ -1252,7 +1258,29 @@ func (e *Engine) prepareModelData(
 	logger.V(logging.DEBUG).Info("Using source infrastructure for replica metrics",
 		"modelID", modelID,
 		"namespace", namespace)
-	replicaMetrics, err := e.ReplicaMetricsCollector.CollectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, e.vaEventTracker, variantCosts)
+
+	// Build the per-cycle VA attributor. The default reads the llm-d.ai/variant
+	// label from the pod object via the uncached APIReader (no Pod informer), so
+	// VA attribution is decoupled from the per-replica metric labels.
+	// prepareModelData is per-model; the labeled LIST is per-namespace, so two
+	// models sharing a namespace re-list (acceptable).
+	var reader client.Reader = k8sClient
+	if e.APIReader != nil {
+		reader = e.APIReader
+	}
+	attributor, err := attribution.BuildLabelAttributor(ctx, reader, []string{namespace})
+	if err != nil {
+		// Attribution is degraded this cycle: pods that cannot be resolved are
+		// skipped downstream, so no scaling decisions are made for them. Surface
+		// once per cycle here rather than once per skipped pod.
+		logger.Error(err, "VA attribution degraded: failed to list variant-labeled pods; affected pods will be skipped this cycle",
+			"namespace", namespace)
+	}
+	// Proceed even on error: BuildLabelAttributor returns a usable (possibly
+	// empty or partial) attributor; the downstream empty-vaName skip handles
+	// unresolved pods.
+
+	replicaMetrics, err := e.ReplicaMetricsCollector.CollectReplicaMetrics(ctx, modelID, namespace, scaleTargets, variantAutoscalings, e.vaEventTracker, variantCosts, attributor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect Saturation metrics for model %s: %w", modelID, err)
 	}


### PR DESCRIPTION
Implements #1263. Moves VariantAutoscaling (VA) attribution out of the PromQL queries and behind an `Attributor` seam resolved once per pod, after the query.

## What changed

- **Per-replica queries carry replica identity only.** Drops `llm_d_ai_variant` from all 11 per-replica query templates (saturation ×6, queueing-model ×2, throughput-analyzer ×3). The 3 throughput queries additionally gain `instance` so they group by `(instance, pod)` like the rest — this also fixes a latent key-mismatch where a KV-cache sample and a generation-token-rate sample for the same replica produced two `ReplicaMetrics` entries (the throughput one dropped); they now merge into one.
- **New `internal/collector/attribution` package** — an `Attributor` interface (`VAForPod`) plus a default label attributor that performs one bounded, labeled pod `List` per namespace via the uncached API reader (`mgr.GetAPIReader()`, so no Pod informer/cache is started) and maps pod → VA from the `llm-d.ai/variant` **pod-object** label. The ServiceMonitor/PodMonitor relabel rule is **no longer required for attribution** (kept optional for back-compat; the metric label and its constant remain).
- **Degraded-attribution handling** — on a `List` failure the builder returns a partial attributor plus a joined error; the engine logs once per cycle and proceeds with whatever resolved. Unresolved pods are skipped at the existing gate (demoted to DEBUG).
- **`UnattributedReadyPods` warning event** — a per-VA K8s Warning event when a VA's scale target has Ready pods but none are attributed this cycle (fires only when the model produced at least one attributed replica, so scrape-lag windows stay quiet; deduped per cycle). Surfaces a missing/wrong pod label directly in `kubectl describe va`.

Future attribution mechanisms (e.g. the #1267 owner-walk locator) plug in behind the seam without touching the queries, the collector hot path, or any analyzer.

## Docs

- `docs/developer-guide/variant-attribution.md` (new) — the seam, the default label attributor, how to add a mechanism.
- `docs/design/controller-behavior.md` — attribution reads the pod-object label; relabel rule reframed as optional; `UnattributedReadyPods` added to troubleshooting.

## Tests

Attribution unit tests (resolve/miss/nil-safe/empty; builder error + partial-map); the KV+throughput merge regression guard; `UnattributedReadyPods` positive + two negatives (ready==0, model-wide empty).

Fixes #1263
