### PR TITLE
feat(metrics): add wva_pod_mapping_miss_total for unattributed pods

### DIFF
--- a/docs/developer-guide/prometheus.md
+++ b/docs/developer-guide/prometheus.md
@@ -412,6 +412,35 @@ With WVA metrics, the value for the label `namespace` is the WVA controller name
   }
   ```
 
+### `wva_pod_mapping_miss_total`
+- **Type**: Counter
+- **Description**: Total number of pods whose metrics could not be attributed to a managed scaler — neither the `llm-d.ai/variant` label nor the pod locator (ownerReference walk) resolved an owning HPA/ScaledObject. Makes the otherwise-silent skip observable.
+- **Labels**:
+  - `namespace`: Kubernetes namespace of the unattributed pod
+  - `reason`: Why the pod was unattributed (currently always `unresolved`)
+- **Use Case**: Alert on a rising rate of unattributed pods — usually a missing `llm-d.ai/variant` label, a scaler missing the `llm-d.ai/managed` annotation, or a shadow-pod layout without the label
+- **Example**:
+  ```
+  {
+    "metric": {
+      "__name__": "wva_pod_mapping_miss_total",
+      "container": "manager",
+      "endpoint": "https",
+      "instance": "10.244.2.59:8443",
+      "job": "workload-variant-autoscaler-metrics",
+      "namespace": "workload-variant-autoscaler-system",
+      "pod": "workload-variant-autoscaler-controller-manager-f9fdb95df-wvd9p",
+      "exported_namespace": "llm-d-sim",
+      "reason": "unresolved",
+      "service": "workload-variant-autoscaler-metrics"
+    },
+    "value": [
+      1778854211.669,
+      "2"
+    ]
+  }
+  ```
+
 ### Optimization Metrics
 
 ### `wva_optimization_duration_seconds`

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -762,6 +762,11 @@ func (c *ReplicaMetricsCollector) collectReplicaMetrics(
 		}
 
 		if vaName == "" {
+			// Neither the llm-d.ai/variant label nor the pod locator attributed
+			// this pod to a managed scaler. Count it so the otherwise-silent skip
+			// is observable; the pod is unattributed, so the metric is keyed by
+			// namespace and reason only.
+			metrics.IncPodMappingMiss(namespace, constants.PodMappingMissUnresolved)
 			logger.Info("Skipping pod that doesn't match any scale target",
 				"pod", podName,
 				"instance", instanceKey,

--- a/internal/constants/metrics.go
+++ b/internal/constants/metrics.go
@@ -185,6 +185,19 @@ const (
 	// WVAKvCacheTokensCapacity is a gauge that tracks total KV cache token capacity per variant.
 	// Labels: variant_name, namespace, model_name
 	WVAKvCacheTokensCapacity = "wva_kv_cache_tokens_capacity"
+
+	// WVAPodMappingMissTotal is a counter that tracks pods whose metrics could not be
+	// attributed to a managed scaler (neither the llm-d.ai/variant label nor the
+	// pod locator resolved them). Makes the otherwise-silent skip visible.
+	// Labels: namespace, reason
+	WVAPodMappingMissTotal = "wva_pod_mapping_miss_total"
+)
+
+// Pod-mapping miss reasons (values for the `reason` label of WVAPodMappingMissTotal).
+const (
+	// PodMappingMissUnresolved indicates a scraped pod resolved to no managed scaler —
+	// no llm-d.ai/variant label and the locator found no owning HPA/ScaledObject.
+	PodMappingMissUnresolved = "unresolved"
 )
 
 // Metric Label Names

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -38,6 +38,7 @@ var (
 	metricsCollectionErrors             *prometheus.CounterVec
 	metricsPodsDiscovered               *prometheus.GaugeVec
 	metricsFreshnessStatus              *prometheus.GaugeVec
+	podMappingMissTotal                 *prometheus.CounterVec
 
 	// Saturation and capacity metrics
 	saturationUtilization *prometheus.GaugeVec
@@ -321,6 +322,18 @@ func InitMetrics(registry prometheus.Registerer) error {
 		metricsFreshnessStatusLabels,
 	)
 
+	podMappingMissLabels := []string{constants.LabelNamespace, constants.LabelReason}
+	if controllerInstance != "" {
+		podMappingMissLabels = append(podMappingMissLabels, constants.LabelControllerInstance)
+	}
+	podMappingMissTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: constants.WVAPodMappingMissTotal,
+			Help: "Total number of pods whose metrics could not be attributed to a managed scaler",
+		},
+		podMappingMissLabels,
+	)
+
 	// Register metrics with the registry
 	if err := registry.Register(replicaScalingTotal); err != nil {
 		return fmt.Errorf("failed to register replicaScalingTotal metric: %w", err)
@@ -375,6 +388,9 @@ func InitMetrics(registry prometheus.Registerer) error {
 	}
 	if err := registry.Register(metricsPodsDiscovered); err != nil {
 		return fmt.Errorf("failed to register metricsPodsDiscovered metric: %w", err)
+	}
+	if err := registry.Register(podMappingMissTotal); err != nil {
+		return fmt.Errorf("failed to register podMappingMissTotal metric: %w", err)
 	}
 	if err := registry.Register(metricsFreshnessStatus); err != nil {
 		return fmt.Errorf("failed to register metricsFreshnessStatus metric: %w", err)
@@ -675,6 +691,21 @@ func IncMetricsCollectionErrors(queryType, reason string) {
 		labels[constants.LabelControllerInstance] = controllerInstance
 	}
 	metricsCollectionErrors.With(labels).Inc()
+}
+
+// IncPodMappingMiss increments the pod-to-managed-scaler mapping miss counter.
+func IncPodMappingMiss(namespace, reason string) {
+	if podMappingMissTotal == nil {
+		return
+	}
+	labels := prometheus.Labels{
+		constants.LabelNamespace: namespace,
+		constants.LabelReason:    reason,
+	}
+	if controllerInstance != "" {
+		labels[constants.LabelControllerInstance] = controllerInstance
+	}
+	podMappingMissTotal.With(labels).Inc()
 }
 
 // SetMetricsPodsDiscovered sets the number of pods discovered in a namespace.

--- a/internal/metrics/pod_mapping_miss_metric_test.go
+++ b/internal/metrics/pod_mapping_miss_metric_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+var _ = Describe("IncPodMappingMiss", func() {
+	// series returns the gathered series for wva_pod_mapping_miss_total.
+	series := func(registry *prometheus.Registry) []*dto.Metric {
+		mfs, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		for _, mf := range mfs {
+			if mf.GetName() == constants.WVAPodMappingMissTotal {
+				return mf.GetMetric()
+			}
+		}
+		return nil
+	}
+
+	It("counts misses per namespace, keyed by namespace and reason", func() {
+		registry := prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+
+		// Two misses in ns-a, one in ns-b — the counter aggregates per namespace.
+		IncPodMappingMiss("ns-a", constants.PodMappingMissUnresolved)
+		IncPodMappingMiss("ns-a", constants.PodMappingMissUnresolved)
+		IncPodMappingMiss("ns-b", constants.PodMappingMissUnresolved)
+
+		got := series(registry)
+		Expect(got).To(HaveLen(2), "one series per namespace")
+
+		counts := map[string]float64{}
+		for _, m := range got {
+			Expect(m.GetCounter()).NotTo(BeNil(), "expected a counter metric")
+			Expect(getLabelValue(m, constants.LabelReason)).To(Equal(constants.PodMappingMissUnresolved))
+			counts[getLabelValue(m, constants.LabelNamespace)] = m.GetCounter().GetValue()
+		}
+		Expect(counts).To(HaveKeyWithValue("ns-a", float64(2)))
+		Expect(counts).To(HaveKeyWithValue("ns-b", float64(1)))
+	})
+
+	It("includes the controller_instance label when configured", func() {
+		// InitMetrics reads CONTROLLER_INSTANCE and rebuilds the metric vectors,
+		// so save/restore the globals it mutates. GinkgoT().Setenv restores the
+		// env var after the spec.
+		savedInstance := controllerInstance
+		savedMetric := podMappingMissTotal
+		DeferCleanup(func() {
+			controllerInstance = savedInstance
+			podMappingMissTotal = savedMetric
+		})
+		GinkgoT().Setenv(ControllerInstanceEnvVar, testControllerInstance)
+
+		registry := prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+
+		IncPodMappingMiss("ns-a", constants.PodMappingMissUnresolved)
+
+		got := series(registry)
+		Expect(got).To(HaveLen(1))
+		Expect(getLabelValue(got[0], constants.LabelControllerInstance)).To(Equal(testControllerInstance))
+		Expect(getLabelValue(got[0], constants.LabelNamespace)).To(Equal("ns-a"))
+	})
+})


### PR DESCRIPTION
When a scraped pod has metrics but resolves to no managed scaler (neither the llm-d.ai/variant label nor the pod locator attributed it), the collector silently skips it. Add wva_pod_mapping_miss_total{namespace,reason} and increment it once per pod at the skip site (reason=unresolved) so the otherwise-silent miss is observable. The pod is unattributed by definition, so the metric carries no variant_name label.

Includes Ginkgo unit tests (per-namespace counting + controller_instance label) and a docs/developer-guide/prometheus.md catalog entry.