### PR TITLE
engine: emit saturation cycle summary log per model per cycle

### DIFF
--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -168,7 +168,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 	if rec := a.capacityStore.Get(namespace, modelID, rm.VariantName); rec != nil {
 		vllmParams = rec.VLLMParams
 	}
-	k2 := a.computeK2(
+	k2, k2Priority := a.computeK2(
 		modelID, rm.AcceleratorName,
 		gpuCount,
 		rm.QueueLength, rm.TokensInUse,
@@ -210,6 +210,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacity(
 		TotalKvCapacityTokens: rm.TotalKvCapacityTokens,
 		MemoryBoundCapacity:   k1,
 		ComputeBoundCapacity:  k2,
+		K2Priority:            k2Priority,
 		EffectiveCapacity:     effectiveCapacity,
 		IsSaturated:           isSaturated,
 		ReplicaDemand:         replicaDemand,
@@ -270,6 +271,7 @@ func (a *SaturationAnalyzer) computeReplicaCapacityFallback(
 // 2. Historical → rolling average from previous observations
 // 3. Derived (from deployment args) → formula-based estimate
 // 4. Fallback → k1 (memory-bound only)
+// Returns the k2 value and the priority level (1–4) that produced it.
 func (a *SaturationAnalyzer) computeK2(
 	modelID, accelerator string,
 	gpuCount int,
@@ -278,7 +280,7 @@ func (a *SaturationAnalyzer) computeK2(
 	queueThreshold float64,
 	vllmParams *VLLMEngineParams,
 	k1 int64,
-) int64 {
+) (int64, int) {
 	outputBucket := classifyOutputLength(avgOutput)
 	historyKey := fmt.Sprintf("%s|%s|%d|%s", modelID, accelerator, gpuCount, outputBucket)
 
@@ -293,7 +295,7 @@ func (a *SaturationAnalyzer) computeK2(
 		}
 		ra.Add(float64(k2Observed))
 		a.mu.Unlock()
-		return k2Observed
+		return k2Observed, 1
 	}
 
 	// Priority 2: Historical — lock must cover Average() since Add() mutates
@@ -305,16 +307,16 @@ func (a *SaturationAnalyzer) computeK2(
 	}
 	a.mu.Unlock()
 	if histAvg > 0 {
-		return int64(histAvg)
+		return int64(histAvg), 2
 	}
 
 	// Priority 3: Derived from deployment args
 	if k2Derived := estimateCapacityFromParams(vllmParams, avgInput, avgOutput); k2Derived > 0 {
-		return k2Derived
+		return k2Derived, 3
 	}
 
 	// Priority 4: Fallback to k1
-	return k1
+	return k1, 4
 }
 
 // aggregateByVariant groups replica capacities by variant and computes
@@ -360,6 +362,9 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			readyCount = 0
 		}
 
+		var medianK1, medianK2 int64
+		var k2Source string
+
 		if len(replicas) > 0 {
 			// Use median effective capacity from ready pods
 			capacities := make([]int64, 0, len(replicas))
@@ -371,6 +376,9 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			if accelerator == "" {
 				accelerator = replicas[0].AcceleratorName
 			}
+			medianK1 = median(k1Slice(replicas))
+			medianK2 = median(k2Slice(replicas))
+			k2Source = k2SourceLabel(replicas)
 		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
@@ -398,6 +406,9 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        totalDemand,
 			Utilization:        utilization,
+			MedianK1:           medianK1,
+			MedianK2:           medianK2,
+			K2SourceLabel:      k2Source,
 		}
 		result = append(result, vc)
 	}
@@ -634,6 +645,49 @@ func estimateSchedulerQueueDemand(
 	}
 
 	return schedulerQueueDemand{total: total, byRole: byRole}
+}
+
+// k1Slice extracts MemoryBoundCapacity from a slice of ReplicaCapacity.
+func k1Slice(replicas []ReplicaCapacity) []int64 {
+	s := make([]int64, len(replicas))
+	for i, r := range replicas {
+		s[i] = r.MemoryBoundCapacity
+	}
+	return s
+}
+
+// k2Slice extracts ComputeBoundCapacity from a slice of ReplicaCapacity.
+func k2Slice(replicas []ReplicaCapacity) []int64 {
+	s := make([]int64, len(replicas))
+	for i, r := range replicas {
+		s[i] = r.ComputeBoundCapacity
+	}
+	return s
+}
+
+// k2SourceLabel returns the K2Priority label for the representative replica —
+// the one whose EffectiveCapacity equals the median EffectiveCapacity (the
+// same replica that determines PerReplicaCapacity). On tie, the first match
+// is used. Returns "" when replicas is empty.
+func k2SourceLabel(replicas []ReplicaCapacity) string {
+	if len(replicas) == 0 {
+		return ""
+	}
+	effs := make([]int64, len(replicas))
+	for i, r := range replicas {
+		effs[i] = r.EffectiveCapacity
+	}
+	medEff := median(effs)
+	k2PriorityLabels := map[int]string{1: "P1-obs", 2: "P2-hist", 3: "P3-deriv", 4: "P4-k1"}
+	for _, r := range replicas {
+		if r.EffectiveCapacity == medEff {
+			if label, ok := k2PriorityLabels[r.K2Priority]; ok {
+				return label
+			}
+			return ""
+		}
+	}
+	return ""
 }
 
 // median returns the median value from a sorted slice of int64 values.

--- a/internal/engines/analyzers/saturation_v2/analyzer.go
+++ b/internal/engines/analyzers/saturation_v2/analyzer.go
@@ -87,7 +87,7 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 	}
 
 	// Phase 2: Per-variant aggregation
-	variantCapacities := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
+	variantCapacities, satVCs := a.aggregateByVariant(replicaCapacities, input.ReplicaMetrics, input.VariantStates, input.ModelID, input.Namespace, satConfig.KvCacheThreshold)
 
 	// Phase 3: Model-level aggregation via shared helpers (enforces linearity invariant).
 	totalSupply := aggregation.SumTotalSupply(variantCapacities)
@@ -122,16 +122,17 @@ func (a *SaturationAnalyzer) Analyze(ctx context.Context, input interfaces.Analy
 	// the engine post-step overwrites them using TotalDemand, TotalSupply,
 	// and TotalAnticipatedSupply with the resolved thresholds.
 	result := &interfaces.AnalyzerResult{
-		AnalyzerName:           a.Name(),
-		ModelID:                input.ModelID,
-		Namespace:              input.Namespace,
-		AnalyzedAt:             time.Now(),
-		VariantCapacities:      variantCapacities,
-		TotalSupply:            totalSupply,
-		TotalDemand:            totalDemand,
-		TotalAnticipatedSupply: totalAnticipatedSupply,
-		Utilization:            utilization,
-		RoleCapacities:         roleCapacities,
+		AnalyzerName:                a.Name(),
+		ModelID:                     input.ModelID,
+		Namespace:                   input.Namespace,
+		AnalyzedAt:                  time.Now(),
+		VariantCapacities:           variantCapacities,
+		TotalSupply:                 totalSupply,
+		TotalDemand:                 totalDemand,
+		TotalAnticipatedSupply:      totalAnticipatedSupply,
+		Utilization:                 utilization,
+		RoleCapacities:              roleCapacities,
+		SaturationVariantCapacities: satVCs,
 	}
 
 	return result, nil
@@ -320,14 +321,15 @@ func (a *SaturationAnalyzer) computeK2(
 }
 
 // aggregateByVariant groups replica capacities by variant and computes
-// per-variant capacity metrics.
+// per-variant capacity metrics. The second return value carries saturation-
+// specific k1/k2/k2Source detail for each variant with ready replicas.
 func (a *SaturationAnalyzer) aggregateByVariant(
 	replicaCapacities []ReplicaCapacity,
 	inputMetrics []interfaces.ReplicaMetrics,
 	variantStates []interfaces.VariantReplicaState,
 	modelID, namespace string,
 	kvCacheThreshold float64,
-) []interfaces.VariantCapacity {
+) ([]interfaces.VariantCapacity, []interfaces.SaturationVariantCapacity) {
 	// Group replicas by variant
 	byVariant := make(map[string][]ReplicaCapacity)
 	for _, rc := range replicaCapacities {
@@ -349,6 +351,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 	modelAvgInput, modelAvgOutput, _ := computeModelWorkloadAverages(inputMetrics)
 
 	result := make([]interfaces.VariantCapacity, 0, len(variantStates))
+	satVCs := make([]interfaces.SaturationVariantCapacity, 0, len(variantStates))
 	for _, vs := range variantStates {
 		replicas := byVariant[vs.VariantName]
 
@@ -362,9 +365,6 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			readyCount = 0
 		}
 
-		var medianK1, medianK2 int64
-		var k2Source string
-
 		if len(replicas) > 0 {
 			// Use median effective capacity from ready pods
 			capacities := make([]int64, 0, len(replicas))
@@ -376,9 +376,12 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			if accelerator == "" {
 				accelerator = replicas[0].AcceleratorName
 			}
-			medianK1 = median(k1Slice(replicas))
-			medianK2 = median(k2Slice(replicas))
-			k2Source = k2SourceLabel(replicas)
+			satVCs = append(satVCs, interfaces.SaturationVariantCapacity{
+				VariantName:   vs.VariantName,
+				MedianK1:      median(k1Slice(replicas)),
+				MedianK2:      median(k2Slice(replicas)),
+				K2SourceLabel: k2SourceLabel(replicas),
+			})
 		} else if rec := a.capacityStore.Get(namespace, modelID, vs.VariantName); rec != nil && rec.EffectiveCapacity > 0 {
 			// No ready replicas — use stored capacity, enhanced with k2 derivation
 			// for deployment-derived records when workload data is available.
@@ -395,7 +398,7 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			utilization = totalDemand / totalCapacity
 		}
 
-		vc := interfaces.VariantCapacity{
+		result = append(result, interfaces.VariantCapacity{
 			VariantName:        vs.VariantName,
 			AcceleratorName:    accelerator,
 			Cost:               cost,
@@ -406,14 +409,10 @@ func (a *SaturationAnalyzer) aggregateByVariant(
 			TotalCapacity:      totalCapacity,
 			TotalDemand:        totalDemand,
 			Utilization:        utilization,
-			MedianK1:           medianK1,
-			MedianK2:           medianK2,
-			K2SourceLabel:      k2Source,
-		}
-		result = append(result, vc)
+		})
 	}
 
-	return result
+	return result, satVCs
 }
 
 // aggregateByRole groups variant capacities by role and returns per-role
@@ -665,27 +664,24 @@ func k2Slice(replicas []ReplicaCapacity) []int64 {
 	return s
 }
 
-// k2SourceLabel returns the K2Priority label for the representative replica —
-// the one whose EffectiveCapacity equals the median EffectiveCapacity (the
-// same replica that determines PerReplicaCapacity). On tie, the first match
-// is used. Returns "" when replicas is empty.
+// k2SourceLabel returns the K2Priority label for the lower-median replica by
+// EffectiveCapacity. It sorts a copy of the slice and picks index
+// (n-1)/2, which always resolves to an actual replica (no average is taken),
+// avoiding the even-replica case where a median average matches no element.
+// Returns "" when replicas is empty.
 func k2SourceLabel(replicas []ReplicaCapacity) string {
 	if len(replicas) == 0 {
 		return ""
 	}
-	effs := make([]int64, len(replicas))
-	for i, r := range replicas {
-		effs[i] = r.EffectiveCapacity
-	}
-	medEff := median(effs)
+	sorted := make([]ReplicaCapacity, len(replicas))
+	copy(sorted, replicas)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].EffectiveCapacity < sorted[j].EffectiveCapacity
+	})
+	medIdx := (len(sorted) - 1) / 2
 	k2PriorityLabels := map[int]string{1: "P1-obs", 2: "P2-hist", 3: "P3-deriv", 4: "P4-k1"}
-	for _, r := range replicas {
-		if r.EffectiveCapacity == medEff {
-			if label, ok := k2PriorityLabels[r.K2Priority]; ok {
-				return label
-			}
-			return ""
-		}
+	if label, ok := k2PriorityLabels[sorted[medIdx].K2Priority]; ok {
+		return label
 	}
 	return ""
 }

--- a/internal/engines/analyzers/saturation_v2/types.go
+++ b/internal/engines/analyzers/saturation_v2/types.go
@@ -14,6 +14,7 @@ type ReplicaCapacity struct {
 	TotalKvCapacityTokens int64
 	MemoryBoundCapacity   int64 // k1: KV-cache-limited capacity
 	ComputeBoundCapacity  int64 // k2: compute/scheduling-limited capacity
+	K2Priority            int   // how k2 was computed: 1=observed, 2=history, 3=derived, 4=fallback
 	EffectiveCapacity     int64 // min(k1, k2)
 	IsSaturated           bool
 	ReplicaDemand         int64 // tokensInUse + queueLength * avgInputTokens

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -832,6 +832,7 @@ func (e *Engine) optimizeV2(
 		}
 	}
 	allDecisions := e.optimizer.Optimize(ctx, requests, constraints)
+	logDecisionSummary(ctx, requests, allDecisions)
 
 	logger.Info("V2 optimizer produced decisions",
 		"optimizer", e.optimizer.Name(),

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -319,6 +319,96 @@ func computeCurrentGPUUsage(requests []pipeline.ModelScalingRequest) map[string]
 	return usage
 }
 
+// logDecisionSummary emits one "saturation cycle summary" INFO line per model,
+// combining per-variant capacity data from the saturation analyzer result with
+// the optimizer's per-variant decisions.
+func logDecisionSummary(
+	ctx context.Context,
+	modelRequests []pipeline.ModelScalingRequest,
+	decisions []interfaces.VariantDecision,
+) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	type decKey struct{ ns, model, variant string }
+	decMap := make(map[decKey]interfaces.VariantDecision, len(decisions))
+	for _, d := range decisions {
+		decMap[decKey{d.Namespace, d.ModelID, d.VariantName}] = d
+	}
+
+	for _, req := range modelRequests {
+		var satResult *interfaces.AnalyzerResult
+		for _, nr := range req.AnalyzerResults {
+			if nr.Name == interfaces.SaturationAnalyzerName {
+				satResult = nr.Result
+				break
+			}
+		}
+		if satResult == nil {
+			continue
+		}
+
+		type analyzerSignal struct {
+			Name string  `json:"name"`
+			RC   float64 `json:"rc"`
+			SC   float64 `json:"sc"`
+		}
+		signals := make([]analyzerSignal, 0, len(req.AnalyzerResults))
+		for _, nr := range req.AnalyzerResults {
+			if nr.Result == nil {
+				continue
+			}
+			signals = append(signals, analyzerSignal{
+				Name: nr.Name,
+				RC:   nr.Result.RequiredCapacity,
+				SC:   nr.Result.SpareCapacity,
+			})
+		}
+
+		type variantSummary struct {
+			Name         string  `json:"name"`
+			K1           int64   `json:"k1"`
+			K2           int64   `json:"k2"`
+			K2Source     string  `json:"k2Source"`
+			Cost         float64 `json:"cost"`
+			PRC          float64 `json:"prc"`
+			Eff          float64 `json:"eff"`
+			CurrReplicas int     `json:"currReplicas"`
+			TgtReplicas  int     `json:"tgtReplicas"`
+			Action       string  `json:"action"`
+		}
+
+		summaries := make([]variantSummary, 0, len(satResult.VariantCapacities))
+		for _, vc := range satResult.VariantCapacities {
+			d := decMap[decKey{req.Namespace, req.ModelID, vc.VariantName}]
+			var eff float64
+			if vc.PerReplicaCapacity > 0 {
+				eff = vc.Cost / vc.PerReplicaCapacity
+			}
+			summaries = append(summaries, variantSummary{
+				Name:         vc.VariantName,
+				K1:           vc.MedianK1,
+				K2:           vc.MedianK2,
+				K2Source:     vc.K2SourceLabel,
+				Cost:         vc.Cost,
+				PRC:          vc.PerReplicaCapacity,
+				Eff:          eff,
+				CurrReplicas: d.CurrentReplicas,
+				TgtReplicas:  d.TargetReplicas,
+				Action:       string(d.Action),
+			})
+		}
+
+		logger.Info("saturation cycle summary",
+			"model", req.Namespace+"/"+req.ModelID,
+			"totalSupply", satResult.TotalSupply,
+			"totalDemand", satResult.TotalDemand,
+			"utilization", satResult.Utilization,
+			"analyzerSignals", signals,
+			"variants", summaries,
+		)
+	}
+}
+
 // collectV2ModelRequest performs V2 analysis for a single model and returns
 // a ModelScalingRequest for the optimizer, or nil if analysis should be skipped.
 func (e *Engine) collectV2ModelRequest(

--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -377,18 +377,24 @@ func logDecisionSummary(
 			Action       string  `json:"action"`
 		}
 
+		satVCByVariant := make(map[string]interfaces.SaturationVariantCapacity, len(satResult.SaturationVariantCapacities))
+		for _, svc := range satResult.SaturationVariantCapacities {
+			satVCByVariant[svc.VariantName] = svc
+		}
+
 		summaries := make([]variantSummary, 0, len(satResult.VariantCapacities))
 		for _, vc := range satResult.VariantCapacities {
 			d := decMap[decKey{req.Namespace, req.ModelID, vc.VariantName}]
+			svc := satVCByVariant[vc.VariantName]
 			var eff float64
 			if vc.PerReplicaCapacity > 0 {
 				eff = vc.Cost / vc.PerReplicaCapacity
 			}
 			summaries = append(summaries, variantSummary{
 				Name:         vc.VariantName,
-				K1:           vc.MedianK1,
-				K2:           vc.MedianK2,
-				K2Source:     vc.K2SourceLabel,
+				K1:           svc.MedianK1,
+				K2:           svc.MedianK2,
+				K2Source:     svc.K2SourceLabel,
 				Cost:         vc.Cost,
 				PRC:          vc.PerReplicaCapacity,
 				Eff:          eff,

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -1,0 +1,128 @@
+package saturation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+func TestLogDecisionSummary_EmitsRequiredFields(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zapr.NewLogger(zap.New(core))
+	ctx := logr.NewContext(context.Background(), logger)
+
+	req := pipeline.ModelScalingRequest{
+		ModelID:   "mymodel",
+		Namespace: "ns",
+		AnalyzerResults: []pipeline.NamedAnalyzerResult{
+			{
+				Name: interfaces.SaturationAnalyzerName,
+				Result: &interfaces.AnalyzerResult{
+					TotalSupply:      100000,
+					TotalDemand:      80000,
+					Utilization:      0.8,
+					RequiredCapacity: 0,
+					SpareCapacity:    20000,
+					VariantCapacities: []interfaces.VariantCapacity{
+						{
+							VariantName:        "primary",
+							Cost:               10,
+							PerReplicaCapacity: 50000,
+							MedianK1:           60000,
+							MedianK2:           50000,
+							K2SourceLabel:      "P2-hist",
+							ReplicaCount:       1,
+						},
+					},
+				},
+			},
+		},
+	}
+	decisions := []interfaces.VariantDecision{
+		{
+			ModelID:         "mymodel",
+			Namespace:       "ns",
+			VariantName:     "primary",
+			CurrentReplicas: 1,
+			TargetReplicas:  2,
+			Action:          interfaces.ActionScaleUp,
+		},
+	}
+
+	logDecisionSummary(ctx, []pipeline.ModelScalingRequest{req}, decisions)
+
+	require.Equal(t, 1, logs.Len(), "expected one log line")
+	entry := logs.All()[0]
+	require.Equal(t, "saturation cycle summary", entry.Message)
+
+	fields := entry.ContextMap()
+	for _, key := range []string{"model", "totalSupply", "totalDemand", "utilization", "analyzerSignals", "variants"} {
+		assert.Contains(t, fields, key, "missing key %q", key)
+	}
+	assert.Equal(t, "ns/mymodel", fields["model"])
+}
+
+func TestLogDecisionSummary_SkipsModelWithNoSatResult(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zapr.NewLogger(zap.New(core))
+	ctx := logr.NewContext(context.Background(), logger)
+
+	req := pipeline.ModelScalingRequest{
+		ModelID:   "mymodel",
+		Namespace: "ns",
+		AnalyzerResults: []pipeline.NamedAnalyzerResult{
+			{Name: "throughput", Result: &interfaces.AnalyzerResult{}},
+		},
+	}
+
+	logDecisionSummary(ctx, []pipeline.ModelScalingRequest{req}, nil)
+
+	assert.Equal(t, 0, logs.Len(), "expected no log line when saturation result absent")
+}
+
+func TestLogDecisionSummary_MultipleAnalyzerSignals(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zapr.NewLogger(zap.New(core))
+	ctx := logr.NewContext(context.Background(), logger)
+
+	req := pipeline.ModelScalingRequest{
+		ModelID:   "m",
+		Namespace: "ns",
+		AnalyzerResults: []pipeline.NamedAnalyzerResult{
+			{
+				Name: interfaces.SaturationAnalyzerName,
+				Result: &interfaces.AnalyzerResult{
+					TotalSupply:       200000,
+					TotalDemand:       150000,
+					Utilization:       0.75,
+					RequiredCapacity:  0,
+					SpareCapacity:     50000,
+					VariantCapacities: []interfaces.VariantCapacity{},
+				},
+			},
+			{
+				Name: "throughput",
+				Result: &interfaces.AnalyzerResult{
+					RequiredCapacity: 15000,
+					SpareCapacity:    0,
+				},
+			},
+		},
+	}
+
+	logDecisionSummary(ctx, []pipeline.ModelScalingRequest{req}, nil)
+
+	require.Equal(t, 1, logs.Len())
+	fields := logs.All()[0].ContextMap()
+	assert.Contains(t, fields, "analyzerSignals")
+}

--- a/internal/engines/saturation/engine_v2_log_test.go
+++ b/internal/engines/saturation/engine_v2_log_test.go
@@ -38,10 +38,15 @@ func TestLogDecisionSummary_EmitsRequiredFields(t *testing.T) {
 							VariantName:        "primary",
 							Cost:               10,
 							PerReplicaCapacity: 50000,
-							MedianK1:           60000,
-							MedianK2:           50000,
-							K2SourceLabel:      "P2-hist",
 							ReplicaCount:       1,
+						},
+					},
+					SaturationVariantCapacities: []interfaces.SaturationVariantCapacity{
+						{
+							VariantName:   "primary",
+							MedianK1:      60000,
+							MedianK2:      50000,
+							K2SourceLabel: "P2-hist",
 						},
 					},
 				},

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -82,6 +82,15 @@ type RoleCapacity struct {
 	SpareCapacity          float64
 }
 
+// SaturationVariantCapacity carries per-variant k1/k2/k2Source detail
+// produced by the saturation V2 analyzer. Nil for all other analyzers.
+type SaturationVariantCapacity struct {
+	VariantName   string
+	MedianK1      int64
+	MedianK2      int64
+	K2SourceLabel string // k2 priority of the lower-median replica by EffectiveCapacity: "P1-obs","P2-hist","P3-deriv","P4-k1"
+}
+
 // AnalyzerResult is the common output produced by all analyzers.
 // The engine consumes these results to build scaling plans.
 type AnalyzerResult struct {
@@ -120,6 +129,10 @@ type AnalyzerResult struct {
 	// RoleCapacities holds per-role capacity aggregation for P/D disaggregated models.
 	// nil when no disaggregation is active (all variants are role "both").
 	RoleCapacities map[string]RoleCapacity
+
+	// SaturationVariantCapacities carries per-variant k1/k2/k2Source detail
+	// produced by the saturation V2 analyzer. Nil for all other analyzers.
+	SaturationVariantCapacities []SaturationVariantCapacity
 }
 
 // VariantCapacity holds per-variant capacity data in analyzer-specific units.
@@ -136,12 +149,6 @@ type VariantCapacity struct {
 	// PerReplicaCapacity is the representative capacity per replica.
 	// For saturation V2: median(effectiveCapacity) in tokens across ready replicas.
 	PerReplicaCapacity float64
-
-	// Per-variant capacity detail set by the saturation V2 analyzer.
-	// Zero for all other analyzers.
-	MedianK1      int64  // median memory-bound capacity per replica (tokens)
-	MedianK2      int64  // median compute-bound capacity per replica (tokens)
-	K2SourceLabel string // how k2 was computed: "P1-obs","P2-hist","P3-deriv","P4-k1"
 
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.
 	TotalCapacity float64

--- a/internal/interfaces/analyzer.go
+++ b/internal/interfaces/analyzer.go
@@ -137,6 +137,12 @@ type VariantCapacity struct {
 	// For saturation V2: median(effectiveCapacity) in tokens across ready replicas.
 	PerReplicaCapacity float64
 
+	// Per-variant capacity detail set by the saturation V2 analyzer.
+	// Zero for all other analyzers.
+	MedianK1      int64  // median memory-bound capacity per replica (tokens)
+	MedianK2      int64  // median compute-bound capacity per replica (tokens)
+	K2SourceLabel string // how k2 was computed: "P1-obs","P2-hist","P3-deriv","P4-k1"
+
 	// TotalCapacity is ReplicaCount × PerReplicaCapacity.
 	TotalCapacity float64
 


### PR DESCRIPTION
## Summary

- Adds one permanent `"saturation cycle summary"` INFO log line per model per reconcile cycle, emitted after the V2 optimizer produces decisions
- Records model-level supply/demand/utilization, per-analyzer RC/SC signals (shows whether TA's RC was positive when sat_v2's was zero), and per-variant k1/k2/k2Source/cost/prc/efficiency/replicas/action — all in a single grep-friendly line
- No behavioral change; no config flags; existing LEVEL(-4) lines untouched

**Motivation:** currently there is no way to read per-cycle analyzer/optimizer outputs without scraping `--v=4` debug lines. This line is always-on at INFO level and is the foundation for the benchmark correctness analysis tooling.

**Implementation:**
- `saturation_v2.ReplicaCapacity` gains `K2Priority int`; `computeK2` returns `(int64, int)` so the call site can record which priority path fired (observed/history/derived/fallback)
- `k1Slice`, `k2Slice`, `k2SourceLabel` helpers added; `aggregateByVariant` now populates `MedianK1`, `MedianK2`, `K2SourceLabel` per variant
- `interfaces.VariantCapacity` gains `MedianK1`, `MedianK2`, `K2SourceLabel` (zero for non-saturation analyzers)
- `logDecisionSummary` package-level helper in `engine_v2.go`; called from `optimizeV2` after `optimizer.Optimize` returns

## Test plan

- [ ] `engine_v2_log_test.go` — three new tests using `zaptest/observer`: required keys present, skips model with no saturation result, `analyzerSignals` populated with multiple analyzers
- [ ] `make test` passes
- [ ] `make lint` clean
- [ ] `go build ./...` clean
- [ ] Verify log line appears in `kubectl logs` on a running controller: `kubectl logs -l app.kubernetes.io/name=workload-variant-autoscaler | grep '"saturation cycle summary"'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)