### PR TITLE
Improvement: Dynamic detect LWS CRD

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	flag "github.com/spf13/pflag"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -88,7 +89,14 @@ func init() {
 	// KEDA scheme is registered unconditionally so the client can list ScaledObjects
 	// when the CRD is present. Listing fails gracefully (NoMatchError) when not installed.
 	utilruntime.Must(kedav1alpha1.AddToScheme(scheme))
-	// Note: LeaderWorkerSet scheme is added conditionally in main() after checking if CRD exists
+	// LeaderWorkerSet scheme is registered unconditionally (like KEDA) so the client
+	// can list and watch LeaderWorkerSets when the CRD is present.
+	// Listing and watching fail gracefully (NoMatchError) when not installed.
+	utilruntime.Must(lwsv1.AddToScheme(scheme))
+	// apiextensions scheme is required for CRDWatcher to query CustomResourceDefinition objects
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	// Note: LeaderWorkerSet CRD availability is checked dynamically at startup and runtime
+	// via CRDWatcher. See internal/controller/crd_watcher.go
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -166,18 +174,6 @@ func main() {
 		os.Exit(1)     //nolint:gocritic // exitAfterDefer: Sync() called explicitly above
 	}
 	setupLog.Info("Configuration loaded successfully")
-
-	// Conditionally add LeaderWorkerSet scheme if CRD exists
-	lwsEnabled := crd.CheckLeaderWorkerSetCRD(restConfig, setupLog)
-	if lwsEnabled {
-		if err := lwsv1.AddToScheme(scheme); err != nil {
-			setupLog.Error(err, "failed to add LeaderWorkerSet scheme")
-			os.Exit(1)
-		}
-		setupLog.Info("LeaderWorkerSet CRD detected - support enabled")
-	} else {
-		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode)")
-	}
 
 	// Detect KEDA for annotation-based ScaledObject discovery (dual-mode, Phase 1)
 	kedaEnabled := crd.CheckKEDACRD(restConfig, setupLog)
@@ -479,6 +475,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Check initial LWS CRD state
+	initialLWSAvailable := crd.CheckLeaderWorkerSetCRD(restConfig, setupLog)
+	lwsStateManager := crd.NewLWSStateManager()
+	lwsStateManager.SetAvailable(initialLWSAvailable)
+	if initialLWSAvailable {
+		setupLog.Info("LeaderWorkerSet CRD detected - support enabled")
+	} else {
+		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (will auto-enable if installed)")
+	}
+
+	// Register CRD watcher to detect LWS CRD installation/removal at runtime
+	setupLog.Info("Registering CRD watcher for dynamic LWS detection")
+	crdWatcher := controller.NewCRDWatcher(
+		mgr.GetClient(),
+		"leaderworkersets.leaderworkerset.x-k8s.io",
+		lwsStateManager,
+		ctrl.Log.WithName("crd-watcher"),
+	)
+	if err := mgr.Add(crdWatcher); err != nil {
+		setupLog.Error(err, "unable to add CRD watcher")
+		os.Exit(1)
+	}
+	setupLog.Info("CRD watcher registered successfully")
+
 	// Create the reconciler with unified Config and datastore
 	reconciler := controller.NewVariantAutoscalingReconciler(
 		mgr.GetClient(),
@@ -486,7 +506,7 @@ func main() {
 		mgr.GetEventRecorderFor("workload-variant-autoscaler-controller-manager"),
 		cfg,
 		ds,
-		lwsEnabled,
+		initialLWSAvailable,
 	)
 
 	// Setup the controller with the manager

--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -75,22 +75,12 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - resourcequotas
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - inference.networking.k8s.io

--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.5
-	k8s.io/apiextensions-apiserver v0.34.3 // indirect
+	k8s.io/apiextensions-apiserver v0.34.3
 	k8s.io/apiserver v0.34.3 // indirect
 	k8s.io/component-base v0.34.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -39,6 +39,15 @@ var (
 		Jitter:   0.1,
 		Steps:    6, // 5s, 10s, 20s, 40s, 80s, 160s = ~5 minutes total
 	}
+
+	// CRDWatchBackoff is the backoff configuration for CRD watcher connection failures
+	CRDWatchBackoff = wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    6, // 1s, 2s, 4s, 8s, 16s, 32s, max 60s = ~63s total
+		Cap:      60 * time.Second,
+	}
 )
 
 var (

--- a/internal/controller/crd_watcher.go
+++ b/internal/controller/crd_watcher.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/crd"
+)
+
+// CRDWatcher watches CustomResourceDefinition resources and updates a state manager
+// when the CRD is created or deleted. It is generic and can be used for any CRD.
+type CRDWatcher struct {
+	client.Client
+	crdName      string
+	stateManager crd.CRDStateManager
+	logger       logr.Logger
+}
+
+// NewCRDWatcher creates a new CRDWatcher for the specified CRD.
+func NewCRDWatcher(c client.Client, crdName string, stateManager crd.CRDStateManager, logger logr.Logger) *CRDWatcher {
+	return &CRDWatcher{
+		Client:       c,
+		crdName:      crdName,
+		stateManager: stateManager,
+		logger:       logger,
+	}
+}
+
+// Start implements manager.Runnable.
+func (w *CRDWatcher) Start(ctx context.Context) error {
+	return w.watchWithRetry(ctx)
+}
+
+// watchWithRetry starts the CRD watch with exponential backoff retry on failures.
+func (w *CRDWatcher) watchWithRetry(ctx context.Context) error {
+	backoff := constants.CRDWatchBackoff
+
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		err := w.watch(ctx)
+		if err == nil || ctx.Err() != nil {
+			return true, err
+		}
+
+		w.logger.Error(err, "CRD watch failed, will retry",
+			"backoff", backoff.Duration)
+		return false, nil
+	})
+}
+
+// watch performs the actual watch on CRD resources.
+func (w *CRDWatcher) watch(ctx context.Context) error {
+	// Initial check for CRD existence
+	crdObj := &apiextensionsv1.CustomResourceDefinition{}
+	err := w.Get(ctx, client.ObjectKey{Name: w.crdName}, crdObj)
+	if err == nil {
+		w.stateManager.SetAvailable(true)
+		w.logger.Info("CRD detected during initial check", "crd", w.crdName)
+	} else {
+		w.stateManager.SetAvailable(false)
+	}
+
+	// Watch for CRD changes
+	// For now, we poll every 30 seconds as a simple implementation
+	// This can be enhanced to use actual watches in the future
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			err := w.Get(ctx, client.ObjectKey{Name: w.crdName}, crdObj)
+			if err == nil {
+				if !w.stateManager.IsAvailable() {
+					// This code is executed whenever CRD is created
+					w.stateManager.SetAvailable(true)
+					w.logger.Info("CRD installed - support enabled", "crd", w.crdName)
+				}
+			} else {
+				if w.stateManager.IsAvailable() {
+					// This code is executed whenever CRD is removed
+					w.stateManager.SetAvailable(false)
+					w.logger.Info("CRD removed - support disabled", "crd", w.crdName)
+				}
+			}
+		}
+	}
+}

--- a/internal/controller/crd_watcher_test.go
+++ b/internal/controller/crd_watcher_test.go
@@ -1,0 +1,88 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/controller"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/crd"
+)
+
+func TestCRDWatcher_Creation(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	stateManager := crd.NewLWSStateManager()
+	logger := logr.Discard()
+
+	watcher := controller.NewCRDWatcher(fakeClient, "leaderworkersets.leaderworkerset.x-k8s.io", stateManager, logger)
+	if watcher == nil {
+		t.Error("Expected NewCRDWatcher to return non-nil watcher")
+	}
+}
+
+func TestCRDWatcher_DetectsCRDCreate(t *testing.T) {
+	lwsCRD := &apiextensionsv1.CustomResourceDefinition{}
+	lwsCRD.Name = "leaderworkersets.leaderworkerset.x-k8s.io"
+
+	scheme := runtime.NewScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(lwsCRD).
+		Build()
+
+	stateManager := crd.NewLWSStateManager()
+	logger := logr.Discard()
+
+	watcher := controller.NewCRDWatcher(fakeClient, "leaderworkersets.leaderworkerset.x-k8s.io", stateManager, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = watcher.Start(ctx)
+	}()
+
+	// Give watcher time to detect CRD
+	time.Sleep(100 * time.Millisecond)
+
+	if !stateManager.IsAvailable() {
+		t.Error("Expected state manager to show CRD as available")
+	}
+}
+
+func TestCRDWatcher_DetectsCRDDelete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	stateManager := crd.NewLWSStateManager()
+	stateManager.SetAvailable(true) // Start with CRD available
+
+	logger := logr.Discard()
+
+	watcher := controller.NewCRDWatcher(fakeClient, "leaderworkersets.leaderworkerset.x-k8s.io", stateManager, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = watcher.Start(ctx)
+	}()
+
+	// Give watcher time to detect CRD absence
+	time.Sleep(100 * time.Millisecond)
+
+	if stateManager.IsAvailable() {
+		t.Error("Expected state manager to show CRD as unavailable")
+	}
+}

--- a/internal/utils/crd/crd.go
+++ b/internal/utils/crd/crd.go
@@ -57,7 +57,6 @@ func CheckKEDACRD(restConfig *rest.Config, logger logr.Logger) bool {
 }
 
 // CheckLeaderWorkerSetCRD reports whether the LeaderWorkerSet CRD is installed.
-// TODO: checked once at startup; handle LWS installed after controller starts.
 func CheckLeaderWorkerSetCRD(restConfig *rest.Config, logger logr.Logger) bool {
 	return CheckCRDInstalled(restConfig, "leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet", logger)
 }

--- a/internal/utils/crd/state_manager_lws.go
+++ b/internal/utils/crd/state_manager_lws.go
@@ -1,0 +1,56 @@
+package crd
+
+import "sync"
+
+// CRDStateManager is an interface for tracking CRD availability state.
+// Implemented by LWSStateManager and can be implemented by other CRD-specific managers.
+type CRDStateManager interface {
+	IsAvailable() bool
+	SetAvailable(available bool)
+}
+
+// LWSStateManager tracks LeaderWorkerSet CRD availability in a thread-safe manner.
+type LWSStateManager struct {
+	mu        sync.RWMutex
+	available bool
+	callbacks []func(bool)
+}
+
+// NewLWSStateManager creates a new LWSStateManager with available set to false.
+func NewLWSStateManager() *LWSStateManager {
+	return &LWSStateManager{
+		available: false,
+		callbacks: []func(bool){},
+	}
+}
+
+// IsAvailable returns whether the LeaderWorkerSet CRD is currently available.
+func (m *LWSStateManager) IsAvailable() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.available
+}
+
+// SetAvailable updates the availability state of the LeaderWorkerSet CRD.
+// If the state changes, all registered callbacks are invoked with the new state.
+func (m *LWSStateManager) SetAvailable(available bool) {
+	m.mu.Lock()
+	oldValue := m.available
+	m.available = available
+	callbacks := m.callbacks
+	m.mu.Unlock()
+
+	// Only trigger callbacks if state actually changed
+	if oldValue != available {
+		for _, cb := range callbacks {
+			cb(available)
+		}
+	}
+}
+
+// OnStateChange registers a callback to be invoked when the availability state changes.
+func (m *LWSStateManager) OnStateChange(callback func(bool)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callbacks = append(m.callbacks, callback)
+}

--- a/internal/utils/crd/state_manager_lws_test.go
+++ b/internal/utils/crd/state_manager_lws_test.go
@@ -1,0 +1,103 @@
+package crd_test
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/utils/crd"
+)
+
+func TestLWSStateManager_BasicState(t *testing.T) {
+	sm := crd.NewLWSStateManager()
+
+	if sm.IsAvailable() {
+		t.Error("Expected IsAvailable to be false initially")
+	}
+
+	sm.SetAvailable(true)
+	if !sm.IsAvailable() {
+		t.Error("Expected IsAvailable to be true after SetAvailable(true)")
+	}
+
+	sm.SetAvailable(false)
+	if sm.IsAvailable() {
+		t.Error("Expected IsAvailable to be false after SetAvailable(false)")
+	}
+}
+
+func TestLWSStateManager_ConcurrentAccess(t *testing.T) {
+	sm := crd.NewLWSStateManager()
+	done := make(chan bool)
+
+	// 10 goroutines writing
+	for i := 0; i < 10; i++ {
+		go func(val bool) {
+			for j := 0; j < 100; j++ {
+				sm.SetAvailable(val)
+			}
+			done <- true
+		}(i%2 == 0)
+	}
+
+	// 10 goroutines reading
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = sm.IsAvailable()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	// If we got here without data races, test passes
+}
+
+func TestLWSStateManager_CallbacksTriggered(t *testing.T) {
+	sm := crd.NewLWSStateManager()
+
+	callbackCalled := false
+	var callbackValue bool
+
+	sm.OnStateChange(func(available bool) {
+		callbackCalled = true
+		callbackValue = available
+	})
+
+	sm.SetAvailable(true)
+
+	if !callbackCalled {
+		t.Error("Expected callback to be called")
+	}
+	if !callbackValue {
+		t.Error("Expected callback to receive true")
+	}
+}
+
+func TestLWSStateManager_IdempotentStateChange(t *testing.T) {
+	sm := crd.NewLWSStateManager()
+
+	callCount := 0
+	sm.OnStateChange(func(available bool) {
+		callCount++
+	})
+
+	sm.SetAvailable(true)
+	if callCount != 1 {
+		t.Errorf("Expected 1 callback, got %d", callCount)
+	}
+
+	// Set to same value - should not trigger callback
+	sm.SetAvailable(true)
+	if callCount != 1 {
+		t.Errorf("Expected 1 callback after idempotent change, got %d", callCount)
+	}
+
+	sm.SetAvailable(false)
+	if callCount != 2 {
+		t.Errorf("Expected 2 callbacks after state change, got %d", callCount)
+	}
+}


### PR DESCRIPTION
Ref: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/992
- Before the fix:
  - start manager -> install lws CRD -> create lws -> create VA with lws as scaleRef -> Error in WVA manager "Failed to get scale target".
- After the fix:
  - start manager -> install lws CRD -> create lws -> create VA with lws as scaleRef -> "Target found".
- The same pattern can be applied KEDA