### PR TITLE
fix: correct typo in Grafana operational dashboard description

### DIFF
--- a/deploy/grafana/operational-dashboard.json
+++ b/deploy/grafana/operational-dashboard.json
@@ -92,7 +92,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Number of available GPUs by accelerator type. WVA only discovers GPUs when a configuration such as \"enableLimiter\" is \"true\". Only available in clusters such as OpenShift where WVA can iterate over node objects. There is no exclusions such as tained nodes or GPUs operating in different modes such as MIG. Metric is wva_available_gpus.",
+      "description": "Number of available GPUs by accelerator type. WVA only discovers GPUs when a configuration such as \"enableLimiter\" is \"true\". Only available in clusters such as OpenShift where WVA can iterate over node objects. There is no exclusions such as tainted nodes or GPUs operating in different modes such as MIG. Metric is wva_available_gpus.",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
## What this PR does

Fixes a typo in the Grafana operational dashboard JSON: `tained` → `tainted` in the GPU panel description. The text refers to Kubernetes tainted nodes, so `tainted` is the correct word.

## Why

Closes #1268

## How tested

- Single character change in a JSON string — no logic affected
- Verified the surrounding context confirms this refers to Kubernetes node taints