### PR TITLE
refactor: replace fragile string matching in sanitizeReasonForMetrics

### DIFF
--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1591,7 +1591,7 @@ func (e *Engine) applySaturationDecisions(
 		if hasDecision {
 			if decision.Action != interfaces.ActionNoChange {
 				// Sanitize reason to prevent Prometheus cardinality explosion from dynamic numeric values
-				sanitizedReason := sanitizeReasonForMetrics(reason, decision.Action)
+				sanitizedReason := sanitizeReasonForMetrics(&decision)
 				if err := e.metricsEmitter.EmitReplicaScalingMetrics(ctx, &updateVa, string(decision.Action), sanitizedReason); err != nil {
 					logger.Error(err, "Failed to emit replica scaling metrics")
 				}
@@ -1606,14 +1606,26 @@ func (e *Engine) applySaturationDecisions(
 	}
 }
 
-// sanitizeReasonForMetrics converts detailed reason strings into bounded categorical
-// values safe for use as Prometheus label values. This prevents cardinality explosion
-// from dynamic numeric values embedded in reason strings.
-// TODO: look fragile, refactor this function for better solution
-func sanitizeReasonForMetrics(reason string, action interfaces.SaturationAction) string {
-	// Check for saturation-only mode patterns
-	if strings.Contains(reason, "saturation-only mode:") {
-		switch action {
+// scalingReasonPrefix* define the expected reason-string prefixes set by each scaling
+// source. sanitizeReasonForMetrics checks against these constants so that renaming
+// a prefix in any producer requires only a single constant update here.
+const (
+	scalingReasonPrefixScaleFromZero = "scalefromzero"
+	scalingReasonPrefixV2            = "V2"
+)
+
+// sanitizeReasonForMetrics maps a VariantDecision to a bounded categorical string
+// safe for use as a Prometheus label value. Dynamic numeric values embedded in
+// reason strings are removed to prevent cardinality explosion.
+//
+// Classification priority:
+//  1. SaturationOnly flag — set structurally by the saturation-only path, no string match needed.
+//  2. Reason prefix — scale-from-zero and V2-optimizer decisions carry a stable prefix.
+//  3. Action — default fallback when no source-specific prefix is present.
+func sanitizeReasonForMetrics(decision *interfaces.VariantDecision) string {
+	// Saturation-only mode is indicated by a dedicated struct field — no string match needed.
+	if decision.SaturationOnly {
+		switch decision.Action {
 		case interfaces.ActionScaleUp:
 			return "saturation-only mode: scale-up"
 		case interfaces.ActionScaleDown:
@@ -1623,9 +1635,10 @@ func sanitizeReasonForMetrics(reason string, action interfaces.SaturationAction)
 		}
 	}
 
-	// Check for scale-from-zero pattern
-	if strings.Contains(reason, "scalefromzero") {
-		switch action {
+	// Scale-from-zero and V2-optimizer decisions carry a stable reason prefix.
+	switch {
+	case strings.HasPrefix(decision.Reason, scalingReasonPrefixScaleFromZero):
+		switch decision.Action {
 		case interfaces.ActionScaleUp:
 			return "scalefromzero: scale-up"
 		case interfaces.ActionScaleDown:
@@ -1633,11 +1646,8 @@ func sanitizeReasonForMetrics(reason string, action interfaces.SaturationAction)
 		default:
 			return "scalefromzero: no-change"
 		}
-	}
-
-	// Check for V2 optimizer patterns (cost-aware, greedy-by-score, enforced)
-	if strings.Contains(reason, "V2") {
-		switch action {
+	case strings.HasPrefix(decision.Reason, scalingReasonPrefixV2):
+		switch decision.Action {
 		case interfaces.ActionScaleUp:
 			return "V2 scale-up"
 		case interfaces.ActionScaleDown:
@@ -1647,8 +1657,8 @@ func sanitizeReasonForMetrics(reason string, action interfaces.SaturationAction)
 		}
 	}
 
-	// Default fallback based on action
-	switch action {
+	// Default: categorize by action only.
+	switch decision.Action {
 	case interfaces.ActionScaleUp:
 		return "scale-up"
 	case interfaces.ActionScaleDown:

--- a/internal/engines/saturation/sanitize_reason_test.go
+++ b/internal/engines/saturation/sanitize_reason_test.go
@@ -25,106 +25,136 @@ import (
 func TestSanitizeReasonForMetrics(t *testing.T) {
 	tests := []struct {
 		name     string
-		reason   string
-		action   interfaces.SaturationAction
+		decision interfaces.VariantDecision
 		expected string
 	}{
-		// Saturation-only mode patterns
+		// Saturation-only mode: classification driven by the SaturationOnly flag,
+		// not by the reason string content.
 		{
 			name:     "saturation-only scale-up",
-			reason:   "saturation-only mode: ScaleUp",
-			action:   interfaces.ActionScaleUp,
+			decision: interfaces.VariantDecision{SaturationOnly: true, Action: interfaces.ActionScaleUp},
 			expected: "saturation-only mode: scale-up",
 		},
 		{
 			name:     "saturation-only scale-down",
-			reason:   "saturation-only mode: ScaleDown",
-			action:   interfaces.ActionScaleDown,
+			decision: interfaces.VariantDecision{SaturationOnly: true, Action: interfaces.ActionScaleDown},
 			expected: "saturation-only mode: scale-down",
 		},
 		{
 			name:     "saturation-only no-change",
-			reason:   "saturation-only mode: NoChange",
-			action:   interfaces.ActionNoChange,
+			decision: interfaces.VariantDecision{SaturationOnly: true, Action: interfaces.ActionNoChange},
 			expected: "saturation-only mode: no-change",
 		},
-		// Scale-from-zero patterns
+		// Scale-from-zero: identified by the scalefromzero reason prefix.
 		{
-			name:     "scalefromzero scale-up",
-			reason:   "scalefromzero mode: pending request - scale-up",
-			action:   interfaces.ActionScaleUp,
+			name: "scalefromzero scale-up",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleUp,
+				Reason: "scalefromzero mode: pending request - scale-up",
+			},
 			expected: "scalefromzero: scale-up",
 		},
 		{
-			name:     "scalefromzero scale-down",
-			reason:   "scalefromzero mode: some reason",
-			action:   interfaces.ActionScaleDown,
+			name: "scalefromzero scale-down",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleDown,
+				Reason: "scalefromzero mode: some reason",
+			},
 			expected: "scalefromzero: scale-down",
 		},
-		// V2 optimizer patterns with dynamic values (cardinality issue)
+		// V2 optimizer: identified by the "V2" reason prefix.
+		// Dynamic values embedded in the reason string (required capacity, spare
+		// capacity, optimizer name) are stripped to prevent cardinality explosion.
 		{
-			name:     "V2 scale-up with cost-aware optimizer and dynamic required capacity",
-			reason:   "V2 scale-up (optimizer: cost-aware, required: 1500)",
-			action:   interfaces.ActionScaleUp,
+			name: "V2 scale-up with cost-aware optimizer and dynamic required capacity",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleUp,
+				Reason: "V2 scale-up (optimizer: cost-aware, required: 1500)",
+			},
 			expected: "V2 scale-up",
 		},
 		{
-			name:     "V2 scale-down with greedy-by-score optimizer and dynamic spare capacity",
-			reason:   "V2 scale-down (optimizer: greedy-by-score, spare: 2300)",
-			action:   interfaces.ActionScaleDown,
+			name: "V2 scale-down with greedy-by-score optimizer and dynamic spare capacity",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleDown,
+				Reason: "V2 scale-down (optimizer: greedy-by-score, spare: 2300)",
+			},
 			expected: "V2 scale-down",
 		},
 		{
-			name:     "V2 enforced scale-up",
-			reason:   "V2 ScaleUp (optimizer: cost-aware, enforced)",
-			action:   interfaces.ActionScaleUp,
+			name: "V2 enforced scale-up",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleUp,
+				Reason: "V2 ScaleUp (optimizer: cost-aware, enforced)",
+			},
 			expected: "V2 scale-up",
 		},
 		{
-			name:     "V2 enforced scale-down",
-			reason:   "V2 ScaleDown (optimizer: greedy-by-score, enforced)",
-			action:   interfaces.ActionScaleDown,
+			name: "V2 enforced scale-down",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleDown,
+				Reason: "V2 ScaleDown (optimizer: greedy-by-score, enforced)",
+			},
 			expected: "V2 scale-down",
 		},
 		{
-			name:     "V2 steady state",
-			reason:   "V2 steady state",
-			action:   interfaces.ActionNoChange,
+			name: "V2 steady state",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionNoChange,
+				Reason: "V2 steady state",
+			},
 			expected: "V2 no-change",
 		},
-		// Fallback patterns
+		// Default fallback: any other reason maps to action only.
 		{
-			name:     "no scaling decision optimization loop scale-up",
-			reason:   "No scaling decision (optimization loop)",
-			action:   interfaces.ActionScaleUp,
+			name: "no scaling decision optimization loop scale-up",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleUp,
+				Reason: "No scaling decision (optimization loop)",
+			},
 			expected: "scale-up",
 		},
 		{
-			name:     "no scaling decision optimization loop scale-down",
-			reason:   "No scaling decision (optimization loop)",
-			action:   interfaces.ActionScaleDown,
+			name: "no scaling decision optimization loop scale-down",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleDown,
+				Reason: "No scaling decision (optimization loop)",
+			},
 			expected: "scale-down",
 		},
 		{
-			name:     "unknown pattern scale-up",
-			reason:   "some unknown reason",
-			action:   interfaces.ActionScaleUp,
+			name: "unknown pattern scale-up",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionScaleUp,
+				Reason: "some unknown reason",
+			},
 			expected: "scale-up",
 		},
 		{
-			name:     "unknown pattern no-change",
-			reason:   "some unknown reason",
-			action:   interfaces.ActionNoChange,
+			name: "unknown pattern no-change",
+			decision: interfaces.VariantDecision{
+				Action: interfaces.ActionNoChange,
+				Reason: "some unknown reason",
+			},
 			expected: "no-change",
+		},
+		// SaturationOnly flag takes precedence over any reason prefix.
+		{
+			name: "saturation-only flag beats scalefromzero prefix",
+			decision: interfaces.VariantDecision{
+				SaturationOnly: true,
+				Action:         interfaces.ActionScaleUp,
+				Reason:         "scalefromzero mode: pending request - scale-up",
+			},
+			expected: "saturation-only mode: scale-up",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeReasonForMetrics(tt.reason, tt.action)
+			result := sanitizeReasonForMetrics(&tt.decision)
 			if result != tt.expected {
-				t.Errorf("sanitizeReasonForMetrics(%q, %v) = %q, want %q",
-					tt.reason, tt.action, result, tt.expected)
+				t.Errorf("sanitizeReasonForMetrics() = %q, want %q", result, tt.expected)
 			}
 		})
 	}
@@ -133,34 +163,33 @@ func TestSanitizeReasonForMetrics(t *testing.T) {
 // TestSanitizeReasonForMetrics_CardinalityBounded verifies that all possible
 // output values are bounded and won't cause Prometheus cardinality explosion.
 func TestSanitizeReasonForMetrics_CardinalityBounded(t *testing.T) {
-	// All possible reasons from the codebase
-	inputReasons := []string{
-		// Saturation patterns
-		"saturation-only mode: ScaleUp",
-		"saturation-only mode: ScaleDown",
-		"saturation-only mode: NoChange",
-		// Scale-from-zero patterns
-		"scalefromzero mode: pending request - scale-up",
-		// V2 patterns with unbounded dynamic values
-		"V2 scale-up (optimizer: cost-aware, required: 1500)",
-		"V2 scale-up (optimizer: cost-aware, required: 2300)",
-		"V2 scale-up (optimizer: greedy-by-score, required: 999)",
-		"V2 scale-down (optimizer: cost-aware, spare: 800)",
-		"V2 scale-down (optimizer: greedy-by-score, spare: 1200)",
-		"V2 ScaleUp (optimizer: cost-aware, enforced)",
-		"V2 ScaleDown (optimizer: greedy-by-score, enforced)",
-		"V2 steady state",
-		// Other patterns
-		"No scaling decision (optimization loop)",
-	}
-
 	actions := []interfaces.SaturationAction{
 		interfaces.ActionScaleUp,
 		interfaces.ActionScaleDown,
 		interfaces.ActionNoChange,
 	}
 
-	// Expected bounded set of output values
+	// Representative decisions covering every classification branch.
+	// Reason strings include dynamic numeric values to confirm they are stripped.
+	decisionTemplates := []interfaces.VariantDecision{
+		// Saturation-only (flag-driven, reason irrelevant)
+		{SaturationOnly: true},
+		// Scale-from-zero prefix
+		{Reason: "scalefromzero mode: pending request - scale-up"},
+		// V2 prefix with dynamic values
+		{Reason: "V2 scale-up (optimizer: cost-aware, required: 1500)"},
+		{Reason: "V2 scale-up (optimizer: cost-aware, required: 2300)"},
+		{Reason: "V2 scale-up (optimizer: greedy-by-score, required: 999)"},
+		{Reason: "V2 scale-down (optimizer: cost-aware, spare: 800)"},
+		{Reason: "V2 scale-down (optimizer: greedy-by-score, spare: 1200)"},
+		{Reason: "V2 ScaleUp (optimizer: cost-aware, enforced)"},
+		{Reason: "V2 ScaleDown (optimizer: greedy-by-score, enforced)"},
+		{Reason: "V2 steady state"},
+		// Default fallback
+		{Reason: "No scaling decision (optimization loop)"},
+	}
+
+	// Expected bounded set of output values — 12 in total.
 	expectedOutputs := map[string]bool{
 		"saturation-only mode: scale-up":   true,
 		"saturation-only mode: scale-down": true,
@@ -178,26 +207,20 @@ func TestSanitizeReasonForMetrics_CardinalityBounded(t *testing.T) {
 
 	seenOutputs := make(map[string]bool)
 
-	// Test all combinations
-	for _, reason := range inputReasons {
+	for _, tmpl := range decisionTemplates {
 		for _, action := range actions {
-			result := sanitizeReasonForMetrics(reason, action)
+			d := tmpl
+			d.Action = action
+			result := sanitizeReasonForMetrics(&d)
 			seenOutputs[result] = true
 
-			// Verify the output is in the expected bounded set
 			if !expectedOutputs[result] {
-				t.Errorf("Unexpected output value: %q (input: %q, action: %v)",
-					result, reason, action)
+				t.Errorf("unexpected output value %q (reason: %q, saturationOnly: %v, action: %v)",
+					result, d.Reason, d.SaturationOnly, action)
 			}
 		}
 	}
 
-	// Verify cardinality is bounded (should be exactly 12 possible values)
-	if len(seenOutputs) > len(expectedOutputs) {
-		t.Errorf("Output cardinality exceeds expected bound: got %d unique values, want at most %d",
-			len(seenOutputs), len(expectedOutputs))
-	}
-
-	t.Logf("Verified bounded cardinality: %d unique output values from %d input combinations",
-		len(seenOutputs), len(inputReasons)*len(actions))
+	t.Logf("verified bounded cardinality: %d unique output values from %d input combinations",
+		len(seenOutputs), len(decisionTemplates)*len(actions))
 }


### PR DESCRIPTION
## What this PR does

`sanitizeReasonForMetrics` converts raw decision reason strings into bounded Prometheus label values to prevent cardinality explosion. It previously used `strings.Contains` on free-form reason strings set across three different packages. Renaming any reason string in a producer would silently break metric categorization — no compile error, no failing test.

This PR replaces that approach:

- **Saturation-only path**: uses `decision.SaturationOnly` (an existing struct field set at the decision source) — no string matching at all
- **Scale-from-zero and V2 paths**: defined named prefix constants (`scalingReasonPrefixScaleFromZero`, `scalingReasonPrefixV2`) as a single source of truth, and switched from `strings.Contains` to `strings.HasPrefix` for precision
- **Tests**: updated `sanitize_reason_test.go` to drive the function via `*VariantDecision` and added a precedence test confirming the `SaturationOnly` flag beats any reason prefix

## Why

Closes #1262

The existing `// TODO: look fragile, refactor this function for better solution` comment (added in PR #1114) identified this as a known debt. The classification now relies on structured data where it exists, and on stable prefixes defined as constants where it does not.

## How tested

- `go test ./internal/engines/saturation/... -run TestSanitizeReasonForMetrics -v` — all 16 cases pass including cardinality bound check
- `go build ./...` — clean
- `go vet ./internal/engines/saturation/...` — clean