### PR TITLE
Revert "feat(config): default to V2 token-based saturation analyzer (…

### DIFF
--- a/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
+++ b/charts/workload-variant-autoscaler/templates/manager/wva-cp-configmap.yaml
@@ -23,12 +23,6 @@ metadata:
 data:
   # Global defaults applied to all variants unless overridden
   default: |
-    # Select the V2 token-based saturation analyzer. A non-empty analyzers list
-    # routes the engine to the V2 path (GetAnalyzerName() == "saturation").
-    # Remove this list (and leave analyzerName unset) to fall back to the V1
-    # percentage-based analyzer.
-    analyzers:
-      - name: saturation
     kvCacheThreshold: {{ .Values.wva.capacityScaling.default.kvCacheThreshold }}
     queueLengthThreshold: {{ .Values.wva.capacityScaling.default.queueLengthThreshold }}
     kvSpareTrigger: {{ .Values.wva.capacityScaling.default.kvSpareTrigger }}

--- a/config/base/manager/saturation-scaling-configmap.yaml
+++ b/config/base/manager/saturation-scaling-configmap.yaml
@@ -17,12 +17,6 @@ metadata:
 data:
   # Global defaults applied to all variants unless overridden
   default: |
-    # Select the V2 token-based saturation analyzer. A non-empty analyzers list
-    # routes the engine to the V2 path (GetAnalyzerName() == "saturation").
-    # Remove this list (and leave analyzerName unset) to fall back to the V1
-    # percentage-based analyzer.
-    analyzers:
-      - name: saturation
     kvCacheThreshold: 0.80
     queueLengthThreshold: 5
     kvSpareTrigger: 0.1

--- a/docs/developer-guide/saturation-scaling-config.md
+++ b/docs/developer-guide/saturation-scaling-config.md
@@ -44,31 +44,7 @@ These parameters apply when `analyzerName: "saturation"` is set or when the `ana
 
 ### Default Configuration
 
-As shipped (kustomize base and helm chart), the **default ConfigMap selects the V2 token-based analyzer**:
-
-```yaml
-analyzers:
-  - name: saturation
-    # Per-analyzer threshold overrides (optional; shown with their defaults):
-    # scaleUpThreshold: 0.85     # default
-    # scaleDownBoundary: 0.70    # default
-# Global threshold overrides (optional; apply to every analyzer):
-# scaleUpThreshold: 0.85
-# scaleDownBoundary: 0.70
-kvCacheThreshold: 0.80
-queueLengthThreshold: 5
-kvSpareTrigger: 0.1
-queueSpareTrigger: 3
-enableLimiter: false
-```
-
-The non-empty `analyzers:` list routes the engine to V2 (`GetAnalyzerName() == "saturation"`).
-The V2 thresholds (`scaleUpThreshold` / `scaleDownBoundary`) are filled from their defaults
-(0.85 / 0.70) when omitted, and the `kvCacheThreshold` / `queueLengthThreshold` / spare-trigger
-values are retained because V2 still uses them for the per-replica saturation check.
-
-**To use the V1 (percentage-based) analyzer instead,** remove the `analyzers:` list and leave
-`analyzerName` unset:
+The recommended values for the V1 (percentage-based) saturation analyzer are:
 
 ```yaml
 kvCacheThreshold: 0.80
@@ -77,11 +53,10 @@ kvSpareTrigger: 0.1
 queueSpareTrigger: 3
 ```
 
-> **Important:** The V1 threshold values are **not hardcoded** in the analyzer code.
-> If a V1 ConfigMap is missing or has no `default` entry, all V1 thresholds default to zero,
+> **Important:** These V1 threshold values are **not hardcoded** in the analyzer code.
+> If the ConfigMap is missing or has no `default` entry, all V1 thresholds default to zero,
 > which will cause every replica to appear saturated and trigger continuous scale-up.
-> Always deploy a V1 `default` entry containing valid thresholds. (V2 has safe hardcoded
-> threshold defaults, so it degrades gracefully.)
+> Always deploy the ConfigMap with a `default` entry containing valid thresholds.
 
 ### How Scale-Up Triggers Work
 

--- a/internal/config/saturation_scaling_test.go
+++ b/internal/config/saturation_scaling_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 )
 
 func float64Ptr(v float64) *float64 { return &v }
@@ -451,60 +450,6 @@ var _ = Describe("SaturationScalingConfig", func() {
 		It("should return empty when no analyzers and no analyzerName", func() {
 			config := SaturationScalingConfig{}
 			Expect(config.GetAnalyzerName()).To(BeEmpty())
-		})
-	})
-
-	Context("YAML round-trip", func() {
-
-		It("parses the shipped V2 default and fills V2 thresholds via ApplyDefaults", func() {
-			// Mirrors the ConfigMap "default" entry now shipped by kustomize/helm.
-			const yamlStr = `analyzers:
-  - name: saturation
-kvCacheThreshold: 0.80
-queueLengthThreshold: 5
-kvSpareTrigger: 0.1
-queueSpareTrigger: 3
-enableLimiter: false
-`
-			var cfg SaturationScalingConfig
-			Expect(yaml.Unmarshal([]byte(yamlStr), &cfg)).To(Succeed())
-			Expect(cfg.IsV2()).To(BeTrue(), "non-empty analyzers list selects V2")
-			Expect(cfg.Analyzers).To(HaveLen(1))
-			Expect(cfg.Analyzers[0].Name).To(Equal("saturation"))
-
-			// Defaults are not present in the YAML; ApplyDefaults must fill them.
-			Expect(cfg.ScaleUpThreshold).To(BeZero())
-			Expect(cfg.ScaleDownBoundary).To(BeZero())
-			cfg.ApplyDefaults()
-			Expect(cfg.ScaleUpThreshold).To(Equal(DefaultScaleUpThreshold))   // 0.85
-			Expect(cfg.ScaleDownBoundary).To(Equal(DefaultScaleDownBoundary)) // 0.70
-		})
-
-		It("preserves an explicit top-level scaleUpThreshold through unmarshal", func() {
-			const yamlStr = `analyzers:
-  - name: saturation
-scaleUpThreshold: 0.90
-`
-			var cfg SaturationScalingConfig
-			Expect(yaml.Unmarshal([]byte(yamlStr), &cfg)).To(Succeed())
-			Expect(cfg.ScaleUpThreshold).To(Equal(0.90))
-			// ApplyDefaults must not clobber an explicitly-set value.
-			cfg.ApplyDefaults()
-			Expect(cfg.ScaleUpThreshold).To(Equal(0.90))
-		})
-
-		It("sets the per-analyzer *float64 override from YAML", func() {
-			const yamlStr = `analyzers:
-  - name: saturation
-    scaleUpThreshold: 0.90
-`
-			var cfg SaturationScalingConfig
-			Expect(yaml.Unmarshal([]byte(yamlStr), &cfg)).To(Succeed())
-			Expect(cfg.Analyzers).To(HaveLen(1))
-			Expect(cfg.Analyzers[0].ScaleUpThreshold).NotTo(BeNil(), "per-analyzer override pointer must be set")
-			Expect(*cfg.Analyzers[0].ScaleUpThreshold).To(Equal(0.90))
-			// The per-analyzer override wins over the global default.
-			Expect(cfg.Analyzers[0].EffectiveScaleUpThreshold(DefaultScaleUpThreshold)).To(Equal(0.90))
 		})
 	})
 })

--- a/internal/controller/configmap_reconciler_test.go
+++ b/internal/controller/configmap_reconciler_test.go
@@ -486,34 +486,6 @@ var _ = Describe("ConfigMapReconciler", func() {
 			Expect(result).To(Equal(ctrl.Result{}))
 		})
 
-		It("parses a V2 saturation entry end-to-end via parseSaturationConfig", func() {
-			By("Parsing ConfigMap data with a V2 analyzers entry and a per-analyzer threshold")
-			cmData := map[string]string{
-				"default": `analyzers:
-  - name: saturation
-    scaleUpThreshold: 0.90
-kvCacheThreshold: 0.80
-queueLengthThreshold: 5
-kvSpareTrigger: 0.1
-queueSpareTrigger: 3
-`,
-			}
-			configs, count := parseSaturationConfig(cmData, GinkgoLogr)
-
-			Expect(count).To(Equal(1))
-			Expect(configs).To(HaveKey("default"))
-			got := configs["default"]
-			Expect(got.IsV2()).To(BeTrue())
-			Expect(got.Analyzers).To(HaveLen(1))
-
-			// ApplyDefaults ran inside parseSaturationConfig: the global V2 default
-			// is filled while the per-analyzer override survives the parse path.
-			Expect(got.ScaleUpThreshold).To(Equal(config.DefaultScaleUpThreshold))   // 0.85
-			Expect(got.ScaleDownBoundary).To(Equal(config.DefaultScaleDownBoundary)) // 0.70
-			Expect(got.Analyzers[0].ScaleUpThreshold).NotTo(BeNil())
-			Expect(*got.Analyzers[0].ScaleUpThreshold).To(Equal(0.90))
-		})
-
 	})
 
 	Context("Metrics Recording", func() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -180,17 +180,6 @@ var _ = BeforeSuite(func() {
 		g.Expect(runningPods).To(BeNumerically(">", 0), "No running WVA controller pods")
 	}).Should(Succeed(), "WVA controller should be running")
 
-	// The kustomize base now ships the saturation ConfigMap with
-	// analyzers:[saturation] (the V2 token-based path). Revert it to the V1
-	// percentage-based default so the existing scaling specs run the same path
-	// they were written and validated against. The shipped value is snapshotted
-	// and restored in AfterSuite, so the suite leaves the deployed ConfigMap as
-	// it found it. Suites that exercise V2 (saturation_v2_test.go,
-	// saturation_analyzer_path_test.go) set and restore their own config, so
-	// they are unaffected.
-	By("Reverting saturation config to V1 for suite consistency")
-	revertSaturationConfigToV1()
-
 	By("Verifying llm-d infrastructure")
 	// Verify Gateway CRDs exist
 	Eventually(func(g Gomega) {
@@ -265,77 +254,6 @@ var _ = BeforeSuite(func() {
 	GinkgoWriter.Println("BeforeSuite completed successfully - infrastructure ready")
 })
 
-// satConfigV1Default mirrors the pre-V2 kustomize default for the saturation
-// ConfigMap (no analyzers list and no analyzerName → V1 percentage-based path).
-const satConfigV1Default = `kvCacheThreshold: 0.80
-queueLengthThreshold: 5
-kvSpareTrigger: 0.1
-queueSpareTrigger: 3
-enableLimiter: false
-`
-
-// Snapshot of the saturation ConfigMap "default" entry as it was deployed
-// (the shipped V2 config) before revertSaturationConfigToV1 overwrote it.
-// restoreSaturationConfig uses it in AfterSuite to leave the ConfigMap as the
-// suite found it. saturationDefaultCaptured guards against restoring when the
-// snapshot was never taken (BeforeSuite failed before the revert).
-var (
-	savedSaturationDefault    string
-	saturationDefaultExisted  bool
-	saturationDefaultCaptured bool
-)
-
-// revertSaturationConfigToV1 patches the deployed saturation ConfigMap's
-// "default" entry to the V1 config, so the general e2e suite runs the V1
-// percentage-based analyzer regardless of the kustomize default (which now
-// selects V2). It first snapshots the shipped value so AfterSuite can restore
-// it. The controller hot-reloads the labeled ConfigMap, so no restart is
-// required.
-func revertSaturationConfigToV1() {
-	name := saturationConfigMapName()
-	ns := cfg.WVANamespace
-	cm, err := k8sClient.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to get saturation ConfigMap %s/%s", ns, name)
-	if cm.Data == nil {
-		cm.Data = map[string]string{}
-	}
-	savedSaturationDefault, saturationDefaultExisted = cm.Data["default"]
-	saturationDefaultCaptured = true
-	cm.Data["default"] = satConfigV1Default
-	_, err = k8sClient.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to revert saturation ConfigMap to V1")
-}
-
-// restoreSaturationConfig returns the saturation ConfigMap "default" entry to
-// the value captured by revertSaturationConfigToV1 (the shipped V2 config), so
-// the suite leaves the deployed ConfigMap as it found it. Best-effort: it runs
-// during teardown on context.Background() (the suite ctx may be cancelled) and
-// logs rather than fails on error.
-func restoreSaturationConfig() {
-	if !saturationDefaultCaptured || k8sClient == nil {
-		return
-	}
-	name := saturationConfigMapName()
-	ns := cfg.WVANamespace
-	bg := context.Background()
-	cm, err := k8sClient.CoreV1().ConfigMaps(ns).Get(bg, name, metav1.GetOptions{})
-	if err != nil {
-		GinkgoWriter.Printf("Warning: failed to get saturation ConfigMap %s/%s for restore: %v\n", ns, name, err)
-		return
-	}
-	if cm.Data == nil {
-		cm.Data = map[string]string{}
-	}
-	if saturationDefaultExisted {
-		cm.Data["default"] = savedSaturationDefault
-	} else {
-		delete(cm.Data, "default")
-	}
-	if _, err := k8sClient.CoreV1().ConfigMaps(ns).Update(bg, cm, metav1.UpdateOptions{}); err != nil {
-		GinkgoWriter.Printf("Warning: failed to restore saturation ConfigMap %s/%s to shipped config: %v\n", ns, name, err)
-	}
-}
-
 // ReportAfterEach dumps controller logs and VA status after a failed test.
 // This makes E2E failures self-contained and easier to debug (why scaling happened / didn't happen).
 var _ = ReportAfterEach(func(report SpecReport) {
@@ -352,9 +270,6 @@ var _ = ReportAfterEach(func(report SpecReport) {
 })
 
 var _ = AfterSuite(func() {
-	By("Restoring the saturation ConfigMap to its shipped (V2) config")
-	restoreSaturationConfig()
-
 	By("Cleaning up any leftover test resources")
 	if k8sClient != nil && crClient != nil {
 		// Clean up any resources with test labels that might have been left behind


### PR DESCRIPTION
…#1271)"

This reverts commit 04f95779e39bca3767a6c65a35aa529f2f4de284.