### PR TITLE
fix(metrics): emit replica scaling signal even when accelerator is unresolved

### DIFF
--- a/internal/constants/accelerator_test.go
+++ b/internal/constants/accelerator_test.go
@@ -1,0 +1,21 @@
+package constants_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+)
+
+var _ = Describe("IsAcceleratorResolved", func() {
+	DescribeTable("classifies an accelerator name as resolved or not",
+		func(name string, want bool) {
+			Expect(constants.IsAcceleratorResolved(name)).To(Equal(want))
+		},
+		Entry("empty is unresolved", "", false),
+		Entry("the \"unknown\" internal sentinel is unresolved", constants.DefaultAcceleratorName, false),
+		Entry("the \"unresolved\" label placeholder is unresolved", constants.UnresolvedAcceleratorType, false),
+		Entry("a real accelerator type is resolved", "A100", true),
+		Entry("a real long accelerator type is resolved", "NVIDIA-A100-PCIE-80GB", true),
+	)
+})

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -83,6 +83,14 @@ const (
 	// the real type before it reaches status or metrics. This value must never
 	// be persisted to VA status or used as a Prometheus label.
 	DefaultAcceleratorName = "unknown"
+
+	// UnresolvedAcceleratorType is the bounded accelerator_type label value used
+	// on the replica scaling gauges (wva_current_replicas / wva_desired_replicas /
+	// wva_desired_ratio) when the real accelerator type is not yet known. Unlike
+	// the internal DefaultAcceleratorName sentinel, this IS a valid label value:
+	// it lets the scaling signal flow to HPA/KEDA without leaking "unknown" and
+	// without withholding scaling. It is never persisted to VA status.
+	UnresolvedAcceleratorType = "unresolved"
 )
 
 // Component names identify WVA components for observability (metrics, logging, tracing).
@@ -96,7 +104,11 @@ const (
 )
 
 // IsAcceleratorResolved returns true if the accelerator name is a real GPU type
-// (not empty and not the "unknown" sentinel).
+// (not empty, not the "unknown" internal sentinel, and not the "unresolved"
+// label placeholder). UnresolvedAcceleratorType is a label-only output value;
+// treating it as unresolved here means that if it ever flows back in as an
+// accelerator name it is re-mapped rather than mistaken for a real type, and it
+// is never persisted to VA status.
 func IsAcceleratorResolved(name string) bool {
-	return name != "" && name != DefaultAcceleratorName
+	return name != "" && name != DefaultAcceleratorName && name != UnresolvedAcceleratorType
 }

--- a/internal/constants/suite_test.go
+++ b/internal/constants/suite_test.go
@@ -1,0 +1,13 @@
+package constants_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConstants(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Constants Suite")
+}

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -1433,7 +1433,7 @@ func (e *Engine) applySaturationDecisions(
 		// cycle.
 		if !constants.IsAcceleratorResolved(acceleratorName) {
 			e.emitAcceleratorNotResolvedEvent(&updateVa)
-			logger.V(logging.DEBUG).Info("Accelerator name not resolved - status will be updated but metrics will not be emitted",
+			logger.V(logging.DEBUG).Info("Accelerator name not resolved - replica scaling metrics emitted with accelerator_type=\"unresolved\"; accelerator-specific saturation/capacity metrics withheld",
 				"variant", vaName)
 		}
 
@@ -1505,13 +1505,13 @@ func (e *Engine) applySaturationDecisions(
 		// 	isSaturationOnly = decision.SaturationOnly
 		// }
 
-		// Skip metric emission when accelerator is unresolved to avoid publishing
-		// wva_* gauges under an empty or incorrect accelerator_type label.
-		// Status updates and conditions still proceed so the controller can reconcile.
-		if !constants.IsAcceleratorResolved(acceleratorName) {
-			logger.V(logging.DEBUG).Info("Skipping metric emission - no accelerator name available",
-				"variant", updateVa.Name)
-		} else if err := act.EmitMetrics(ctx, &updateVa); err != nil {
+		// Always emit the replica scaling signal (the HPA/KEDA external metric).
+		// EmitReplicaMetrics labels an unresolved accelerator as the bounded
+		// "unresolved" value (never the internal sentinel), so the scaling signal
+		// is never withheld; the scaler matches on variant/namespace rather than
+		// accelerator_type, so it keeps working regardless. Accelerator-dimensioned
+		// metrics (saturation/capacity) remain gated on resolution below.
+		if err := act.EmitMetrics(ctx, &updateVa); err != nil {
 			msg := "Failed to emit metrics for external autoscalers"
 			// K8s best practice: events should reference the current resource version
 			e.recordOptimizationFailedEvent([]llmdVariantAutoscalingV1alpha1.VariantAutoscaling{updateVa}, msg)
@@ -1534,12 +1534,14 @@ func (e *Engine) applySaturationDecisions(
 		}
 
 		// Record saturation and capacity metrics when this cycle produced a
-		// fresh decision for the variant. When there is no fresh decision the
-		// existing series persist with their last-recorded values until
-		// Prometheus' staleness marker fires; surfacing freshness on the
+		// fresh decision for the variant. These series carry the accelerator_type
+		// label, so they are emitted only when the type is resolved — otherwise
+		// the internal sentinel would leak into a label. When there is no fresh
+		// decision the existing series persist with their last-recorded values
+		// until Prometheus' staleness marker fires; surfacing freshness on the
 		// dashboard side is tracked in #1082 (an explicit "up" gauge per VA,
 		// rather than deleting series here).
-		if hasDecision {
+		if hasDecision && constants.IsAcceleratorResolved(acceleratorName) {
 			act.RecordSaturationMetrics(ctx, decision)
 		}
 
@@ -1553,10 +1555,12 @@ func (e *Engine) applySaturationDecisions(
 			//   for this variant during this loop (metrics pipeline is working).
 			// - hasDecision is true when the optimizer produced a scaling decision based on
 			//   saturation metrics in this run.
-			// - The accelerator must also be resolved: when it is the sentinel, the
-			//   metric-emission branch above is skipped (no wva_* gauges are published),
-			//   so reporting MetricsAvailable=True would leave HPA/KEDA-side reasoning
-			//   inconsistent with controller-side reporting.
+			// - The accelerator must also be resolved: the replica scaling gauges are
+			//   always emitted (with an "unresolved" accelerator_type) so scaling is not
+			//   blocked, but the accelerator-dimensioned saturation/capacity metrics are
+			//   only emitted when the type is resolved. MetricsAvailable therefore tracks
+			//   full (accelerator-dimensioned) observability, and is False until the
+			//   accelerator resolves even though scaling itself proceeds.
 			metricsAvailable := (hasAllocation || hasDecision) && constants.IsAcceleratorResolved(acceleratorName)
 			metricsReason := llmdVariantAutoscalingV1alpha1.ReasonMetricsMissing
 			metricsMessage := llmdVariantAutoscalingV1alpha1.MessageMetricsUnavailable
@@ -1669,7 +1673,8 @@ func (e *Engine) emitAcceleratorNotResolvedEvent(va *llmdVariantAutoscalingV1alp
 		"Cannot resolve accelerator type from Deployment nodeSelector/nodeAffinity or VA label "+
 			utils.AcceleratorNameLabel+". "+
 			"Set nodeSelector on Deployment or add the label to the VariantAutoscaling resource. "+
-			"HPA/KEDA metrics will not be emitted until the accelerator is resolved.")
+			"Replica scaling metrics are still emitted with accelerator_type=\"unresolved\" so HPA/KEDA can scale; "+
+			"accelerator-specific saturation/capacity metrics are withheld until the accelerator is resolved.")
 }
 
 // emitSafetyNetMetrics emits fallback metrics when saturation analysis fails.
@@ -1731,9 +1736,12 @@ func (e *Engine) emitSafetyNetMetrics(
 			}
 		}
 		if !constants.IsAcceleratorResolved(accelerator) {
-			logger.Info("Safety net: skipping metric emission - no accelerator name available",
+			// Do NOT withhold the scaling signal: EmitReplicaMetrics labels an
+			// unresolved accelerator with the bounded "unresolved" value, so the
+			// safety-net signal still reaches HPA/KEDA (which match on
+			// variant/namespace, not accelerator_type). Mirrors the main path.
+			logger.V(logging.DEBUG).Info("Safety net: accelerator unresolved, emitting scaling signal with 'unresolved' accelerator_type",
 				"variant", va.Name)
-			continue
 		}
 
 		// Emit safety net metrics

--- a/internal/engines/saturation/engine_event_test.go
+++ b/internal/engines/saturation/engine_event_test.go
@@ -55,8 +55,10 @@ var _ = Describe("emitAcceleratorNotResolvedEvent", func() {
 		Expect(got).To(HavePrefix("Warning AcceleratorNotResolved "))
 		Expect(got).To(ContainSubstring("nodeSelector"),
 			"event message should mention nodeSelector remediation")
-		Expect(got).To(ContainSubstring("HPA/KEDA metrics will not be emitted"),
-			"event message should warn that metrics are gated")
+		Expect(got).To(ContainSubstring("accelerator_type=\"unresolved\""),
+			"event message should note scaling metrics are still emitted with the unresolved label")
+		Expect(got).To(ContainSubstring("saturation/capacity metrics are withheld"),
+			"event message should warn that accelerator-specific metrics are gated until resolution")
 	})
 
 	It("is a no-op when the engine has no recorder configured", func() {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 
 	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
@@ -14,6 +15,29 @@ import (
 
 // ControllerInstanceEnvVar is the environment variable name for controller instance label
 const ControllerInstanceEnvVar = "CONTROLLER_INSTANCE"
+
+// replicaSeriesAccel tracks the last accelerator_type label emitted for each VA
+// (keyed by variant/namespace) on the replica scaling gauges. It lets
+// EmitReplicaMetrics evict a stale series only when the accelerator label
+// actually changes, instead of delete-and-reset every cycle (which would expose
+// a zero-value gap to a concurrent scrape of the scaling signal).
+//
+// TODO: entries are not pruned on VariantAutoscaling deletion, so the map grows
+// by one small entry per (variant, namespace) ever seen. This matches the
+// pre-existing behavior of the gauge series themselves (also not deleted on VA
+// removal — they expire via Prometheus staleness). Wire a deletion hook if/when
+// per-VA metric cleanup is added.
+var (
+	replicaSeriesMu    sync.Mutex
+	replicaSeriesAccel = map[string]string{}
+)
+
+// replicaSeriesKey identifies a VA's replica-gauge series independent of
+// accelerator_type. controllerInstance is process-global (set once at
+// InitMetrics) so it is intentionally not part of the key.
+func replicaSeriesKey(variantName, namespace string) string {
+	return variantName + "\x00" + namespace
+}
 
 var (
 	replicaScalingTotal *prometheus.CounterVec
@@ -65,6 +89,12 @@ func GetControllerInstance() string {
 func InitMetrics(registry prometheus.Registerer) error {
 	// Read controller instance from environment
 	controllerInstance = os.Getenv(ControllerInstanceEnvVar)
+
+	// Fresh registry => fresh gauges; drop any stale replica-series tracking so
+	// it never references series from a previous registry.
+	replicaSeriesMu.Lock()
+	replicaSeriesAccel = map[string]string{}
+	replicaSeriesMu.Unlock()
 
 	// Build label sets based on whether controller_instance is configured.
 	// Existing replica metrics (baseLabels, scalingLabels) are unchanged.
@@ -479,34 +509,69 @@ func SetModelsProcessed(count int) {
 	modelsProcessedGauge.With(labels).Set(float64(count))
 }
 
-// EmitReplicaMetrics emits current and desired replica metrics
+// EmitReplicaMetrics emits current and desired replica metrics — the scaling
+// signal consumed by HPA/KEDA. These gauges are emitted regardless of whether
+// the accelerator type is resolved: the signal must never be withheld just
+// because the accelerator is unknown. When the type is unresolved the
+// accelerator_type label carries the bounded UnresolvedAcceleratorType value
+// (never the internal "unknown" sentinel).
+//
+// The HPA/KEDA query selects a VA by variant_name + namespace, NOT by
+// accelerator_type, so scaling must not depend on that label. To keep that true
+// across an accelerator transition (e.g. unresolved -> a real type) without
+// exposing a gap on the steady-state path, we set the current series first and
+// then — only when the accelerator label actually changed since the last emit —
+// delete the now-stale prior series. Steady state (no label change) is therefore
+// a plain idempotent Set: no gap, no per-cycle churn, exactly one series. Only
+// during an accelerator transition do the old and new series briefly coexist
+// (set-before-delete), which is preferable to a zero-value gap.
 func (m *MetricsEmitter) EmitReplicaMetrics(ctx context.Context, va *llmdOptv1alpha1.VariantAutoscaling, current, desired int32, acceleratorType string) error {
-	baseLabels := prometheus.Labels{
-		constants.LabelVariantName:     va.Name,
-		constants.LabelNamespace:       va.Namespace,
-		constants.LabelAcceleratorType: acceleratorType,
-	}
-
-	// Add controller_instance label if configured
-	if controllerInstance != "" {
-		baseLabels[constants.LabelControllerInstance] = controllerInstance
-	}
-
 	// These operations are local and should never fail, but we handle errors for debugging
 	if currentReplicas == nil || desiredReplicas == nil || desiredRatio == nil {
 		return errors.New("replica metrics not initialized")
 	}
 
+	if !constants.IsAcceleratorResolved(acceleratorType) {
+		acceleratorType = constants.UnresolvedAcceleratorType
+	}
+
+	labelsFor := func(accel string) prometheus.Labels {
+		l := prometheus.Labels{
+			constants.LabelVariantName:     va.Name,
+			constants.LabelNamespace:       va.Namespace,
+			constants.LabelAcceleratorType: accel,
+		}
+		if controllerInstance != "" {
+			l[constants.LabelControllerInstance] = controllerInstance
+		}
+		return l
+	}
+
+	// Set the current series first so a concurrent scrape never sees a gap.
+	baseLabels := labelsFor(acceleratorType)
 	currentReplicas.With(baseLabels).Set(float64(current))
 	desiredReplicas.With(baseLabels).Set(float64(desired))
-
-	// Avoid division by 0 if current replicas is zero: set the ratio to the desired replicas
-	// Going 0 -> N is treated by using `desired_ratio = N`
+	// Avoid division by 0 if current replicas is zero: set the ratio to the desired replicas.
+	// Going 0 -> N is treated by using `desired_ratio = N`.
 	if current == 0 {
 		desiredRatio.With(baseLabels).Set(float64(desired))
-		return nil
+	} else {
+		desiredRatio.With(baseLabels).Set(float64(desired) / float64(current))
 	}
-	desiredRatio.With(baseLabels).Set(float64(desired) / float64(current))
+
+	// If the accelerator label changed since the last emit for this VA, evict the
+	// stale prior series (done after Set, so there is no zero-value window).
+	key := replicaSeriesKey(va.Name, va.Namespace)
+	replicaSeriesMu.Lock()
+	prev, had := replicaSeriesAccel[key]
+	replicaSeriesAccel[key] = acceleratorType
+	replicaSeriesMu.Unlock()
+	if had && prev != acceleratorType {
+		stale := labelsFor(prev)
+		currentReplicas.Delete(stale)
+		desiredReplicas.Delete(stale)
+		desiredRatio.Delete(stale)
+	}
 	return nil
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -159,6 +159,9 @@ func resetMetrics() {
 	kvCacheTokensUsed = nil
 	kvCacheTokensCapacity = nil
 	controllerInstance = ""
+	replicaSeriesMu.Lock()
+	replicaSeriesAccel = map[string]string{}
+	replicaSeriesMu.Unlock()
 }
 
 func gatherMetric(registry *prometheus.Registry, name string) *dto.MetricFamily {

--- a/internal/metrics/replica_metrics_test.go
+++ b/internal/metrics/replica_metrics_test.go
@@ -1,0 +1,144 @@
+package metrics
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+
+	llmdOptv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/constants"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newReplicaTestVA(name, namespace string) *llmdOptv1alpha1.VariantAutoscaling {
+	return &llmdOptv1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+var _ = Describe("EmitReplicaMetrics", func() {
+	var (
+		registry *prometheus.Registry
+		emitter  *MetricsEmitter
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		resetMetrics()
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		emitter = NewMetricsEmitter()
+		ctx = context.Background()
+	})
+
+	// series returns the series of the named metric family from the registry.
+	series := func(name string) []*dto.Metric {
+		mfs, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		for _, mf := range mfs {
+			if mf.GetName() == name {
+				return mf.GetMetric()
+			}
+		}
+		return nil
+	}
+
+	// The scaling signal must be emitted even when the accelerator is unresolved,
+	// labelled with the bounded "unresolved" value (never the "unknown" sentinel
+	// and never empty).
+	DescribeTable("labels an unresolved accelerator as \"unresolved\"",
+		func(in string) {
+			Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("v1", "ns1"), 2, 3, in)).To(Succeed())
+
+			s := series(constants.WVADesiredReplicas)
+			Expect(s).To(HaveLen(1))
+			Expect(getLabelValue(s[0], constants.LabelAcceleratorType)).To(Equal(constants.UnresolvedAcceleratorType))
+			Expect(s[0].GetGauge().GetValue()).To(Equal(3.0))
+		},
+		Entry("empty", ""),
+		Entry("unknown sentinel", constants.DefaultAcceleratorName),
+		Entry("\"unresolved\" fed back in (idempotent)", constants.UnresolvedAcceleratorType),
+	)
+
+	It("labels a resolved accelerator verbatim", func() {
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("v1", "ns1"), 1, 2, "A100")).To(Succeed())
+
+		s := series(constants.WVADesiredReplicas)
+		Expect(s).To(HaveLen(1))
+		Expect(getLabelValue(s[0], constants.LabelAcceleratorType)).To(Equal("A100"))
+	})
+
+	It("falls back to the desired count for the ratio when current==0", func() {
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("v1", "ns1"), 0, 5, "A100")).To(Succeed())
+
+		s := series(constants.WVADesiredRatio)
+		Expect(s).To(HaveLen(1))
+		Expect(s[0].GetGauge().GetValue()).To(Equal(5.0), "ratio falls back to desired count when current==0")
+	})
+
+	// The HPA/KEDA scaler matches a VA on variant_name+namespace, NOT
+	// accelerator_type, so an accelerator transition must leave exactly one series.
+	It("keeps a single series when the accelerator resolves (unresolved -> real)", func() {
+		va := newReplicaTestVA("v1", "ns1")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 3, "")).To(Succeed())
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 4, "A100")).To(Succeed())
+
+		s := series(constants.WVADesiredReplicas)
+		Expect(s).To(HaveLen(1), "stale 'unresolved' series must be evicted")
+		Expect(getLabelValue(s[0], constants.LabelAcceleratorType)).To(Equal("A100"))
+		Expect(s[0].GetGauge().GetValue()).To(Equal(4.0))
+		// Eviction must cover all three replica gauges, not just desired_replicas.
+		Expect(series(constants.WVACurrentReplicas)).To(HaveLen(1))
+		Expect(series(constants.WVADesiredRatio)).To(HaveLen(1))
+	})
+
+	It("keeps a single series when the accelerator regresses (real -> unresolved)", func() {
+		va := newReplicaTestVA("v1", "ns1")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 4, "A100")).To(Succeed())
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 2, 3, "")).To(Succeed())
+
+		s := series(constants.WVADesiredReplicas)
+		Expect(s).To(HaveLen(1), "stale 'A100' series must be evicted")
+		Expect(getLabelValue(s[0], constants.LabelAcceleratorType)).To(Equal(constants.UnresolvedAcceleratorType))
+		Expect(s[0].GetGauge().GetValue()).To(Equal(3.0))
+		Expect(series(constants.WVACurrentReplicas)).To(HaveLen(1))
+		Expect(series(constants.WVADesiredRatio)).To(HaveLen(1))
+	})
+
+	It("does not churn the series when the accelerator is unchanged across cycles", func() {
+		va := newReplicaTestVA("v1", "ns1")
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 2, "A100")).To(Succeed())
+		Expect(emitter.EmitReplicaMetrics(ctx, va, 1, 3, "A100")).To(Succeed())
+
+		s := series(constants.WVADesiredReplicas)
+		Expect(s).To(HaveLen(1), "same accelerator => single stable series, no eviction")
+		Expect(getLabelValue(s[0], constants.LabelAcceleratorType)).To(Equal("A100"))
+		Expect(s[0].GetGauge().GetValue()).To(Equal(3.0), "value updates in place")
+	})
+
+	It("does not evict another VA's series in the same namespace", func() {
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("va-a", "ns"), 1, 2, "A100")).To(Succeed())
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("va-b", "ns"), 1, 3, "")).To(Succeed())
+
+		Expect(series(constants.WVADesiredReplicas)).To(HaveLen(2), "one series per VA")
+	})
+
+	It("sets the controller_instance label when configured", func() {
+		// controller_instance is read from the env at InitMetrics, so set it and
+		// re-init on a fresh registry for this spec only.
+		GinkgoT().Setenv(ControllerInstanceEnvVar, "ctrl-a")
+		resetMetrics()
+		registry = prometheus.NewRegistry()
+		Expect(InitMetrics(registry)).To(Succeed())
+		DeferCleanup(resetMetrics)
+
+		Expect(emitter.EmitReplicaMetrics(ctx, newReplicaTestVA("v1", "ns1"), 1, 2, "A100")).To(Succeed())
+
+		s := series(constants.WVADesiredReplicas)
+		Expect(s).To(HaveLen(1))
+		Expect(getLabelValue(s[0], constants.LabelControllerInstance)).To(Equal("ctrl-a"))
+	})
+})


### PR DESCRIPTION
## Problem

A synthetic (HPA/KEDA-sourced) `VariantAutoscaling` has no CRD to patch — its emitted
`wva_desired_replicas` gauge **is** the scaling signal the external scaler consumes. When the
accelerator type couldn't be resolved (no nodeSelector/nodeAffinity and no
`inference.optimization/acceleratorName` label), the engine skipped **all** metric emission on
both the main and safety-net paths, so the scaler got no signal and the workload **silently
stopped scaling** — surfaced only as a repeating `AcceleratorNotResolved` warning.

## Fix

Decouple the scaling signal from accelerator resolution:

- `EmitReplicaMetrics` now **always** emits `wva_current_replicas` / `wva_desired_replicas` /
  `wva_desired_ratio`. An unresolved accelerator is labelled with the bounded
  `accelerator_type="unresolved"` value — never the internal `"unknown"` sentinel, never empty.
- The HPA/KEDA query matches a VA by `variant_name`+`namespace`, not `accelerator_type`. To keep
  that true across an `unresolved → real` transition without a scrape gap, the current series is
  set first and the prior series is evicted **only when the accelerator label changes** (tracked
  per VA). Steady state is a plain idempotent `Set` — one series, no churn.
- Accelerator-dimensioned saturation/capacity metrics stay gated on `IsAcceleratorResolved`, so
  the sentinel never reaches their label. `IsAcceleratorResolved` also rejects `"unresolved"`.
- The `AcceleratorNotResolved` warning still fires; its message (and the related logs) now
  state that scaling metrics are emitted with `accelerator_type="unresolved"` while
  accelerator-specific metrics are withheld until the type resolves.

## Tests

Ginkgo specs in `internal/metrics` (unresolved→`"unresolved"`, resolved verbatim, `current==0`
ratio, single-series across both transition directions, steady-state no-churn, per-VA isolation,
`controller_instance`) and `internal/constants` (`IsAcceleratorResolved`). `go vet` clean.

## Notes

- Behavioral: a synthetic VA with no decision now emits `wva_desired_replicas=0` rather than an
  absent series (signal always present).
- The replica-series tracker is not pruned on VA deletion (one tiny entry per VA ever seen);
  series themselves expire via Prometheus staleness, as before. Marked with a TODO.