### PR TITLE
fix(rbac): add gpu-rebalance markers

### DIFF
--- a/config/base/rbac/manager-clusterrole.yaml
+++ b/config/base/rbac/manager-clusterrole.yaml
@@ -31,6 +31,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - resourcequotas
   - secrets
   - services
   verbs:
@@ -70,14 +71,6 @@ rules:
   resources:
   - replicasets
   - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - resourcequotas
   verbs:
   - get
   - list

--- a/internal/coordinator/plugins/gpurebalance/plugin.go
+++ b/internal/coordinator/plugins/gpurebalance/plugin.go
@@ -27,6 +27,9 @@ type Plugin struct {
 	promAPI promv1.API
 }
 
+// +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;patch;update
+
 // New constructs the gpu-rebalance Plugin.
 func New(c client.Client, promAPI promv1.API) *Plugin {
 	return &Plugin{client: c, promAPI: promAPI}


### PR DESCRIPTION
## Summary

Add missing kubebuilder RBAC markers for the gpu-rebalance plugin.

The plugin lists `ResourceQuota` objects and patches managed HPAs. Without these markers, regenerating manifests can drop the required permissions from the manager ClusterRole.

## Test plan

- [x] `make LOCALBIN=/root/oss/llm-d-workload-variant-autoscaler/bin manifests`
- [x] `go test ./internal/coordinator/plugins/gpurebalance`
- [x] `git diff --check`
