### PR TITLE
fix(saturation): fall back to cost-aware optimizer when GPU capacity is unknown (V2)

### DIFF
--- a/internal/engines/pipeline/optimizer_equivalence_test.go
+++ b/internal/engines/pipeline/optimizer_equivalence_test.go
@@ -1,0 +1,140 @@
+package pipeline
+
+import (
+	"context"
+	"maps"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// These tests answer: does the fair-share optimizer (GreedyByScore) produce the
+// same per-variant targets as the cost-aware optimizer when GPUs are NOT
+// constrained? That is the premise behind falling back to "unlimited" when the
+// GPU inventory cannot be discovered.
+//
+// CostAware is run with nil constraints (its unlimited mode). GreedyByScore is
+// run with a non-binding huge per-type budget (effectively unlimited), since
+// GreedyByScore treats absent/empty constraints as zero (deny), not unlimited.
+//
+// NOTE: the optimizers decrement AnalyzerResult.Remaining in place, so each
+// optimizer must be given a FRESHLY built request set (build() is called twice).
+//
+// Scope: these cases cover the non-disaggregated scale-up path (the common
+// case). Equivalence on scale-down and on P/D-disaggregated (per-role) requests
+// is not asserted here — the fallback's correctness does not depend on it, since
+// the cost-aware optimizer is itself a valid unlimited optimizer for those paths
+// (it is the optimizer the engine already runs when enableLimiter is false).
+var _ = Describe("GreedyByScore vs CostAware when GPUs are unconstrained", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	hugeConstraints := func(types ...string) []*ResourceConstraints {
+		pools := map[string]ResourcePool{}
+		for _, t := range types {
+			pools[t] = ResourcePool{Limit: 1_000_000}
+		}
+		return []*ResourceConstraints{{Pools: pools}}
+	}
+
+	targets := func(decisions []interfaces.VariantDecision) map[string]int {
+		m := make(map[string]int, len(decisions))
+		for _, d := range decisions {
+			m[d.VariantName] = d.TargetReplicas
+		}
+		return m
+	}
+
+	keys := func(m map[string]int) []string {
+		return slices.Sorted(maps.Keys(m))
+	}
+
+	// compare builds two independent request sets and reports both optimizers'
+	// targets. Returns (costAware, greedyByScore) for the caller to assert on.
+	run := func(build func() []ModelScalingRequest, types ...string) (map[string]int, map[string]int) {
+		ca := targets(NewCostAwareOptimizer().Optimize(ctx, build(), nil))
+		gs := targets(NewGreedyByScoreOptimizer().Optimize(ctx, build(), hugeConstraints(types...)))
+		return ca, gs
+	}
+
+	It("single model, single variant: identical", func() {
+		build := func() []ModelScalingRequest {
+			r := &interfaces.AnalyzerResult{
+				ModelID: "m", Namespace: "ns", RequiredCapacity: 50000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "v", AcceleratorName: "A100", Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			return []ModelScalingRequest{withSatEntry(r, ModelScalingRequest{
+				ModelID: "m", Namespace: "ns", Priority: 1,
+				VariantStates: []interfaces.VariantReplicaState{{VariantName: "v", CurrentReplicas: 1, GPUsPerReplica: 2}},
+			})}
+		}
+		ca, gs := run(build, "A100")
+		Expect(keys(gs)).To(Equal(keys(ca)))
+		// Anchor the absolute target so the equivalence check can't pass vacuously
+		// (both staying at 1): ceil(50000/10000)=5 additional -> 1+5=6.
+		Expect(ca["v"]).To(Equal(6))
+		Expect(gs["v"]).To(Equal(ca["v"]), "ca=%d gs=%d", ca["v"], gs["v"])
+	})
+
+	It("single model, multiple variants (cost-efficiency selection): identical", func() {
+		build := func() []ModelScalingRequest {
+			r := &interfaces.AnalyzerResult{
+				ModelID: "m", Namespace: "ns", RequiredCapacity: 25000,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: "cheap", AcceleratorName: "A100", Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
+					{VariantName: "pricey", AcceleratorName: "H100", Cost: 15, ReplicaCount: 1, PerReplicaCapacity: 20000},
+				},
+			}
+			return []ModelScalingRequest{withSatEntry(r, ModelScalingRequest{
+				ModelID: "m", Namespace: "ns", Priority: 1,
+				VariantStates: []interfaces.VariantReplicaState{
+					{VariantName: "cheap", CurrentReplicas: 1, GPUsPerReplica: 1},
+					{VariantName: "pricey", CurrentReplicas: 1, GPUsPerReplica: 1},
+				},
+			})}
+		}
+		ca, gs := run(build, "A100", "H100")
+		Expect(keys(gs)).To(Equal(keys(ca)))
+		// Anchor absolute targets: cheap is most cost-efficient (5/10000 < 15/20000)
+		// so it absorbs demand — ceil(25000/10000)=3 -> 1+3=4; pricey stays at 1.
+		Expect(ca["cheap"]).To(Equal(4))
+		Expect(ca["pricey"]).To(Equal(1))
+		Expect(gs["cheap"]).To(Equal(ca["cheap"]), "cheap ca=%d gs=%d", ca["cheap"], gs["cheap"])
+		Expect(gs["pricey"]).To(Equal(ca["pricey"]), "pricey ca=%d gs=%d", ca["pricey"], gs["pricey"])
+	})
+
+	It("multiple models scaling up at once: report both", func() {
+		mk := func(id, variant, accel string, req float64, prio float64) ModelScalingRequest {
+			r := &interfaces.AnalyzerResult{
+				ModelID: id, Namespace: "ns", RequiredCapacity: req,
+				VariantCapacities: []interfaces.VariantCapacity{
+					{VariantName: variant, AcceleratorName: accel, Cost: 5, ReplicaCount: 1, PerReplicaCapacity: 10000},
+				},
+			}
+			return withSatEntry(r, ModelScalingRequest{
+				ModelID: id, Namespace: "ns", Priority: prio,
+				VariantStates: []interfaces.VariantReplicaState{{VariantName: variant, CurrentReplicas: 1, GPUsPerReplica: 1}},
+			})
+		}
+		build := func() []ModelScalingRequest {
+			return []ModelScalingRequest{
+				mk("a", "av", "A100", 30000, 1),
+				mk("b", "bv", "A100", 50000, 1),
+			}
+		}
+		ca, gs := run(build, "A100")
+		GinkgoWriter.Printf("multi-model unconstrained: cost-aware=%v  greedy-by-score=%v\n", ca, gs)
+		// Concrete targets prove real scale-up (not both trivially staying at 1):
+		// a: ceil(30000/10000)=3 -> 1+3=4 ; b: ceil(50000/10000)=5 -> 1+5=6.
+		Expect(ca["av"]).To(Equal(4))
+		Expect(ca["bv"]).To(Equal(6))
+		Expect(gs["av"]).To(Equal(ca["av"]), "av ca=%d gs=%d", ca["av"], gs["av"])
+		Expect(gs["bv"]).To(Equal(ca["bv"]), "bv ca=%d gs=%d", ca["bv"], gs["bv"])
+	})
+})

--- a/internal/engines/saturation/engine.go
+++ b/internal/engines/saturation/engine.go
@@ -753,6 +753,49 @@ func (e *Engine) analyzeRoleGroups(
 	return modelDecisions
 }
 
+// selectV2Optimizer chooses the optimizer and GPU constraints for a V2
+// optimization cycle.
+//
+// When the configured optimizer is GreedyByScore it is GPU-aware and expects
+// per-type resource constraints. Those constraints are computed from the GPU
+// limiter's inventory. GreedyByScore interprets absent constraints as zero
+// available capacity (deny-all), NOT as unlimited — so if it were run with
+// empty constraints it would silently suppress all scale-up.
+//
+// Therefore, whenever real constraints cannot be obtained — the limiter does
+// not provide constraints (no ConstraintProvider), or computing them failed
+// because, e.g., node objects are not readable on this cluster — we fall back
+// to the cost-aware optimizer, which is the engine's unlimited path (the same
+// optimizer used when enableLimiter is false), so scale-up proceeds
+// unconstrained instead of being blocked. A constraint that is present but
+// reports zero GPUs is left intact:
+// that is a genuine "no capacity" signal and should still block scale-up.
+func (e *Engine) selectV2Optimizer(
+	ctx context.Context,
+	requests []pipeline.ModelScalingRequest,
+) (pipeline.ScalingOptimizer, []*pipeline.ResourceConstraints) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// GreedyByScore is currently the only GPU-aware optimizer; any future
+	// constraint-consuming optimizer must be added to this guard.
+	optimizer := e.optimizer
+	if _, ok := optimizer.(*pipeline.GreedyByScoreOptimizer); !ok {
+		return optimizer, nil
+	}
+
+	provider, ok := e.GPULimiter.(pipeline.ConstraintProvider)
+	if !ok {
+		return pipeline.NewCostAwareOptimizer(), nil
+	}
+
+	constraint, err := provider.ComputeConstraints(ctx, computeCurrentGPUUsage(requests))
+	if err != nil {
+		logger.Error(err, "Failed to compute GPU constraints, falling back to unlimited (cost-aware) optimizer for this cycle")
+		return pipeline.NewCostAwareOptimizer(), nil
+	}
+	return optimizer, []*pipeline.ResourceConstraints{constraint}
+}
+
 // optimizeV2 runs the V2 token-based optimizer path (saturation-token-based).
 // Collects AnalyzerResults for all models, calls the optimizer once, then applies enforcer per-model.
 func (e *Engine) optimizeV2(
@@ -818,22 +861,11 @@ func (e *Engine) optimizeV2(
 	}
 
 	// Stage 2: Compute GPU constraints and call optimizer
-	var constraints []*pipeline.ResourceConstraints
-	if _, ok := e.optimizer.(*pipeline.GreedyByScoreOptimizer); ok {
-		currentUsage := computeCurrentGPUUsage(requests)
-		if limiter, ok := e.GPULimiter.(*pipeline.DefaultLimiter); ok {
-			constraint, err := limiter.ComputeConstraints(ctx, currentUsage)
-			if err != nil {
-				logger.Error(err, "Failed to compute GPU constraints, falling back to unlimited")
-			} else {
-				constraints = append(constraints, constraint)
-			}
-		}
-	}
-	allDecisions := e.optimizer.Optimize(ctx, requests, constraints)
+	optimizer, constraints := e.selectV2Optimizer(ctx, requests)
+	allDecisions := optimizer.Optimize(ctx, requests, constraints)
 
 	logger.Info("V2 optimizer produced decisions",
-		"optimizer", e.optimizer.Name(),
+		"optimizer", optimizer.Name(),
 		"decisionCount", len(allDecisions),
 		"modelCount", len(requests))
 
@@ -850,7 +882,7 @@ func (e *Engine) optimizeV2(
 
 		scaledToZero := e.ScaleToZeroEnforcer.EnforcePolicyOnDecisions(
 			ctx, req.ModelID, req.Namespace,
-			allDecisions, scaleToZeroConfig, e.optimizer.Name(),
+			allDecisions, scaleToZeroConfig, optimizer.Name(),
 		)
 		if scaledToZero {
 			logger.Info("Scale-to-zero enforcement applied (V2)",

--- a/internal/engines/saturation/engine_v2_optimizer_select_test.go
+++ b/internal/engines/saturation/engine_v2_optimizer_select_test.go
@@ -1,0 +1,146 @@
+package saturation
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/engines/pipeline"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/internal/interfaces"
+)
+
+// selectInventory is a minimal pipeline.Inventory whose Refresh result and
+// resource pools are configurable, so selectV2Optimizer's handling of the
+// inventory limiter can be exercised without a real cluster.
+type selectInventory struct {
+	refreshErr    error
+	pools         map[string]pipeline.ResourcePool
+	refreshCalled bool
+}
+
+func (s *selectInventory) Name() string {
+	return "select-inventory"
+}
+
+func (s *selectInventory) Refresh(context.Context) error {
+	s.refreshCalled = true
+	return s.refreshErr
+}
+
+func (s *selectInventory) SetUsed(map[string]int) {}
+
+func (s *selectInventory) CreateAllocator(context.Context) pipeline.ResourceAllocator {
+	return nil
+}
+
+func (s *selectInventory) GetResourcePools() map[string]pipeline.ResourcePool {
+	return s.pools
+}
+
+func (s *selectInventory) TotalLimit() int {
+	t := 0
+	for _, p := range s.pools {
+		t += p.Limit
+	}
+	return t
+}
+func (s *selectInventory) TotalUsed() int {
+	t := 0
+	for _, p := range s.pools {
+		t += p.Used
+	}
+	return t
+}
+func (s *selectInventory) TotalAvailable() int {
+	t := 0
+	for _, p := range s.pools {
+		t += p.Available()
+	}
+	return t
+}
+
+// selectLimiter is a pipeline.Limiter that is NOT the inventory-backed
+// DefaultLimiter, used to exercise the "limiter cannot be queried" branch.
+type selectLimiter struct{}
+
+func (selectLimiter) Name() string { return "select-limiter" }
+func (selectLimiter) Limit(context.Context, []*interfaces.VariantDecision) error {
+	return nil
+}
+
+var _ = Describe("selectV2Optimizer", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	newInventoryLimiter := func(refreshErr error, pools map[string]pipeline.ResourcePool) *pipeline.DefaultLimiter {
+		return pipeline.NewDefaultLimiter("gpu-limiter",
+			&selectInventory{refreshErr: refreshErr, pools: pools},
+			pipeline.NewGreedyBySaturation())
+	}
+
+	It("falls back to the cost-aware (unlimited) optimizer when inventory refresh fails", func() {
+		// Models the cluster-limitation case: node objects cannot be listed, so
+		// ComputeConstraints errors. GreedyByScore with empty constraints would
+		// silently block all scale-up, so we must run cost-aware instead.
+		e := &Engine{
+			optimizer:  pipeline.NewGreedyByScoreOptimizer(),
+			GPULimiter: newInventoryLimiter(errors.New("failed to list nodes"), nil),
+		}
+		opt, constraints := e.selectV2Optimizer(ctx, nil)
+		Expect(opt.Name()).To(Equal("cost-aware"))
+		Expect(constraints).To(BeEmpty())
+	})
+
+	It("uses greedy-by-score with constraints when the inventory reports GPUs (heterogeneous pools)", func() {
+		e := &Engine{
+			optimizer: pipeline.NewGreedyByScoreOptimizer(),
+			GPULimiter: newInventoryLimiter(nil, map[string]pipeline.ResourcePool{
+				"A100": {Limit: 8},
+				"H100": {Limit: 4},
+			}),
+		}
+		opt, constraints := e.selectV2Optimizer(ctx, nil)
+		Expect(opt.Name()).To(Equal("greedy-by-score"))
+		Expect(constraints).To(HaveLen(1))
+		Expect(constraints[0].Pools).To(HaveKey("A100"))
+		Expect(constraints[0].Pools).To(HaveKey("H100"))
+	})
+
+	It("keeps greedy-by-score when refresh succeeds but reports zero GPUs (genuine no-capacity)", func() {
+		// A present-but-empty constraint is a real "no capacity" signal and must
+		// still block scale-up — distinct from "capacity unknown".
+		e := &Engine{
+			optimizer:  pipeline.NewGreedyByScoreOptimizer(),
+			GPULimiter: newInventoryLimiter(nil, map[string]pipeline.ResourcePool{}),
+		}
+		opt, constraints := e.selectV2Optimizer(ctx, nil)
+		Expect(opt.Name()).To(Equal("greedy-by-score"))
+		Expect(constraints).To(HaveLen(1))
+		Expect(constraints[0].Pools).To(BeEmpty())
+	})
+
+	It("falls back to cost-aware when the GPU limiter is not the inventory limiter", func() {
+		e := &Engine{
+			optimizer:  pipeline.NewGreedyByScoreOptimizer(),
+			GPULimiter: selectLimiter{},
+		}
+		opt, constraints := e.selectV2Optimizer(ctx, nil)
+		Expect(opt.Name()).To(Equal("cost-aware"))
+		Expect(constraints).To(BeEmpty())
+	})
+
+	It("leaves a non-greedy optimizer untouched and never queries the limiter", func() {
+		inv := &selectInventory{refreshErr: errors.New("must not be called")}
+		e := &Engine{
+			optimizer:  pipeline.NewCostAwareOptimizer(),
+			GPULimiter: pipeline.NewDefaultLimiter("gpu-limiter", inv, pipeline.NewGreedyBySaturation()),
+		}
+		opt, constraints := e.selectV2Optimizer(ctx, nil)
+		Expect(opt.Name()).To(Equal("cost-aware"))
+		Expect(constraints).To(BeEmpty())
+		Expect(inv.refreshCalled).To(BeFalse(), "the limiter must not be queried for a non-greedy optimizer")
+	})
+})


### PR DESCRIPTION
Fixes #1298

## What

On the V2 (token-based) saturation path with `enableLimiter: true`, the engine selects the GPU-aware `GreedyByScoreOptimizer`. When GPU capacity could not be determined — e.g. the cluster does not permit listing `Node` objects, so the inventory refresh errors — `optimizeV2` logged `"falling back to unlimited"` but then ran `GreedyByScore` with **empty** constraints. `GreedyByScore` interprets absent constraints as *zero available capacity* (deny-all), not as unlimited, so it stopped fair-share and **silently suppressed all scale-up** — the opposite of the log message, and inconsistent with the V1 path, which fails open.

This change extracts `selectV2Optimizer`: when the GPU-aware optimizer cannot obtain *real* constraints (the limiter is not a `ConstraintProvider`, or computing constraints failed), it falls back to the **`CostAwareOptimizer`** — the engine's genuine unlimited path, the same optimizer used when `enableLimiter: false`. A constraint that is *present but reports zero GPUs* is left intact: that is a real "no capacity" signal and must still block scale-up.

## Why it's safe

The fair-share and cost-aware optimizers produce **identical per-variant targets when GPUs are unconstrained** — fair-share contention only changes outcomes under scarcity; with unlimited budget every model is scaled to fully meet its demand, which equals cost-aware's `RequiredCapacity`-driven target. A new equivalence test documents this across single-variant, multi-variant (cost-efficiency selection), and multi-model scenarios. This also aligns V2 with the V1 path, which already proceeds with original (unconstrained) decisions on a limiter error.

The GPU limiter is a soft fairness layer, not an enforcement boundary: the hard cap remains with the Kubernetes scheduler / `ResourceQuota`. Failing open here produces at worst over-eager replica targets that the scheduler leaves Pending, not resource exhaustion.

## Behavior summary

| GPU capacity state (`enableLimiter: true`, V2) | Before | After |
|---|---|---|
| inventory refresh **errors** (e.g. nodes unreadable) | scale-up silently **blocked** (logged "unlimited") | falls back to cost-aware → scale-up proceeds (unlimited) |
| limiter is not a `ConstraintProvider` | scale-up blocked | falls back to cost-aware |
| refresh succeeds, **zero GPUs** reported | blocked | **blocked** (unchanged — genuine no-capacity) |
| refresh succeeds, GPUs available | capped by capacity | capped by capacity (unchanged) |

## Changes

- `internal/engines/saturation/engine.go` — extract `selectV2Optimizer`; assert the `ConstraintProvider` interface (not the concrete `*DefaultLimiter`); use the selected optimizer consistently in logging and scale-to-zero enforcement.
- `internal/engines/saturation/engine_v2_optimizer_select_test.go` — unit tests for all branches (refresh failure, non-`ConstraintProvider` limiter, present-but-zero capacity, heterogeneous pools, non-greedy optimizer left untouched with a spy asserting the limiter is never queried).
- `internal/engines/pipeline/optimizer_equivalence_test.go` — documents fair-share ≡ cost-aware when unconstrained (scoped to the non-disaggregated scale-up path).