### PR TITLE
fix(collector): attribute pod metrics via VA when scaler is unmanaged

### DIFF
--- a/internal/collector/build_instance_key_test.go
+++ b/internal/collector/build_instance_key_test.go
@@ -167,7 +167,8 @@ func TestBuildInstanceKey_VANameExtraction(t *testing.T) {
 
 // mockLocator implements locator.PodLocator for testing.
 type mockLocator struct {
-	locateFunc func(ctx context.Context, namespace, podName string) (*locator.ManagedScaler, error)
+	locateFunc  func(ctx context.Context, namespace, podName string) (*locator.ManagedScaler, error)
+	resolveFunc func(ctx context.Context, namespace, podName string) (autoscalingv2.CrossVersionObjectReference, bool, error)
 }
 
 func (m *mockLocator) Locate(ctx context.Context, namespace, podName string) (*locator.ManagedScaler, error) {
@@ -181,6 +182,15 @@ func (m *mockLocator) LocateByVariant(_ context.Context, _, _ string) (*locator.
 	return nil, nil
 }
 
+// TODO(va-removal): remove ResolveScaleTarget from the mock when the CRD-based
+// dual-mode fallback (and the interface method) are removed.
+func (m *mockLocator) ResolveScaleTarget(ctx context.Context, namespace, podName string) (autoscalingv2.CrossVersionObjectReference, bool, error) {
+	if m.resolveFunc != nil {
+		return m.resolveFunc(ctx, namespace, podName)
+	}
+	return autoscalingv2.CrossVersionObjectReference{}, false, nil
+}
+
 // TestBuildInstanceKey_VACRDNameDiffersFromHPAName is the regression test for
 // https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1290.
 //
@@ -189,6 +199,9 @@ func (m *mockLocator) LocateByVariant(_ context.Context, _, _ string) (*locator.
 // buildInstanceKey returned the HPA name as vaName; filterReplicaMetricsByVariants
 // then filtered every metric out because the HPA name was not in the VA-CRD-keyed
 // allowed set.
+//
+// TODO(va-removal): remove this test when the VariantAutoscaling CRD is removed;
+// without the CRD the HPA name is always the correct vaName.
 func TestBuildInstanceKey_VACRDNameDiffersFromHPAName(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	if err := metrics.InitMetrics(registry); err != nil {
@@ -288,5 +301,181 @@ func TestBuildInstanceKey_VACRDNameDiffersFromHPAName(t *testing.T) {
 	if got != wantVAName {
 		t.Errorf("VariantName = %q; want %q (HPA name is %q — fix must resolve to VA CRD name via scaleTargetRef lookup)",
 			got, wantVAName, hpaName)
+	}
+}
+
+// TestBuildInstanceKey_UnmanagedHPAFallsBackToVALookup is the regression test for
+// the v0.7.0 → v0.8.0-rc4 regression where KServe pod metrics were dropped.
+//
+// KServe creates its own HPA WITHOUT llm-d.ai/managed=true, so the locator's
+// managed-only lookup returns (nil, nil). The fallback resolves the pod's scale
+// target (Deployment) via ResolveScaleTarget and looks up the VA that targets
+// it, restoring the v0.7.0 Pod → Deployment → VA attribution.
+//
+// TODO(va-removal): remove this test together with the CRD-based dual-mode
+// fallback when the VariantAutoscaling CRD is removed.
+func TestBuildInstanceKey_UnmanagedHPAFallsBackToVALookup(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	const namespace = "test-ns"
+	const deployName = "foo-deploy"
+	const wantVAName = "foo-kserve-va"
+
+	deployRef := autoscalingv2.CrossVersionObjectReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       deployName,
+	}
+
+	va := &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wantVAName,
+			Namespace: namespace,
+		},
+		Spec: llmdVariantAutoscalingV1alpha1.VariantAutoscalingSpec{
+			ScaleTargetRef: deployRef,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(va).
+		WithIndex(&llmdVariantAutoscalingV1alpha1.VariantAutoscaling{}, indexers.VAScaleTargetKey, indexers.VAScaleTargetIndexFunc).
+		Build()
+
+	// Locate returns (nil, nil): the KServe HPA is not managed, so no managed
+	// scaler is found. ResolveScaleTarget returns the Deployment the pod's owner
+	// chain reaches.
+	mockLoc := &mockLocator{
+		locateFunc: func(_ context.Context, _, _ string) (*locator.ManagedScaler, error) {
+			return nil, nil
+		},
+		resolveFunc: func(_ context.Context, ns, podName string) (autoscalingv2.CrossVersionObjectReference, bool, error) {
+			if ns == namespace && podName == "foo-pod" {
+				return deployRef, true, nil
+			}
+			return autoscalingv2.CrossVersionObjectReference{}, false, nil
+		},
+	}
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				"kv_cache_usage": {
+					Values: []source.MetricValue{
+						{
+							Labels: map[string]string{
+								"pod":      "foo-pod",
+								"instance": "10.0.0.1:8000",
+							},
+							Value:     0.5,
+							Timestamp: time.Now(),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	c := NewReplicaMetricsCollector(mockSource, k8sClient, nil, mockLoc)
+	results, err := c.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		namespace,
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatalf("expected one ReplicaMetrics result; got none — unmanaged-HPA fallback did not attribute the pod to VA %q", wantVAName)
+	}
+	if got := results[0].VariantName; got != wantVAName {
+		t.Errorf("VariantName = %q; want %q (fallback must resolve VA via ResolveScaleTarget + FindVAForScaleTarget)", got, wantVAName)
+	}
+}
+
+// TestBuildInstanceKey_UnmanagedHPANoMatchingVA verifies that when neither a
+// managed scaler nor a VA targeting the resolved scale target exists, the pod
+// stays unattributed (vaName="") and is skipped — no ReplicaMetrics produced.
+//
+// TODO(va-removal): remove this test together with the CRD-based dual-mode
+// fallback when the VariantAutoscaling CRD is removed.
+func TestBuildInstanceKey_UnmanagedHPANoMatchingVA(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if err := metrics.InitMetrics(registry); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+
+	const namespace = "test-ns"
+
+	scheme := runtime.NewScheme()
+	if err := llmdVariantAutoscalingV1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	// No VA objects: FindVAForScaleTarget returns (nil, nil).
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&llmdVariantAutoscalingV1alpha1.VariantAutoscaling{}, indexers.VAScaleTargetKey, indexers.VAScaleTargetIndexFunc).
+		Build()
+
+	mockLoc := &mockLocator{
+		locateFunc: func(_ context.Context, _, _ string) (*locator.ManagedScaler, error) {
+			return nil, nil
+		},
+		resolveFunc: func(_ context.Context, _, _ string) (autoscalingv2.CrossVersionObjectReference, bool, error) {
+			return autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "foo-deploy",
+			}, true, nil
+		},
+	}
+
+	mockSource := &mockMetricsSource{
+		refreshFunc: func(_ context.Context, _ source.RefreshSpec) (map[string]*source.MetricResult, error) {
+			return map[string]*source.MetricResult{
+				"kv_cache_usage": {
+					Values: []source.MetricValue{
+						{
+							Labels: map[string]string{
+								"pod":      "foo-pod",
+								"instance": "10.0.0.1:8000",
+							},
+							Value:     0.5,
+							Timestamp: time.Now(),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	c := NewReplicaMetricsCollector(mockSource, k8sClient, nil, mockLoc)
+	results, err := c.CollectReplicaMetrics(
+		context.Background(),
+		"test-model",
+		namespace,
+		make(map[string]scaletarget.ScaleTargetAccessor),
+		make(map[string]*llmdVariantAutoscalingV1alpha1.VariantAutoscaling),
+		nil,
+		make(map[string]float64),
+	)
+	if err != nil {
+		t.Fatalf("CollectReplicaMetrics: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected no results when no VA targets the scale target, got %d", len(results))
 	}
 }

--- a/internal/collector/locator/locator.go
+++ b/internal/collector/locator/locator.go
@@ -60,6 +60,20 @@ type PodLocator interface {
 	// metadata.name). Use this for shadow-pod layouts where the pod's
 	// ownerReferences chain does not reach the scaler's scaleTargetRef.
 	LocateByVariant(ctx context.Context, namespace, variantName string) (*ManagedScaler, error)
+
+	// ResolveScaleTarget returns the top-level Deployment / LWS scale target
+	// in the pod's ownerReferences chain, independent of whether a managed
+	// scaler controls it. ok is false when the pod has no scaler-eligible
+	// ancestor (shadow pod, unknown chain) or does not exist. Reuses the
+	// pod→target cache, so a call following Locate for the same pod issues
+	// no extra API reads. Use this to attribute metrics for scale targets
+	// fronted by an unmanaged scaler (e.g. a KServe-created HPA without
+	// llm-d.ai/managed=true), where Locate returns (nil, nil).
+	//
+	// TODO(va-removal): this method exists only for the CRD-based dual-mode
+	// fallback in the collector (buildInstanceKey). Remove it when the
+	// VariantAutoscaling CRD is removed.
+	ResolveScaleTarget(ctx context.Context, namespace, podName string) (ref autoscalingv2.CrossVersionObjectReference, ok bool, err error)
 }
 
 // New constructs a PodLocator.
@@ -96,21 +110,9 @@ type podLocator struct {
 func (l *podLocator) Locate(ctx context.Context, namespace, podName string) (*ManagedScaler, error) {
 	// Step 1: pod → top-level scale target. Immutable per Kubernetes'
 	// ownerReference rules, so the result is cacheable indefinitely.
-	target, hit := l.cache.get(podKey{Namespace: namespace, Name: podName})
-	if !hit {
-		pod := &corev1.Pod{}
-		if err := l.apiReader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("get pod %s/%s: %w", namespace, podName, err)
-		}
-		var err error
-		target, err = l.resolveScaleTarget(ctx, pod, namespace)
-		if err != nil {
-			return nil, err
-		}
-		l.cache.add(podKey{Namespace: namespace, Name: podName}, target)
+	target, err := l.resolveTarget(ctx, namespace, podName)
+	if err != nil {
+		return nil, err
 	}
 	if target == (chainNode{}) {
 		return nil, nil
@@ -119,6 +121,46 @@ func (l *podLocator) Locate(ctx context.Context, namespace, podName string) (*Ma
 	// Step 2: scale target → managed scaler. NOT cached; field-index reads
 	// are cheap and reflect the current annotation / scaleTargetRef state.
 	return l.resolveScaler(ctx, target)
+}
+
+// TODO(va-removal): remove ResolveScaleTarget together with the CRD-based
+// dual-mode fallback in the collector when the VariantAutoscaling CRD is removed.
+func (l *podLocator) ResolveScaleTarget(ctx context.Context, namespace, podName string) (autoscalingv2.CrossVersionObjectReference, bool, error) {
+	target, err := l.resolveTarget(ctx, namespace, podName)
+	if err != nil {
+		return autoscalingv2.CrossVersionObjectReference{}, false, err
+	}
+	if target == (chainNode{}) {
+		return autoscalingv2.CrossVersionObjectReference{}, false, nil
+	}
+	return autoscalingv2.CrossVersionObjectReference{
+		APIVersion: target.APIVersion,
+		Kind:       target.Kind,
+		Name:       target.Name,
+	}, true, nil
+}
+
+// resolveTarget runs Step 1 of resolution: pod → top-level scale-target
+// chainNode, memoized in the pod→target cache. Returns the zero chainNode
+// (with nil error) when the pod has no scaler-eligible ancestor or does not
+// exist. Shared by Locate and ResolveScaleTarget.
+func (l *podLocator) resolveTarget(ctx context.Context, namespace, podName string) (chainNode, error) {
+	if target, hit := l.cache.get(podKey{Namespace: namespace, Name: podName}); hit {
+		return target, nil
+	}
+	pod := &corev1.Pod{}
+	if err := l.apiReader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return chainNode{}, nil
+		}
+		return chainNode{}, fmt.Errorf("get pod %s/%s: %w", namespace, podName, err)
+	}
+	target, err := l.resolveScaleTarget(ctx, pod, namespace)
+	if err != nil {
+		return chainNode{}, err
+	}
+	l.cache.add(podKey{Namespace: namespace, Name: podName}, target)
+	return target, nil
 }
 
 func (l *podLocator) LocateByVariant(ctx context.Context, namespace, variantName string) (*ManagedScaler, error) {

--- a/internal/collector/locator/locator_test.go
+++ b/internal/collector/locator/locator_test.go
@@ -336,3 +336,95 @@ func TestLocateByVariant_KEDADisabledSkipsScaledObject(t *testing.T) {
 		t.Fatalf("got=%v, want HPA=v", got)
 	}
 }
+
+// TODO(va-removal): the TestResolveScaleTarget_* tests below cover the method
+// added for the CRD-based dual-mode fallback. Remove them when the
+// VariantAutoscaling CRD (and ResolveScaleTarget) are removed.
+
+// TestResolveScaleTarget_UnmanagedDeployment is the locator-side counterpart to
+// the KServe regression: the Deployment is fronted by no managed scaler (the
+// same shape as TestLocate_UnmanagedReturnsNil), yet ResolveScaleTarget still
+// returns the Deployment ref so the collector can fall back to a VA lookup.
+func TestResolveScaleTarget_UnmanagedDeployment(t *testing.T) {
+	ns := testNamespace
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d", Namespace: ns, UID: "uid-d"}}
+	rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "rs", Namespace: ns, UID: "uid-rs",
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "d", UID: "uid-d", Controller: ptr.To(true)}}}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns,
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs", UID: "uid-rs", Controller: ptr.To(true)}}}}
+
+	cached, apiReader := newClients(t, deploy, rs, pod)
+	loc, _ := locator.New(cached, apiReader)
+
+	ref, ok, err := loc.ResolveScaleTarget(context.Background(), ns, "p")
+	if err != nil {
+		t.Fatalf("ResolveScaleTarget: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok=false, want true (chain reaches Deployment d)")
+	}
+	if ref.Kind != "Deployment" || ref.Name != "d" || ref.APIVersion != "apps/v1" {
+		t.Errorf("ref=%+v, want apps/v1 Deployment d", ref)
+	}
+}
+
+func TestResolveScaleTarget_NoScalerEligibleAncestor(t *testing.T) {
+	ns := testNamespace
+	// Pod with no controller owner → no Deployment/LWS ancestor.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns}}
+	cached, apiReader := newClients(t, pod)
+	loc, _ := locator.New(cached, apiReader)
+
+	ref, ok, err := loc.ResolveScaleTarget(context.Background(), ns, "p")
+	if err != nil {
+		t.Fatalf("ResolveScaleTarget: %v", err)
+	}
+	if ok {
+		t.Errorf("ok=true, want false; ref=%+v", ref)
+	}
+}
+
+func TestResolveScaleTarget_PodNotFound(t *testing.T) {
+	cached, apiReader := newClients(t)
+	loc, _ := locator.New(cached, apiReader)
+
+	_, ok, err := loc.ResolveScaleTarget(context.Background(), testNamespace, "missing")
+	if err != nil {
+		t.Fatalf("ResolveScaleTarget: %v", err)
+	}
+	if ok {
+		t.Errorf("ok=true, want false for a missing pod")
+	}
+}
+
+// TestResolveScaleTarget_ReusesLocateCache verifies the pod→target step is
+// memoized across Locate and ResolveScaleTarget: after Locate warms the cache,
+// deleting the pod from apiReader does not prevent ResolveScaleTarget from
+// resolving the same Deployment.
+func TestResolveScaleTarget_ReusesLocateCache(t *testing.T) {
+	ns := testNamespace
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d", Namespace: ns, UID: "uid-d"}}
+	rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "rs", Namespace: ns, UID: "uid-rs",
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "d", UID: "uid-d", Controller: ptr.To(true)}}}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns,
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs", UID: "uid-rs", Controller: ptr.To(true)}}}}
+
+	cached, apiReader := newClients(t, deploy, rs, pod)
+	loc, _ := locator.New(cached, apiReader)
+
+	// Warm the pod→target cache via Locate (no managed scaler, returns nil).
+	if _, err := loc.Locate(context.Background(), ns, "p"); err != nil {
+		t.Fatalf("Locate: %v", err)
+	}
+	// Delete the pod; a cache hit means ResolveScaleTarget never reads it.
+	if err := apiReader.Delete(context.Background(), pod); err != nil {
+		t.Fatalf("delete pod: %v", err)
+	}
+	ref, ok, err := loc.ResolveScaleTarget(context.Background(), ns, "p")
+	if err != nil {
+		t.Fatalf("ResolveScaleTarget: %v", err)
+	}
+	if !ok || ref.Name != "d" {
+		t.Errorf("cache miss: ok=%v ref=%+v, want ok=true Deployment d", ok, ref)
+	}
+}

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -246,11 +246,12 @@ func (c *ReplicaMetricsCollector) buildInstanceKey(ctx context.Context, namespac
 	vaName = labels[constants.VariantLabelPrometheusKey]
 	if vaName == "" && podName != "" && c.locator != nil {
 		ms, err := c.locator.Locate(ctx, namespace, podName)
-		if err != nil {
+		switch {
+		case err != nil:
 			ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("locator.Locate failed; treating pod as unmanaged",
 				"pod", podName, "namespace", namespace, "error", err)
-		} else if ms == nil {
-			// TODO(va-removal): delete this whole branch when the VariantAutoscaling
+		case ms == nil:
+			// TODO(va-removal): delete this whole case when the VariantAutoscaling
 			// CRD is removed. It exists only for the CRD-based dual-mode path; the
 			// locator's ResolveScaleTarget method added for it can also go.
 			//
@@ -268,7 +269,7 @@ func (c *ReplicaMetricsCollector) buildInstanceKey(ctx context.Context, namespac
 					vaName = va.Name
 				}
 			}
-		} else {
+		default:
 			switch {
 			case ms.HPA != nil:
 				// Prefer the VA CRD name over the HPA name: for CRD-based setups (e.g.

--- a/internal/collector/replica_metrics.go
+++ b/internal/collector/replica_metrics.go
@@ -249,13 +249,36 @@ func (c *ReplicaMetricsCollector) buildInstanceKey(ctx context.Context, namespac
 		if err != nil {
 			ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("locator.Locate failed; treating pod as unmanaged",
 				"pod", podName, "namespace", namespace, "error", err)
-		} else if ms != nil {
+		} else if ms == nil {
+			// TODO(va-removal): delete this whole branch when the VariantAutoscaling
+			// CRD is removed. It exists only for the CRD-based dual-mode path; the
+			// locator's ResolveScaleTarget method added for it can also go.
+			//
+			// No managed scaler in the pod's owner chain. This is the v0.7.0
+			// CRD dual-mode path: KServe creates its own HPA without
+			// llm-d.ai/managed=true, so the locator's managed-only lookup
+			// returns nil. Resolve the pod's scale target directly and look up
+			// the VA that targets it. Leaves vaName="" when no VA matches,
+			// preserving the unattributed-pod skip below.
+			if ref, ok, terr := c.locator.ResolveScaleTarget(ctx, namespace, podName); terr != nil {
+				ctrl.LoggerFrom(ctx).V(logging.DEBUG).Info("locator.ResolveScaleTarget failed; treating pod as unmanaged",
+					"pod", podName, "namespace", namespace, "error", terr)
+			} else if ok {
+				if va, lookupErr := indexers.FindVAForScaleTarget(ctx, c.k8sClient, ref, namespace); lookupErr == nil && va != nil {
+					vaName = va.Name
+				}
+			}
+		} else {
 			switch {
 			case ms.HPA != nil:
 				// Prefer the VA CRD name over the HPA name: for CRD-based setups (e.g.
 				// KServe) the VA name and HPA name differ, and metrics are keyed by VA
 				// name. Fall back to HPA name for annotation-based setups where no VA
 				// CRD exists and the synthetic VA is keyed by the scaler name.
+				//
+				// TODO(va-removal): when the VariantAutoscaling CRD is removed, drop the
+				// FindVAForScaleTarget lookup and keep only `vaName = ms.HPA.Name` (the
+				// synthetic VA is always keyed by the scaler name).
 				if va, lookupErr := indexers.FindVAForScaleTarget(ctx, c.k8sClient, ms.HPA.Spec.ScaleTargetRef, namespace); lookupErr == nil && va != nil {
 					vaName = va.Name
 				} else {
@@ -267,6 +290,9 @@ func (c *ReplicaMetricsCollector) buildInstanceKey(ctx context.Context, namespac
 					Kind:       ms.ScaledObject.Spec.ScaleTargetRef.Kind,
 					Name:       ms.ScaledObject.Spec.ScaleTargetRef.Name,
 				}
+				// TODO(va-removal): when the VariantAutoscaling CRD is removed, drop the
+				// FindVAForScaleTarget lookup and keep only `vaName = ms.ScaledObject.Name`
+				// (the synthetic VA is always keyed by the scaler name).
 				if va, lookupErr := indexers.FindVAForScaleTarget(ctx, c.k8sClient, soRef, namespace); lookupErr == nil && va != nil {
 					vaName = va.Name
 				} else {


### PR DESCRIPTION
## Problem

In v0.7.0, WVA attributed pod metrics to a `VariantAutoscaling` (VA) by walking ownerRefs Pod → Deployment → VA. In v0.8.0-rc4 this was replaced by the `PodLocator`, which goes Pod → Deployment → **managed scaler (HPA/ScaledObject)** → VA.

`indexers.FindHPAForScaleTarget` (and the locator's HPA index) only match HPAs carrying `llm-d.ai/managed=true`. For KServe, WVA creates its **own** HPA without that annotation, so:

1. `buildInstanceKey` calls `locator.Locate()`.
2. `Locate` walks to the Deployment, finds no *managed* HPA, returns `(nil, nil)`.
3. `buildInstanceKey` leaves `vaName == ""`.
4. Every pod metric for that VA is skipped → `MetricsMissing`.

## Fix

Restore the v0.7.0 CRD dual-mode path. When `Locate` finds no managed scaler, resolve the pod's scale target directly and look up the VA that targets it.

- **`PodLocator.ResolveScaleTarget`** (new) — exposes the top-level Deployment/LWS scale target from the pod's ownerRef chain, independent of whether a *managed* scaler controls it. Reuses the existing pod→target LRU (so it is a cache hit after `Locate`); the shared Step-1 logic is factored into a private `resolveTarget` helper.
- **`buildInstanceKey` fallback** — on `ms == nil`, call `ResolveScaleTarget` + the existing `indexers.FindVAForScaleTarget`. Leaves `vaName=""` (and the existing unattributed-pod skip + `wva_pod_mapping_miss_total` accounting) when no VA matches.

The VA lookup stays in the collector layer, keeping the locator's design property of holding no VA index.

## VA-removal markers

All CRD-coupled sites are tagged `TODO(va-removal)` (`grep -rn "TODO(va-removal)"`) so they can be found and removed when the deprecated `VariantAutoscaling` CRD is dropped — including the pre-existing managed-HPA/ScaledObject branches (drop the lookup, keep `vaName = ms.<scaler>.Name`).

## Tests

- Collector: KServe unmanaged-HPA → VA via fallback; no-matching-VA → skip.
- Locator: `ResolveScaleTarget` for an unmanaged Deployment chain, no eligible ancestor, missing pod, and cache reuse across `Locate`.

`go build ./...`, `go vet`, and `go test ./internal/collector/... ./internal/collector/locator/...` all pass.
