### PR TITLE
Enhancement: add panel showing wva_pod_mapping_miss_total metric in dashboard

### DIFF
--- a/deploy/grafana/operational-dashboard.json
+++ b/deploy/grafana/operational-dashboard.json
@@ -417,6 +417,88 @@
         "type": "prometheus",
         "uid": "$datasource_uid"
       },
+      "description": "Number of pods whose metrics could not be attributed to a managed scaler in the last hour - filtered by namespace(s). Non-zero indicates mapping issues. Metric is wva_pod_mapping_miss_total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 53,
+      "options": {
+        "barShape": "flat",
+        "barWidthFactor": 0.3,
+        "effects": {
+          "barGlow": false,
+          "centerGlow": false,
+          "gradient": true
+        },
+        "endpointMarker": "point",
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "segmentCount": 1,
+        "segmentSpacing": 0.3,
+        "shape": "gauge",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "sizing": "auto",
+        "sparkline": true,
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource_uid"
+          },
+          "editorMode": "code",
+          "expr": "floor(sum(increase(wva_pod_mapping_miss_total{$namespace_label=~\"$namespace\"}[1h])))",
+          "instant": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Mapping Misses",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource_uid"
+      },
       "description": "Number of pods with metrics discovered for a namespace. Metric is wva_metrics_pods_discovered.",
       "fieldConfig": {
         "defaults": {
@@ -443,8 +525,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 4
       },
       "id": 24,
@@ -568,8 +650,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 4
       },
       "id": 25,
@@ -636,8 +718,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 4
       },
       "id": 26,


### PR DESCRIPTION
- New Panel:
<img width="1512" height="161" alt="image" src="https://github.com/user-attachments/assets/c29cab67-4a43-42e4-805e-5f616ffb5488" />

- If there's no new error for the duration of 1 hour, the panel shows:
<img width="381" height="156" alt="image" src="https://github.com/user-attachments/assets/aee042c2-5a65-49d6-96ff-2006f4b4b0e3" />

- Help message:
<img width="1516" height="151" alt="image" src="https://github.com/user-attachments/assets/59e13594-f457-405b-8c81-ab7efb418492" />
