### PR TITLE
fix(saturation): stop LWS group>1 from being stuck in "model in transition" (V1)

### DIFF
--- a/internal/saturation/analyzer.go
+++ b/internal/saturation/analyzer.go
@@ -282,12 +282,14 @@ func (a *Analyzer) isScaleDownSafe(
 
 // CalculateSaturationTargets determines target replicas per variant based on saturation analysis.
 // Step 1: Pure saturation-based target calculation
-// Uses replica count from Saturation metrics (ready replicas) to avoid excessive scale-up.
+// Replica counts come from the scale-target status (CurrentReplicas / PendingReplicas),
+// which are group-consistent for LeaderWorkerSet; they are not derived from the number
+// of metric-reporting pods, which would be in pod units for LWS group size > 1.
 // Rules:
-// - If ANY variant is transitioning (desired ≠ current OR metrics ≠ current): block all scaling for the model
-// - Else if Saturation needs scale-up: cheapest variant (without pending replicas) gets readyReplicas+1
-// - Else if Saturation allows scale-down: most expensive variant gets readyReplicas-1
-// - Else: target = readyReplicas (replicas with metrics)
+// - If ANY variant is transitioning (desired ≠ current OR pending > 0): block all scaling for the model
+// - Else if Saturation needs scale-up: cheapest variant (without pending replicas) gets currentReplicas+1
+// - Else if Saturation allows scale-down: most expensive variant gets currentReplicas-1
+// - Else: target = currentReplicas
 func (a *Analyzer) CalculateSaturationTargets(
 	ctx context.Context,
 	saturationAnalysis *interfaces.ModelSaturationAnalysis,
@@ -329,12 +331,19 @@ func (a *Analyzer) CalculateSaturationTargets(
 				fmt.Sprintf("%s: desired(%d)!=current(%d)", va.VariantName, state.DesiredReplicas, state.CurrentReplicas))
 		}
 
-		// Check 2: Metrics vs Current mismatch (pods not yet ready/reporting)
-		metricsCurrentMismatch := va.ReplicaCount != state.CurrentReplicas
-		if metricsCurrentMismatch {
+		// Check 2: Pods not yet ready (scale-up in progress / cold start)
+		// Use PendingReplicas (CurrentReplicas - ReadyReplicas, from scale-target
+		// status) rather than comparing va.ReplicaCount (count of metric-reporting
+		// pod instances) against state.CurrentReplicas. Those two are in different
+		// units for LeaderWorkerSet: CurrentReplicas counts groups while
+		// va.ReplicaCount counts pods, so for a group size > 1 the equality check
+		// was permanently true and blocked all scaling ("model in transition"
+		// forever). PendingReplicas is group-consistent and is already the signal
+		// used for per-variant pending-skip below.
+		if state.PendingReplicas > 0 {
 			modelInTransition = true
 			transitionReasons = append(transitionReasons,
-				fmt.Sprintf("%s: metrics(%d)!=current(%d)", va.VariantName, va.ReplicaCount, state.CurrentReplicas))
+				fmt.Sprintf("%s: pending(%d)", va.VariantName, state.PendingReplicas))
 		}
 	}
 
@@ -356,10 +365,17 @@ func (a *Analyzer) CalculateSaturationTargets(
 					"variant", va.VariantName, "current", state.CurrentReplicas)
 			}
 		} else {
-			// Model stable: use metrics count
-			targets[va.VariantName] = va.ReplicaCount
-			logger.V(logging.DEBUG).Info("Target initialized to metrics count (stable)",
-				"variant", va.VariantName, "count", va.ReplicaCount)
+			// Model stable: base the target on current replicas (scale-target
+			// status), not va.ReplicaCount. va.ReplicaCount is the number of
+			// metric-reporting pod instances, which for a LeaderWorkerSet group
+			// size > 1 exceeds the replica (group) count and would over-scale.
+			// The model only reaches this branch when not in transition, so
+			// PendingReplicas == 0 and CurrentReplicas == ReadyReplicas; using
+			// CurrentReplicas preserves the prior "ready replicas" base for
+			// Deployments while staying group-consistent for LWS.
+			targets[va.VariantName] = state.CurrentReplicas
+			logger.V(logging.DEBUG).Info("Target initialized to current replicas (stable)",
+				"variant", va.VariantName, "count", state.CurrentReplicas)
 		}
 	}
 

--- a/internal/saturation/analyzer_test.go
+++ b/internal/saturation/analyzer_test.go
@@ -474,7 +474,7 @@ func TestCalculatesaturationTargets_ModelLevelTransitionBlocking(t *testing.T) {
 	}
 }
 
-func TestCalculatesaturationTargets_MetricsMismatchBlocksScaling(t *testing.T) {
+func TestCalculatesaturationTargets_PendingReplicasBlocksScaling(t *testing.T) {
 	analyzer := NewAnalyzer()
 
 	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
@@ -483,28 +483,61 @@ func TestCalculatesaturationTargets_MetricsMismatchBlocksScaling(t *testing.T) {
 		ShouldScaleUp: true,
 		ScaleUpReason: "KV spare Saturation low",
 		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
-			// v1 has 3 replicas but only 2 are reporting metrics
 			{VariantName: "v1-expensive", Cost: 20, ReplicaCount: 2},
 			{VariantName: "v2-cheap", Cost: 5, ReplicaCount: 2},
 		},
 	}
 
-	// v1 has metrics(2) != current(3) - some pods not reporting yet
-	// This puts the MODEL in transition state
+	// v1 has a pending replica (3 current, only 2 ready) - scale-up in progress.
+	// This puts the MODEL in transition state, blocking all scaling decisions.
 	variantStates := []interfaces.VariantReplicaState{
-		{VariantName: "v1-expensive", CurrentReplicas: 3, DesiredReplicas: 0},
+		{VariantName: "v1-expensive", CurrentReplicas: 3, DesiredReplicas: 0, PendingReplicas: 1},
 		{VariantName: "v2-cheap", CurrentReplicas: 2, DesiredReplicas: 0},
 	}
 
 	targets := analyzer.CalculateSaturationTargets(context.Background(), saturationAnalysis, variantStates)
 
-	// v1 should stay at current replicas (metrics incomplete)
+	// v1 should stay at current replicas (pods still starting)
 	if targets["v1-expensive"] != 3 {
-		t.Errorf("expected v1-expensive target=3 (current, metrics incomplete), got %d", targets["v1-expensive"])
+		t.Errorf("expected v1-expensive target=3 (current, pods pending), got %d", targets["v1-expensive"])
 	}
 
-	// v2 should NOT be scaled up because model is in transition (v1 has incomplete metrics)
+	// v2 should NOT be scaled up because model is in transition (v1 has pending replicas)
 	if targets["v2-cheap"] != 2 {
 		t.Errorf("expected v2-cheap target=2 (blocked by model transition), got %d", targets["v2-cheap"])
+	}
+}
+
+// TestCalculatesaturationTargets_LWSGroupSizeDoesNotBlock is the regression test
+// for #1302: a LeaderWorkerSet variant with group size > 1 reports more metric
+// pods (ReplicaCount) than it has replicas/groups (CurrentReplicas). The old
+// metrics(ReplicaCount) != current(CurrentReplicas) transition check treated this
+// as a permanent transition and blocked all scaling. With the pending-based
+// check, a stable LWS variant scales normally and targets are in group units.
+func TestCalculatesaturationTargets_LWSGroupSizeDoesNotBlock(t *testing.T) {
+	analyzer := NewAnalyzer()
+
+	saturationAnalysis := &interfaces.ModelSaturationAnalysis{
+		ModelID:       "test-model",
+		Namespace:     "test-ns",
+		ShouldScaleUp: true,
+		ScaleUpReason: "KV spare Saturation low",
+		VariantAnalyses: []interfaces.VariantSaturationAnalysis{
+			// LWS group size 2: 1 group, 2 pods reporting metrics.
+			{VariantName: "lws-variant", Cost: 5, ReplicaCount: 2},
+		},
+	}
+
+	// 1 group (CurrentReplicas), fully ready (PendingReplicas 0). ReplicaCount (2
+	// metric pods) deliberately differs from CurrentReplicas (1 group).
+	variantStates := []interfaces.VariantReplicaState{
+		{VariantName: "lws-variant", CurrentReplicas: 1, DesiredReplicas: 0, PendingReplicas: 0},
+	}
+
+	targets := analyzer.CalculateSaturationTargets(context.Background(), saturationAnalysis, variantStates)
+
+	// Not blocked: scales up by one group, in group units (1 -> 2), NOT pods (2 -> 3).
+	if targets["lws-variant"] != 2 {
+		t.Errorf("expected lws-variant target=2 (1 group scaled up by 1, in group units), got %d", targets["lws-variant"])
 	}
 }


### PR DESCRIPTION
Fixes #1302

## Problem

The V1 saturation analyzer compared two values that are in different units for LeaderWorkerSet workloads:

- `state.CurrentReplicas` — replicas (LWS **groups**)
- `va.ReplicaCount` — metric-reporting **pod** instances

For a LWS group size > 1 these never match (e.g. 1 group, 2 pods), so the `metrics != current` transition check in `CalculateSaturationTargets` was permanently true. The model was treated as forever "in transition" and **all scaling was blocked**, leaving the workload stuck at its initial replica count regardless of load.

## Fix

- **Transition check:** use `state.PendingReplicas > 0` (the group-consistent "pods not yet ready" signal already used for the per-variant pending-skip in the same function) instead of comparing metric-pod count to replica count.
- **Stable target base:** seed the target from `state.CurrentReplicas` instead of `va.ReplicaCount`. The stable branch is only reached when `PendingReplicas == 0` (so `CurrentReplicas == ReadyReplicas`), preserving Deployment behavior while keeping LWS targets in group units. This also prevents a latent over-scale (scaling in pod units) that the transition block had been masking.

**V2 (token-based) is unaffected** — it derives its replica count from the scale-target status (`CurrentReplicas - PendingReplicas`, group-consistent) and has no metrics-count transition check.
