### PR TITLE
fix(saturation): log V2 capacity after threshold post-step, not before

### DIFF
--- a/internal/engines/saturation/engine_v2.go
+++ b/internal/engines/saturation/engine_v2.go
@@ -64,14 +64,10 @@ func (e *Engine) runV2AnalysisOnly(
 		return nil, fmt.Errorf("V2 saturation analysis failed: %w", err)
 	}
 
-	logger.Info("V2 saturation analysis completed",
-		"modelID", modelID,
-		"totalSupply", result.TotalSupply,
-		"totalDemand", result.TotalDemand,
-		"utilization", result.Utilization,
-		"requiredCapacity", result.RequiredCapacity,
-		"spareCapacity", result.SpareCapacity)
-
+	// Analysis results are logged by the caller (runAnalyzersAndScore) after the
+	// applyUniversalThreshold post-step, so the single Info line can include the
+	// real RequiredCapacity/SpareCapacity. They are left zero here, so logging
+	// them at this point would always report 0 and be misleading.
 	return result, nil
 }
 
@@ -108,6 +104,19 @@ func (e *Engine) runAnalyzersAndScore(
 	// resolved threshold for the saturation entry (per-analyzer override over global).
 	satUp, satDown := resolveThresholds(interfaces.SaturationAnalyzerName, config)
 	applyUniversalThreshold(baseResult, satUp, satDown)
+
+	// Single Info line for the V2 saturation analysis, emitted after the
+	// post-step so RequiredCapacity/SpareCapacity hold the real values scaling
+	// uses (they are zero in the raw analyzer result; see runV2AnalysisOnly).
+	logger.Info("V2 saturation analysis completed",
+		"modelID", modelID,
+		"totalSupply", baseResult.TotalSupply,
+		"totalDemand", baseResult.TotalDemand,
+		"utilization", baseResult.Utilization,
+		"requiredCapacity", baseResult.RequiredCapacity,
+		"spareCapacity", baseResult.SpareCapacity,
+		"scaleUpThreshold", satUp,
+		"scaleDownBoundary", satDown)
 
 	// Build AnalyzerInput once; shared by all non-saturation analyzers.
 	// Note: &config has had saturation's per-entry threshold overrides applied


### PR DESCRIPTION
Fixes #1305

## Problem

The `"V2 saturation analysis completed"` log reported `requiredCapacity` and `spareCapacity` straight from the raw analyzer result. The V2 analyzer **deliberately leaves those two fields at 0** — they are filled in by the engine's `applyUniversalThreshold` post-step that runs afterward in `runAnalyzersAndScore`. So the log printed `requiredCapacity=0, spareCapacity=0` on every cycle regardless of actual demand, which reads as a phantom "no demand / no scale" signal and has cost real debugging time.

## Fix

Move the single Info line to `runAnalyzersAndScore`, **after** `applyUniversalThreshold`, so it reports the real `RequiredCapacity`/`SpareCapacity` (plus the resolved scale-up/down thresholds) alongside `totalSupply`/`totalDemand`/`utilization`. `runV2AnalysisOnly` no longer logs, so there's no second per-cycle Info line.

No behavior change beyond logging.

## Testing

`go build` + `go vet` clean; `golangci-lint` clean; `internal/engines/saturation` (envtest) passes. No test asserts on log output, and the underlying `applyUniversalThreshold` capacity computation is already covered by `engine_v2_threshold_test.go`.