### PR TITLE
ci(): publish :main image tag on every merge to main

### DIFF
--- a/.github/workflows/ci-main-image.yaml
+++ b/.github/workflows/ci-main-image.yaml
@@ -1,0 +1,51 @@
+name: CI - Main - Docker Container Image
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-main-image
+  cancel-in-progress: true
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push :main image
+        run: |
+          IMAGE=ghcr.io/llm-d/${GITHUB_REPOSITORY##*/}
+          echo "Building $IMAGE:main for linux/amd64 and linux/arm64"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.description=Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads" \
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
+            -t $IMAGE:main .
+
+      - name: Run Trivy scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/llm-d/${{ github.event.repository.name }}:main


### PR DESCRIPTION
## Context

Today the container image `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` is only built and pushed on version tags (`v*`) or published GitHub releases, via `ci-release.yaml`. There is no floating tag that tracks the tip of `main`, so consumers who want the latest merged code have no published image to pull.

## Change

Adds `.github/workflows/ci-main-image.yaml`, which builds and pushes a multi-arch (`linux/amd64,linux/arm64`) image tagged `:main` on every push to `main` (doc-only changes excluded).

It closely mirrors `ci-release.yaml`:
- Same `GHCR_TOKEN` login, QEMU/Buildx setup, and OCI annotations
- Same Trivy scan via the existing composite action
- Adds an `org.opencontainers.image.revision` annotation pointing at the commit SHA so the floating tag stays traceable
- Uses a `cancel-in-progress` concurrency group so rapid merges do not stack redundant builds

`:latest` remains reserved for releases — untouched.

## Verification

Can only be verified end-to-end once merged:
- `gh run list --workflow=ci-main-image.yaml`
- `docker buildx imagetools inspect ghcr.io/llm-d/llm-d-workload-variant-autoscaler:main`
- Confirm the `revision` annotation matches the merged commit SHA
