### PR TITLE
ci: publish main image tag on every merge to main

### DIFF
--- a/.github/workflows/ci-main-image.yaml
+++ b/.github/workflows/ci-main-image.yaml
@@ -1,0 +1,51 @@
+name: CI - Main - Docker Container Image
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-main-image
+  cancel-in-progress: true
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push :main image
+        run: |
+          IMAGE=ghcr.io/llm-d/${GITHUB_REPOSITORY##*/}
+          echo "Building $IMAGE:main for linux/amd64 and linux/arm64"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.description=Workload Variant Autoscaler (WVA) - GPU-aware autoscaler for LLM inference workloads" \
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
+            -t $IMAGE:main .
+
+      - name: Run Trivy scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/llm-d/${{ github.event.repository.name }}:main


### PR DESCRIPTION
Add a workflow that builds and pushes a multi-arch image tagged :main to ghcr.io on every push to main (doc-only changes excluded), giving consumers a continuously-updated development image without disturbing the release flow. Mirrors ci-release.yaml: same GHCR login, QEMU/Buildx setup, OCI annotations, and Trivy scan. Leaves :latest reserved for releases.