### PR TITLE
Bumping llm-d release to latest version v0.8.1

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -387,7 +387,8 @@ jobs:
       HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       SKIP_CLEANUP: ${{ github.event.inputs.skip_cleanup || 'false' }}
       # Pin llm-d release for deterministic CI behavior
-      LLM_D_RELEASE: v0.7.0
+      LLM_D_RELEASE: v0.8.1
+      LLM_D_ROUTER_VERSION: v0.9.0
       GAIE_VERSION: v1.5.0
       # PR-specific namespaces for isolation between concurrent PR tests
       LLMD_NAMESPACE: llm-d-autoscaler-pr-${{ needs.gate.outputs.pr_number || github.run_id }}

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -326,9 +326,10 @@ jobs:
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "false"
           CREATE_CLUSTER: "true"
-          # Emulated Kind: llm-d model serving is deployed by install-epp.sh (GAIE standalone chart + simulator).
+          # Emulated Kind: llm-d model serving is deployed by install-epp.sh (llm-d-router-standalone chart + simulator).
           # Pin llm-d release for deterministic CI behavior
-          LLM_D_RELEASE: "v0.7.0"
+          LLM_D_RELEASE: "v0.8.1"
+          LLM_D_ROUTER_VERSION: "v0.9.0"
           # Dual-controller smoke installs a secondary controller via Kustomize; overlay path must be explicit in CI.
           WVA_E2E_SECONDARY_OVERLAY_PATH: ${{ github.workspace }}/test/e2e/testdata/secondary-controller
           IMG: ${{ steps.build-image.outputs.image }}
@@ -424,7 +425,8 @@ jobs:
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "true"
           CREATE_CLUSTER: "true"
-          LLM_D_RELEASE: "v0.7.0"
+          LLM_D_RELEASE: "v0.8.1"
+          LLM_D_ROUTER_VERSION: "v0.9.0"
           DEPLOY_LWS: "true"
           IMG: ${{ steps.build-image.outputs.image }}
           SKIP_BUILD: "true"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ ENVIRONMENT                 ?= kind-emulator
 USE_SIMULATOR               ?= true
 SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
-LLM_D_RELEASE               ?= v0.7.0
+LLM_D_RELEASE               ?= v0.8.1
+LLM_D_ROUTER_VERSION        ?= v0.9.0
 GAIE_VERSION                ?= v1.5.0
 KV_SPARE_TRIGGER           ?=
 QUEUE_SPARE_TRIGGER         ?=
@@ -216,6 +217,7 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 	fi
 	@ENVIRONMENT=$(ENVIRONMENT) \
 		LLM_D_RELEASE=$(LLM_D_RELEASE) \
+		LLM_D_ROUTER_VERSION=$(LLM_D_ROUTER_VERSION) \
 		GAIE_VERSION=$(GAIE_VERSION) \
 		LLMD_NS=$${LLMD_NS:-$(E2E_EMULATED_LLMD_NAMESPACE)} \
 		WVA_PROJECT=$(CURDIR) \

--- a/config/samples/hpa/co-ordinator/model-a-epp-values.yaml
+++ b/config/samples/hpa/co-ordinator/model-a-epp-values.yaml
@@ -1,58 +1,61 @@
-inferencePool:
+# Values overlay for the llm-d-router-standalone chart (oci://ghcr.io/llm-d/charts/llm-d-router-standalone).
+# Schema follows the chart's `router:` wrapper introduced with the project
+# rebrand (Inference Scheduler → llm-d Router) in llm-d v0.8.0 / chart v0.9.0.
+router:
+  inferencePool:
+    failureMode: FailOpen
   modelServers:
     matchLabels:
       llm-d.ai/model-id: model-a
-
-inferenceExtension:
-  image:
-    registry: ghcr.io
-    repository: llm-d/llm-d-inference-scheduler
-    tag: v0.8.0
-  replicas: 1
-  failureMode: FailOpen
-  flags:
-    v: 2
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
   extraServicePorts:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 8081
-  monitoring:
-    prometheus:
-      enabled: true
-      auth:
-        enabled: false
-  pluginsConfigFile: model-a-plugins.yaml
-  pluginsCustomConfig:
-    model-a-plugins.yaml: |
-      apiVersion: inference.networking.x-k8s.io/v1alpha1
-      kind: EndpointPickerConfig
-      featureGates:
-      - flowControl
-      plugins:
-      - type: queue-scorer
-      - type: kv-cache-utilization-scorer
-      - type: prefix-cache-scorer
-      - type: no-hit-lru-scorer
-      schedulingProfiles:
-      - name: default
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  epp:
+    image:
+      registry: ghcr.io
+      repository: llm-d/llm-d-router-endpoint-picker
+      tag: v0.9.0
+    replicas: 1
+    flags:
+      v: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    monitoring:
+      prometheus:
+        enabled: true
+        auth:
+          enabled: false
+    pluginsConfigFile: model-a-plugins.yaml
+    pluginsCustomConfig:
+      model-a-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+        - flowControl
         plugins:
-        - pluginRef: queue-scorer
-          weight: 2
-        - pluginRef: kv-cache-utilization-scorer
-          weight: 2
-        - pluginRef: prefix-cache-scorer
-          weight: 3
-        - pluginRef: no-hit-lru-scorer
-          weight: 2
-  sidecar:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+  proxy:
     args:
     - --service-node
     - envoy-sidecar

--- a/config/samples/hpa/co-ordinator/model-b-epp-values.yaml
+++ b/config/samples/hpa/co-ordinator/model-b-epp-values.yaml
@@ -1,58 +1,61 @@
-inferencePool:
+# Values overlay for the llm-d-router-standalone chart (oci://ghcr.io/llm-d/charts/llm-d-router-standalone).
+# Schema follows the chart's `router:` wrapper introduced with the project
+# rebrand (Inference Scheduler → llm-d Router) in llm-d v0.8.0 / chart v0.9.0.
+router:
+  inferencePool:
+    failureMode: FailOpen
   modelServers:
     matchLabels:
       llm-d.ai/model-id: model-b
-
-inferenceExtension:
-  image:
-    registry: ghcr.io
-    repository: llm-d/llm-d-inference-scheduler
-    tag: v0.8.0
-  replicas: 1
-  failureMode: FailOpen
-  flags:
-    v: 2
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
   extraServicePorts:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 8081
-  monitoring:
-    prometheus:
-      enabled: true
-      auth:
-        enabled: false
-  pluginsConfigFile: model-b-plugins.yaml
-  pluginsCustomConfig:
-    model-b-plugins.yaml: |
-      apiVersion: inference.networking.x-k8s.io/v1alpha1
-      kind: EndpointPickerConfig
-      featureGates:
-      - flowControl
-      plugins:
-      - type: queue-scorer
-      - type: kv-cache-utilization-scorer
-      - type: prefix-cache-scorer
-      - type: no-hit-lru-scorer
-      schedulingProfiles:
-      - name: default
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  epp:
+    image:
+      registry: ghcr.io
+      repository: llm-d/llm-d-router-endpoint-picker
+      tag: v0.9.0
+    replicas: 1
+    flags:
+      v: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    monitoring:
+      prometheus:
+        enabled: true
+        auth:
+          enabled: false
+    pluginsConfigFile: model-b-plugins.yaml
+    pluginsCustomConfig:
+      model-b-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+        - flowControl
         plugins:
-        - pluginRef: queue-scorer
-          weight: 2
-        - pluginRef: kv-cache-utilization-scorer
-          weight: 2
-        - pluginRef: prefix-cache-scorer
-          weight: 3
-        - pluginRef: no-hit-lru-scorer
-          weight: 2
-  sidecar:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+  proxy:
     args:
     - --service-node
     - envoy-sidecar

--- a/config/samples/hpa/co-ordinator/poc.mk
+++ b/config/samples/hpa/co-ordinator/poc.mk
@@ -5,6 +5,8 @@ POC_DIR      := config/samples/hpa/co-ordinator
 POC_WVA_NS  := workload-variant-autoscaler-system
 POC_MON_NS  := workload-variant-autoscaler-monitoring
 GAIE_VERSION ?= v1.5.0
+LLM_D_RELEASE ?= v0.8.1
+LLM_D_ROUTER_VERSION ?= v0.9.0
 
 .PHONY: poc-install
 poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Prometheus Adapter rules
@@ -26,16 +28,16 @@ poc-install: ## [POC] Install per-model EPPs, sim workloads, gateway, and Promet
 	@echo ""
 	@echo "--- Step 2: Install model-a EPP (flowControl enabled) ---"
 	@helm upgrade --install model-a \
-	  oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
-	  --version $(GAIE_VERSION) \
+	  oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+	  --version $(LLM_D_ROUTER_VERSION) \
 	  --namespace $(POC_NS) \
 	  -f $(POC_DIR)/model-a-epp-values.yaml
 	@echo ""
 	@echo "--- Step 3: Install model-b EPP (flowControl enabled) ---"
 	@kubectl delete configmap envoy -n $(POC_NS) --ignore-not-found=true 2>/dev/null; true
 	@helm upgrade --install model-b \
-	  oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
-	  --version $(GAIE_VERSION) \
+	  oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+	  --version $(LLM_D_ROUTER_VERSION) \
 	  --namespace $(POC_NS) \
 	  -f $(POC_DIR)/model-b-epp-values.yaml
 	@echo ""

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -186,7 +186,7 @@ Options:
   -h, --help               Show help
 ```
 
-**llm-d stack** (gateway, EPP, ModelService): deploy using the [llm-d guides](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) directly. For EPP-only setup (GAIE standalone chart + tokenreview RBAC), use `deploy/install-epp.sh` after `install.sh`.
+**llm-d stack** (gateway, EPP, ModelService): deploy using the [llm-d guides](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) directly. For EPP-only setup (llm-d-router-standalone chart + tokenreview RBAC), use `deploy/install-epp.sh` after `install.sh`.
 
 **Environment variables** (see [Configuration Reference](#configuration-reference)):
 
@@ -214,8 +214,8 @@ export DEPLOY_OPERATIONAL_DASHBOARD=true    # Deploy Grafana and operational das
 
 ```bash
 ./deploy/install.sh -e kubernetes
-# EPP (GAIE standalone chart + RBAC):
-LLM_D_RELEASE=v0.7.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-optimized-baseline \
+# EPP (llm-d-router-standalone chart + RBAC):
+LLM_D_RELEASE=v0.8.1 LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-optimized-baseline \
   ./deploy/install-epp.sh
 # Model server: follow llm-d/llm-d guides/optimized-baseline
 ```

--- a/deploy/ci-e2e-openshift/deploy-infrastructure.sh
+++ b/deploy/ci-e2e-openshift/deploy-infrastructure.sh
@@ -35,13 +35,14 @@ kubectl patch deployment "$MODELSERVICE" -n "$LLMD_NAMESPACE" --type=json \
 [ -n "${VLLM_MAX_NUM_SEQS:-}" ] && kubectl patch deployment "$MODELSERVICE" -n "$LLMD_NAMESPACE" --type=json \
   -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--max-num-seqs=$VLLM_MAX_NUM_SEQS\"}]"
 
-# EPP / scheduler via install-epp.sh (handles GAIE standalone chart +
+# EPP / scheduler via install-epp.sh (handles llm-d-router-standalone chart +
 # flowControl feature gate + tokenreview RBAC).  llm-d is already
 # checked out at $GITHUB_WORKSPACE/llm-d so the script reuses it.
 WVA_PROJECT="$GITHUB_WORKSPACE" \
 LLMD_NS="$LLMD_NAMESPACE" \
 GAIE_VERSION="$GAIE_VERSION" \
 LLM_D_RELEASE="$LLM_D_RELEASE" \
+LLM_D_ROUTER_VERSION="$LLM_D_ROUTER_VERSION" \
 ENVIRONMENT=openshift \
 ENABLE_SCALE_TO_ZERO=true \
 SKIP_CLUSTER_CRDS=true \

--- a/deploy/install-epp.sh
+++ b/deploy/install-epp.sh
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 #
 # EPP infrastructure setup for all environments (kind-emulator, kubernetes, openshift).
-# Installs Gateway API CRDs, GAIE CRDs, and the GAIE standalone chart (EPP + InferencePool).
+# Installs Gateway API CRDs, GAIE CRDs, and the llm-d-router-standalone chart (EPP + InferencePool).
+# Three independent version axes:
+#   - LLM_D_RELEASE         pins the upstream llm-d/llm-d release whose guide
+#                           values files we fetch (router/base.values.yaml etc.)
+#   - LLM_D_ROUTER_VERSION  pins the llm-d-router chart + EPP image (released
+#                           from llm-d/llm-d-router on its own cadence)
+#   - GAIE_VERSION          pins the kubernetes-sigs Gateway API Inference
+#                           Extension CRDs (separate project)
 # For llm-d model serving, see the llm-d project guides at https://github.com/llm-d/llm-d.
 #
 # Usage:
-#   LLM_D_RELEASE=v0.8.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-sim ./deploy/install-epp.sh
+#   LLM_D_RELEASE=v0.8.1 LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 \
+#     LLMD_NS=llm-d-sim ./deploy/install-epp.sh
 #
 
 set -e
 set -o pipefail
 
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
-LLM_D_RELEASE=${LLM_D_RELEASE:-v0.8.0}
+LLM_D_RELEASE=${LLM_D_RELEASE:-v0.8.1}
+LLM_D_ROUTER_VERSION=${LLM_D_ROUTER_VERSION:-v0.9.0}
 GAIE_VERSION=${GAIE_VERSION:-v1.5.0}
 LLMD_NS=${LLMD_NS:-llm-d-sim}
 ENVIRONMENT=${ENVIRONMENT:-kind-emulator}

--- a/deploy/kind-emulator/README.md
+++ b/deploy/kind-emulator/README.md
@@ -36,7 +36,7 @@ This deploys:
 
 - Kind cluster with 3 nodes, emulated GPUs (mixed vendors)
 - WVA controller
-- llm-d EPP (GAIE standalone)
+- llm-d EPP (llm-d-router-standalone chart)
 - Prometheus monitoring + Prometheus Adapter
 
 To also deploy a simulator model service for manual testing:

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -20,7 +20,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Configuration (Kind emulator). EPP deploy is via deploy/install-epp.sh — set LLM_D_RELEASE / GAIE_VERSION / LLMD_NS there or in Makefile.
+# Configuration (Kind emulator). EPP deploy is via deploy/install-epp.sh — set LLM_D_RELEASE / LLM_D_ROUTER_VERSION / GAIE_VERSION / LLMD_NS there or in Makefile.
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
 NAMESPACE_SUFFIX="sim"
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -62,7 +62,7 @@ This script automates the complete deployment process on kubernetes cluster incl
 export HF_TOKEN="your-hf-token-here"
 
 # Optional: Customize deployment (basename under llm-d guides/; llm-d main uses optimized-baseline)
-export GUIDE_NAME="optimized-baseline"                                  # Default for LLM_D_RELEASE v0.7.0+
+export GUIDE_NAME="optimized-baseline"                                  # Default for LLM_D_RELEASE v0.7.0+ (current default v0.8.1)
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"                               # Default
 export WVA_IMAGE_REPO="ghcr.io/llm-d/llm-d-workload-variant-autoscaler"         # Default
 export WVA_IMAGE_TAG="latest"                                             # Default

--- a/deploy/lib/cleanup.sh
+++ b/deploy/lib/cleanup.sh
@@ -92,7 +92,7 @@ cleanup() {
         undeploy_prometheus_adapter
     fi
 
-    # EPP (GAIE standalone chart) is torn down via undeploy_epp() from infra_epp.sh.
+    # EPP (llm-d-router-standalone chart) is torn down via undeploy_epp() from infra_epp.sh.
     undeploy_epp
 
     if [ "$DEPLOY_WVA" = "true" ]; then

--- a/deploy/lib/epp-flow-control.values.yaml
+++ b/deploy/lib/epp-flow-control.values.yaml
@@ -1,34 +1,39 @@
-# Helm values overlay for GAIE standalone chart to enable the EPP flowControl feature gate.
-# Applied on top of the optimized-baseline guide values when ENABLE_SCALE_TO_ZERO=true.
-# The flowControl gate exposes inference_extension_flow_control_queue_size, which the
-# WVA scale-from-zero engine reads to detect pending requests.
+# Helm values overlay for the llm-d-router-standalone chart to enable the EPP
+# flowControl feature gate. Applied on top of the optimized-baseline guide
+# values when ENABLE_SCALE_TO_ZERO=true. The flowControl gate exposes
+# inference_extension_flow_control_queue_size, which the WVA scale-from-zero
+# engine reads to detect pending requests.
 #
 # The plugins and schedulingProfiles below are NOT new — they are copied verbatim from
-# llm-d/guides/optimized-baseline/scheduler/optimized-baseline.values.yaml (fetched at
+# llm-d/guides/optimized-baseline/router/optimized-baseline.values.yaml (fetched at
 # install time). They must be repeated here because pluginsCustomConfig is a string value
 # in the Helm chart; Helm's last-(-f)-wins semantics replace the entire string, so the
 # overlay must carry the full config. The only addition over the guide values is the
 # featureGates entry.
-inferenceExtension:
-  pluginsCustomConfig:
-    optimized-baseline-plugins.yaml: |
-      apiVersion: inference.networking.x-k8s.io/v1alpha1
-      kind: EndpointPickerConfig
-      featureGates:
-      - flowControl
-      plugins:
-      - type: queue-scorer
-      - type: kv-cache-utilization-scorer
-      - type: prefix-cache-scorer
-      - type: no-hit-lru-scorer
-      schedulingProfiles:
-      - name: default
+#
+# v0.8.0+ note: keys live under `router.epp.*` (was top-level `inferenceExtension.*`)
+# following the upstream rebrand to llm-d Router.
+router:
+  epp:
+    pluginsCustomConfig:
+      optimized-baseline-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+        - flowControl
         plugins:
-        - pluginRef: queue-scorer
-          weight: 2
-        - pluginRef: kv-cache-utilization-scorer
-          weight: 2
-        - pluginRef: prefix-cache-scorer
-          weight: 3
-        - pluginRef: no-hit-lru-scorer
-          weight: 2
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2

--- a/deploy/lib/infra_epp.sh
+++ b/deploy/lib/infra_epp.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 #
 # EPP and InferencePool setup for all environments (kind-emulator, kubernetes, openshift).
-# Installs Gateway API CRDs, GAIE CRDs, and the GAIE standalone chart (EPP + InferencePool).
+# Installs Gateway API CRDs, GAIE CRDs, and the llm-d-router-standalone chart (EPP + InferencePool).
 #
-# Required vars: LLM_D_RELEASE, GAIE_VERSION, LLMD_NS
+# Required vars: LLM_D_RELEASE, LLM_D_ROUTER_VERSION, GAIE_VERSION, LLMD_NS
+#   LLM_D_RELEASE         — guide values ref under llm-d/llm-d (e.g. v0.8.1)
+#   LLM_D_ROUTER_VERSION  — chart + EPP image tag from llm-d/llm-d-router
+#                            (e.g. v0.9.0; released independently of LLM_D_RELEASE)
+#   GAIE_VERSION          — kubernetes-sigs GAIE CRDs ref (e.g. v1.5.0)
 # Required funcs: log_info, log_success, log_warning
 #
 
@@ -24,19 +28,25 @@ install_inference_crds() {
 }
 
 deploy_epp() {
-    log_info "Deploying EPP infrastructure (GAIE standalone chart v${GAIE_VERSION})..."
+    log_info "Deploying EPP infrastructure (llm-d-router-standalone chart ${LLM_D_ROUTER_VERSION}, llm-d guide values ${LLM_D_RELEASE}, GAIE CRDs ${GAIE_VERSION})..."
 
     local _lib_dir
     _lib_dir="$(dirname "${BASH_SOURCE[0]}")"
 
-    # Download guide values files pinned to LLM_D_RELEASE — version-coupled to EPP image tag.
+    # Download guide values files pinned to LLM_D_RELEASE — version-coupled to
+    # the llm-d-router-standalone chart published from the same release. From
+    # v0.8.0 onward the upstream guide values target the llm-d Router chart
+    # family (rebrand: Inference Scheduler → llm-d Router) and live under a
+    # `router:` wrapper. Earlier releases (v0.7.x) used a different chart
+    # (kubernetes-sigs GAIE standalone) with a flat schema and lived under
+    # guides/.../scheduler/; those are not supported here anymore.
     local _llmd_raw="https://raw.githubusercontent.com/llm-d/llm-d/${LLM_D_RELEASE}"
     local _tmpdir
     _tmpdir="$(mktemp -d)"
     log_info "Fetching llm-d guide values (ref=${LLM_D_RELEASE})..."
-    curl -fsSL "$_llmd_raw/guides/recipes/scheduler/base.values.yaml" \
+    curl -fsSL "$_llmd_raw/guides/recipes/router/base.values.yaml" \
         -o "$_tmpdir/epp-base.values.yaml"
-    curl -fsSL "$_llmd_raw/guides/optimized-baseline/scheduler/optimized-baseline.values.yaml" \
+    curl -fsSL "$_llmd_raw/guides/optimized-baseline/router/optimized-baseline.values.yaml" \
         -o "$_tmpdir/epp-optimized-baseline.values.yaml"
 
     # CRD installation — skipped on shared clusters where CRDs are pre-installed
@@ -67,9 +77,14 @@ deploy_epp() {
         log_info "llm-d-hf-token secret already exists in $LLMD_NS — skipping"
     fi
 
-    # GAIE standalone chart — bundles EPP + Envoy proxy; no external gateway controller needed.
-    # Override chart's production resource requests (4CPU/8Gi per container) to fit a kind cluster.
-    log_info "Installing GAIE standalone chart (release=optimized-baseline)..."
+    # llm-d-router-standalone chart — bundles EPP + Envoy proxy; no external
+    # gateway controller needed. Chart + EPP image are released from
+    # llm-d/llm-d-router on its own cadence (LLM_D_ROUTER_VERSION), separate
+    # from the llm-d/llm-d umbrella release that produces the guide values
+    # (LLM_D_RELEASE).
+    # Override chart's production resource requests (4CPU/8Gi per container)
+    # to fit a kind cluster.
+    log_info "Installing llm-d-router-standalone chart (release=optimized-baseline, version=${LLM_D_ROUTER_VERSION})..."
 
     # When scale-to-zero is enabled, add flowControl feature gate to EPP config so the
     # scale-from-zero engine can read inference_extension_flow_control_queue_size metrics.
@@ -80,19 +95,19 @@ deploy_epp() {
     fi
 
     helm upgrade --install optimized-baseline \
-        oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+        oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
         -f "$_tmpdir/epp-base.values.yaml" \
         -f "$_tmpdir/epp-optimized-baseline.values.yaml" \
         "${extra_helm_args[@]}" \
-        --set inferenceExtension.resources.requests.cpu=100m \
-        --set inferenceExtension.resources.requests.memory=256Mi \
-        --set inferenceExtension.resources.limits.cpu=500m \
-        --set inferenceExtension.resources.limits.memory=512Mi \
-        --set inferenceExtension.sidecar.resources.requests.cpu=100m \
-        --set inferenceExtension.sidecar.resources.requests.memory=128Mi \
-        --set inferenceExtension.sidecar.resources.limits.cpu=500m \
-        --set inferenceExtension.sidecar.resources.limits.memory=256Mi \
-        -n "$LLMD_NS" --version "$GAIE_VERSION" --create-namespace
+        --set router.epp.resources.requests.cpu=100m \
+        --set router.epp.resources.requests.memory=256Mi \
+        --set router.epp.resources.limits.cpu=500m \
+        --set router.epp.resources.limits.memory=512Mi \
+        --set router.proxy.resources.requests.cpu=100m \
+        --set router.proxy.resources.requests.memory=128Mi \
+        --set router.proxy.resources.limits.cpu=500m \
+        --set router.proxy.resources.limits.memory=256Mi \
+        -n "$LLMD_NS" --version "$LLM_D_ROUTER_VERSION" --create-namespace
 
     # Grant EPP SA permission to create tokenreviews/subjectaccessreviews so its
     # metrics endpoint authentication works (otherwise /metrics returns 500).
@@ -109,7 +124,7 @@ deploy_epp() {
         -n "$LLMD_NS" --timeout=120s || \
         log_warning "EPP not ready yet — check 'kubectl get pods -n $LLMD_NS'"
 
-    log_success "EPP infrastructure deployed (GAIE standalone v${GAIE_VERSION})"
+    log_success "EPP infrastructure deployed (llm-d-router-standalone ${LLM_D_ROUTER_VERSION}, guide values ${LLM_D_RELEASE})"
 }
 
 undeploy_epp() {

--- a/test/e2e/scale_from_zero_test.go
+++ b/test/e2e/scale_from_zero_test.go
@@ -21,6 +21,7 @@ import (
 
 	variantautoscalingv1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/e2e/fixtures"
+	"github.com/llm-d/llm-d-workload-variant-autoscaler/test/utils"
 )
 
 // cleanupScaleFromZeroResources deletes all resources created by scale-from-zero tests to ensure clean state
@@ -179,17 +180,20 @@ var _ = Describe("Scale-From-Zero Feature", Serial, Label("full"), Ordered, func
 			g.Expect(err).NotTo(HaveOccurred(), "EPP service should exist")
 		}).Should(Succeed(), "EPP service should exist")
 
-		// Wait for EPP pods to be ready
+		// Wait for EPP pods to be ready. Use the EPP Service's own selector
+		// (via FindExistingEPPPods) rather than hard-coding a label key —
+		// the llm-d chart changed the EPP pod label in v0.9.0 from
+		// `inferencepool=<name>` to `llm-d-router-gateway=<name>`, and
+		// future changes are likely. The Service.spec.selector is the
+		// authoritative source.
 		Eventually(func(g Gomega) {
-			podList, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
-				LabelSelector: "inferencepool=" + eppServiceName,
-			})
-			g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
-			g.Expect(podList.Items).ToNot(BeEmpty(), "EPP pods should exist")
+			pods, err := utils.FindExistingEPPPods(ctx, k8sClient, cfg.LLMDNamespace, eppServiceName)
+			g.Expect(err).NotTo(HaveOccurred(), "Should be able to find EPP pods")
+			g.Expect(pods).ToNot(BeEmpty(), "EPP pods should exist")
 
 			// Check that at least one pod is ready
 			hasReadyPod := false
-			for _, pod := range podList.Items {
+			for _, pod := range pods {
 				for _, condition := range pod.Status.Conditions {
 					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 						hasReadyPod = true
@@ -649,17 +653,20 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet", Serial, Label("
 			g.Expect(err).NotTo(HaveOccurred(), "EPP service should exist")
 		}).Should(Succeed(), "EPP service should exist")
 
-		// Wait for EPP pods to be ready
+		// Wait for EPP pods to be ready. Use the EPP Service's own selector
+		// (via FindExistingEPPPods) rather than hard-coding a label key —
+		// the llm-d chart changed the EPP pod label in v0.9.0 from
+		// `inferencepool=<name>` to `llm-d-router-gateway=<name>`, and
+		// future changes are likely. The Service.spec.selector is the
+		// authoritative source.
 		Eventually(func(g Gomega) {
-			podList, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
-				LabelSelector: "inferencepool=" + eppServiceName,
-			})
-			g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
-			g.Expect(podList.Items).ToNot(BeEmpty(), "EPP pods should exist")
+			pods, err := utils.FindExistingEPPPods(ctx, k8sClient, cfg.LLMDNamespace, eppServiceName)
+			g.Expect(err).NotTo(HaveOccurred(), "Should be able to find EPP pods")
+			g.Expect(pods).ToNot(BeEmpty(), "EPP pods should exist")
 
 			// Check that at least one pod is ready
 			hasReadyPod := false
-			for _, pod := range podList.Items {
+			for _, pod := range pods {
 				for _, condition := range pod.Status.Conditions {
 					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 						hasReadyPod = true
@@ -1076,17 +1083,20 @@ var _ = Describe("Scale-From-Zero Feature with LeaderWorkerSet (single-node)", S
 			g.Expect(err).NotTo(HaveOccurred(), "EPP service should exist")
 		}).Should(Succeed(), "EPP service should exist")
 
-		// Wait for EPP pods to be ready
+		// Wait for EPP pods to be ready. Use the EPP Service's own selector
+		// (via FindExistingEPPPods) rather than hard-coding a label key —
+		// the llm-d chart changed the EPP pod label in v0.9.0 from
+		// `inferencepool=<name>` to `llm-d-router-gateway=<name>`, and
+		// future changes are likely. The Service.spec.selector is the
+		// authoritative source.
 		Eventually(func(g Gomega) {
-			podList, err := k8sClient.CoreV1().Pods(cfg.LLMDNamespace).List(ctx, metav1.ListOptions{
-				LabelSelector: "inferencepool=" + eppServiceName,
-			})
-			g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
-			g.Expect(podList.Items).ToNot(BeEmpty(), "EPP pods should exist")
+			pods, err := utils.FindExistingEPPPods(ctx, k8sClient, cfg.LLMDNamespace, eppServiceName)
+			g.Expect(err).NotTo(HaveOccurred(), "Should be able to find EPP pods")
+			g.Expect(pods).ToNot(BeEmpty(), "EPP pods should exist")
 
 			// Check that at least one pod is ready
 			hasReadyPod := false
-			for _, pod := range podList.Items {
+			for _, pod := range pods {
 				for _, condition := range pod.Status.Conditions {
 					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 						hasReadyPod = true


### PR DESCRIPTION
This PR bumps  llm-d release version `v0.8.1` (latest).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
  - :gift: Migrate EPP install to the upstream llm-d-router-standalone chart
  (oci://ghcr.io/llm-d/charts/llm-d-router-standalone), replacing the
  kubernetes-sigs GAIE standalone chart. Updates deploy/lib/infra_epp.sh.
  - :broom: Pin the new llm-d-router-standalone chart and llm-d-router-endpoint-picker
  EPP image to v0.9.0 via a new LLM_D_ROUTER_VERSION variable (default v0.9.0),
  separate from LLM_D_RELEASE (default v0.8.1, controls only the guide values
  fetched from llm-d/llm-d). The two are released independently — the
  llm-d/llm-d-router repo never published a v0.8.1 chart, so deriving the
  chart version from LLM_D_RELEASE would 404. Threaded through Makefile,
  CI workflows, install scripts, and poc.mk.
  - :broom: Bump EPP image to ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
  (was llm-d-inference-scheduler:v0.8.0) following the upstream rename
  Inference Scheduler → llm-d Router. The old image repo no longer ships
  new tags.
  - :bug: Reshape values overlays for the new chart: model-{a,b}-epp-values.yaml
  and epp-flow-control.values.yaml now use the chart's router: wrapper
  (was flat inferenceExtension:/inferencePool:) and the v0.8.0
  EndpointPickerConfig apiVersion (llm-d.ai/v1alpha1). Without this,
  the new chart fails to render with
  .Values.inferencePool.modelServers.matchLabels is required.
  - :broom: Default LLM_D_RELEASE to v0.8.1 everywhere
  (Makefile, ci-e2e-openshift.yaml, ci-pr-checks.yaml, deploy/README.md,
  deploy/kubernetes/README.md). install-epp.sh was already at v0.8.1; the
  rest were stuck at v0.7.0, so make deploy-… and direct script invocations
  picked different versions.
  - :broom: Update remaining references to the old chart name in poc.mk,
  install-epp.sh, cleanup.sh, deploy-infrastructure.sh, and
  kind-emulator/README.md. Comment/docs only.





### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Proposal PR** for any new enhancement or change to existing behavior

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
  The bundled EPP image is now `ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0` (was `ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0`); the upstream image was
  renamed when the project rebranded to llm-d Router. The EPP Helm install also moved from the kubernetes-sigs GAIE standalone chart to the upstream
  `llm-d-router-standalone` chart at `oci://ghcr.io/llm-d/charts/llm-d-router-standalone`, with the chart version now pinned by `LLM_D_RELEASE` (default `v0.8.1`).
  action required: users overriding `LLM_D_RELEASE` to `v0.7.x` are no longer supported by `deploy/install-epp.sh`; users with custom EPP values overrides must rewrap
   them under the chart's new `router:` key (e.g. `inferenceExtension.image` → `router.epp.image`, `inferenceExtension.sidecar` → `router.proxy`). `GAIE_VERSION`
  continues to pin the GAIE CRDs independently.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
