### PR TITLE
fix: honor minReplicaCount:0 in annotation mode (restore scale-to-zero)

### DIFF
--- a/internal/utils/variant_fromannotations.go
+++ b/internal/utils/variant_fromannotations.go
@@ -56,7 +56,7 @@ func VariantAutoscalingFromScaledObject(so *kedav1alpha1.ScaledObject) (*wvav1al
 		apiVersion = "apps/v1"
 	}
 
-	minReplicas := so.GetHPAMinReplicas()
+	minReplicas := so.Spec.MinReplicaCount
 	maxReplicas := so.GetHPAMaxReplicas()
 
 	return &wvav1alpha1.VariantAutoscaling{

--- a/internal/utils/variant_fromannotations_test.go
+++ b/internal/utils/variant_fromannotations_test.go
@@ -205,3 +205,33 @@ func TestIsSynthetic_False(t *testing.T) {
 		t.Error("VA without synthetic annotation must not be synthetic")
 	}
 }
+
+// Regression: a ScaledObject with minReplicaCount:0 must yield MinReplicas=0 so the
+// analyzer can scale the variant to zero. Before the fix, annotation mode read
+// so.GetHPAMinReplicas() which floors at 1 (an HPA's minReplicas can't be 0), hiding the
+// real minReplicaCount:0 and pinning the variant at >=1.
+func TestVariantAutoscalingFromScaledObject_ScaleToZero(t *testing.T) {
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "idle-variant",
+			Namespace:   "production",
+			Annotations: wvaAnnotations("ibm/granite-13b", "40.0"),
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "granite-13b",
+			},
+			MinReplicaCount: ptr.To(int32(0)),
+			MaxReplicaCount: ptr.To(int32(5)),
+		},
+	}
+	va, err := utils.VariantAutoscalingFromScaledObject(so)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if va.Spec.MinReplicas == nil || *va.Spec.MinReplicas != 0 {
+		t.Errorf("MinReplicas = %v, want 0 (scale-to-zero must be honored, not floored to 1)", va.Spec.MinReplicas)
+	}
+}


### PR DESCRIPTION
Fixes #1338.

## Problem

`VariantAutoscalingFromScaledObject` read `so.GetHPAMinReplicas()` (KEDA's HPA-floor accessor, which returns `1` for `minReplicaCount <= 0`) instead of the ScaledObject's actual `minReplicaCount`. So a `minReplicaCount: 0` variant was synthesized as `MinReplicas: 1`, the saturation analyzer clamped its target up to 1, and it could never scale to zero. `wva_desired_replicas=1` was emitted even for a variant with no running pods.

This contradicts the VA-deprecation plan this discovery path implements [`docs/plans/va-deprecation.md` L89](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/docs/plans/va-deprecation.md#L89) says read `minReplicaCount`, and [`deprecate-va-crd.md` L243](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/docs/proposals/deprecate-va-crd.md) requires *"Scale-to-zero … still works."* `GetHPAMinReplicas` is KEDA's HPA-construction helper (it floors at 1 because a generated HPA can't be 0; KEDA scales to zero via its controller's activation), not the workload's minimum. The **max** path already reads the raw value (`GetHPAMaxReplicas` is a pass-through), so only min deviated.

## Change

`internal/utils/variant_fromannotations.go`:
```diff
- minReplicas := so.GetHPAMinReplicas()
+ minReplicas := so.Spec.MinReplicaCount
```

- `minReplicaCount >= 1` → **identical** to before.
- `minReplicaCount: 0` → `MinReplicas: 0` (scale-to-zero honored).
- unset (`nil`) → `nil`, which the analyzer clamp and the metric emitter already treat as the documented *"default 0, allows scale to zero"* (`internal/interfaces/saturation_analyzer.go`); consistent with KEDA's own `minReplicaCount` default. No downstream consumer assumes `>= 1` (the limiter / `ensureMinimumReplicasOnDecisions` are model-total based).

WVA still only emits `wva_desired_replicas`; KEDA still builds and clamps the HPA and owns the 0↔1 boundary via activation. This only lets WVA's emitted value reach 0 without altering the HPA floor.

## Test

Adds `TestVariantAutoscalingFromScaledObject_ScaleToZero` **fails on `main`** (`MinReplicas=1`), **passes** with the fix (`MinReplicas=0`).
