### PR TITLE
fix: allow annotation mode without VA CRD

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,6 +201,17 @@ func main() {
 		setupLog.Info("LeaderWorkerSet CRD not found - support disabled (Deployment-only mode)")
 	}
 
+	vaCRDEnabled, err := crd.CheckVariantAutoscalingCRD(restConfig, setupLog)
+	if err != nil {
+		setupLog.Error(err, "failed to determine VariantAutoscaling CRD availability")
+		os.Exit(1)
+	}
+	if vaCRDEnabled {
+		setupLog.Info("VariantAutoscaling CRD detected - support enabled")
+	} else {
+		setupLog.Info("VariantAutoscaling CRD not found - VA reconciler disabled; annotation-based discovery remains enabled")
+	}
+
 	// Detect KEDA for annotation-based ScaledObject discovery (dual-mode, Phase 1)
 	kedaEnabled := crd.CheckKEDACRD(restConfig, setupLog)
 	if kedaEnabled {
@@ -384,7 +395,7 @@ func main() {
 
 	// Setup custom indexes for lookups on VariantAutoscalings
 	setupLog.Info("Setting up indexes")
-	if err := indexers.SetupIndexes(context.Background(), mgr, kedaEnabled); err != nil {
+	if err := indexers.SetupIndexes(context.Background(), mgr, vaCRDEnabled, kedaEnabled); err != nil {
 		setupLog.Error(err, "unable to setup indexes")
 		os.Exit(1)
 	}
@@ -512,20 +523,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create the reconciler with unified Config and datastore
-	reconciler := controller.NewVariantAutoscalingReconciler(
-		mgr.GetClient(),
-		mgr.GetScheme(),
-		mgr.GetEventRecorderFor("workload-variant-autoscaler-controller-manager"),
-		cfg,
-		ds,
-		lwsEnabled,
-	)
+	if vaCRDEnabled {
+		// Create the reconciler with unified Config and datastore
+		reconciler := controller.NewVariantAutoscalingReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorderFor("workload-variant-autoscaler-controller-manager"),
+			cfg,
+			ds,
+			lwsEnabled,
+		)
 
-	// Setup the controller with the manager
-	if err = reconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller")
-		os.Exit(1)
+		// Setup the controller with the manager
+		if err = reconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller")
+			os.Exit(1)
+		}
 	}
 
 	// HPAReconciler: tracks namespaces for annotation-based discovery (always registered).

--- a/deploy/lib/infra_monitoring.sh
+++ b/deploy/lib/infra_monitoring.sh
@@ -4,7 +4,7 @@
 # Keeps install.sh main flow concise while delegating to environment/plugin functions.
 # Requires funcs: deploy_prometheus_stack(), log_info/log_warning/log_success,
 # wait_deployment_available_nonfatal().
-# Requires vars: DEPLOY_PROMETHEUS, INSTALL_GRAFANA, MONITORING_NAMESPACE, WVA_PROJECT.
+# Requires vars: DEPLOY_PROMETHEUS.
 #
 
 deploy_monitoring_stack() {
@@ -15,4 +15,3 @@ deploy_monitoring_stack() {
         log_info "Skipping Prometheus deployment (DEPLOY_PROMETHEUS=false)"
     fi
 }
-

--- a/deploy/lib/install_core.sh
+++ b/deploy/lib/install_core.sh
@@ -75,7 +75,6 @@ main() {
     create_namespaces
 
     deploy_monitoring_stack
-    deploy_optional_benchmark_grafana
 
     # Deploy WVA prerequisites first (environment-specific).
     if [ "$DEPLOY_WVA" = "true" ]; then

--- a/internal/controller/indexers/indexers.go
+++ b/internal/controller/indexers/indexers.go
@@ -43,10 +43,13 @@ func scaleTargetIndexKey(namespace string, ref autoscalingv2.CrossVersionObjectR
 }
 
 // SetupIndexes registers custom field indexes with the manager's cache.
+// vaCRDEnabled controls whether the VariantAutoscaling index is registered; set to false when VariantAutoscaling CRD is not installed.
 // kedaEnabled controls whether the ScaledObject index is registered; set to false when KEDA CRDs are not installed.
-func SetupIndexes(ctx context.Context, mgr manager.Manager, kedaEnabled bool) error {
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{}, VAScaleTargetKey, VAScaleTargetIndexFunc); err != nil {
-		return fmt.Errorf("failed to set up index by scale target for VariantAutoscaling: %w", err)
+func SetupIndexes(ctx context.Context, mgr manager.Manager, vaCRDEnabled bool, kedaEnabled bool) error {
+	if vaCRDEnabled {
+		if err := mgr.GetFieldIndexer().IndexField(ctx, &llmdVariantAutoscalingV1alpha1.VariantAutoscaling{}, VAScaleTargetKey, VAScaleTargetIndexFunc); err != nil {
+			return fmt.Errorf("failed to set up index by scale target for VariantAutoscaling: %w", err)
+		}
 	}
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &autoscalingv2.HorizontalPodAutoscaler{}, HPAByScaleTargetKey, HPAByScaleTargetIndexFunc); err != nil {
 		return fmt.Errorf("failed to set up index by scale target for HPA: %w", err)

--- a/internal/controller/indexers/indexers_test.go
+++ b/internal/controller/indexers/indexers_test.go
@@ -63,8 +63,9 @@ var _ = Describe("Indexers", Ordered, func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Setup indexes
-		err = SetupIndexes(testCtx, mgr, true)
+		// Register all indexes for the main indexer suite; focused gating
+		// coverage below verifies the VA-disabled startup path.
+		err = SetupIndexes(testCtx, mgr, true, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the manager's cache
@@ -96,6 +97,65 @@ var _ = Describe("Indexers", Ordered, func() {
 			// The indexes are set up in the BeforeAll
 			// If we got here without error, the indexes were registered successfully
 			Expect(mgr).NotTo(BeNil())
+		})
+
+		It("should skip optional VA and ScaledObject indexes while keeping HPA indexing", func() {
+			ctx, cancelDisabledMgr := context.WithCancel(context.Background())
+			defer cancelDisabledMgr()
+
+			disabledMgr, err := manager.New(cfg, manager.Options{
+				Metrics: metricsserver.Options{BindAddress: "0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulates a cluster where optional CRDs are absent: startup should not
+			// register their indexes, but HPA annotation discovery still needs its index.
+			Expect(SetupIndexes(ctx, disabledMgr, false, false)).To(Succeed())
+
+			go func() {
+				defer GinkgoRecover()
+				_ = disabledMgr.Start(ctx)
+			}()
+			Expect(disabledMgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+			ns := namespace + "-hpa-only-index"
+			Expect(k8sClient.Create(testCtx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})).To(Succeed())
+			defer func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}))).To(Succeed())
+			}()
+
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "managed-hpa-only",
+					Namespace:   ns,
+					Annotations: map[string]string{"llm-d.ai/managed": "true"},
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1", Kind: "Deployment", Name: "target-deploy",
+					},
+					MaxReplicas: 3,
+				},
+			}
+			Expect(k8sClient.Create(testCtx, hpa)).To(Succeed())
+			defer func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, hpa))).To(Succeed())
+			}()
+
+			disabledClient := disabledMgr.GetClient()
+			Eventually(func() string {
+				got, err := FindHPAForScaleTarget(ctx, disabledClient, hpa.Spec.ScaleTargetRef, ns)
+				if err != nil || got == nil {
+					return ""
+				}
+				return got.Name
+			}).Should(Equal("managed-hpa-only"))
+
+			// Envtest still has the VA CRD installed; this checks that skipping
+			// the VA index disables indexed lookup, not a true CRD-absent API path.
+			_, err = FindVAForDeployment(ctx, disabledClient, "target-deploy", ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(VAScaleTargetKey))
 		})
 	})
 

--- a/internal/utils/crd/crd.go
+++ b/internal/utils/crd/crd.go
@@ -2,6 +2,7 @@ package crd
 
 import (
 	"github.com/go-logr/logr"
+	llmdVariantAutoscalingV1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -16,23 +17,40 @@ type serverGroupsAndResourcesIface interface {
 // registered in the cluster. It is called once at startup; dynamic CRD installation
 // after the controller starts is not yet handled.
 func CheckCRDInstalled(restConfig *rest.Config, groupVersion, kind string, logger logr.Logger) bool {
+	installed, err := DetectCRDInstalled(restConfig, groupVersion, kind, logger)
+	if err != nil {
+		logger.Error(err, "failed to discover API resources",
+			"groupVersion", groupVersion, "kind", kind)
+	}
+	return installed
+}
+
+// DetectCRDInstalled reports whether a CRD with the given groupVersion and kind
+// is registered in the cluster, returning an error when discovery could not
+// determine API resources at all.
+func DetectCRDInstalled(restConfig *rest.Config, groupVersion, kind string, logger logr.Logger) (bool, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
 	if err != nil {
-		logger.Error(err, "failed to create discovery client for CRD detection",
-			"groupVersion", groupVersion, "kind", kind)
-		return false
+		return false, err
 	}
-	return checkCRDInstalled(discoveryClient, groupVersion, kind, logger)
+	return detectCRDInstalled(discoveryClient, groupVersion, kind, logger)
 }
 
 func checkCRDInstalled(disc serverGroupsAndResourcesIface, groupVersion, kind string, logger logr.Logger) bool {
+	installed, err := detectCRDInstalled(disc, groupVersion, kind, logger)
+	if err != nil {
+		logger.Error(err, "failed to discover API resources",
+			"groupVersion", groupVersion, "kind", kind)
+	}
+	return installed
+}
+
+func detectCRDInstalled(disc serverGroupsAndResourcesIface, groupVersion, kind string, logger logr.Logger) (bool, error) {
 	_, apiLists, err := disc.ServerGroupsAndResources()
 	if err != nil {
 		// Partial errors are common (e.g. unavailable API services); continue if we got results.
 		if apiLists == nil {
-			logger.Error(err, "failed to discover API resources",
-				"groupVersion", groupVersion, "kind", kind)
-			return false
+			return false, err
 		}
 		logger.V(1).Info("partial error discovering API resources (this is usually fine)", "error", err)
 	}
@@ -41,13 +59,13 @@ func checkCRDInstalled(disc serverGroupsAndResourcesIface, groupVersion, kind st
 		if apiList.GroupVersion == groupVersion {
 			for _, resource := range apiList.APIResources {
 				if resource.Kind == kind {
-					return true
+					return true, nil
 				}
 			}
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // CheckKEDACRD reports whether the KEDA ScaledObject CRD is installed.
@@ -60,4 +78,10 @@ func CheckKEDACRD(restConfig *rest.Config, logger logr.Logger) bool {
 // TODO: checked once at startup; handle LWS installed after controller starts.
 func CheckLeaderWorkerSetCRD(restConfig *rest.Config, logger logr.Logger) bool {
 	return CheckCRDInstalled(restConfig, "leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet", logger)
+}
+
+// CheckVariantAutoscalingCRD reports whether the deprecated VA CRD is installed.
+// Annotation-only deployments should continue when this returns false with no error.
+func CheckVariantAutoscalingCRD(restConfig *rest.Config, logger logr.Logger) (bool, error) {
+	return DetectCRDInstalled(restConfig, llmdVariantAutoscalingV1alpha1.GroupVersion.String(), "VariantAutoscaling", logger)
 }

--- a/internal/utils/crd/crd_test.go
+++ b/internal/utils/crd/crd_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -81,6 +82,31 @@ func TestCheckCRDInstalled(t *testing.T) {
 		}
 		if checkCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log) {
 			t.Error("want false when discovery returns no results at all")
+		}
+	})
+
+	t.Run("detect total failure returns error", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: nil,
+			err:      errors.New("discovery completely failed"),
+		}
+		installed, err := detectCRDInstalled(disc, "keda.sh/v1alpha1", "ScaledObject", log)
+		if err == nil {
+			t.Fatal("want error when discovery returns no results at all")
+		}
+		if installed {
+			t.Error("want false when discovery cannot determine CRD availability")
+		}
+	})
+
+	t.Run("VariantAutoscaling uses canonical llmd.ai group version", func(t *testing.T) {
+		disc := &fakeDiscovery{
+			apiLists: []*metav1.APIResourceList{
+				apiList(wvav1alpha1.GroupVersion.String(), "VariantAutoscaling"),
+			},
+		}
+		if !checkCRDInstalled(disc, wvav1alpha1.GroupVersion.String(), "VariantAutoscaling", log) {
+			t.Error("want true for VariantAutoscaling in the canonical API group")
 		}
 	})
 }

--- a/internal/utils/variant.go
+++ b/internal/utils/variant.go
@@ -187,7 +187,11 @@ func readyVariantAutoscalings(ctx context.Context, k8sClient client.Client) ([]w
 	// List VAs using the informer cache with optional label selector
 	var vaList wvav1alpha1.VariantAutoscalingList
 	if err := k8sClient.List(ctx, &vaList, listOpts...); err != nil {
-		return nil, err
+		if !apimeta.IsNoMatchError(err) {
+			return nil, err
+		}
+		// The deprecated VA CRD is optional in annotation mode; treat its
+		// absence as an empty CRD-sourced list and continue with HPA/SO discovery.
 	}
 
 	// Filter out VAs being deleted

--- a/internal/utils/variant_test.go
+++ b/internal/utils/variant_test.go
@@ -337,6 +337,53 @@ func TestReadyVariantAutoscalingsMergePath(t *testing.T) {
 		}
 	})
 
+	t.Run("VA CRD NoMatch still returns annotation-sourced variants", func(t *testing.T) {
+		s := variantTestScheme(t)
+		vaGK := schema.GroupKind{Group: wvav1alpha1.GroupVersion.Group, Kind: "VariantAutoscaling"}
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(
+			managedHPA("ns1", "hpa-ann", "deploy-ann", "model-ann"),
+		).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*wvav1alpha1.VariantAutoscalingList); ok {
+					return &apimeta.NoKindMatchError{GroupKind: vaGK}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		result, err := readyVariantAutoscalings(ctx, cl)
+		if err != nil {
+			t.Fatalf("expected VA NoMatch to be non-fatal, got error: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("want 1 annotation-sourced VA, got %d", len(result))
+		}
+		if result[0].Name != "hpa-ann" || result[0].Spec.ModelID != "model-ann" {
+			t.Errorf("unexpected synthetic VA: name=%q modelID=%q", result[0].Name, result[0].Spec.ModelID)
+		}
+		if !IsSynthetic(&result[0]) {
+			t.Error("want annotation-sourced VA to be marked synthetic")
+		}
+	})
+
+	t.Run("VA CRD non-NoMatch list error is returned", func(t *testing.T) {
+		s := variantTestScheme(t)
+		expectedErr := errors.New("api server unavailable")
+		cl := fake.NewClientBuilder().WithScheme(s).WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*wvav1alpha1.VariantAutoscalingList); ok {
+					return expectedErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+		_, err := readyVariantAutoscalings(ctx, cl)
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("want non-NoMatch VA list error %v, got %v", expectedErr, err)
+		}
+	})
+
 	t.Run("CRD wins when same namespace/kind/name as annotation-sourced", func(t *testing.T) {
 		s := variantTestScheme(t)
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(


### PR DESCRIPTION
## Summary

Fixes #1345.

This makes the deprecated `VariantAutoscaling` CRD optional for annotation-mode deployments. When the VA CRD is absent, WVA now skips VA-specific startup wiring and continues with HPA / KEDA annotation discovery.

## Changes

- Detect whether the `VariantAutoscaling` CRD is installed at startup.
- Register the VA scale-target field index only when the VA CRD exists.
- Register the `VariantAutoscalingReconciler` only when the VA CRD exists.
- Treat `NoMatch` while listing `VariantAutoscalingList` as an empty CRD-sourced variant list, then continue to annotation-sourced HPA / ScaledObject discovery.
- Add regression coverage for:
  - `SetupIndexes(false, false)` skipping optional VA / ScaledObject indexes while keeping HPA indexing available.
  - `readyVariantAutoscalings` continuing to return annotation-sourced synthetic VAs when the VA CRD list path returns `NoMatch`.

## Testing

- `go test ./internal/controller/indexers`
- `go test ./internal/utils`
- `go test ./cmd/...`
- `go test ./internal/collector`
- `go test ./internal/utils/crd`
- `go test ./internal/controller/...`
- `gofmt -l changed-files`
- `git diff --check`
