### PR TITLE
deploy: remove LLM_D_RELEASE dependency on llm-d/llm-d

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -386,8 +386,6 @@ jobs:
       MAX_NUM_SEQS: ${{ github.event.inputs.max_num_seqs || '5' }}
       HPA_STABILIZATION_SECONDS: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       SKIP_CLEANUP: ${{ github.event.inputs.skip_cleanup || 'false' }}
-      # Pin llm-d release for deterministic CI behavior
-      LLM_D_RELEASE: v0.8.1
       LLM_D_ROUTER_VERSION: v0.9.0
       GAIE_VERSION: v1.5.0
       # PR-specific namespaces for isolation between concurrent PR tests
@@ -404,13 +402,6 @@ jobs:
         with:
           # Use PR head SHA from gate (works for both pull_request and issue_comment)
           ref: ${{ needs.gate.outputs.pr_head_sha }}
-
-      - name: Checkout llm-d/llm-d
-        uses: actions/checkout@v6
-        with:
-          repository: llm-d/llm-d
-          ref: ${{ env.LLM_D_RELEASE }}
-          path: llm-d
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -327,8 +327,6 @@ jobs:
           SCALE_TO_ZERO_ENABLED: "false"
           CREATE_CLUSTER: "true"
           # Emulated Kind: llm-d model serving is deployed by install-epp.sh (llm-d-router-standalone chart + simulator).
-          # Pin llm-d release for deterministic CI behavior
-          LLM_D_RELEASE: "v0.8.1"
           LLM_D_ROUTER_VERSION: "v0.9.0"
           # Dual-controller smoke installs a secondary controller via Kustomize; overlay path must be explicit in CI.
           WVA_E2E_SECONDARY_OVERLAY_PATH: ${{ github.workspace }}/test/e2e/testdata/secondary-controller
@@ -425,7 +423,6 @@ jobs:
           USE_SIMULATOR: "true"
           SCALE_TO_ZERO_ENABLED: "true"
           CREATE_CLUSTER: "true"
-          LLM_D_RELEASE: "v0.8.1"
           LLM_D_ROUTER_VERSION: "v0.9.0"
           DEPLOY_LWS: "true"
           IMG: ${{ steps.build-image.outputs.image }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ ENVIRONMENT                 ?= kind-emulator
 USE_SIMULATOR               ?= true
 SCALE_TO_ZERO_ENABLED       ?= false
 SCALER_BACKEND              ?= prometheus-adapter  # prometheus-adapter (HPA), keda (ScaledObject), or none (skip, use pre-installed backend)
-LLM_D_RELEASE               ?= v0.8.1
 LLM_D_ROUTER_VERSION        ?= v0.9.0
 GAIE_VERSION                ?= v1.5.0
 KV_SPARE_TRIGGER           ?=
@@ -216,7 +215,6 @@ deploy-e2e-infra: ## Deploy e2e test infrastructure (WVA + EPP; no model server 
 		./deploy/install.sh; \
 	fi
 	@ENVIRONMENT=$(ENVIRONMENT) \
-		LLM_D_RELEASE=$(LLM_D_RELEASE) \
 		LLM_D_ROUTER_VERSION=$(LLM_D_ROUTER_VERSION) \
 		GAIE_VERSION=$(GAIE_VERSION) \
 		LLMD_NS=$${LLMD_NS:-$(E2E_EMULATED_LLMD_NAMESPACE)} \

--- a/config/samples/hpa/co-ordinator/poc.mk
+++ b/config/samples/hpa/co-ordinator/poc.mk
@@ -5,7 +5,6 @@ POC_DIR      := config/samples/hpa/co-ordinator
 POC_WVA_NS  := workload-variant-autoscaler-system
 POC_MON_NS  := workload-variant-autoscaler-monitoring
 GAIE_VERSION ?= v1.5.0
-LLM_D_RELEASE ?= v0.8.1
 LLM_D_ROUTER_VERSION ?= v0.9.0
 
 .PHONY: poc-install

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -215,7 +215,7 @@ export DEPLOY_OPERATIONAL_DASHBOARD=true    # Deploy Grafana and operational das
 ```bash
 ./deploy/install.sh -e kubernetes
 # EPP (llm-d-router-standalone chart + RBAC):
-LLM_D_RELEASE=v0.8.1 LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-optimized-baseline \
+LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-optimized-baseline \
   ./deploy/install-epp.sh
 # Model server: follow llm-d/llm-d guides/optimized-baseline
 ```

--- a/deploy/ci-e2e-openshift/deploy-infrastructure.sh
+++ b/deploy/ci-e2e-openshift/deploy-infrastructure.sh
@@ -24,9 +24,8 @@ kubectl create secret generic llm-d-hf-token \
 # OpenShift: install GAIE CRDs before standalone chart.
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/?ref=${GAIE_VERSION}" || true
 
-# Model server via Kustomize (reduce replicas for CI).
-yq ".spec.replicas = 1" -i llm-d/guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-kubectl apply -k llm-d/guides/optimized-baseline/modelserver/gpu/vllm/base -n "$LLMD_NAMESPACE"
+# Model server — vendored pre-rendered manifest (replicas already set to 1 for CI).
+kubectl apply -f deploy/ci-e2e-openshift/modelserver.yaml -n "$LLMD_NAMESPACE"
 
 # Post-apply: patch model ID and vLLM batch size.
 MODELSERVICE="optimized-baseline-nvidia-gpu-vllm-decode"
@@ -36,12 +35,10 @@ kubectl patch deployment "$MODELSERVICE" -n "$LLMD_NAMESPACE" --type=json \
   -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--max-num-seqs=$VLLM_MAX_NUM_SEQS\"}]"
 
 # EPP / scheduler via install-epp.sh (handles llm-d-router-standalone chart +
-# flowControl feature gate + tokenreview RBAC).  llm-d is already
-# checked out at $GITHUB_WORKSPACE/llm-d so the script reuses it.
+# flowControl feature gate + tokenreview RBAC).
 WVA_PROJECT="$GITHUB_WORKSPACE" \
 LLMD_NS="$LLMD_NAMESPACE" \
 GAIE_VERSION="$GAIE_VERSION" \
-LLM_D_RELEASE="$LLM_D_RELEASE" \
 LLM_D_ROUTER_VERSION="$LLM_D_ROUTER_VERSION" \
 ENVIRONMENT=openshift \
 ENABLE_SCALE_TO_ZERO=true \

--- a/deploy/ci-e2e-openshift/modelserver.yaml
+++ b/deploy/ci-e2e-openshift/modelserver.yaml
@@ -1,0 +1,123 @@
+# Pre-rendered output of kustomize build on llm-d/llm-d@v0.8.1
+# guides/optimized-baseline/modelserver/gpu/vllm/base.
+#
+# replicas is set to 1 (was 8 in the upstream guide) for CI resource constraints.
+# deploy-infrastructure.sh patches args[1] with MODEL_ID and appends --max-num-seqs
+# after apply.
+#
+# To regenerate: check out llm-d/llm-d@<new-tag>, run
+#   kustomize build guides/optimized-baseline/modelserver/gpu/vllm/base
+# then set replicas: 1 and prefix the vllm image with docker.io/.
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/guide: optimized-baseline
+    llm-d.ai/model: Qwen3-32B
+  name: optimized-baseline-nvidia-gpu-vllm-sa
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/guide: optimized-baseline
+    llm-d.ai/model: Qwen3-32B
+    llm-d.ai/role: decode
+  name: optimized-baseline-nvidia-gpu-vllm-decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-variant: gpu
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/guide: optimized-baseline
+        llm-d.ai/model: Qwen3-32B
+        llm-d.ai/role: decode
+    spec:
+      containers:
+      - args:
+        - Qwen/Qwen3-32B
+        - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+        - --tensor-parallel-size=2
+        command:
+        - vllm
+        - serve
+        env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: HF_TOKEN
+              name: llm-d-hf-token
+        - name: USER
+          value: llm-d
+        image: docker.io/vllm/vllm-openai:v0.23.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: modelserver
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: modelserver
+        ports:
+        - containerPort: 8000
+          name: modelserver
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /v1/models
+            port: modelserver
+          periodSeconds: 5
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: "16"
+            memory: 128Gi
+            nvidia.com/gpu: 2
+          requests:
+            cpu: "8"
+            memory: 96Gi
+            nvidia.com/gpu: 2
+        startupProbe:
+          failureThreshold: 120
+          httpGet:
+            path: /v1/models
+            port: modelserver
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+        - mountPath: /.cache
+          name: torch-compile-cache
+        - mountPath: /.triton
+          name: triton-cache
+        - mountPath: /.config
+          name: vllm-config
+      serviceAccountName: optimized-baseline-nvidia-gpu-vllm-sa
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 20Gi
+        name: shm
+      - emptyDir: {}
+        name: torch-compile-cache
+      - emptyDir: {}
+        name: triton-cache
+      - emptyDir: {}
+        name: vllm-config

--- a/deploy/install-epp.sh
+++ b/deploy/install-epp.sh
@@ -2,25 +2,17 @@
 #
 # EPP infrastructure setup for all environments (kind-emulator, kubernetes, openshift).
 # Installs Gateway API CRDs, GAIE CRDs, and the llm-d-router-standalone chart (EPP + InferencePool).
-# Three independent version axes:
-#   - LLM_D_RELEASE         pins the upstream llm-d/llm-d release whose guide
-#                           values files we fetch (router/base.values.yaml etc.)
-#   - LLM_D_ROUTER_VERSION  pins the llm-d-router chart + EPP image (released
-#                           from llm-d/llm-d-router on its own cadence)
-#   - GAIE_VERSION          pins the kubernetes-sigs Gateway API Inference
-#                           Extension CRDs (separate project)
-# For llm-d model serving, see the llm-d project guides at https://github.com/llm-d/llm-d.
+# EPP helm values are vendored in deploy/lib/epp-base.values.yaml and
+# deploy/lib/epp-optimized-baseline.values.yaml — no network fetch required.
 #
 # Usage:
-#   LLM_D_RELEASE=v0.8.1 LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 \
-#     LLMD_NS=llm-d-sim ./deploy/install-epp.sh
+#   LLM_D_ROUTER_VERSION=v0.9.0 GAIE_VERSION=v1.5.0 LLMD_NS=llm-d-sim ./deploy/install-epp.sh
 #
 
 set -e
 set -o pipefail
 
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
-LLM_D_RELEASE=${LLM_D_RELEASE:-v0.8.1}
 LLM_D_ROUTER_VERSION=${LLM_D_ROUTER_VERSION:-v0.9.0}
 GAIE_VERSION=${GAIE_VERSION:-v1.5.0}
 LLMD_NS=${LLMD_NS:-llm-d-sim}

--- a/deploy/kind-emulator/install.sh
+++ b/deploy/kind-emulator/install.sh
@@ -20,7 +20,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Configuration (Kind emulator). EPP deploy is via deploy/install-epp.sh — set LLM_D_RELEASE / LLM_D_ROUTER_VERSION / GAIE_VERSION / LLMD_NS there or in Makefile.
+# Configuration (Kind emulator). EPP deploy is via deploy/install-epp.sh — set LLM_D_ROUTER_VERSION / GAIE_VERSION / LLMD_NS there or in Makefile.
 WVA_PROJECT=${WVA_PROJECT:-$PWD}
 NAMESPACE_SUFFIX="sim"
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -62,7 +62,7 @@ This script automates the complete deployment process on kubernetes cluster incl
 export HF_TOKEN="your-hf-token-here"
 
 # Optional: Customize deployment (basename under llm-d guides/; llm-d main uses optimized-baseline)
-export GUIDE_NAME="optimized-baseline"                                  # Default for LLM_D_RELEASE v0.7.0+ (current default v0.8.1)
+export GUIDE_NAME="optimized-baseline"                                  # Default guide name
 export MODEL_ID="unsloth/Meta-Llama-3.1-8B"                               # Default
 export WVA_IMAGE_REPO="ghcr.io/llm-d/llm-d-workload-variant-autoscaler"         # Default
 export WVA_IMAGE_TAG="latest"                                             # Default

--- a/deploy/lib/epp-base.values.yaml
+++ b/deploy/lib/epp-base.values.yaml
@@ -1,0 +1,58 @@
+## Base values shared by both standalone and llm-d Router charts.
+## Layer chart-specific or guide-specific overrides on top with additional -f flags.
+##
+## Vendored from llm-d/llm-d@v0.8.1 guides/recipes/router/base.values.yaml.
+## Update alongside LLM_D_ROUTER_VERSION when the chart schema changes.
+
+router:
+  epp:
+    replicas: 1
+    flags:
+      v: 2
+    pluginsConfigFile: "default-plugins.yaml"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+
+  inferencePool:
+    failureMode: "FailOpen"
+
+  modelServers:
+    protocol: http # http, grpc
+
+  proxy:
+    # CLI args for the Envoy sidecar. Override the chart's defaults of
+    # `--log-level trace` (very expensive under load) and no `--concurrency`
+    # (Envoy spawns ~hardware_concurrency() worker threads, oversubscribing
+    # the cgroup's CPU slice). `--concurrency 8` matches the resources.limits
+    # equivalent below; trace-level logging would burn a meaningful share of
+    # the sidecar's CPU at high QPS.
+    args:
+      - "--service-node"
+      - "envoy-sidecar"
+      - "--log-level"
+      - "warn"
+      - "--concurrency"
+      - "8"
+      - "--drain-strategy"
+      - "immediate"
+      - "--drain-time-s"
+      - "60"
+      - "-c"
+      - "/etc/envoy/envoy.yaml"
+    # Resource requests and limits for the Envoy sidecar.
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+
+  tracing:
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"

--- a/deploy/lib/epp-flow-control.values.yaml
+++ b/deploy/lib/epp-flow-control.values.yaml
@@ -5,14 +5,10 @@
 # engine reads to detect pending requests.
 #
 # The plugins and schedulingProfiles below are NOT new — they are copied verbatim from
-# llm-d/guides/optimized-baseline/router/optimized-baseline.values.yaml (fetched at
-# install time). They must be repeated here because pluginsCustomConfig is a string value
-# in the Helm chart; Helm's last-(-f)-wins semantics replace the entire string, so the
-# overlay must carry the full config. The only addition over the guide values is the
-# featureGates entry.
-#
-# v0.8.0+ note: keys live under `router.epp.*` (was top-level `inferenceExtension.*`)
-# following the upstream rebrand to llm-d Router.
+# deploy/lib/epp-optimized-baseline.values.yaml. They must be repeated here because
+# pluginsCustomConfig is a string value in the Helm chart; Helm's last-(-f)-wins
+# semantics replace the entire string, so the overlay must carry the full config.
+# The only addition over the base values is the featureGates entry.
 router:
   epp:
     pluginsCustomConfig:

--- a/deploy/lib/epp-optimized-baseline.values.yaml
+++ b/deploy/lib/epp-optimized-baseline.values.yaml
@@ -1,0 +1,39 @@
+## optimized-baseline guide overrides for the llm-d router.
+## Layer on top of: epp-base.values.yaml
+##
+## Vendored from llm-d/llm-d@v0.8.1 guides/optimized-baseline/router/optimized-baseline.values.yaml.
+## Update alongside LLM_D_ROUTER_VERSION when the chart schema changes.
+
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    pluginsConfigFile: "optimized-baseline-plugins.yaml"
+    pluginsCustomConfig:
+      optimized-baseline-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "optimized-baseline"

--- a/deploy/lib/infra_epp.sh
+++ b/deploy/lib/infra_epp.sh
@@ -3,10 +3,8 @@
 # EPP and InferencePool setup for all environments (kind-emulator, kubernetes, openshift).
 # Installs Gateway API CRDs, GAIE CRDs, and the llm-d-router-standalone chart (EPP + InferencePool).
 #
-# Required vars: LLM_D_RELEASE, LLM_D_ROUTER_VERSION, GAIE_VERSION, LLMD_NS
-#   LLM_D_RELEASE         — guide values ref under llm-d/llm-d (e.g. v0.8.1)
-#   LLM_D_ROUTER_VERSION  — chart + EPP image tag from llm-d/llm-d-router
-#                            (e.g. v0.9.0; released independently of LLM_D_RELEASE)
+# Required vars: LLM_D_ROUTER_VERSION, GAIE_VERSION, LLMD_NS
+#   LLM_D_ROUTER_VERSION  — chart + EPP image tag from llm-d/llm-d-router (e.g. v0.9.0)
 #   GAIE_VERSION          — kubernetes-sigs GAIE CRDs ref (e.g. v1.5.0)
 # Required funcs: log_info, log_success, log_warning
 #
@@ -28,26 +26,10 @@ install_inference_crds() {
 }
 
 deploy_epp() {
-    log_info "Deploying EPP infrastructure (llm-d-router-standalone chart ${LLM_D_ROUTER_VERSION}, llm-d guide values ${LLM_D_RELEASE}, GAIE CRDs ${GAIE_VERSION})..."
+    log_info "Deploying EPP infrastructure (llm-d-router-standalone chart ${LLM_D_ROUTER_VERSION}, GAIE CRDs ${GAIE_VERSION})..."
 
     local _lib_dir
     _lib_dir="$(dirname "${BASH_SOURCE[0]}")"
-
-    # Download guide values files pinned to LLM_D_RELEASE — version-coupled to
-    # the llm-d-router-standalone chart published from the same release. From
-    # v0.8.0 onward the upstream guide values target the llm-d Router chart
-    # family (rebrand: Inference Scheduler → llm-d Router) and live under a
-    # `router:` wrapper. Earlier releases (v0.7.x) used a different chart
-    # (kubernetes-sigs GAIE standalone) with a flat schema and lived under
-    # guides/.../scheduler/; those are not supported here anymore.
-    local _llmd_raw="https://raw.githubusercontent.com/llm-d/llm-d/${LLM_D_RELEASE}"
-    local _tmpdir
-    _tmpdir="$(mktemp -d)"
-    log_info "Fetching llm-d guide values (ref=${LLM_D_RELEASE})..."
-    curl -fsSL "$_llmd_raw/guides/recipes/router/base.values.yaml" \
-        -o "$_tmpdir/epp-base.values.yaml"
-    curl -fsSL "$_llmd_raw/guides/optimized-baseline/router/optimized-baseline.values.yaml" \
-        -o "$_tmpdir/epp-optimized-baseline.values.yaml"
 
     # CRD installation — skipped on shared clusters where CRDs are pre-installed
     # (e.g. OpenShift e2e). Set SKIP_CLUSTER_CRDS=true to skip.
@@ -78,10 +60,7 @@ deploy_epp() {
     fi
 
     # llm-d-router-standalone chart — bundles EPP + Envoy proxy; no external
-    # gateway controller needed. Chart + EPP image are released from
-    # llm-d/llm-d-router on its own cadence (LLM_D_ROUTER_VERSION), separate
-    # from the llm-d/llm-d umbrella release that produces the guide values
-    # (LLM_D_RELEASE).
+    # gateway controller needed. Chart + EPP image version is LLM_D_ROUTER_VERSION.
     # Override chart's production resource requests (4CPU/8Gi per container)
     # to fit a kind cluster.
     log_info "Installing llm-d-router-standalone chart (release=optimized-baseline, version=${LLM_D_ROUTER_VERSION})..."
@@ -96,8 +75,8 @@ deploy_epp() {
 
     helm upgrade --install optimized-baseline \
         oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
-        -f "$_tmpdir/epp-base.values.yaml" \
-        -f "$_tmpdir/epp-optimized-baseline.values.yaml" \
+        -f "$_lib_dir/epp-base.values.yaml" \
+        -f "$_lib_dir/epp-optimized-baseline.values.yaml" \
         "${extra_helm_args[@]}" \
         --set router.epp.resources.requests.cpu=100m \
         --set router.epp.resources.requests.memory=256Mi \
@@ -124,7 +103,7 @@ deploy_epp() {
         -n "$LLMD_NS" --timeout=120s || \
         log_warning "EPP not ready yet — check 'kubectl get pods -n $LLMD_NS'"
 
-    log_success "EPP infrastructure deployed (llm-d-router-standalone ${LLM_D_ROUTER_VERSION}, guide values ${LLM_D_RELEASE})"
+    log_success "EPP infrastructure deployed (llm-d-router-standalone ${LLM_D_ROUTER_VERSION})"
 }
 
 undeploy_epp() {


### PR DESCRIPTION
Fixes #1330
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :wastebasket: Remove `LLM_D_RELEASE` entirely - Makefile, both CI workflows, `install-epp.sh`, `deploy-infrastructure.sh`, `poc.mk`, and `tuner-test/`
- :broom: Vendor the two EPP helm values files (`guides/recipes/router/base.values.yaml` and `guides/optimized-baseline/router/optimized-baseline.values.yaml` from `llm-d/llm-d@v0.8.1`) into `deploy/lib/` and replace the runtime `curl` calls in `infra_epp.sh` with local file references
- :broom: Pre-render the OpenShift model server kustomize (`llm-d/llm-d@v0.8.1 guides/optimized-baseline/modelserver/gpu/vllm/base`) into `deploy/ci-e2e-openshift/modelserver.yaml` (replicas set to 1 for CI) and replace the `actions/checkout llm-d/llm-d` step + `kubectl apply -k` in the OpenShift CI workflow with `kubectl apply -f` against the vendored manifest


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **E2E tests** for any new behavior - no new behavior; existing smoke/full Kind e2e and OpenShift e2e cover the deploy path
- [x] **Docs PR** for any user-facing impact - n/a; `LLM_D_RELEASE` was an internal CI/deploy variable, not surfaced in user-facing install docs beyond example commands (updated inline)
- [x] **Proposal PR** for any new enhancement or change to existing behavior - tracked in #1330
**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other wva contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
None
```


**Docs**
No user-facing doc changes required, LLM_D_RELEASE was not part of the public install surface.
<!--
:book: If this change has user-visible impact, link to an issue or PR in
- https://github.com/llm-d/llm-d/tree/main/docs/architecture/advanced/autoscaling for user-facingdocumentation
- https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling for guides
-->
